### PR TITLE
Add Makefile and build instructions

### DIFF
--- a/Lynx.sln
+++ b/Lynx.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		Directory.Build.props = Directory.Build.props
 		LICENSE = LICENSE
+		Makefile = Makefile
 		.github\workflows\on_release.yml = .github\workflows\on_release.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection

--- a/Makefile
+++ b/Makefile
@@ -1,40 +1,35 @@
 .DEFAULT_GOAL := publish
 
+RUNTIME=
 OUTPUT_DIR:=artifacts/Lynx/
 
 ifeq ($(OS),Windows_NT)
-    RUNTIME=win-x64
     ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
         RUNTIME=win-x64
-    else
-        ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
-            RUNTIME=win-x64
-        else ifeq ($(PROCESSOR_ARCHITECTURE),x86)
-            RUNTIME=win-x86
-        endif
-    endif
+	else
+		RUNTIME=win-x86
+	endif
 else
-    UNAME_S := $(shell uname -s)
+	UNAME_S := $(shell uname -s)
 	UNAME_P := $(shell uname -p)
-    ifeq ($(UNAME_S),Linux)
-		RUNTIME=linux-x64
-		ifeq ($(UNAME_P),x86_64)
-			RUNTIME=linux-x64
-		else ifneq ($(filter aarch64%,$(UNAME_P)),)
+	ifeq ($(UNAME_S),Linux)
+	    RUNTIME=linux-x64
+		ifneq ($(filter aarch64%,$(UNAME_P)),)
 			RUNTIME=linux-arm64
 		else ifneq ($(filter armv8%,$(UNAME_P)),)
 			RUNTIME=linux-arm64
 		else ifneq ($(filter arm%,$(UNAME_P)),)
 			RUNTIME=linux-arm
 		endif
-	else ifeq ($(UNAME_S),Darwin)
+	else ifneq ($(filter arm%,$(UNAME_P)),)
+		RUNTIME=osx.11.0-arm64
+	else
 		RUNTIME=osx-x64
-		ifeq ($(UNAME_P),x86_64)
-			RUNTIME=osx-x64
-		else ifneq ($(filter arm%,$(UNAME_P)),)
-			RUNTIME=osx.11.0-arm64
-		endif
-    endif
+	endif
+endif
+
+ifndef RUNTIME
+$(error RUNTIME is not set for $(OS) $(UNAME_S) $(UNAME_P), please fill an issue in https://github.com/lynx-chess/Lynx/issues/new/choose)
 endif
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 OUTPUT_DIR:=artifacts/Lynx/
 
 ifeq ($(OS),Windows_NT)
+    RUNTIME=win-x64
     ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
         RUNTIME=win-x64
     else
@@ -16,6 +17,7 @@ else
     UNAME_S := $(shell uname -s)
 	UNAME_P := $(shell uname -p)
     ifeq ($(UNAME_S),Linux)
+		RUNTIME=linux-x64
 		ifeq ($(UNAME_P),x86_64)
 			RUNTIME=linux-x64
 		else ifneq ($(filter aarch64%,$(UNAME_P)),)
@@ -26,6 +28,7 @@ else
 			RUNTIME=linux-arm
 		endif
 	else ifeq ($(UNAME_S),Darwin)
+		RUNTIME=osx-x64
 		ifeq ($(UNAME_P),x86_64)
 			RUNTIME=osx-x64
 		else ifneq ($(filter arm%,$(UNAME_P)),)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.DEFAULT_GOAL := publish
+
+OUTPUT_DIR:=artifacts/Lynx/
+
+ifeq ($(OS),Windows_NT)
+    ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
+        RUNTIME=win-x64
+    else
+        ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+            RUNTIME=win-x64
+        else ifeq ($(PROCESSOR_ARCHITECTURE),x86)
+            RUNTIME=win-x86
+        endif
+    endif
+else
+    UNAME_S := $(shell uname -s)
+	UNAME_P := $(shell uname -p)
+    ifeq ($(UNAME_S),Linux)
+		ifeq ($(UNAME_P),x86_64)
+			RUNTIME=linux-x64
+		else ifneq ($(filter aarch64%,$(UNAME_P)),)
+			RUNTIME=linux-arm64
+		else ifneq ($(filter armv8%,$(UNAME_P)),)
+			RUNTIME=linux-arm64
+		else ifneq ($(filter arm%,$(UNAME_P)),)
+			RUNTIME=linux-arm
+		endif
+	else ifeq ($(UNAME_S),Darwin)
+		ifeq ($(UNAME_P),x86_64)
+			RUNTIME=osx-x64
+		else ifneq ($(filter arm%,$(UNAME_P)),)
+			RUNTIME=osx.11.0-arm64
+		endif
+    endif
+endif
+
+build:
+	dotnet build -c Release
+
+test:
+	dotnet test -c Release & dotnet test -c Release --filter "TestCategory=LongRunning"
+
+publish:
+	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true -o ${OUTPUT_DIR}
+
+run:
+	dotnet run --project src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Lichess bot can be played directly, but a chess GUI that supports UCI protocol i
 
 Requirements:
 
-- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0). You can find instructions about how to install it in your preferred OS/Distro [here](https://dotnet.microsoft.com/download/dotnet/6.0).
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0). You can find instructions about how to install it in your preferred OS/Distro either [here](https://docs.microsoft.com/en-us/dotnet/core/install/) or [here](https://github.com/dotnet/core/tree/main/release-notes/6.0).
 
 Instructions:
 
@@ -32,6 +32,13 @@ Instructions:
   Disclaimer: I do not use the Makefile myself, which means it is not fully tested and may occasionally get out of date.
 
 - Alternatively, you can get the exact `dotnet publish (...)` command from [`release.yml`](https://github.com/lynx-chess/Lynx/blob/main/.github/workflows/release.yml) that is used by the CI to create the binaries and run it yourself (with the right [runtime identifier](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#using-rids)).
+
+   Examples:
+
+  ```bash
+  dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime linux-x64 --self-contained /p:Optimized=true -o /home/your_user/engines/Lynx
+  dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime win-x64 --self-contained /p:Optimized=true -o C:/Users/your_user/engines/Lynx
+  ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ You can find Lynx:
 
 Lichess bot can be played directly, but a chess GUI that supports UCI protocol is needed to play against the self-contained version.
 
+## Building Lynx
+
+Requirements:
+
+- [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0). You can find instructions about how to install it in your preferred OS/Distro [here](https://dotnet.microsoft.com/download/dotnet/6.0).
+
+Instructions:
+
+- Run `make` to build a self-contained binary similar to the pre-compiled ones.
+
+  Disclaimer: I do not use the Makefile myself, which means it is not fully tested and may occasionally get out of date.
+
+- Alternatively, you can get the exact `dotnet publish (...)` command from [`release.yml`](https://github.com/lynx-chess/Lynx/blob/main/.github/workflows/release.yml) that is used by the CI to create the binaries and run it yourself (with the right [runtime identifier](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog#using-rids)).
+
 ---
 
 More details to follow.


### PR DESCRIPTION
* Add basic Makefile that builds a self-contained version of Lynx (equivalent to the ones that can be found under [Releases](https://github.com/lynx-chess/Lynx/releases) for the user's OS.
* Add build instructions to the README, which includes how to install .NET locally in order to build it and how to find the right dotnet command and runtime identifier to be able to build it yourself.

This closes #33.