### PR TITLE
Detect lack of configuration at startup

### DIFF
--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -21,7 +21,7 @@ var config = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
 
-Configuration.Parameters = config.GetSection(nameof(GameParameters)).Get<GameParameters>();
+config.GetRequiredSection(nameof(GameParameters)).Bind(Configuration.Parameters);
 
 LogManager.Configuration = new NLogLoggingConfiguration(config.GetSection("NLog"));
 


### PR DESCRIPTION
Use `GetRequiredSection` + `Bind` instead of `GetSection` + `Get`.
This should detect when there's no section (no appsettings file).