### PR TITLE
⚡ Speed up `Position.IsInCheck()`

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -119,6 +119,22 @@ public static class Attacks
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsSquareInCheck(int squareIndex, Side sideToMove, BitBoard[] piecePosition, BitBoard[] occupancy)
+    {
+        Utils.Assert(sideToMove != Side.Both);
+
+        var offset = Utils.PieceOffset(sideToMove);
+
+        // I tried to order them from most to least likely
+        return
+            IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
+            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
+            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
+            || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
+            || IsSquareAttackedByPawns(squareIndex, sideToMove, offset, piecePosition);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByPawns(int squareIndex, Side sideToMove, int offset, BitBoard[] pieces)
     {
         var oppositeColorIndex = ((int)sideToMove + 1) % 2;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -254,7 +254,7 @@ public sealed class Position
         var kingSquare = PieceBitBoards[(int)Piece.K + Utils.PieceOffset(Side)].GetLS1BIndex();
         var oppositeSide = (Side)Utils.OppositeSide(Side);
 
-        return Attacks.IsSquaredAttacked(kingSquare, oppositeSide, PieceBitBoards, OccupancyBitBoards);
+        return Attacks.IsSquareInCheck(kingSquare, oppositeSide, PieceBitBoards, OccupancyBitBoards);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Avoid checking king attacks and try to optimize attack checking order