### PR TITLE
Follow mate lines immediately

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -5,9 +5,8 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+  <PropertyGroup>
     <PublishSingleFile>true</PublishSingleFile>
-    <SelfContained>true</SelfContained>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>link</TrimMode>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -124,6 +124,11 @@
         "logger": "*",
         "minLevel": "Debug",
         "writeTo": "logs"
+      },
+      "100": {
+        "logger": "*",
+        "minLevel": "Warn",
+        "writeTo": "console"
       }
     }
   }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,5 +1,8 @@
 ﻿using NLog;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace Lynx.Model

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,14 +1,15 @@
 ﻿using NLog;
-using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
 
 namespace Lynx.Model
 {
     public readonly struct Position
     {
+        internal const int CheckMateEvaluation = 1_000_000_000;
+
+        internal const int DepthFactor = 1_000_000;
+
         private static readonly ILogger Logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
@@ -373,10 +374,6 @@ namespace Lynx.Model
                 ? eval
                 : -eval;
         }
-
-        internal const int CheckMateEvaluation = 1_000_000_000;
-
-        internal const int DepthFactor = 1_000_000;
 
         /// <summary>
         /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -154,7 +154,7 @@ namespace Lynx.Search
 
                 PrintPreMove(position, plies, move, isQuiescence: true);
 
-                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition,quiescenceDepthLimit, ref nodes, plies + 1, -beta, -alpha, cancellationToken, absoluteCancellationToken);
+                var (evaluation, bestMoveExistingMoveList) = QuiescenceSearch_NegaMax_AlphaBeta(newPosition, quiescenceDepthLimit, ref nodes, plies + 1, -beta, -alpha, cancellationToken, absoluteCancellationToken);
                 evaluation = -evaluation;
 
                 PrintMove(plies, move, evaluation, position);
@@ -179,7 +179,12 @@ namespace Lynx.Search
             if (bestMove is null)
             {
                 ++nodes;
-                return (position.EvaluateFinalPosition_NegaMax(plies), new Result() { MaxDepth = plies });
+
+                var eval = position.AllPossibleMoves().Any(move => new Position(position, move).WasProduceByAValidMove())
+                    ? position.StaticEvaluation_NegaMax()
+                    : position.EvaluateFinalPosition_NegaMax(plies);
+
+                return (eval, new Result() { MaxDepth = plies });
             }
 
             // Node fails low

--- a/src/Lynx/Search/NegaMax_IDDFS.cs
+++ b/src/Lynx/Search/NegaMax_IDDFS.cs
@@ -53,7 +53,7 @@ namespace Lynx.Search
 
             static bool stopSearchCondition(int depth, int? depthLimit, int bestEvaluation)
             {
-                if(Math.Abs(bestEvaluation) > 0.1 * Position.CheckMateEvaluation)   // Mate detected
+                if (Math.Abs(bestEvaluation) > 0.1 * Position.CheckMateEvaluation)   // Mate detected
                 {
                     return false;
                 }

--- a/src/Lynx/Search/NegaMax_IDDFS.cs
+++ b/src/Lynx/Search/NegaMax_IDDFS.cs
@@ -32,7 +32,7 @@ namespace Lynx.Search
                     }
                     nodes = 0;
                     (bestEvaluation, bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken);
-                } while (stopSearchCondition(++depth, maxDepth));
+                } while (stopSearchCondition(++depth, maxDepth, bestEvaluation));
             }
             catch (OperationCanceledException)
             {
@@ -51,8 +51,13 @@ namespace Lynx.Search
             bestResult?.Moves.Reverse();
             return new SearchResult(bestResult!.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult!.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / (0.001 * sw.ElapsedMilliseconds + 1), 0, Int64.MaxValue)), bestResult!.Moves);
 
-            static bool stopSearchCondition(int depth, int? depthLimit)
+            static bool stopSearchCondition(int depth, int? depthLimit, int bestEvaluation)
             {
+                if(Math.Abs(bestEvaluation) > 0.1 * Position.CheckMateEvaluation)   // Mate detected
+                {
+                    return false;
+                }
+
                 if (depthLimit is not null)
                 {
                     return depth <= depthLimit;


### PR DESCRIPTION
* Follow mate lines immediately, both when winning and losing.
* Remove self-contained property from project, and remove Release condition for the lasting properties to be used, since they should only apply to publish commands.
* Show warnings and above in console by default, even if GUIs/lichess-bot complains about them.