### PR TITLE
Fix `DivideByZeroException` when a non moves-to-go game exceeds 100 moves

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -177,23 +177,27 @@ namespace Lynx
 
         internal double CalculateDecisionTime(int movesToGo, int millisecondsLeft, int millisecondsIncrement)
         {
-            double decisionTime;
+            double decisionTime = 0;
             millisecondsLeft -= millisecondsIncrement; // Since we're going to spend them, shouldn't take into account for our calculations
 
             if (movesToGo == default)
             {
                 int movesLeft = Configuration.Parameters.TotalMovesWhenNoMovesToGoProvided - (Game.MoveHistory.Count >> 1);
-                if (millisecondsLeft >= Configuration.Parameters.FirstTimeLimitWhenNoMovesToGoProvided)
+
+                if (movesLeft > 0)
                 {
-                    decisionTime = Configuration.Parameters.FirstCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
-                }
-                else if (millisecondsLeft >= Configuration.Parameters.SecondTimeLimitWhenNoMovesToGoProvided)
-                {
-                    decisionTime = Configuration.Parameters.SecondCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
-                }
-                else
-                {
-                    decisionTime = millisecondsLeft / movesLeft;
+                    if (millisecondsLeft >= Configuration.Parameters.FirstTimeLimitWhenNoMovesToGoProvided)
+                    {
+                        decisionTime = Configuration.Parameters.FirstCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
+                    }
+                    else if (millisecondsLeft >= Configuration.Parameters.SecondTimeLimitWhenNoMovesToGoProvided)
+                    {
+                        decisionTime = Configuration.Parameters.SecondCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
+                    }
+                    else
+                    {
+                        decisionTime = millisecondsLeft / movesLeft;
+                    }
                 }
             }
             else

--- a/tests/Lynx.NUnit.Test/TimeManagementTest.cs
+++ b/tests/Lynx.NUnit.Test/TimeManagementTest.cs
@@ -84,8 +84,14 @@ namespace Lynx.NUnit.Test
             29000,      // 29s (< SecondTimeLimitWhenNoMovesToGoProvided)
             0,          // No increment
             0,          // No moves to go
-            414,        // 0.41, millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / TotalMovesWhenNoMovesToGoProvided - (Game.MoveHistory.Count / 2 ))
+            414,        // 0.41s, millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / TotalMovesWhenNoMovesToGoProvided - (Game.MoveHistory.Count / 2 ))
             60)]        // ~Endgame of a 3 + 2 game: 60 moves: 30 moves each
+        [TestCase(
+            5710,       // 5.7s
+            5000,       // 5s increment
+            0,          // No moves to go
+            5000,       // 5s, millisecondsIncrement
+            200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black#201
         public void CalculateDecisionTime(
             int millisecondsLeft, int millisecondsIncrement, int movesToGo, double expectedTimeToMove, int moveHistoryCount = 0)
         {

--- a/tests/Lynx.NUnit.Test/TimeManagementTest.cs
+++ b/tests/Lynx.NUnit.Test/TimeManagementTest.cs
@@ -90,8 +90,14 @@ namespace Lynx.NUnit.Test
             5710,       // 5.7s
             5000,       // 5s increment
             0,          // No moves to go
-            5000,       // 5s, millisecondsIncrement
-            200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black#201
+            4500,       // 4.5s, millisecondsIncrement * 0.9
+            200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black
+        [TestCase(
+            6001,       // 6s
+            5000,       // 5s increment
+            0,          // No moves to go
+            5000,       // 5, millisecondsIncrement
+            200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black
         public void CalculateDecisionTime(
             int millisecondsLeft, int millisecondsIncrement, int movesToGo, double expectedTimeToMove, int moveHistoryCount = 0)
         {


### PR DESCRIPTION
* Add test to reproduce the issue
* Add fix that avoids `DivideByZeroException and` just uses the increment when moves exceed `TotalMovesWhenNoMovesToGoProvided`.