### PR TITLE
Remove custom move ordering implementation

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -23,7 +23,7 @@ namespace Lynx.Search
 
             try
             {
-                var orderedMoves = new Dictionary<long, PriorityQueue<Move, int>>(10_000);
+                //var orderedMoves = new Dictionary<long, PriorityQueue<Move, int>>(10_000);
                 var killerMoves = new int[2, EvaluationConstants.MaxPlies];
 
                 sw.Start();
@@ -36,7 +36,7 @@ namespace Lynx.Search
                         cancellationToken.ThrowIfCancellationRequested();
                     }
                     nodes = 0;
-                    (bestEvaluation, Result bestResult) = NegaMax(position, positionHistory, movesWithoutCaptureOrPawnMove, orderedMoves, killerMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken, absoluteCancellationToken);
+                    (bestEvaluation, Result bestResult) = NegaMax(position, positionHistory, movesWithoutCaptureOrPawnMove,  /*orderedMoves,*/ killerMoves, minDepth: minDepth, depthLimit: depth, nodes: ref nodes, plies: 0, alpha: MinValue, beta: MaxValue, cancellationToken, absoluteCancellationToken);
 
                     if (bestResult is not null)
                     {
@@ -50,7 +50,7 @@ namespace Lynx.Search
             catch (OperationCanceledException)
             {
                 isCancelled = true;
-                _logger.Info($"Search cancellation requested after {sw.ElapsedMilliseconds}ms, best move will be returned");
+                _logger.Info($"Search cancellation requested after {sw.ElapsedMilliseconds}ms (depth {depth}, nodes {nodes}), best move will be returned");
             }
             catch (Exception e)
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -54,7 +54,7 @@ namespace Lynx.Search
                     if (new Position(position, candidateMove).WasProduceByAValidMove())
                     {
                         //        orderedMoves.Remove(positionId);
-                        return QuiescenceSearch(position, positionHistory, movesWithoutCaptureOrPawnMove, Configuration.EngineSettings.QuiescenceSearchDepth, ref nodes, plies + 1, alpha, beta, cancellationToken, absoluteCancellationToken);
+                        return QuiescenceSearch(position, positionHistory, movesWithoutCaptureOrPawnMove, Configuration.EngineSettings.QuiescenceSearchDepth, ref nodes, plies, alpha, beta, cancellationToken, absoluteCancellationToken);
                     }
                 }
 


### PR DESCRIPTION
* Remove custom move ordering implementation:
  * This is done in preparation of a better move ordering.
  * Existing one it's not proven to provide a clear advantage vs default move ordering anyway.
* Avoid increasing depth (`plies`) when invoking Quiescence search for the first time. 