### PR TITLE
Avoid unnecessary `Move.ToString()` executions

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -140,6 +140,12 @@ namespace Lynx.Search
         }
 
         [Conditional("DEBUG")]
+        private static void PrintMessage(string message)
+        {
+            _logger.Trace(message);
+        }
+
+        [Conditional("DEBUG")]
         private void PrintPvTable(int target = -1, int source = -1)
         {
             Console.WriteLine(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,7 +75,7 @@ namespace Lynx.Search
                 // Fail-hard beta-cutoff
                 if (evaluation >= beta)
                 {
-                    _logger.Trace($"Pruning: {move} is enough");
+                    PrintMessage($"Pruning: {move} is enough");
 
                     //if (!move.IsCapture())
                     {
@@ -186,7 +186,7 @@ namespace Lynx.Search
                 // Fail-hard beta-cutoff
                 if (evaluation >= beta)
                 {
-                    _logger.Trace($"Pruning: {move} is enough to discard this line");
+                    PrintMessage($"Pruning: {move} is enough to discard this line");
                     return (evaluation, depth); // The refutation doesn't matter, since it'll be pruned
                 }
 


### PR DESCRIPTION
Avoid Move.ToString() execution in beta-cutof trace message unless in Debug mode.