### PR TITLE
🐛 Fix `stop` and `position` commands handling

### DIFF
--- a/src/Lynx.Benchmark/OppositeSide.cs
+++ b/src/Lynx.Benchmark/OppositeSide.cs
@@ -28,6 +28,9 @@ using System.Collections.Generic;
 
 namespace Lynx.Benchmark
 {
+    /// <summary>
+    /// <see cref="Utils.OppositeSide(Side)"/>
+    /// </summary>
     public static class OppositeSiteImplementations
     {
         public static int Method_Substraction(Side side) => (int)Side.White - (int)side;

--- a/src/Lynx.Benchmark/PieceOffset.cs
+++ b/src/Lynx.Benchmark/PieceOffset.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 
 namespace Lynx.Benchmark
 {
+    /// <summary>
+    /// <see cref="Utils.PieceOffset(int)"/>
+    /// </summary>
     public static class PieceOffsetImplementations
     {
         public static int Method(Side side) => 6 - (6 * (int)side);

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -44,7 +44,7 @@ _54_ScoreMove();
 const string TrickyPosition = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
 const string TrickyPositionReversed = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R b KQkq - 0 1";
 const string KillerPosition = "rnbqkb1r/pp1p1pPp/8/2p1pP2/1P1P4/3P3P/P1P1P3/RNBQKBNR w KQkq e6 0 1";
-const string CmkPosition = "r2q1rk1/ppp2ppp/2n1bn2/2b1p3/3pP3/3P1NPP/PPP1NPB1/R1BQ1RK1 b - - 0 9 ";
+const string CmkPosition = "r2q1rk1/ppp2ppp/2n1bn2/2b1p3/3pP3/3P1NPP/PPP1NPB1/R1BQ1RK1 b - - 0 9";
 
 static void _2_GettingStarted()
 {

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -94,28 +94,8 @@ namespace Lynx
 
         public void AdjustPosition(string rawPositionCommand)
         {
-            if (_isNewGameComing || !_isNewGameCommandSupported)
-            {
-                ParseWholeGame(rawPositionCommand);
-            }
-            else
-            {
-                if (!PositionCommand.TryParseLastMove(rawPositionCommand, Game, out var lastMove)
-                    || !Game.MakeMove(lastMove.Value))
-                {
-                    _logger.Warn(
-                        $"Position couldn't be adjusted using last move in position command: {rawPositionCommand}" + Environment.NewLine +
-                        "Retrying parsing the whole game");
-
-                    ParseWholeGame(rawPositionCommand);
-                }
-            }
-
-            void ParseWholeGame(string rawPositionCommand)
-            {
-                Game = PositionCommand.ParseGame(rawPositionCommand);
-                _isNewGameComing = false;
-            }
+            Game = PositionCommand.ParseGame(rawPositionCommand);
+            _isNewGameComing = false;
         }
 
         public void PonderHit()

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -169,7 +169,10 @@ namespace Lynx
             var result = NegaMax_AlphaBeta_Quiescence_IDDFS(Game.CurrentPosition, minDepth, maxDepth, _searchCancellationTokenSource.Token, _absoluteSearchCancellationTokenSource.Token);
             _logger.Debug($"Evaluation: {result.Evaluation} (depth: {result.TargetDepth}, refutation: {string.Join(", ", result.Moves)})");
 
-            Game.MakeMove(result.BestMove);
+            if (!result.isCancelled)
+            {
+                Game.MakeMove(result.BestMove);
+            }
             AverageDepth += (result.DepthReached - AverageDepth) / Game.MoveHistory.Count;
 
             return result;
@@ -259,7 +262,7 @@ namespace Lynx
             Game.MakeMove(bestMove);
 
 
-            return new SearchResult(bestMove, evaluation, Configuration.EngineSettings.Depth, moveList.MaxDepth ?? Configuration.EngineSettings.Depth, 0, 0, 0, moveList.Moves);
+            return new SearchResult(bestMove, evaluation, Configuration.EngineSettings.Depth, moveList.MaxDepth ?? Configuration.EngineSettings.Depth, 0, 0, 0, moveList.Moves, isCancelled: false);
         }
 
         public void StartSearching(GoCommand goCommand)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -21,7 +21,7 @@ namespace Lynx.Search
             public List<Move> Moves { get; set; } = new List<Move>(150);
         }
 
-        public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, int DepthReached, int Nodes, long Time, long NodesPerSecond, List<Move> Moves);
+        public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, int DepthReached, int Nodes, long Time, long NodesPerSecond, List<Move> Moves, bool isCancelled);
 
         /// <summary>
         /// Branch-optimized for <paramref name="mostLikely"/>

--- a/src/Lynx/Search/NegaMax_IDDFS.cs
+++ b/src/Lynx/Search/NegaMax_IDDFS.cs
@@ -16,6 +16,7 @@ namespace Lynx.Search
             int depth = 1;
             int nodes = 0;
             var sw = new Stopwatch();
+            bool isCancelled = false;
 
             try
             {
@@ -38,6 +39,7 @@ namespace Lynx.Search
             }
             catch (OperationCanceledException)
             {
+                isCancelled = true;
                 Logger.Info("Search cancellation requested, best move will be returned");
             }
             catch (Exception e)
@@ -51,7 +53,7 @@ namespace Lynx.Search
             }
 
             bestResult?.Moves.Reverse();
-            return new SearchResult(bestResult!.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult!.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / (0.001 * sw.ElapsedMilliseconds + 1), 0, Int64.MaxValue)), bestResult!.Moves);
+            return new SearchResult(bestResult!.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult!.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / (0.001 * sw.ElapsedMilliseconds + 1), 0, Int64.MaxValue)), bestResult!.Moves, isCancelled);
 
             static bool stopSearchCondition(int depth, int? depthLimit, int bestEvaluation)
             {

--- a/src/Lynx/Search/NegaMax_IDDFS.cs
+++ b/src/Lynx/Search/NegaMax_IDDFS.cs
@@ -31,7 +31,7 @@ namespace Lynx.Search
                         cancellationToken.ThrowIfCancellationRequested();
                     }
                     nodes = 0;
-                    (bestEvaluation, bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken);
+                    (bestEvaluation, bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken, absoluteCancellationToken);
 
                     Logger.Debug($"Time {sw.ElapsedMilliseconds} Depth {depth}, eval {bestEvaluation}, nodes {nodes} pv {string.Join(',', bestResult.Moves.Reverse<Move>().Select(m => m))}");
                 } while (stopSearchCondition(++depth, maxDepth, bestEvaluation));

--- a/tests/Lynx.NUnit.Test/PositionCommandTest.cs
+++ b/tests/Lynx.NUnit.Test/PositionCommandTest.cs
@@ -1,0 +1,37 @@
+﻿using Lynx.UCI.Commands.GUI;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Lynx.NUnit.Test
+{
+    /// <summary>
+    /// https://github.com/lynx-chess/Lynx/issues/31
+    /// </summary>
+    internal class PositionCommandTest
+    {
+        [TestCase]
+        public async Task StopCommandShouldNotModifyPositionOrAddMoveToMoveHistory()
+        {
+            // Arrange
+            var engine = new Engine();
+            engine.NewGame();
+            engine.AdjustPosition($"position fen {Constants.InitialPositionFEN} moves e2e4");
+
+            // A command that guarantees ~5s thinking time
+            var goCommand = new GoCommand();
+            await goCommand.Parse("go wtime 1 btime 1 winc 5000 binc 5000");
+
+            var resultTask = Task.Run(() => engine.BestMove());
+
+            engine.StopSearching();
+            await resultTask;
+
+            // Act
+            engine.AdjustPosition($"position fen {Constants.InitialPositionFEN} moves d2d4");
+
+            // Assert
+            Assert.AreEqual(1, engine.Game.MoveHistory.Count);
+        }
+    }
+}

--- a/tests/Lynx.NUnit.Test/StopCommandTest.cs
+++ b/tests/Lynx.NUnit.Test/StopCommandTest.cs
@@ -1,0 +1,40 @@
+﻿using Lynx.UCI.Commands.GUI;
+using Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.Interfaces;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lynx.NUnit.Test
+{
+    /// <summary>
+    /// https://github.com/lynx-chess/Lynx/issues/31
+    /// </summary>
+    internal class StopCommandTest
+    {
+        [TestCase("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1")]
+        public async Task StopCommandShouldNotModifyPositionOrAddMoveToMoveHistory(string initialPositionFEN)
+        {
+            // Arrange
+            var engine = new Engine();
+            engine.NewGame();
+            engine.AdjustPosition($"position fen {initialPositionFEN}");
+
+            // A command that guarantees ~5s thinking time
+            var goCommand = new GoCommand();
+            await goCommand.Parse("go wtime 1 btime 1 winc 5000 binc 5000");
+
+            var resultTask = Task.Run(() => engine.BestMove());
+            // Wait 2s so that there's some best move available
+            Thread.Sleep(2000);
+
+            // Act
+            engine.StopSearching();
+
+            // Assert
+            Assert.AreNotEqual(default, (await resultTask).BestMove.EncodedMove);
+
+            Assert.AreEqual(initialPositionFEN, engine.Game.CurrentPosition.FEN());
+            Assert.IsEmpty(engine.Game.MoveHistory);
+        }
+    }
+}


### PR DESCRIPTION
* Respond `stop` commands immediately, by making sure the 'absolute' cancellation token created for that purpose is propagated everywhere, including the quiescence search method.
* Prevent moves 'generated' as a consequence of a `stop` command from being added to the move list store in the internal state
* Prevent `position` command from relying on internal state, always parsing all the command moves.
   There was some logic in place to try preventing it from parsing the whole game if not necessary, but the risks associated may not be worth it. Might reconsider later.