### PR TITLE
Time handling improvements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Lynx-${{ matrix.runtime-identifier }} artifact
-      if: ${{ github.event.inputs.new_engine_version != '' }}
+      if: github.event.inputs.new_engine_version != ''
       uses: actions/upload-artifact@v2
       with:
         name: Lynx-${{ github.event.inputs.new_engine_version }}-${{ matrix.runtime-identifier }}
@@ -67,7 +67,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
-      if: ${{ github.event.inputs.new_engine_version == '' }}
+      if: github.event.inputs.new_engine_version == ''
       uses: actions/upload-artifact@v2
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }}
@@ -78,7 +78,7 @@ jobs:
 
   release:
     needs: publish-artifacts
-    if: ${{ github.event.inputs.new_engine_version != '' }}
+    if: github.event.inputs.new_engine_version != ''
 
     runs-on: ubuntu-latest
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   <PropertyGroup>
     <Version>0.1.0</Version>
     <Authors>Eduardo Cáceres</Authors>
-    <ApplicationIcon>$(MSBuildThisFileDirectory)\resources\icon.ico</ApplicationIcon>
+    <ApplicationIcon>$(MSBuildThisFileDirectory)/resources/icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/eduherminio/Lynx</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
   <PropertyGroup>
     <Version>0.1.0</Version>
     <Authors>Eduardo Cáceres</Authors>
-    <ApplicationIcon>$(MSBuildThisFileDirectory)/resources/icon.ico</ApplicationIcon>
-    <RepositoryUrl>https://github.com/eduherminio/Lynx</RepositoryUrl>
+    <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
+    <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Lynx
 
-⚠️ Project under development ⚠️
+[![Lynx build][buildlogo]][buildlink]
+[![Lynx release][releaselogo]][releaselink]
 
 ## Introduction
 
@@ -27,3 +28,8 @@ More details to follow.
 ## Credits
 
 Lynx development is heavily influenced by [`BitBoard Chess Engine in C` YouTube playlist](https://www.youtube.com/playlist?list=PLmN0neTso3Jxh8ZIylk74JpwfiWNI76Cs), where [@maksimKorzh](https://github.com/maksimKorzh) explains how he developed his [BBC](https://github.com/maksimKorzh/bbc) engine.
+
+[buildlink]: https://github.com/lynx-chess/Lynx/actions/workflows/ci.yml
+[buildlogo]: https://github.com/lynx-chess/Lynx/actions/workflows/ci.yml/badge.svg
+[releaselink]: https://github.com/lynx-chess/Lynx/releases/latest
+[releaselogo]: https://img.shields.io/github/v/release/lynx-chess/Lynx

--- a/src/Lynx.Benchmark/DivideByHalf.cs
+++ b/src/Lynx.Benchmark/DivideByHalf.cs
@@ -1,0 +1,76 @@
+﻿/*
+ *
+ *  |             Method |   data |            Mean |         Error |        StdDev |          Median |  Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated |
+ *  |------------------- |------- |----------------:|--------------:|--------------:|----------------:|-------:|--------:|------:|------:|------:|----------:|
+ *  |           Dividing |      1 |       0.0490 ns |     0.0396 ns |     0.0351 ns |       0.0426 ns |   1.00 |    0.00 |     - |     - |     - |         - |
+ *  |        Multiplying |      1 |       5.0197 ns |     0.2762 ns |     0.8143 ns |       4.4857 ns | 287.23 |  544.39 |     - |     - |     - |         - |
+ *  | RightShiftOperator |      1 |       0.0467 ns |     0.0200 ns |     0.0187 ns |       0.0417 ns |   2.62 |    3.97 |     - |     - |     - |         - |
+ *  |                    |        |                 |               |               |                 |        |         |       |       |       |           |
+ *  |           Dividing |     10 |       6.6264 ns |     0.1053 ns |     0.0985 ns |       6.6342 ns |   1.00 |    0.00 |     - |     - |     - |         - |
+ *  |        Multiplying |     10 |      41.5049 ns |     0.4451 ns |     0.3475 ns |      41.3493 ns |   6.27 |    0.10 |     - |     - |     - |         - |
+ *  | RightShiftOperator |     10 |       6.0727 ns |     0.0586 ns |     0.0520 ns |       6.0675 ns |   0.92 |    0.01 |     - |     - |     - |         - |
+ *  |                    |        |                 |               |               |                 |        |         |       |       |       |           |
+ *  |           Dividing |   1000 |     664.4654 ns |     3.9397 ns |     3.4925 ns |     664.1221 ns |   1.00 |    0.00 |     - |     - |     - |         - |
+ *  |        Multiplying |   1000 |   4,075.5717 ns |    53.9482 ns |    47.8237 ns |   4,072.6608 ns |   6.13 |    0.07 |     - |     - |     - |         - |
+ *  | RightShiftOperator |   1000 |     501.3558 ns |     4.0566 ns |     3.7946 ns |     501.1838 ns |   0.75 |    0.01 |     - |     - |     - |         - |
+ *  |                    |        |                 |               |               |                 |        |         |       |       |       |           |
+ *  |           Dividing |  10000 |   6,526.4149 ns |    42.4275 ns |    37.6109 ns |   6,513.2679 ns |   1.00 |    0.00 |     - |     - |     - |         - |
+ *  |        Multiplying |  10000 |  40,794.3372 ns |   583.7972 ns |   517.5210 ns |  40,730.7404 ns |   6.25 |    0.09 |     - |     - |     - |         - |
+ *  | RightShiftOperator |  10000 |   4,951.7039 ns |    38.9041 ns |    32.4867 ns |   4,958.1413 ns |   0.76 |    0.01 |     - |     - |     - |         - |
+ *  |                    |        |                 |               |               |                 |        |         |       |       |       |           |
+ *  |           Dividing | 100000 |  65,583.7874 ns |   693.6764 ns |   648.8653 ns |  65,513.7207 ns |   1.00 |    0.00 |     - |     - |     - |         - |
+ *  |        Multiplying | 100000 | 372,849.5736 ns | 2,621.9462 ns | 2,452.5701 ns | 372,794.5801 ns |   5.69 |    0.06 |     - |     - |     - |         - |
+ *  | RightShiftOperator | 100000 |  48,995.2628 ns |   288.9946 ns |   256.1861 ns |  49,024.7467 ns |   0.75 |    0.01 |     - |     - |     - |         - |
+ *
+ */
+
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+
+namespace Lynx.Benchmark
+{
+    public class DivideByHalf : BaseBenchmark
+    {
+        public static IEnumerable<int> Data => new[] { 1, 10, 1_000, 10_000, 100_000 };
+
+        [Benchmark(Baseline = true)]
+        [ArgumentsSource(nameof(Data))]
+        public int Dividing(int data)
+        {
+            int sum = 0;
+            for (int i = 0; i < data; ++i)
+            {
+                sum += i / 2;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(Data))]
+        public int Multiplying(int data)
+        {
+            int sum = 0;
+            for (int i = 0; i < data; ++i)
+            {
+                sum += Convert.ToInt32(i * 0.5);
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        [ArgumentsSource(nameof(Data))]
+        public int RightShiftOperator(int data)
+        {
+            int sum = 0;
+            for (int i = 0; i < data; ++i)
+            {
+                sum += i >> 1;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -15,6 +15,11 @@
         "logger": "*",
         "minLevel": "Trace",
         "writeTo": "moves"
+      },
+      "100": {
+        "logger": "*",
+        "minLevel": "Debug",
+        "writeTo": "console"
       }
     }
   }

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -6,6 +6,12 @@
     "KeyMovesBeforeMovesToGo": 10,
     "CoefficientAfterKeyMovesBeforeMovesToGo": 0.9,
     "TotalMovesWhenNoMovesToGoProvided": 100,
+    "FirstTimeLimitWhenNoMovesToGoProvided": 120000,
+    "FirstMultiplierWhenNoMovesToGoProvided": 3,
+    "SecondTimeLimitWhenNoMovesToGoProvided": 30000,
+    "SecondMultiplierWhenNoMovesToGoProvided": 2,
+    "MinDepth": 5,
+    "MinDepthWhenLessThanMinMoveTime": 3,
     "MinMoveTime": 1000,
     "MaxMoveTime": 3600000,
     "MinTimeToClamp": 5000
@@ -26,10 +32,10 @@
         "fileName": "${logDirectory}/errors-${date:format=yyyy-MM-dd}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
-        "archiveFileName": "${archiveLogDirectory}/errors-{#}.log",
-        "archiveEvery": "Day",
-        "archiveNumbering": "DateAndSequence",
-        "archiveDateFormat": "yyyy-MM-dd__HH_mm_ss",
+        "archiveFileName": "${archiveLogDirectory}/archived-errors-{#}.log",
+        "archiveEvery": "Monday",
+        "archiveNumbering": "Date",
+        "archiveDateFormat": "yyyy-MM-dd",
         "maxArchiveFiles": 100
       },
       "logs": {
@@ -38,10 +44,10 @@
         "fileName": "${logDirectory}/logs-${date:format=yyyy-MM-dd}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
-        "archiveFileName": "${archiveLogDirectory}/logs-{#}.log",
-        "archiveEvery": "Day",
-        "archiveNumbering": "DateAndSequence",
-        "archiveDateFormat": "yyyy-MM-dd__HH_mm_ss",
+        "archiveFileName": "${archiveLogDirectory}/archived-logs-{#}.log",
+        "archiveEvery": "Monday",
+        "archiveNumbering": "Date",
+        "archiveDateFormat": "yyyy-MM-dd",
         "maxArchiveFiles": 100
       },
       "moves": {
@@ -50,10 +56,10 @@
         "fileName": "${logDirectory}/moves-${date:format=yyyy-MM-dd}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
-        "archiveFileName": "${archiveLogDirectory}/moves-{#}.log",
-        "archiveEvery": "Day",
-        "archiveNumbering": "DateAndSequence",
-        "archiveDateFormat": "yyyy-MM-dd__HH_mm_ss",
+        "archiveFileName": "${archiveLogDirectory}/archived-moves-{#}.log",
+        "archiveEvery": "Monday",
+        "archiveNumbering": "Date",
+        "archiveDateFormat": "yyyy-MM-dd",
         "maxArchiveFiles": 100
       },
       "console": {

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -126,11 +126,6 @@
         "logger": "*",
         "minLevel": "Debug",
         "writeTo": "logs"
-      },
-      "2": {
-        "logger": "*",
-        "minLevel": "Debug",
-        "writeTo": "console"
       }
     }
   }

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -7,14 +7,12 @@
     "CoefficientAfterKeyMovesBeforeMovesToGo": 0.9,
     "TotalMovesWhenNoMovesToGoProvided": 100,
     "FirstTimeLimitWhenNoMovesToGoProvided": 120000,
-    "FirstMultiplierWhenNoMovesToGoProvided": 3,
+    "FirstCoefficientWhenNoMovesToGoProvided": 3,
     "SecondTimeLimitWhenNoMovesToGoProvided": 30000,
-    "SecondMultiplierWhenNoMovesToGoProvided": 2,
+    "SecondCoefficientWhenNoMovesToGoProvided": 2,
     "MinDepth": 5,
-    "MinDepthWhenLessThanMinMoveTime": 3,
     "MinMoveTime": 1000,
-    "MaxMoveTime": 3600000,
-    "MinTimeToClamp": 5000
+    "MinDepthWhenLessThanMinMoveTime": 3
   },
   "NLog": {
     "autoreload": true,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -86,22 +86,18 @@ namespace Lynx
 
         public int FirstTimeLimitWhenNoMovesToGoProvided { get; set; } = 120_000;
 
-        public int FirstMultiplierWhenNoMovesToGoProvided { get; set; } = 3;
+        public int FirstCoefficientWhenNoMovesToGoProvided { get; set; } = 3;
 
         public int SecondTimeLimitWhenNoMovesToGoProvided { get; set; } = 30_000;
 
-        public int SecondMultiplierWhenNoMovesToGoProvided { get; set; } = 2;
+        public int SecondCoefficientWhenNoMovesToGoProvided { get; set; } = 2;
 
         #endregion
 
         public int MinDepth { get; set; } = 5;
 
+        public int MinMoveTime { get; set; } = 1_000;
+
         public int MinDepthWhenLessThanMinMoveTime { get; set; } = 3;
-
-        public int MinMoveTime { get; set; } = 1_000;       // 1 second
-
-        public int MaxMoveTime { get; set; } = 3_600_000;   // 1 hour
-
-        public int MinTimeToClamp { get; set; } = 5_000;    // 5 seconds
     }
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -70,15 +70,35 @@ namespace Lynx
 
         public int QuiescenceSearchDepth { get; set; } = 8;
 
+        #region MovesToGo provided
+
         public double CoefficientBeforeKeyMovesBeforeMovesToGo { get; set; } = 1.5;
 
         public int KeyMovesBeforeMovesToGo { get; set; } = 10;
 
-        public double CoefficientAfterKeyMovesBeforeMovesToGo { get; set; } = 0.9;
+        public double CoefficientAfterKeyMovesBeforeMovesToGo { get; set; } = 0.95;
 
         public int TotalMovesWhenNoMovesToGoProvided { get; set; } = 100;
 
-        public int MinMoveTime { get; set; } = 1000;        // 1 second
+        #endregion
+
+        #region No MovesToGo provided
+
+        public int FirstTimeLimitWhenNoMovesToGoProvided { get; set; } = 120_000;
+
+        public int FirstMultiplierWhenNoMovesToGoProvided { get; set; } = 3;
+
+        public int SecondTimeLimitWhenNoMovesToGoProvided { get; set; } = 30_000;
+
+        public int SecondMultiplierWhenNoMovesToGoProvided { get; set; } = 2;
+
+        #endregion
+
+        public int MinDepth { get; set; } = 5;
+
+        public int MinDepthWhenLessThanMinMoveTime { get; set; } = 3;
+
+        public int MinMoveTime { get; set; } = 1_000;       // 1 second
 
         public int MaxMoveTime { get; set; } = 3_600_000;   // 1 hour
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -68,6 +68,7 @@ namespace Lynx
         public event NotifyEndOfSearch? OnSearchFinished;
 
         private CancellationTokenSource _searchCancellationTokenSource;
+        private CancellationTokenSource _absoluteSearchCancellationTokenSource;
 
         public Engine()
         {
@@ -77,6 +78,7 @@ namespace Lynx
             _isNewGameComing = true;
             _logger = LogManager.GetCurrentClassLogger();
             _searchCancellationTokenSource = new();
+            _absoluteSearchCancellationTokenSource = new();
         }
 
         internal void SetGame(Game game)
@@ -127,6 +129,7 @@ namespace Lynx
         public SearchResult BestMove(GoCommand? goCommand)
         {
             _searchCancellationTokenSource = new CancellationTokenSource();
+            _absoluteSearchCancellationTokenSource = new CancellationTokenSource();
             int? millisecondsLeft;
             int? millisecondsIncrement;
             int? depthLimit = null;
@@ -162,7 +165,7 @@ namespace Lynx
                 depthLimit = Configuration.Parameters.Depth;
             }
 
-            var result = NegaMax_AlphaBeta_Quiescence_IDDFS(Game.CurrentPosition, depthLimit, _searchCancellationTokenSource.Token);
+            var result = NegaMax_AlphaBeta_Quiescence_IDDFS(Game.CurrentPosition, depthLimit, _searchCancellationTokenSource.Token, _absoluteSearchCancellationTokenSource.Token);
             _logger.Debug($"Evaluation: {result.Evaluation} (depth: {result.TargetDepth}, refutation: {string.Join(", ", result.Moves)})");
 
             Game.MakeMove(result.BestMove);
@@ -276,7 +279,7 @@ namespace Lynx
 
         public void StopSearching()
         {
-            _searchCancellationTokenSource.Cancel();
+            _absoluteSearchCancellationTokenSource.Cancel();
             IsSearching = false;
             // TODO
         }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -163,7 +163,7 @@ namespace Lynx
             }
             else // EngineTest
             {
-                minDepth = Configuration.Parameters.Depth;
+                maxDepth = Configuration.Parameters.MinDepth;
             }
 
             var result = NegaMax_AlphaBeta_Quiescence_IDDFS(Game.CurrentPosition, minDepth, maxDepth, _searchCancellationTokenSource.Token, _absoluteSearchCancellationTokenSource.Token);

--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -205,7 +205,11 @@ namespace Lynx
 
         private static void HandleDebug(string command) => Configuration.IsDebug = DebugCommand.Parse(command);
 
-        private void HandleQuit() => _engineWriter.Writer.Complete();
+        private void HandleQuit()
+        {
+            _logger.Info($"Average depth: {_engine.AverageDepth}");
+            _engineWriter.Writer.Complete();
+        }
 
         private void HandleRegister(string rawCommand) => _engine.Registration = new RegisterCommand(rawCommand);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -31,7 +31,7 @@ namespace Lynx.Search
                 var result = new Result();
                 if (pseudoLegalMoves.Any(move => new Position(position, move).WasProduceByAValidMove()))
                 {
-                    return QuiescenceSearch_NegaMax_AlphaBeta(position, Configuration.Parameters.QuiescenceSearchDepth, ref nodes , plies + 1, alpha, beta);
+                    return QuiescenceSearch_NegaMax_AlphaBeta(position, Configuration.Parameters.QuiescenceSearchDepth, ref nodes, plies + 1, alpha, beta);
                 }
                 else
                 {
@@ -103,7 +103,7 @@ namespace Lynx.Search
         /// Defaults to the works possible score for Black, Int.MaxValue
         /// </param>
         /// <returns></returns>
-        public static (int Evaluation, Result MoveList) QuiescenceSearch_NegaMax_AlphaBeta(Position position, int quiescenceDepthLimit, ref int nodes, int plies,  int alpha, int beta, CancellationToken? cancellationToken = null)
+        public static (int Evaluation, Result MoveList) QuiescenceSearch_NegaMax_AlphaBeta(Position position, int quiescenceDepthLimit, ref int nodes, int plies, int alpha, int beta, CancellationToken? cancellationToken = null)
         {
             //cancellationToken?.ThrowIfCancellationRequested();
 
@@ -114,7 +114,7 @@ namespace Lynx.Search
             {
                 ++nodes;
                 PrintMessage(plies - 1, "Prunning before starting quiescence search");
-                return (staticEvaluation, new Result() {  MaxDepth = plies });
+                return (staticEvaluation, new Result() { MaxDepth = plies });
             }
 
             // Better move
@@ -153,7 +153,7 @@ namespace Lynx.Search
 
                 PrintPreMove(position, plies, move, isQuiescence: true);
 
-                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition, quiescenceDepthLimit, ref nodes, plies + 1,  -beta, -alpha, cancellationToken);
+                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition,quiescenceDepthLimit, ref nodes, plies + 1, -beta, -alpha, cancellationToken);
                 evaluation = -evaluation;
 
                 PrintMove(plies, move, evaluation, position);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -103,8 +103,9 @@ namespace Lynx.Search
         /// Defaults to the works possible score for Black, Int.MaxValue
         /// </param>
         /// <returns></returns>
-        public static (int Evaluation, Result MoveList) QuiescenceSearch_NegaMax_AlphaBeta(Position position, int quiescenceDepthLimit, ref int nodes, int plies, int alpha, int beta, CancellationToken? cancellationToken = null)
+        public static (int Evaluation, Result MoveList) QuiescenceSearch_NegaMax_AlphaBeta(Position position, int quiescenceDepthLimit, ref int nodes, int plies, int alpha, int beta, CancellationToken? cancellationToken = null, CancellationToken? absoluteCancellationToken = null)
         {
+            absoluteCancellationToken?.ThrowIfCancellationRequested();
             //cancellationToken?.ThrowIfCancellationRequested();
 
             var staticEvaluation = position.StaticEvaluation_NegaMax();
@@ -153,7 +154,7 @@ namespace Lynx.Search
 
                 PrintPreMove(position, plies, move, isQuiescence: true);
 
-                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition,quiescenceDepthLimit, ref nodes, plies + 1, -beta, -alpha, cancellationToken);
+                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition,quiescenceDepthLimit, ref nodes, plies + 1, -beta, -alpha, cancellationToken, absoluteCancellationToken);
                 evaluation = -evaluation;
 
                 PrintMove(plies, move, evaluation, position);

--- a/src/Lynx/Search/NegaMax_IDDFS.cs
+++ b/src/Lynx/Search/NegaMax_IDDFS.cs
@@ -9,10 +9,8 @@ namespace Lynx.Search
 {
     public static partial class SearchAlgorithms
     {
-        public static SearchResult NegaMax_AlphaBeta_Quiescence_IDDFS(Position position, int? minDepth, CancellationToken cancellationToken, CancellationToken absoluteCancellationToken)
+        public static SearchResult NegaMax_AlphaBeta_Quiescence_IDDFS(Position position, int minDepth, int? maxDepth, CancellationToken cancellationToken, CancellationToken absoluteCancellationToken)
         {
-            var minDepthToCancel = minDepth ?? Configuration.Parameters.MinDepth;
-
             int bestEvaluation = 0;
             Result? bestResult = new();
             int depth = 1;
@@ -28,13 +26,13 @@ namespace Lynx.Search
                 do
                 {
                     absoluteCancellationToken.ThrowIfCancellationRequested();
-                    if (depth > minDepthToCancel)
+                    if (depth > minDepth)
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                     }
                     nodes = 0;
-                    (bestEvaluation, bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepthToCancel, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken);
-                } while (stopSearchCondition(++depth, minDepth));
+                    (bestEvaluation, bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken);
+                } while (stopSearchCondition(++depth, maxDepth));
             }
             catch (OperationCanceledException)
             {

--- a/tests/Lynx.NUnit.Test/BaseTest.cs
+++ b/tests/Lynx.NUnit.Test/BaseTest.cs
@@ -14,7 +14,8 @@ namespace Lynx.NUnit.Test
             engine.SetGame(new Game(fen));
 
             // Act
-            var bestMoveFound = engine.BestMove().BestMove;
+            var searchResult = engine.BestMove();
+            var bestMoveFound = searchResult.BestMove;
 
             // Assert
             if (allowedUCIMoveString is not null)

--- a/tests/Lynx.NUnit.Test/EngineTest.cs
+++ b/tests/Lynx.NUnit.Test/EngineTest.cs
@@ -64,8 +64,8 @@ namespace Lynx.NUnit.Test
 
         [TestCase("r1bq2k1/1pp1n2p/2nppr1Q/p7/2PP2P1/5N2/PP3P1P/2KR1B1R w - - 0 15", new[] { "h6f6" },
             Category = "LongRunning", Explicit = true, Description = "AlphaBeta/NegaMax depth 5 spends almost 3 minutes with a simple retake")]
-        [TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
-            Category = "LongRunning", Explicit = true, Description = "At depth 3 White takes the pawn")]
+        //[TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
+        //    Category = "LongRunning", Explicit = true, Description = "At depth 3 White takes the pawn")]
         public void BestMove_Regression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
         {
             TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);

--- a/tests/Lynx.NUnit.Test/EngineTest.cs
+++ b/tests/Lynx.NUnit.Test/EngineTest.cs
@@ -64,6 +64,8 @@ namespace Lynx.NUnit.Test
 
         [TestCase("r1bq2k1/1pp1n2p/2nppr1Q/p7/2PP2P1/5N2/PP3P1P/2KR1B1R w - - 0 15", new[] { "h6f6" },
             Category = "LongRunning", Explicit = true, Description = "AlphaBeta/NegaMax depth 5 spends almost 3 minutes with a simple retake")]
+        [TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
+            Category = "LongRunning", Explicit = true, Description = "At depth 3 White takes the pawn")]
         public void BestMove_Regression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
         {
             TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);

--- a/tests/Lynx.NUnit.Test/NonParallelizableTest.cs
+++ b/tests/Lynx.NUnit.Test/NonParallelizableTest.cs
@@ -3,7 +3,7 @@
 namespace Lynx.NUnit.Test
 {
     [NonParallelizable]
-    public class NonParallelizable : BaseTest
+    public class NonParallelizableTest : BaseTest
     {
         [TestCase("r2qkb1r/ppp2ppp/2n2n2/1B1p1b2/3P4/2N2N2/PPP2PPP/R1BQ1RK1 b kq - 0 1", 1, 8,
             null,

--- a/tests/Lynx.NUnit.Test/PerftTest.cs
+++ b/tests/Lynx.NUnit.Test/PerftTest.cs
@@ -6,7 +6,7 @@ namespace Lynx.Test
     /// <summary>
     /// https://www.chessprogramming.org/Perft_Results
     /// </summary>
-    public class PerftTests
+    public class PerftTest
     {
         [TestCase(Constants.InitialPositionFEN, 1, 20)]
         [TestCase(Constants.InitialPositionFEN, 2, 400)]

--- a/tests/Lynx.NUnit.Test/TimeManagementTest.cs
+++ b/tests/Lynx.NUnit.Test/TimeManagementTest.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+
+namespace Lynx.NUnit.Test
+{
+    public class TimeManagementTest
+    {
+        [TestCase(
+            300_000,    // 5 min
+            0,
+            40,         // 40 moves left
+            11_250)]    // 11.25s, CoefficientBeforeKeyMovesBeforeMovesToGo * millisecondsLeft) / movesToGo
+        [TestCase(
+            300_000,    // 5 min
+            10_000,     // 10s increment
+            40,         // 40 moves left
+            20_875)]    // 20.9s, millisecondsIncrement + CoefficientAfterKeyMovesBeforeMovesToGo * (millisecondsLeft - millisecondsIncrement) / movesToGo
+        [TestCase(
+            20_000,     // 20s
+            0,
+            5,          // 5 moves left
+            3_800)]     // 3.8s, millisecondsIncrement + CoefficientAfterKeyMovesBeforeMovesToGo * (millisecondsLeft - millisecondsIncrement) / movesToGo
+        [TestCase(
+            20_000,     // 20s
+            10_000,     // 10s increment
+            5,          // 5 moves left
+            11_900)]    // 11.9s, millisecondsIncrement + CoefficientAfterKeyMovesBeforeMovesToGo * (millisecondsLeft - millisecondsIncrement) / movesToGo
+        [TestCase(
+            12_000,     // 12s
+            10_000,     // 10s increment
+            5,          // 5 moves left
+            10_380)]    // 10.38s, millisecondsIncrement + CoefficientAfterKeyMovesBeforeMovesToGo * (millisecondsLeft - millisecondsIncrement) / movesToGo
+        [TestCase(
+            10_000,     // 10s
+            10_000,     // 10s increment
+            5,          // 5 moves left
+            9_000)]     // 9s, millisecondsLeft - decisionTime < 1_000 -> decisionTime *= 0.9
+        [TestCase(
+            10_000,     // 10s
+            10_000,     // 10s increment
+            50,         // 50 moves left
+            9_000)]     // 9s, millisecondsLeft - decisionTime < 1_000 -> decisionTime *= 0.9
+        [TestCase(
+            1_000,      // 1s
+            1_000,      // 1s increment
+            10,         // 50 moves left
+            900)]       // 0
+        [TestCase(
+            182_000,    // 3min
+            2_000,      // 2s increment
+            0,         // 50 moves left
+            900)]       // 0.9s, millisecondsLeft - decisionTime  < 1_000 -> decisionTime *= 0.9
+        public void CalculateDecisionTime(
+            int millisecondsLeft, int millisecondsIncrement, int movesToGo,int expectedTimeToMove)
+        {
+            var engine = new Engine();
+            var timeToMove = engine.CalculateDecisionTime(movesToGo, millisecondsLeft, millisecondsIncrement);
+
+            Assert.AreEqual(expectedTimeToMove, timeToMove);
+        }
+    }
+}


### PR DESCRIPTION
* Improve time management handling.
  * Use more time at the 'beginning' of the games, where it takes more time to reach the same depth, when no 'moves-to-go' are provided (FirstTimeLimitWhenNoMovesToGoProvided , SecondTimeLimitWhenNoMovesToGoProvided added).
    We already do something similar with KeyMovesBeforeMovesToGo, CoefficientBeforeKeyMovesBeforeMovesToGo and CoefficientAfterKeyMovesBeforeMovesToGo when 'moves-to-go' are provided.
  * Add a minimum MinDepth used in each of the moves, avoiding the situation of making moves with depth 3 in the middle of the game. 5 seems the highest value we can go for right now.
* Add an 'absolute' `CancellationToken` so that 'stop' commands act immediately, even if MinDepth hasn't been reached.
* Remove debug logs from console.
* Add badges to readme.
* Remove time clamping, as a consequence of that min depth.