### PR TITLE
🐛 Fix crash when depth reaches `MaxDepth`

### DIFF
--- a/src/Lynx/Model/PVTable.cs
+++ b/src/Lynx/Model/PVTable.cs
@@ -8,11 +8,11 @@ public static class PVTable
 
     private static ImmutableArray<int> Initialize()
     {
-        var indexes = new int[Configuration.EngineSettings.MaxDepth];
+        var indexes = new int[Configuration.EngineSettings.MaxDepth + 1];
         int previousPVIndex = 0;
         indexes[0] = previousPVIndex;
 
-        for (int depth = 0; depth < Configuration.EngineSettings.MaxDepth - 1; ++depth)
+        for (int depth = 0; depth < Configuration.EngineSettings.MaxDepth; ++depth)
         {
             indexes[depth + 1] = previousPVIndex + Configuration.EngineSettings.MaxDepth - depth;
             previousPVIndex = indexes[depth + 1];

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -223,7 +223,18 @@ public class RegressionTest : BaseTest
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth 1"));
+        var bestMove = engine.BestMove(new GoCommand("go depth 1"));
         Assert.NotZero(bestMove.Evaluation);
+    }
+
+    [TestCase(Constants.KillerTestPositionFEN)]
+    [TestCase(Constants.TrickyTestPositionFEN)]
+    public void PVTableCrash(string fen)
+    {
+        const int depthWhenMaxDepthInQuiescenceIsReached = 7;
+        var engine = GetEngine(fen);
+
+        var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached }"));
+        Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.TargetDepth);
     }
 }

--- a/tests/Lynx.Test/Model/PVTableTest.cs
+++ b/tests/Lynx.Test/Model/PVTableTest.cs
@@ -1,0 +1,13 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test.Model;
+
+public class PVTableTest
+{
+    [Test]
+    public void PVTable_Indexes_Support_MaxDepthPlusOne()
+    {
+        Assert.DoesNotThrow(() => _ = PVTable.Indexes[Configuration.EngineSettings.MaxDepth]);
+    }
+}


### PR DESCRIPTION
Ensure `PVTable.Indexes` support `Configuration.EngineSettings.MaxDepth`, since NegaMax populates `pvTable[currentDepth + 1]`