### PR TITLE
🐛 Avoid adding bad captures to the PV in the quiescence search

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -242,7 +242,13 @@ namespace Lynx.Search
 
             // Node fails low
             Debug.Assert(existingMoveList is not null);
-            existingMoveList!.Moves.Add(bestMove!.Value);
+
+            // If the best quiescence move produces no gain, don't add it to the PV
+            // because there might be better, unexplored non-quiescence alternatives (unless a Zugzwang-style position with only captures as moves)
+            if (maxEval >= alpha)
+            {
+                existingMoveList!.Moves.Add(bestMove!.Value);
+            }
 
             return (alpha, existingMoveList);
         }


### PR DESCRIPTION
Avoid adding bad captures to the PV in the quiescence search

Example:

```
position fen startpos
go
```

Before, giving away knights with `f6e4` and `f3e5`:
```
info depth 5 seldepth 5 multipv 1 score cp 30 nodes 23752 nps 15995 time 485 pv g1f3 g8f6 b1c3 b8c6 e2e4 f6e4
info depth 6 seldepth 6 multipv 1 score cp 0 nodes 71573 nps 27423 time 1610 pv g1f3 g8f6 b1c3 b8c6 e2e4 e7e5 f3e5
```

After:
```
info depth 5 seldepth 5 multipv 1 score cp 30 nodes 23752 nps 13588 time 748 pv g1f3 g8f6 b1c3 b8c6 e2e4
info depth 6 seldepth 6 multipv 1 score cp 0 nodes 71573 nps 23306 time 2071 pv g1f3 g8f6 b1c3 b8c6 e2e4 e7e5
```