### PR TITLE
Enable single-file compression

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -11,6 +11,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>link</TrimMode>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>


### PR DESCRIPTION
Enable single-file compression
This saves ~30% executable size in exchange of an increased startup time, which in our case is unnoticeable
See https://devblogs.microsoft.com/dotnet/announcing-net-6/#compression