### PR TITLE
Remove commit hash from version string

### DIFF
--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -200,7 +200,7 @@ namespace Lynx
                     {
                         if (int.TryParse(commandItems[4], out var value))
                         {
-                            Configuration.EngineSettings.Depth = value;
+                            Configuration.Hash = value;
                         }
                         _logger.Warn("Hash size modification not supported yet");
                         break;

--- a/src/Lynx/UCI/Commands/Engine/IdCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/IdCommand.cs
@@ -17,8 +17,11 @@ namespace Lynx.UCI.Commands.Engine
 
         private static string GetVersion()
         {
-            return Assembly.GetAssembly(typeof(IdCommand))!.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                ?? "Uknown";
+            return
+                Assembly.GetAssembly(typeof(IdCommand))
+                !.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion?.Split('+')?[0]
+                ?? "Unknown";
         }
 
         public static string Name => $"id name Lynx {GetVersion()}";


### PR DESCRIPTION
Remove commit hash from version string showed as response to `uci` command.

Approach followed taken from https://github.com/dotnet/core/blob/3c539b2313cc8f6c4f57b5aab21e17e342b48fd5/samples/dotnet-runtimeinfo/Program.cs#L9