### PR TITLE
Fix `position` uci command when no args provided

### DIFF
--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -35,7 +35,7 @@ namespace Lynx.UCI.Commands.GUI
         public static Game ParseGame(string positionCommand)
         {
             var items = positionCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            bool isInitialPosition = string.Equals(items[1], StartPositionString, StringComparison.OrdinalIgnoreCase);
+            bool isInitialPosition = string.Equals(items.ElementAtOrDefault(1), StartPositionString, StringComparison.OrdinalIgnoreCase);
 
             var initialPosition = isInitialPosition
                     ? Constants.InitialPositionFEN


### PR DESCRIPTION
Fix crash when `position` command is received through standard input, without other args.