### PR TITLE
Prevent `MoveGenerator.GenerateAllMoves` from being invoked twice

### DIFF
--- a/src/Lynx.Benchmark/FENGeneration.cs
+++ b/src/Lynx.Benchmark/FENGeneration.cs
@@ -203,6 +203,7 @@ using NLog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 
 namespace Lynx.Benchmark
@@ -216,7 +217,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new StructCustomPosition(fen);
-            var newPosition = new StructCustomPosition(position, moves[0]);
+            var newPosition = new StructCustomPosition(position, moves.First());
             return newPosition.FEN;
         }
 
@@ -227,7 +228,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new StructCustomPosition(fen);
-            var newPosition = new StructCustomPosition(position, moves[0], default);
+            var newPosition = new StructCustomPosition(position, moves.First(), default);
 
             return newPosition.FEN;
         }
@@ -239,7 +240,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new ReadonlyStructCustomPosition(fen);
-            var newPosition = new ReadonlyStructCustomPosition(position, moves[0]);
+            var newPosition = new ReadonlyStructCustomPosition(position, moves.First());
 
             return newPosition.FEN;
         }
@@ -251,7 +252,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new ReadonlyStructCustomPosition(fen);
-            var newPosition = new ReadonlyStructCustomPosition(position, moves[0], default);
+            var newPosition = new ReadonlyStructCustomPosition(position, moves.First(), default);
 
             return newPosition.FEN;
         }
@@ -263,7 +264,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new ClassCustomPosition(fen);
-            var newPosition = new ClassCustomPosition(position, moves[0]);
+            var newPosition = new ClassCustomPosition(position, moves.First());
 
             return newPosition.FEN;
         }
@@ -275,7 +276,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new ClassCustomPosition(fen);
-            var newPosition = new ClassCustomPosition(position, moves[0], default);
+            var newPosition = new ClassCustomPosition(position, moves.First(), default);
 
             return newPosition.FEN;
         }
@@ -287,7 +288,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new RecordClassCustomPosition(fen);
-            var newPosition = new RecordClassCustomPosition(position, moves[0]);
+            var newPosition = new RecordClassCustomPosition(position, moves.First());
 
             return newPosition.FEN;
         }
@@ -299,7 +300,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new RecordClassCustomPosition(fen);
-            var newPosition = new RecordClassCustomPosition(position, moves[0], default);
+            var newPosition = new RecordClassCustomPosition(position, moves.First(), default);
 
             return newPosition.FEN;
         }
@@ -311,7 +312,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new RecordStructCustomPosition(fen);
-            var newPosition = new RecordStructCustomPosition(position, moves[0]);
+            var newPosition = new RecordStructCustomPosition(position, moves.First());
 
             return newPosition.FEN;
         }
@@ -323,7 +324,7 @@ namespace Lynx.Benchmark
             var moves = new Position(fen).AllPossibleMoves();
 
             var position = new RecordStructCustomPosition(fen);
-            var newPosition = new RecordStructCustomPosition(position, moves[0], default);
+            var newPosition = new RecordStructCustomPosition(position, moves.First(), default);
 
             return newPosition.FEN;
         }

--- a/src/Lynx.Benchmark/PositionIdGeneration.cs
+++ b/src/Lynx.Benchmark/PositionIdGeneration.cs
@@ -17,6 +17,7 @@
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Lynx.Benchmark
 {
@@ -51,10 +52,10 @@ namespace Lynx.Benchmark
 
         public static IEnumerable<Position> Data => new[] {
             //Constants.EmptyBoardFEN,
-            new Position(Positions[0], Positions[0].AllPossibleMoves()[0]),
-            new Position(Positions[1], Positions[1].AllPossibleMoves()[0]),
-            new Position(Positions[2], Positions[2].AllPossibleMoves()[0]),
-            new Position(Positions[3], Positions[3].AllPossibleMoves()[0])
+            new Position(Positions[0], Positions[0].AllPossibleMoves().First()),
+            new Position(Positions[1], Positions[1].AllPossibleMoves().First()),
+            new Position(Positions[2], Positions[2].AllPossibleMoves().First()),
+            new Position(Positions[3], Positions[3].AllPossibleMoves().First())
         };
     }
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -47,8 +47,8 @@ namespace Lynx.Model
             }
         }
 
-        public List<Move> GetAllMoves() => MoveGenerator.GenerateAllMoves(CurrentPosition);
-        public List<Move> GetAllMovesWithCaptures() => MoveGenerator.GenerateAllMoves(CurrentPosition, capturesOnly: true);
+        public IOrderedEnumerable<Move> GetAllMoves() => MoveGenerator.GenerateAllMoves(CurrentPosition);
+        public IOrderedEnumerable<Move> GetAllMovesWithCaptures() => MoveGenerator.GenerateAllMoves(CurrentPosition, capturesOnly: true);
 
         public void RevertLastMove()
         {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -65,7 +65,7 @@ namespace Lynx.Model
         /// <exception cref="InvalidOperationException"></exception>
         /// <exception cref="IndexOutOfRangeException"></exception>
         /// <returns></returns>
-        public static bool TryParseFromUCIString(string UCIString, List<Move> moveList, [NotNullWhen(true)] out Move? move)
+        public static bool TryParseFromUCIString(string UCIString, IOrderedEnumerable<Move> moveList, [NotNullWhen(true)] out Move? move)
         {
             Debug.Assert(UCIString.Length == 4 || UCIString.Length == 5);
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -366,9 +366,9 @@ namespace Lynx.Model
                 : -eval;
         }
 
-        public List<Move> AllPossibleMoves(int[,]? killerMoves = null, int? plies = null) => MoveGenerator.GenerateAllMoves(this, killerMoves, plies);
+        public IOrderedEnumerable<Move> AllPossibleMoves(int[,]? killerMoves = null, int? plies = null) => MoveGenerator.GenerateAllMoves(this, killerMoves, plies);
 
-        public List<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
+        public IOrderedEnumerable<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
 
         /// <summary>
         /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -43,17 +43,17 @@ namespace Lynx
         /// <param name="position"></param>
         /// <param name="capturesOnly">Filters out all moves but captures</param>
         /// <returns></returns>
-        public static List<Move> GenerateAllMoves(Position position, int[,]? killerMoves = null, int? plies = null, bool capturesOnly = false)
+        public static IOrderedEnumerable<Move> GenerateAllMoves(Position position, int[,]? killerMoves = null, int? plies = null, bool capturesOnly = false)
         {
-            var moves = new List<Move>(150);
-
+#if DEBUG
             if (position.Side == Side.Both)
             {
-                return moves;
+                return Array.Empty<Move>().OrderByDescending(m => m);
             }
-
+#endif
             var offset = Utils.PieceOffset(position.Side);
 
+            var moves = new List<Move>(150);
             moves.AddRange(GeneratePawnMoves(position, offset, capturesOnly));
             moves.AddRange(GenerateCastlingMoves(position, offset));
             moves.AddRange(GeneratePieceMoves((int)Piece.K + offset, position, capturesOnly));
@@ -62,7 +62,7 @@ namespace Lynx
             moves.AddRange(GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly));
             moves.AddRange(GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly));
 
-            return moves.OrderByDescending(move => move.Score(position, killerMoves, plies)).ToList();
+            return moves.OrderByDescending(move => move.Score(position, killerMoves, plies));
         }
 
         internal static IEnumerable<Move> GeneratePawnMoves(Position position, int offset, bool capturesOnly = false)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -180,7 +180,7 @@ namespace Lynx.Search
 
             var movesToEvaluate = position.AllCapturesMoves();
 
-            if (movesToEvaluate.Count == 0)
+            if (!movesToEvaluate.Any())
             {
                 ++nodes;
                 return (staticEvaluation, new Result { MaxDepth = plies });  // TODO check if in check or drawn position
@@ -191,9 +191,8 @@ namespace Lynx.Search
 
             var maxEval = MinValue;
 
-            for (int moveIndex = 0; moveIndex < movesToEvaluate.Count; ++moveIndex)
+            foreach (var move in movesToEvaluate)
             {
-                var move = movesToEvaluate[moveIndex];
                 var newPosition = new Position(position, move);
                 if (!newPosition.WasProduceByAValidMove())
                 {

--- a/tests/Lynx.Test/MoveScoreTest.cs
+++ b/tests/Lynx.Test/MoveScoreTest.cs
@@ -25,7 +25,7 @@ namespace Lynx.Test
         {
             var position = new Position(fen);
 
-            var allMoves = position.AllPossibleMoves();
+            var allMoves = position.AllPossibleMoves().ToList();
 
             Assert.Equal("e2a6", allMoves[0].UCIString());     // BxB
             Assert.Equal("f3f6", allMoves[1].UCIString());     // QxN
@@ -62,7 +62,7 @@ namespace Lynx.Test
         {
             var position = new Position(fen);
 
-            var allMoves = position.AllPossibleMoves();
+            var allMoves = position.AllPossibleMoves().ToList();
 
             Assert.Equal(moveWithHighestScore, allMoves[0].UCIString());
             Assert.Equal(Move.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0,0], allMoves[0].Score(position));


### PR DESCRIPTION
Prevent `MoveGenerator.GenerateAllMoves` from being invoked twice per search invocation by avoiding `IOrderedEnumerable.ToList()`.