### PR TITLE
Take PV into account when sorting moves

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -225,5 +225,11 @@ namespace Lynx
         };
 
         public const int MaxPlies = 64;
+
+        public const int FirstKillerMoveValue = 9_000;
+
+        public const int SecondKillerMoveValue = 8_000;
+
+        public const int PVMoveValue = 20_000;
     }
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -47,8 +47,8 @@ namespace Lynx.Model
             }
         }
 
-        public IOrderedEnumerable<Move> GetAllMoves() => MoveGenerator.GenerateAllMoves(CurrentPosition);
-        public IOrderedEnumerable<Move> GetAllMovesWithCaptures() => MoveGenerator.GenerateAllMoves(CurrentPosition, capturesOnly: true);
+        public List<Move> GetAllMoves() => MoveGenerator.GenerateAllMoves(CurrentPosition);
+        public List<Move> GetAllMovesWithCaptures() => MoveGenerator.GenerateAllMoves(CurrentPosition, capturesOnly: true);
 
         public void RevertLastMove()
         {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -65,7 +65,7 @@ namespace Lynx.Model
         /// <exception cref="InvalidOperationException"></exception>
         /// <exception cref="IndexOutOfRangeException"></exception>
         /// <returns></returns>
-        public static bool TryParseFromUCIString(string UCIString, IOrderedEnumerable<Move> moveList, [NotNullWhen(true)] out Move? move)
+        public static bool TryParseFromUCIString(string UCIString, List<Move> moveList, [NotNullWhen(true)] out Move? move)
         {
             Debug.Assert(UCIString.Length == 4 || UCIString.Length == 5);
 
@@ -184,13 +184,13 @@ namespace Lynx.Model
                     // 1st killer move
                     if (killerMoves[0, plies.Value] == EncodedMove)
                     {
-                        return 9_000;
+                        return EvaluationConstants.FirstKillerMoveValue;
                     }
 
                     // 2nd killer move
                     else if (killerMoves[1, plies.Value] == EncodedMove)
                     {
-                        return 8_000;
+                        return EvaluationConstants.SecondKillerMoveValue;
                     }
                 }
             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -357,10 +357,10 @@ namespace Lynx.Model
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IOrderedEnumerable<Move> AllPossibleMoves(int[,]? killerMoves = null, int? plies = null) => MoveGenerator.GenerateAllMoves(this, killerMoves, plies);
+        public List<Move> AllPossibleMoves() => MoveGenerator.GenerateAllMoves(this);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public IOrderedEnumerable<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
+        public List<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
 
         /// <summary>
         /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -43,12 +43,12 @@ namespace Lynx
         /// <param name="capturesOnly">Filters out all moves but captures</param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static IOrderedEnumerable<Move> GenerateAllMoves(Position position, int[,]? killerMoves = null, int? plies = null, bool capturesOnly = false)
+        public static List<Move> GenerateAllMoves(Position position, bool capturesOnly = false)
         {
 #if DEBUG
             if (position.Side == Side.Both)
             {
-                return Array.Empty<Move>().OrderByDescending(m => m);
+                return new List<Move>();
             }
 #endif
             var offset = Utils.PieceOffset(position.Side);
@@ -62,7 +62,7 @@ namespace Lynx
             moves.AddRange(GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly));
             moves.AddRange(GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly));
 
-            return moves.OrderByDescending(move => move.Score(position, killerMoves, plies));
+            return moves;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -20,6 +20,8 @@ namespace Lynx.Search
         private int MovesWithoutCaptureOrPawnMove;
 
         private int Nodes;
+        private bool IsFollowingPV;
+        private bool IsScoringPV;
 
         private CancellationToken CancellationToken;
         private CancellationToken AbsoluteCancellationToken;
@@ -48,6 +50,7 @@ namespace Lynx.Search
             var sw = new Stopwatch();
             bool isCancelled = false;
 
+
             try
             {
                 sw.Start();
@@ -60,6 +63,7 @@ namespace Lynx.Search
                         CancellationToken.ThrowIfCancellationRequested();
                     }
                     Nodes = 0;
+                    IsFollowingPV = true;
 
                     (bestEvaluation, int maxDepthReached) = NegaMax(position, depthLimit: depth, depth: 0, alpha: MinValue, beta: MaxValue);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -152,18 +152,13 @@ namespace Lynx.Search
                 return (alpha, depth);   // Alpha?
             }
 
-            var movesToEvaluate = SortCaptures(position.AllCapturesMoves(), position, depth);
-
-            if (!movesToEvaluate.TryGetNonEnumeratedCount(out int moveCount))
-            {
-                _logger.Info("TryGetNonEnumeratedCount didn't work :/");
-                moveCount = movesToEvaluate.Count();
-            }
-
-            if (moveCount == 0)
+            var generatedMoves = position.AllCapturesMoves();
+            if (generatedMoves.Count == 0)
             {
                 return (staticEvaluation, depth);  // TODO check if in check or drawn position
             }
+
+            var movesToEvaluate = SortCaptures(generatedMoves, position, depth);
 
             Move? bestMove = null;
             bool isAnyMoveValid = false;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -30,12 +30,11 @@ namespace Lynx.Search
             }
 
             ++Nodes;
+            var pseudoLegalMoves = SortMoves(position.AllPossibleMoves(), position, depth);
 
             var pvIndex = Model.PVTable.Indexes[depth];
             var nextPvIndex = Model.PVTable.Indexes[depth + 1];
-            PVTable[pvIndex] = new Move();
-
-            var pseudoLegalMoves = position.AllPossibleMoves(KillerMoves, depth);
+            PVTable[pvIndex] = new Move();  // After getting psuedoLegalMoves
 
             if (depth >= depthLimit)
             {
@@ -153,9 +152,15 @@ namespace Lynx.Search
                 return (alpha, depth);   // Alpha?
             }
 
-            var movesToEvaluate = position.AllCapturesMoves();
+            var movesToEvaluate = SortCaptures(position.AllCapturesMoves(), position, depth);
 
-            if (!movesToEvaluate.Any())
+            if (!movesToEvaluate.TryGetNonEnumeratedCount(out int moveCount))
+            {
+                _logger.Info("TryGetNonEnumeratedCount didn't work :/");
+                moveCount = movesToEvaluate.Count();
+            }
+
+            if (moveCount == 0)
             {
                 return (staticEvaluation, depth);  // TODO check if in check or drawn position
             }

--- a/tests/Lynx.Test/EngineBestMoveTest.cs
+++ b/tests/Lynx.Test/EngineBestMoveTest.cs
@@ -48,7 +48,16 @@ namespace Lynx.Test
         [TestCase("6k1/1R6/5K2/3p1N2/1P3n2/8/8/3r4 w - -", new[] { "f5h6" },
             Category = "LongRunning", Explicit = true, Description = "Mate in 4, https://gameknot.com/chess-puzzle.pl?pz=260253",
             Ignore = "Not good enough yet")]
+        // TODO http://www.talkchess.com/forum3/viewtopic.php?f=7&t=78583
         public void Mate_in_4(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+        {
+            TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+        }
+
+        [TestCase("3R3N/2pR1p2/4k3/N1P5/1q4PK/2B4B/8/8 w - - 0 1", new[] { "c5c6" },
+            Category = "LongRunning", Explicit = true, Description = "Mate in 5, http://talkchess.com/forum3/viewtopic.php?f=7&t=78428&p=908885&hilit=PLEASE+LEARN#p908885",
+            Ignore = "Not good enough yet")]
+        public void Mate_in_5(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
         {
             TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
         }

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -24,7 +24,7 @@ namespace Lynx.Test.Model
         {
             var position = new Position(fen);
 
-            var allMoves = position.AllPossibleMoves().ToList();
+            var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(position)).ToList();
 
             Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
             Assert.AreEqual("f3f6", allMoves[1].UCIString());     // QxN
@@ -58,12 +58,12 @@ namespace Lynx.Test.Model
         [TestCase("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", "d4e3")]
         public void MoveScoreEnPassant(string fen, string moveWithHighestScore)
         {
-            var position = new Position(fen);
+            Position position = new(fen);
 
-            var allMoves = position.AllPossibleMoves().ToList();
+            var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(position)).ToList();
 
             Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-            Assert.AreEqual(Move.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0,0], allMoves[0].Score(position));
+            Assert.AreEqual(Move.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(position));
         }
     }
 }


### PR DESCRIPTION
* Take PV into account when sorting moves
* Avoid move sorting in some other scenarios.
* ~Try to take advantage of .NET 6 `TryGetNonEnumeratedCount`~
* Add Mate in 5 ignored test