### PR TITLE
🐛 Fix PV collection

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -53,12 +53,34 @@ namespace Lynx
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
         {
+            if (_pVTable[source].EncodedMove == default)
+            {
+                Array.Clear(_pVTable, target, _pVTable.Length - target);
+                return;
+            }
+
             //PrintPvTable(target, source);
             Array.Copy(_pVTable, source, _pVTable, target, moveCountToCopy);
             //PrintPvTable();
         }
 
         #region Debugging
+
+        [Conditional("DEBUG")]
+        private void ValidatePVTable()
+        {
+            for (int i = 0; i < PVTable.Indexes[1]; ++i)
+            {
+                if (_pVTable[i].EncodedMove == default)
+                {
+                    for (int j = i + 1; j < PVTable.Indexes[1]; ++j)
+                    {
+                        Debug.Assert(_pVTable[j].EncodedMove == default);
+                    }
+                    break;
+                }
+            }
+        }
 
         [Conditional("DEBUG")]
         private static void PrintPreMove(Position position, int plies, Move move, bool isQuiescence = false)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -55,6 +55,7 @@ namespace Lynx
 
                     bestEvaluation = NegaMax(Game.CurrentPosition, minDepth, maxDepth: depth, depth: 0, alpha: MinValue, beta: MaxValue);
 
+                    ValidatePVTable();
                     PrintPvTable();
 
                     var pvMoves = _pVTable.TakeWhile(m => m.EncodedMove != default).ToList();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -48,6 +48,7 @@ namespace Lynx
 
             var pvIndex = PVTable.Indexes[depth];
             var nextPvIndex = PVTable.Indexes[depth + 1];
+            _pVTable[pvIndex] = _defaultMove;
 
             foreach (var move in pseudoLegalMoves)
             {
@@ -126,9 +127,6 @@ namespace Lynx
 
             ++_nodes;
 
-            var pvIndex = PVTable.Indexes[depth];
-            var nextPvIndex = PVTable.Indexes[depth + 1];
-
             var staticEvaluation = position.StaticEvaluation(Game.PositionHashHistory, _movesWithoutCaptureOrPawnMove);
 
             // Fail-hard beta-cutoff (updating alpha after this check)
@@ -156,6 +154,10 @@ namespace Lynx
             }
 
             var movesToEvaluate = SortCaptures(generatedMoves, position, depth);
+
+            var pvIndex = PVTable.Indexes[depth];
+            var nextPvIndex = PVTable.Indexes[depth + 1];
+            _pVTable[pvIndex] = _defaultMove;
 
             Move? bestMove = null;
             bool isAnyMoveValid = false;

--- a/tests/Lynx.Test/BaseTest.cs
+++ b/tests/Lynx.Test/BaseTest.cs
@@ -9,21 +9,9 @@ namespace Lynx.Test
     {
         protected static void TestBestMove(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString)
         {
-            var mock = new Mock<ChannelWriter<string>>();
-
-            mock
-                .Setup(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(ValueTask.CompletedTask);
-
-            // Arrange
-            var engine = new Engine(mock.Object);
-            engine.SetGame(new Game(fen));
-
-            // Act
-            var searchResult = engine.BestMove();
+            SearchResult searchResult = SearchBestResult(fen);
             var bestMoveFound = searchResult.BestMove;
 
-            // Assert
             if (allowedUCIMoveString is not null)
             {
                 Assert.Contains(bestMoveFound.UCIString(), allowedUCIMoveString);
@@ -33,6 +21,20 @@ namespace Lynx.Test
             {
                 Assert.False(excludedUCIMoveString.Contains(bestMoveFound.UCIString()));
             }
+        }
+
+        protected static SearchResult SearchBestResult(string fen)
+        {
+            var mock = new Mock<ChannelWriter<string>>();
+
+            mock
+                .Setup(m => m.WriteAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(ValueTask.CompletedTask);
+
+            var engine = new Engine(mock.Object);
+            engine.SetGame(new Game(fen));
+
+            return engine.BestMove();
         }
     }
 }


### PR DESCRIPTION
* Make sure no trash is propagated up in the PV Table when a new good move is found by reverting changes in 
    * `CopyPVTableMoves` method  to clear the table
    * Search methods to ensure `pvTable[pvIndex]` is deleted before start exploring moves).
* Add explicit tests and debug assert, which should help us identify this kind of regressions should they ever happen again.
* Some `EngineBestMoveTests` will also be executed in Debug mode now for this purpose (taken out of the 'Long Running' category)