### PR TITLE
Make `positionHistory` dictionary update more efficient II

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -76,8 +76,7 @@ namespace Lynx.Model
                 return false;
             }
 
-            PositionHashHistory.TryGetValue(CurrentPosition.UniqueIdentifier, out int repetitions);
-            PositionHashHistory[CurrentPosition.UniqueIdentifier] = ++repetitions;
+            Utils.UpdatePositionHistory(CurrentPosition, PositionHashHistory);
 
             MovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, MovesWithoutCaptureOrPawnMove);
 


### PR DESCRIPTION
97c1babba9840495117b45b3d6e3aa94c8603b54 follow up, making positionHistory dictionary update more efficient.