### PR TITLE
Remove TrimmerRoots.xml

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -35,8 +35,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <TrimmerRootDescriptor Include="TrimmerRoots.xml" />
-  </ItemGroup>
-
 </Project>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -21,7 +21,7 @@ var config = new ConfigurationBuilder()
     .AddEnvironmentVariables()
     .Build();
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code - Types annotated in TrimmerRoots.xml
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code - Application code isn't trimmed, see https://github.com/dotnet/runtime/discussions/59230
 config.GetRequiredSection(nameof(EngineSettings)).Bind(Configuration.EngineSettings);
 config.GetRequiredSection(nameof(GeneralSettings)).Bind(Configuration.GeneralSettings);
 #pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code

--- a/src/Lynx.Cli/TrimmerRoots.xml
+++ b/src/Lynx.Cli/TrimmerRoots.xml
@@ -1,6 +1,0 @@
-<linker>
-  <assembly fullname="Lynx" />
-  <type fullname="Lynx.Configuration" preserve="all" />
-  <type fullname="Lynx.GeneralSettings" preserve="all" />
-  <type fullname="Lynx.EngineSettings" preserve="all" />
-</linker>


### PR DESCRIPTION
Follow [this advice](https://github.com/dotnet/runtime/discussions/59230) and get rid of `TrimmerRoots.xml`, since application code won't be trimmed.
The warning shall remain there.