### PR TITLE
Publish Lynx as a NuGet package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           ${{ runner.os }}-nuget-
 
     - name: Build
-      run: dotnet build -c ${{ matrix.configuration }} /p:DeterministicBuild=true
+      run: dotnet build -c ${{ matrix.configuration }} /p:DeterministicBuild=true /p:Optimized=true
 
     - name: Run CI tests
       run: dotnet test -c ${{ matrix.configuration }} --no-build --collect:"XPlat Code Coverage" --logger "console;verbosity=normal"
@@ -115,15 +115,6 @@ jobs:
         path: coveragereport/
         if-no-files-found: error
 
-    - name: Publish library
-      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
-      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
-
-    - name: Push NuGet package to GitHub
-      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
-      run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
-      continue-on-error: true
-
     - name: Publish CLI
       if: matrix.configuration == 'Release'
       run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
@@ -137,6 +128,10 @@ jobs:
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
         if-no-files-found: error
+
+    - name: Publish library
+      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
       if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         if-no-files-found: error
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
-      if: matrix.configuration == 'Release'
+      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
       uses: actions/upload-artifact@v3
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           ${{ runner.os }}-nuget-
 
     - name: Build
-      run: dotnet build -c ${{ matrix.configuration }} /p:DeterministicBuild=true /p:Optimized=true
+      run: dotnet build -c ${{ matrix.configuration }} /p:DeterministicBuild=true
 
     - name: Run CI tests
       run: dotnet test -c ${{ matrix.configuration }} --no-build --collect:"XPlat Code Coverage" --logger "console;verbosity=normal"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
         path: |
-          ${{ env.ARTIFACT_DIR }}/*.nupkg
-          ${{ env.ARTIFACT_DIR }}/*.snupkg
+          ${{ env.ARTIFACT_DIR }}/nuget/*.nupkg
+          ${{ env.ARTIFACT_DIR }}/nuget/*.snupkg
         if-no-files-found: error
 
   winning-at-chess:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           ${{ runner.os }}-nuget-
 
     - name: Build
-      run: dotnet build -c ${{ matrix.configuration }}
+      run: dotnet build -c ${{ matrix.configuration }} /p:DeterministicBuild=true
 
     - name: Run CI tests
       run: dotnet test -c ${{ matrix.configuration }} --no-build --collect:"XPlat Code Coverage" --logger "console;verbosity=normal"
@@ -115,7 +115,11 @@ jobs:
         path: coveragereport/
         if-no-files-found: error
 
-    - name: Publish
+    - name: Publish library
+      if: matrix.configuration == 'Release'
+      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts
+
+    - name: Publish CLI
       if: matrix.configuration == 'Release'
       run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
 
@@ -126,6 +130,7 @@ jobs:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
+          artifacts/*.nupkg
           !artifacts/**/*.pdb
         if-no-files-found: error
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,8 @@ jobs:
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
         path: |
-          ${{ env.ARTIFACT_DIR }}/nuget/*.nupkg
-          ${{ env.ARTIFACT_DIR }}/nuget/*.snupkg
+          artifacts/nuget/*.nupkg
+          artifacts/nuget/*.snupkg
         if-no-files-found: error
 
   winning-at-chess:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,8 +116,13 @@ jobs:
         if-no-files-found: error
 
     - name: Publish library
-      if: matrix.configuration == 'Release'
-      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts
+      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
+
+    #- name: Push NuGet package to GitHub
+    #  if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+    #  run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
+    #  continue-on-error: true
 
     - name: Publish CLI
       if: matrix.configuration == 'Release'
@@ -130,8 +135,17 @@ jobs:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
-          artifacts/*.nupkg
           !artifacts/**/*.pdb
+        if-no-files-found: error
+
+    - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
+      if: matrix.configuration == 'Release'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
+        path: |
+          ${{ env.ARTIFACT_DIR }}/*.nupkg
+          ${{ env.ARTIFACT_DIR }}/*.snupkg
         if-no-files-found: error
 
   winning-at-chess:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,10 @@ jobs:
       if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
       run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
 
-    #- name: Push NuGet package to GitHub
-    #  if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
-    #  run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
-    #  continue-on-error: true
+    - name: Push NuGet package to GitHub
+      if: matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+      run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
+      continue-on-error: true
 
     - name: Publish CLI
       if: matrix.configuration == 'Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
         type: boolean
         default: true
         required: false
+      should_push_new_nuget_version:
+        description: 'Push new NuGet version'
+        type: boolean
+        default: true
+        required: false
       should_tag_new_version:
         description: 'Tag version release. If false, no release will be created either'
         type: boolean
@@ -107,11 +112,11 @@ jobs:
         if-no-files-found: error
 
     - name: Publish NuGet package
-      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
+      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget /p:DeterministicBuild=true
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
-      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
+      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       uses: actions/upload-artifact@v3
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
@@ -121,7 +126,7 @@ jobs:
         if-no-files-found: error
 
     - name: Push NuGet package to GitHub
-      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
+      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,15 +80,6 @@ jobs:
         $regex = "(?<=<Version>).*(?=</Version>)"
         (Get-Content $input_path) -Replace $regex, '${{ github.event.inputs.new_engine_version }}' | Out-File $input_path
 
-    - name: Publish NuGet package
-      if: ${{ matrix.runtime-identifier }} == 'linux-x64'
-      run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts /p:DeterministicBuild=true
-
-    - name: Push NuGet package to GitHub
-      if: ${{ matrix.runtime-identifier }} == 'linux-x64'
-      run: nuget push 'artifacts/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
-      continue-on-error: true
-
     - name: Publish ${{ matrix.runtime-identifier }} version
       run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
 
@@ -99,7 +90,6 @@ jobs:
         name: Lynx-${{ github.event.inputs.new_engine_version }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
-          artifacts/*.nupkg
           !artifacts/**/*.pdb
         if-no-files-found: error
 
@@ -112,6 +102,24 @@ jobs:
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
         if-no-files-found: error
+
+    - name: Publish NuGet package
+      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64'
+      run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget /p:DeterministicBuild=true
+
+    - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
+      if: github.event.inputs.new_engine_version != '' && matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+      uses: actions/upload-artifact@v3
+      with:
+        name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
+        path: |
+          artifacts/nuget/*.nupkg
+          artifacts/nuget/*.snupkg
+        if-no-files-found: error
+
+    - name: Push NuGet package to GitHub
+      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64'
+      run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
 
   release:
     needs: publish-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,15 @@ jobs:
         $regex = "(?<=<Version>).*(?=</Version>)"
         (Get-Content $input_path) -Replace $regex, '${{ github.event.inputs.new_engine_version }}' | Out-File $input_path
 
+    - name: Publish NuGet package
+      if: ${{ matrix.runtime-identifier }} == 'linux-x64'
+      run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts /p:DeterministicBuild=true
+
+    - name: Push NuGet package to GitHub
+      if: ${{ matrix.runtime-identifier }} == 'linux-x64'
+      run: nuget push 'artifacts/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
+      continue-on-error: true
+
     - name: Publish ${{ matrix.runtime-identifier }} version
       run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
 
@@ -90,6 +99,7 @@ jobs:
         name: Lynx-${{ github.event.inputs.new_engine_version }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
+          artifacts/*.nupkg
           !artifacts/**/*.pdb
         if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,19 @@ on:
         default: ''
         required: false
       should_commit_new_version:
-        description: 'Commit and push version increment. If true, this new commit will be the one tagged (in case should_tag_new_version is also set to true)'
-        default: 'true'
+        description: 'Commit and push version increment. If true, this new commit will be the one tagged (in case Tag version release is also set to true)'
+        type: boolean
+        default: true
         required: false
       should_tag_new_version:
         description: 'Tag version release. If false, no release will be created either'
-        default: 'true'
+        type: boolean
+        default: true
         required: false
       should_create_github_release:
         description: 'Create GitHub Release'
-        default: 'true'
+        type: boolean
+        default: true
         required: false
 
 jobs:
@@ -104,11 +107,11 @@ jobs:
         if-no-files-found: error
 
     - name: Publish NuGet package
-      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64'
+      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
       run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget /p:DeterministicBuild=true
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
-      if: github.event.inputs.new_engine_version != '' && matrix.os == 'ubuntu-latest' && matrix.configuration == 'Release'
+      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
       uses: actions/upload-artifact@v3
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
@@ -118,7 +121,7 @@ jobs:
         if-no-files-found: error
 
     - name: Push NuGet package to GitHub
-      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64'
+      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
       run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         if-no-files-found: error
 
     - name: Push NuGet package to GitHub
-      if: github.event.inputs.new_engine_version != '' && ${{ matrix.runtime-identifier }} == 'linux-x64' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
+      if: github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64' && matrix.configuration == 'Release'
       run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ on:
         description: 'New engine version. If empty, run number will be used and no commit/tag/release will be created'
         default: ''
         required: false
-      should_commit_new_version:
-        description: 'Commit and push version increment. If true, this new commit will be the one tagged (in case Tag version release is also set to true)'
+      should_push_new_nuget_version:
+        description: 'Push new NuGet version'
         type: boolean
         default: true
         required: false
-      should_push_new_nuget_version:
-        description: 'Push new NuGet version'
+      should_commit_new_version:
+        description: 'Commit and push version increment. If true, this new commit will be the one tagged (in case Tag version release is also set to true)'
         type: boolean
         default: true
         required: false
@@ -112,11 +112,11 @@ jobs:
         if-no-files-found: error
 
     - name: Publish NuGet package
-      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
+      if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget /p:DeterministicBuild=true
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
-      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
+      if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       uses: actions/upload-artifact@v3
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}
@@ -126,7 +126,7 @@ jobs:
         if-no-files-found: error
 
     - name: Push NuGet package to GitHub
-      if: should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
+      if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
       run: nuget push 'artifacts/nuget/*.nupkg' -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/lynx-chess/index.json -SkipDuplicate -Verbosity detailed
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         (Get-Content $input_path) -Replace $regex, '${{ github.event.inputs.new_engine_version }}' | Out-File $input_path
 
     - name: Publish ${{ matrix.runtime-identifier }} version
-      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
+      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true /p:DeterministicBuild=true -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Lynx-${{ matrix.runtime-identifier }} artifact
       if: github.event.inputs.new_engine_version != ''
@@ -111,9 +111,13 @@ jobs:
           !artifacts/**/*.pdb
         if-no-files-found: error
 
+    - name: Deterministic build
+      if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
+      run: dotnet clean -c Release && dotnet build -c Release /p:DeterministicBuild=true
+
     - name: Publish NuGet package
       if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'
-      run: dotnet pack -c Release src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget /p:DeterministicBuild=true
+      run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
       if: github.event.inputs.should_push_new_nuget_version == 'true' && github.event.inputs.new_engine_version != '' && matrix.runtime-identifier == 'linux-x64'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.0-alpha</Version>
+    <Version>0.9.0</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition="'$(DeterministicBuild)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>xx
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.9.0</Version>
+    <Version>0.9.0-alpha</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <PropertyGroup Condition="'$(DeterministicBuild)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>xx
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
 
   <PropertyGroup Condition="'$(DeterministicBuild)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Lynx;
 using Lynx.Cli;
-using Lynx.Model;
 using Microsoft.Extensions.Configuration;
 using NLog;
 using NLog.Extensions.Logging;
@@ -45,7 +44,6 @@ var tasks = new List<Task>
 
 try
 {
-    InitializeStaticClasses();
     await Task.WhenAny(tasks);
 }
 catch (AggregateException ae)
@@ -75,10 +73,3 @@ finally
 }
 
 Thread.Sleep(2_000);
-
-static void InitializeStaticClasses()
-{
-    _ = PVTable.Indexes[0];
-    _ = Attacks.KingAttacks;
-    _ = ZobristTable.SideHash();
-}

--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -1,4 +1,5 @@
-﻿using Lynx.UCI.Commands.Engine;
+﻿using Lynx.Model;
+using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Threading.Channels;
@@ -18,6 +19,15 @@ public sealed class LinxDriver
         _engineWriter = engineWriter;
         _engine = engine;
         _logger = LogManager.GetCurrentClassLogger();
+
+        InitializeStaticClasses();
+    }
+
+    private static void InitializeStaticClasses()
+    {
+        _ = PVTable.Indexes[0];
+        _ = Attacks.KingAttacks;
+        _ = ZobristTable.SideHash();
     }
 
     public async Task Run(CancellationToken cancellationToken)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using Lynx.UCI.Commands.GUI;
 using NUnit.Framework;
 
 namespace Lynx.Test.Model;


### PR DESCRIPTION
* [Move static initializations from `Lynx.Cli` to `Lynx`](https://github.com/lynx-chess/Lynx/commit/a3561af043dc0f0992fe6e5fd2334a925f5fff7a) to allow proper, independent usage of `Lynx` assembly
* Add CI and release steps to create and upload the NuGet package as an artifact to GH actions
* Add release step to push the NuGet package to GitHub packages (no NuGet - Lynx name not available 😢 )
* Make use of boolean workflow_dispatch input parameters
* Ensure deterministic builds by adding `EmbedUntrackedSources` when deterministic build is used