### PR TITLE
🐛 Fix `mate` sign

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -92,7 +92,7 @@ public sealed partial class Engine
                 if (isMateDetected)
                 {
                     mate = (int)Math.Ceiling(0.5 * ((EvaluationConstants.CheckMateEvaluation - bestEvaluationAbs) / Position.DepthFactor));
-                    Math.CopySign(bestEvaluation, mate);
+                    mate = (int)Math.CopySign(mate, bestEvaluation);
                 }
 
                 var elapsedTime = _stopWatch.ElapsedMilliseconds;


### PR DESCRIPTION
Fix `mate` sign in UCI `info` command, making it negative when a mate is about to be received