### PR TITLE
🐛 Fix time management bug when moves over 100

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -12,6 +12,7 @@
     "KeyMovesBeforeMovesToGo": 10,
     "CoefficientAfterKeyMovesBeforeMovesToGo": 0.9,
     "TotalMovesWhenNoMovesToGoProvided": 100,
+    "FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided": 20,
     "FirstTimeLimitWhenNoMovesToGoProvided": 120000,
     "FirstCoefficientWhenNoMovesToGoProvided": 3,
     "SecondTimeLimitWhenNoMovesToGoProvided": 30000,
@@ -19,7 +20,7 @@
     "MinDepth": 4,
     "MaxDepth": 32,
     "MinMoveTime": 1000,
-    "DepthWhenLessThanMinMoveTime": 3,
+    "DepthWhenLessThanMinMoveTime": 5,
     "MinElapsedTimeToConsiderStopSearching": 900,
     "DecisionTimePercentageToStopSearching": 0.55,
     "LMR_FullDepthMoves": 4,
@@ -150,7 +151,7 @@
       // Logs to console
       "100": {
         "logger": "*",
-        "minLevel": "Warn",
+        "minLevel": "Info",
         "writeTo": "console"
       }
     }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -87,11 +87,13 @@
 
         public double CoefficientAfterKeyMovesBeforeMovesToGo { get; set; } = 0.95;
 
-        public int TotalMovesWhenNoMovesToGoProvided { get; set; } = 100;
-
         #endregion
 
         #region No MovesToGo provided
+
+        public int TotalMovesWhenNoMovesToGoProvided { get; set; } = 100;
+
+        public int FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided { get; set; } = 20;
 
         public int FirstTimeLimitWhenNoMovesToGoProvided { get; set; } = 120_000;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -142,30 +142,32 @@ namespace Lynx
 
         internal double CalculateDecisionTime(int movesToGo, int millisecondsLeft, int millisecondsIncrement)
         {
-            double decisionTime = 0;
+            double decisionTime;
             millisecondsLeft -= millisecondsIncrement; // Since we're going to spend them, shouldn't take into account for our calculations
 
             if (movesToGo == default)
             {
                 int movesLeft = Configuration.EngineSettings.TotalMovesWhenNoMovesToGoProvided - (Game.MoveHistory.Count >> 1);
 
-                if (movesLeft > 0)
+                if (movesLeft <= 0)
                 {
-#pragma warning disable S2184 // Results of integer division should not be assigned to floating point variables
-                    if (millisecondsLeft >= Configuration.EngineSettings.FirstTimeLimitWhenNoMovesToGoProvided)
-                    {
-                        decisionTime = Configuration.EngineSettings.FirstCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
-                    }
-                    else if (millisecondsLeft >= Configuration.EngineSettings.SecondTimeLimitWhenNoMovesToGoProvided)
-                    {
-                        decisionTime = Configuration.EngineSettings.SecondCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
-                    }
-                    else
-                    {
-                        decisionTime = millisecondsLeft / movesLeft;
-                    }
-#pragma warning restore S2184 // Results of integer division should not be assigned to floating point variables
+                    movesLeft = Configuration.EngineSettings.FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided;
                 }
+
+#pragma warning disable S2184 // Results of integer division should not be assigned to floating point variables
+                if (millisecondsLeft >= Configuration.EngineSettings.FirstTimeLimitWhenNoMovesToGoProvided)
+                {
+                    decisionTime = Configuration.EngineSettings.FirstCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
+                }
+                else if (millisecondsLeft >= Configuration.EngineSettings.SecondTimeLimitWhenNoMovesToGoProvided)
+                {
+                    decisionTime = Configuration.EngineSettings.SecondCoefficientWhenNoMovesToGoProvided * millisecondsLeft / movesLeft;
+                }
+                else
+                {
+                    decisionTime = millisecondsLeft / movesLeft;
+                }
+#pragma warning restore S2184 // Results of integer division should not be assigned to floating point variables
             }
             else
             {
@@ -186,6 +188,7 @@ namespace Lynx
             //    decisionTime = Math.Clamp(decisionTime, Configuration.Parameters.MinMoveTime, Configuration.Parameters.MaxMoveTime);
             //}
 
+            // If time left after taking all decision time < 1s
             if (millisecondsLeft + millisecondsIncrement - decisionTime < 1_000)    // i.e. x + 10s, 10s left in the clock
             {
                 decisionTime *= 0.9;

--- a/tests/Lynx.Test/TimeManagementTest.cs
+++ b/tests/Lynx.Test/TimeManagementTest.cs
@@ -92,14 +92,38 @@ namespace Lynx.Test
             5710,       // 5.7s
             5000,       // 5s increment
             0,          // No moves to go
-            4500,       // 4.5s, millisecondsIncrement * 0.9
+            4531.5,     // 0.9 * 5035, 0.9 * (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
             200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black
         [TestCase(
             6001,       // 6s
             5000,       // 5s increment
             0,          // No moves to go
-            5000,       // 5, millisecondsIncrement
+            4545,      // 0.9 * 5050, 0.9 * (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
             200)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black
+        [TestCase(
+            6001,       // 6s
+            5000,       // 5s increment
+            0,          // No moves to go
+            4545,       // 0.9 * 5050, 0.9 * (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
+            250)]       // Over default TotalMovesWhenNoMovesToGoProvided (100), https://lichess.org/GxfJjvUu/black
+        [TestCase(
+            1100,       // 1.1s
+            1000,       // 1s increment
+            0,          // No moves to go
+            904.5,      // 0.9, 0.9 * (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
+            210)]       // Over default TotalMovesWhenNoMovesToGoProvided (100)
+        [TestCase(
+            2100,       // 2.1s
+            1000,       // 1s increment
+            0,          // No moves to go
+            1055,       // 1 + 1.1/20, (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
+            210)]       // Over default TotalMovesWhenNoMovesToGoProvided (100)
+        [TestCase(
+            21000,      // 21s
+            1000,       // 1s increment
+            0,          // No moves to go
+            2000,       // 2, (millisecondsIncrement + (millisecondsLeft - millisecondsIncrement) / FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided)
+            210)]       // Over default TotalMovesWhenNoMovesToGoProvided (100)
         public void CalculateDecisionTime(
             int millisecondsLeft, int millisecondsIncrement, int movesToGo, double expectedTimeToMove, int moveHistoryCount = 0)
         {


### PR DESCRIPTION
* Add `FixedMovesLeftWhenNoMovesToGoProvidedAndOverTotalMovesWhenNoMovesToGoProvided` to calculate time left for each move when the amount of oves goes over `TotalMovesWhenNoMovesToGoProvided`.
* Increase `DepthWhenLessThanMinMoveTime` to 5.