### PR TITLE
Increase uci `info` engine messages frequency

### DIFF
--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -44,7 +44,7 @@ CancellationToken cancellationToken = source.Token;
 var tasks = new List<Task>
 {
     Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
-    Task.Run(() => new LinxDriver(uciChannel, engineChannel, new Engine()).Run(cancellationToken)),
+    Task.Run(() => new LinxDriver(uciChannel, engineChannel, new Engine(engineChannel)).Run(cancellationToken)),
     Task.Run(() => new Listener(uciChannel).Run(cancellationToken)),
     uciChannel.Reader.Completion,
     engineChannel.Reader.Completion

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -29,14 +29,8 @@ if (!Configuration.GeneralSettings.DisableLogging)
     LogManager.Configuration = new NLogLoggingConfiguration(config.GetSection("NLog"));
 }
 
-var opts = new BoundedChannelOptions(1_000)
-{
-    SingleReader = true,
-    SingleWriter = true
-};
-
-var uciChannel = Channel.CreateBounded<string>(opts);
-var engineChannel = Channel.CreateBounded<string>(opts);
+var uciChannel = Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = true });
+var engineChannel = Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false });
 
 using CancellationTokenSource source = new();
 CancellationToken cancellationToken = source.Token;

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -127,11 +127,11 @@ namespace Lynx
             var result = IDDFS(Game.CurrentPosition, minDepth, maxDepth, _engineWriter, _searchCancellationTokenSource.Token, _absoluteSearchCancellationTokenSource.Token);
             _logger.Debug($"Evaluation: {result.Evaluation} (depth: {result.TargetDepth}, refutation: {string.Join(", ", result.Moves)})");
 
-            if (!result.isCancelled)
+            if (!result.IsCancelled && !_absoluteSearchCancellationTokenSource.IsCancellationRequested)
             {
                 Game.MakeMove(result.BestMove);
+                AverageDepth += (result.DepthReached - AverageDepth) / Game.MoveHistory.Count;
             }
-            AverageDepth += (result.DepthReached - AverageDepth) / Game.MoveHistory.Count;
 
             return result;
         }

--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -23,8 +23,6 @@ namespace Lynx
             _engineWriter = engineWriter;
             _engine = engine;
             _logger = LogManager.GetCurrentClassLogger();
-            _engine.OnReady += NotifyReadyOK;
-            _engine.OnSearchFinished += NotifyBestMove;
         }
 
         public async Task Run(CancellationToken cancellationToken)
@@ -108,19 +106,6 @@ namespace Lynx
             _engine.AdjustPosition(command);
 #if DEBUG
             _engine.Game.CurrentPosition.Print();
-
-            //foreach (var move in MoveGenerator.GenerateAllMoves(_engine.Game.CurrentPosition))
-            //{
-            //    var newBlackPosition = new Position(_engine.Game.CurrentPosition, move);
-            //    if (newBlackPosition.IsValid())
-            //    {
-            //        var newWhitePosition = new Position(newBlackPosition, newBlackPosition.AllPossibleMoves()[0]);
-            //        if (newBlackPosition.IsValid())
-            //        {
-            //            Console.WriteLine($"{move,-6} | {newWhitePosition.MaterialEvaluation(),-5} | {newWhitePosition.MaterialAndPositionalEvaluation(),-5}");
-            //        }
-            //    }
-            //}
 #endif
         }
 
@@ -148,10 +133,7 @@ namespace Lynx
 
         private async Task HandleIsReady(CancellationToken cancellationToken)
         {
-            if (_engine.IsReady)
-            {
-                await SendCommand(ReadyOKCommand.Id, cancellationToken);
-            }
+            await SendCommand(ReadyOKCommand.Id, cancellationToken);
         }
 
         private void HandlePonderHit()
@@ -244,11 +226,6 @@ namespace Lynx
         }
 
         #endregion
-
-        private async Task NotifyReadyOK()
-        {
-            await _engineWriter.Writer.WriteAsync(ReadyOKCommand.Id);
-        }
 
         private async Task NotifyBestMove(SearchResult searchResult, Move? moveToPonder)
         {

--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -155,7 +155,7 @@ namespace Lynx
             {
                 case "ponder":
                     {
-                        if (bool.TryParse(commandItems[4], out var value))
+                        if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
                         {
                             Configuration.IsPonder = value;
                         }
@@ -164,7 +164,7 @@ namespace Lynx
                     }
                 case "uci_analysemode":
                     {
-                        if (bool.TryParse(commandItems[4], out var value))
+                        if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
                         {
                             Configuration.UCI_AnalyseMode = value;
                         }
@@ -172,7 +172,7 @@ namespace Lynx
                     }
                 case "depth":
                     {
-                        if (int.TryParse(commandItems[4], out var value))
+                        if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
                         {
                             Configuration.EngineSettings.Depth = value;
                         }
@@ -180,7 +180,7 @@ namespace Lynx
                     }
                 case "hash":
                     {
-                        if (int.TryParse(commandItems[4], out var value))
+                        if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
                         {
                             Configuration.Hash = value;
                         }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -21,7 +21,10 @@ namespace Lynx.Search
             public List<Move> Moves { get; set; } = new List<Move>(150);
         }
 
-        public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, int DepthReached, int Nodes, long Time, long NodesPerSecond, List<Move> Moves, bool isCancelled);
+        public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, int DepthReached, int Nodes, long Time, long NodesPerSecond, List<Move> Moves)
+        {
+            public bool IsCancelled { get; set; }
+        }
 
         /// <summary>
         /// Branch-optimized for <paramref name="mostLikely"/>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -1,0 +1,82 @@
+﻿using Lynx.Model;
+using Lynx.UCI.Commands.Engine;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Lynx.Search
+{
+    public static partial class SearchAlgorithms
+    {
+        public static SearchResult IDDFS(Position position, int minDepth, int? maxDepth, ChannelWriter<string> engineWriter, CancellationToken cancellationToken, CancellationToken absoluteCancellationToken)
+        {
+            int bestEvaluation = 0;
+            SearchResult? searchResult = null;
+            int depth = 1;
+            int nodes = 0;
+            var sw = new Stopwatch();
+            bool isCancelled = false;
+
+            try
+            {
+                var orderedMoves = new Dictionary<string, PriorityQueue<Move, int>>(10_000);
+
+                sw.Start();
+
+                do
+                {
+                    absoluteCancellationToken.ThrowIfCancellationRequested();
+                    if (depth > minDepth)
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+                    nodes = 0;
+                    (bestEvaluation, Result? bestResult) = NegaMax_AlphaBeta_Quiescence_IDDFS(position, orderedMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken, absoluteCancellationToken);
+
+                    if (bestResult is not null)
+                    {
+                        bestResult.Moves.Reverse();
+                        searchResult = new SearchResult(bestResult.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), bestResult.Moves, isCancelled);
+
+                        Task.Run(async () => await engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult)));
+                    }
+                } while (stopSearchCondition(++depth, maxDepth, bestEvaluation));
+            }
+            catch (OperationCanceledException)
+            {
+                isCancelled = true;
+                Logger.Info("Search cancellation requested, best move will be returned");
+            }
+            catch (Exception e)
+            {
+                Logger.Error("Unexpected error ocurred during the search, best move will be returned" +
+                    Environment.NewLine + e.Message + Environment.NewLine + e.StackTrace);
+            }
+            finally
+            {
+                sw.Stop();
+            }
+
+            return searchResult ?? new(default, bestEvaluation, depth, depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), new List<Move>(), isCancelled);
+
+            static bool stopSearchCondition(int depth, int? depthLimit, int bestEvaluation)
+            {
+                if (Math.Abs(bestEvaluation) > 0.1 * Position.CheckMateEvaluation)   // Mate detected
+                {
+                    return false;
+                }
+
+                if (depthLimit is not null)
+                {
+                    return depth <= depthLimit;
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -40,7 +40,7 @@ namespace Lynx.Search
                     if (bestResult is not null)
                     {
                         bestResult.Moves.Reverse();
-                        searchResult = new SearchResult(bestResult.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), bestResult.Moves, isCancelled);
+                        searchResult = new SearchResult(bestResult.Moves.FirstOrDefault(), bestEvaluation, depth, bestResult.MaxDepth ?? depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), bestResult.Moves);
 
                         Task.Run(async () => await engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult)));
                     }
@@ -61,7 +61,15 @@ namespace Lynx.Search
                 sw.Stop();
             }
 
-            return searchResult ?? new(default, bestEvaluation, depth, depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), new List<Move>(), isCancelled);
+            if (searchResult is not null)
+            {
+                searchResult.IsCancelled = isCancelled;
+                return searchResult;
+            }
+            else
+            {
+                return new(default, bestEvaluation, depth, depth, nodes, sw.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(nodes / ((0.001 * sw.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), new List<Move>());
+            }
 
             static bool stopSearchCondition(int depth, int? depthLimit, int bestEvaluation)
             {

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -88,7 +88,5 @@ namespace Lynx.UCI.Commands.Engine
                 $" time {searchResult.Time}" +
                 $" pv {string.Join(" ", searchResult.Moves.Select(move => move.UCIString()))}";
         }
-
-
     }
 }

--- a/tests/Lynx.NUnit.Test/BaseTest.cs
+++ b/tests/Lynx.NUnit.Test/BaseTest.cs
@@ -1,7 +1,11 @@
 ﻿using Lynx.Model;
+using Moq;
 using NUnit.Framework;
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
 
 namespace Lynx.NUnit.Test
 {
@@ -9,8 +13,14 @@ namespace Lynx.NUnit.Test
     {
         protected static void TestBestMove(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString)
         {
+            var mock = new Mock<ChannelWriter<string>>();
+
+            mock
+                .Setup(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ValueTask.CompletedTask);
+
             // Arrange
-            var engine = new Engine();
+            var engine = new Engine(mock.Object);
             engine.SetGame(new Game(fen));
 
             // Act

--- a/tests/Lynx.NUnit.Test/Lynx.NUnit.Test.csproj
+++ b/tests/Lynx.NUnit.Test/Lynx.NUnit.Test.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/tests/Lynx.NUnit.Test/PositionCommandTest.cs
+++ b/tests/Lynx.NUnit.Test/PositionCommandTest.cs
@@ -1,5 +1,7 @@
 ﻿using Lynx.UCI.Commands.GUI;
+using Moq;
 using NUnit.Framework;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace Lynx.NUnit.Test
@@ -10,10 +12,10 @@ namespace Lynx.NUnit.Test
     public class PositionCommandTest
     {
         [TestCase]
-        public async Task StopCommandShouldNotModifyPositionOrAddMoveToMoveHistory()
+        public async Task PositionCommandShouldNotTakeIntoAccountInternalState()
         {
             // Arrange
-            var engine = new Engine();
+            var engine = new Engine(new Mock<ChannelWriter<string>>().Object);
             engine.NewGame();
             engine.AdjustPosition($"position fen {Constants.InitialPositionFEN} moves e2e4");
 

--- a/tests/Lynx.NUnit.Test/StopCommandTest.cs
+++ b/tests/Lynx.NUnit.Test/StopCommandTest.cs
@@ -1,6 +1,8 @@
 ﻿using Lynx.UCI.Commands.GUI;
+using Moq;
 using NUnit.Framework;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 
 namespace Lynx.NUnit.Test
@@ -14,7 +16,7 @@ namespace Lynx.NUnit.Test
         public async Task StopCommandShouldNotModifyPositionOrAddMoveToMoveHistory(string initialPositionFEN)
         {
             // Arrange
-            var engine = new Engine();
+            var engine = new Engine(new Mock<ChannelWriter<string>>().Object);
             engine.NewGame();
             engine.AdjustPosition($"position fen {initialPositionFEN}");
 

--- a/tests/Lynx.NUnit.Test/TimeManagementTest.cs
+++ b/tests/Lynx.NUnit.Test/TimeManagementTest.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using Moq;
+using NUnit.Framework;
+using System.Threading.Channels;
 
 namespace Lynx.NUnit.Test
 {
@@ -101,7 +103,7 @@ namespace Lynx.NUnit.Test
         public void CalculateDecisionTime(
             int millisecondsLeft, int millisecondsIncrement, int movesToGo, double expectedTimeToMove, int moveHistoryCount = 0)
         {
-            var engine = new Engine();
+            var engine = new Engine(new Mock<ChannelWriter<string>>().Object);
             for (int moveIndex = 0; moveIndex < moveHistoryCount; ++moveIndex)
             {
                 engine.Game.MoveHistory.Add(new());


### PR DESCRIPTION
Increase uci `info` engine messages frequency: one per IDFFS level
* Split IDFFS part of the search into its own file.
* Get rid of delegates and pass `ChannelWriter engineWriter` to both `Engine` and static IDDFS search method.
* Remove `Engine.IsReady`.
* Fix old error parsing `setoption name UCI_AnaluseMode value`, without `true` or `false` (see in Arena Windows).