### PR TITLE
Replace `Move` class with `int` and use `'Move'` pool for `MoveGenerator`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,6 @@ global.json
 
 # Environment files
 *.env
+
+# VS diagnostic sessions
+*.diagsession

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,10 @@
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Using Include="System.Int32" Alias="Move" />
+  </ItemGroup >
+
   <PropertyGroup>
     <Version>0.10.0</Version>
     <Authors>Eduardo Cáceres</Authors>

--- a/src/Lynx.Benchmark/FENGeneration.cs
+++ b/src/Lynx.Benchmark/FENGeneration.cs
@@ -215,7 +215,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new StructCustomPosition(fen);
-        var newPosition = new StructCustomPosition(position, moves[0]);
+        var newPosition = new StructCustomPosition(position, moves.First());
         return newPosition.FEN;
     }
 
@@ -226,7 +226,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new StructCustomPosition(fen);
-        var newPosition = new StructCustomPosition(position, moves[0], default);
+        var newPosition = new StructCustomPosition(position, moves.First(), default);
 
         return newPosition.FEN;
     }
@@ -238,7 +238,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new ReadonlyStructCustomPosition(fen);
-        var newPosition = new ReadonlyStructCustomPosition(position, moves[0]);
+        var newPosition = new ReadonlyStructCustomPosition(position, moves.First());
 
         return newPosition.FEN;
     }
@@ -250,7 +250,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new ReadonlyStructCustomPosition(fen);
-        var newPosition = new ReadonlyStructCustomPosition(position, moves[0], default);
+        var newPosition = new ReadonlyStructCustomPosition(position, moves.First(), default);
 
         return newPosition.FEN;
     }
@@ -262,7 +262,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new ClassCustomPosition(fen);
-        var newPosition = new ClassCustomPosition(position, moves[0]);
+        var newPosition = new ClassCustomPosition(position, moves.First());
 
         return newPosition.FEN;
     }
@@ -274,7 +274,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new ClassCustomPosition(fen);
-        var newPosition = new ClassCustomPosition(position, moves[0], default);
+        var newPosition = new ClassCustomPosition(position, moves.First(), default);
 
         return newPosition.FEN;
     }
@@ -286,7 +286,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new RecordClassCustomPosition(fen);
-        var newPosition = new RecordClassCustomPosition(position, moves[0]);
+        var newPosition = new RecordClassCustomPosition(position, moves.First());
 
         return newPosition.FEN;
     }
@@ -298,7 +298,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new RecordClassCustomPosition(fen);
-        var newPosition = new RecordClassCustomPosition(position, moves[0], default);
+        var newPosition = new RecordClassCustomPosition(position, moves.First(), default);
 
         return newPosition.FEN;
     }
@@ -310,7 +310,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new RecordStructCustomPosition(fen);
-        var newPosition = new RecordStructCustomPosition(position, moves[0]);
+        var newPosition = new RecordStructCustomPosition(position, moves.First());
 
         return newPosition.FEN;
     }
@@ -322,7 +322,7 @@ public class FENGeneration : BaseBenchmark
         var moves = new Position(fen).AllPossibleMoves();
 
         var position = new RecordStructCustomPosition(fen);
-        var newPosition = new RecordStructCustomPosition(position, moves[0], default);
+        var newPosition = new RecordStructCustomPosition(position, moves.First(), default);
 
         return newPosition.FEN;
     }

--- a/src/Lynx.Benchmark/MoveGeneratorParallel.cs
+++ b/src/Lynx.Benchmark/MoveGeneratorParallel.cs
@@ -222,14 +222,14 @@ public class MoveGeneratorParallel : BaseBenchmark
                     var targetRank = (singlePushSquare / 8) + 1;
                     if (targetRank == 1 || targetRank == 8)  // Promotion
                     {
-                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                        yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                        yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                        yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                        yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                     }
                     else if (!capturesOnly)
                     {
-                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece);
+                        yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
                     }
 
                     // Double pawn push
@@ -240,7 +240,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
                             && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
                         {
-                            yield return MoveExtensions.New(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                            yield return MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
                         }
                     }
                 }
@@ -251,7 +251,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                 if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
                 // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
                 {
-                    yield return MoveExtensions.New(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
                 }
 
                 // Captures
@@ -264,14 +264,14 @@ public class MoveGeneratorParallel : BaseBenchmark
                     var targetRank = (targetSquare / 8) + 1;
                     if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                     {
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
                     }
                     else
                     {
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                     }
                 }
             }
@@ -297,7 +297,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
                     {
-                        yield return MoveExtensions.New(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                     }
 
                     if (((position.Castle & (int)CastlingRights.WQ) != default)
@@ -308,7 +308,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
                     {
-                        yield return MoveExtensions.New(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                     }
                 }
                 else
@@ -320,7 +320,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
                     {
-                        yield return MoveExtensions.New(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                     }
 
                     if (((position.Castle & (int)CastlingRights.BQ) != default)
@@ -331,7 +331,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
                     {
-                        yield return MoveExtensions.New(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                     }
                 }
             }
@@ -358,11 +358,11 @@ public class MoveGeneratorParallel : BaseBenchmark
 
                     if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
                     {
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                     }
                     else if (!capturesOnly)
                     {
-                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece);
+                        yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece);
                     }
                 }
             }

--- a/src/Lynx.Benchmark/MoveGeneratorParallel.cs
+++ b/src/Lynx.Benchmark/MoveGeneratorParallel.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * 
+ *
  *  |               Method |                  fen |      Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Allocated |
  *  |--------------------- |--------------------- |----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|
  *  |         SingleThread | r2q1r(...)- 0 9 [68] |  8.650 us | 0.1549 us | 0.1293 us |  1.00 |    0.00 | 2.3346 |      - |      5 KB |
@@ -36,7 +36,7 @@
  *  |    SingleThreadArray | rnbqk(...)- 0 1 [56] |  7.986 us | 0.1455 us | 0.1361 us |  1.13 |    0.02 | 2.3956 |      - |      5 KB |
  *  | ParallelForEachArray | rnbqk(...)- 0 1 [56] | 20.664 us | 0.1411 us | 0.1251 us |  2.93 |    0.04 | 1.2512 | 0.6104 |      8 KB |
  *  |         WhenAllArray | rnbqk(...)- 0 1 [56] | 19.929 us | 0.0522 us | 0.0435 us |  2.83 |    0.03 | 3.2959 |      - |      7 KB |
- *  
+ *
 */
 
 using BenchmarkDotNet.Attributes;
@@ -222,14 +222,14 @@ public class MoveGeneratorParallel : BaseBenchmark
                     var targetRank = (singlePushSquare / 8) + 1;
                     if (targetRank == 1 || targetRank == 8)  // Promotion
                     {
-                        yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                        yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                        yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                        yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                     }
                     else if (!capturesOnly)
                     {
-                        yield return new Move(sourceSquare, singlePushSquare, piece);
+                        yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece);
                     }
 
                     // Double pawn push
@@ -240,7 +240,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
                             && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
                         {
-                            yield return new Move(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                            yield return MoveExtensions.New(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
                         }
                     }
                 }
@@ -251,7 +251,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                 if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
                 // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
                 {
-                    yield return new Move(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
                 }
 
                 // Captures
@@ -264,14 +264,14 @@ public class MoveGeneratorParallel : BaseBenchmark
                     var targetRank = (targetSquare / 8) + 1;
                     if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                     {
-                        yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-                        yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-                        yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-                        yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
                     }
                     else
                     {
-                        yield return new Move(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
                     }
                 }
             }
@@ -297,7 +297,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
                     {
-                        yield return new Move(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                     }
 
                     if (((position.Castle & (int)CastlingRights.WQ) != default)
@@ -308,7 +308,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
                     {
-                        yield return new Move(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                     }
                 }
                 else
@@ -320,7 +320,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
                     {
-                        yield return new Move(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                     }
 
                     if (((position.Castle & (int)CastlingRights.BQ) != default)
@@ -331,7 +331,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
                         && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
                     {
-                        yield return new Move(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                     }
                 }
             }
@@ -358,11 +358,11 @@ public class MoveGeneratorParallel : BaseBenchmark
 
                     if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
                     {
-                        yield return new Move(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
                     }
                     else if (!capturesOnly)
                     {
-                        yield return new Move(sourceSquare, targetSquare, piece);
+                        yield return MoveExtensions.New(sourceSquare, targetSquare, piece);
                     }
                 }
             }

--- a/src/Lynx.Benchmark/PositionIdGeneration.cs
+++ b/src/Lynx.Benchmark/PositionIdGeneration.cs
@@ -62,10 +62,10 @@ public class PositionIdGeneration : BaseBenchmark
 
     public static IEnumerable<Position> Data => new[] {
             //Constants.EmptyBoardFEN,
-            new Position(Positions[0], Positions[0].AllPossibleMoves()[0]),
-            new Position(Positions[1], Positions[1].AllPossibleMoves()[0]),
-            new Position(Positions[2], Positions[2].AllPossibleMoves()[0]),
-            new Position(Positions[3], Positions[3].AllPossibleMoves()[0])
+            new Position(Positions[0], Positions[0].AllPossibleMoves().First()),
+            new Position(Positions[1], Positions[1].AllPossibleMoves().First()),
+            new Position(Positions[2], Positions[2].AllPossibleMoves().First()),
+            new Position(Positions[3], Positions[3].AllPossibleMoves().First())
         };
 }
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using static Lynx.Model.Move;
 
 //_2_GettingStarted();
 //_3_PawnAttacks();
@@ -440,16 +439,16 @@ static void _29_Move_List()
 {
     var position = new Position(TrickyPosition);
     var moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+    moves.PrintMoveList();
 
     position = new Position(TrickyPositionReversed);
     moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+    moves.PrintMoveList();
 
     position = new Position(KillerPosition);
     position.Print();
     moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+    moves.PrintMoveList();
 }
 
 static void _32_Make_Move()
@@ -468,7 +467,7 @@ static void _32_Make_Move()
     //CastlingRightsTest(game);
     //CastlingRightsTest(reversedGame);
 
-    PrintMoveList(gameWithPromotion.GetAllMoves());
+    gameWithPromotion.GetAllMoves().PrintMoveList();
 
     GeneralMoveTest(gameWithPromotion);
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -467,13 +467,13 @@ static void _32_Make_Move()
     //CastlingRightsTest(game);
     //CastlingRightsTest(reversedGame);
 
-    gameWithPromotion.GetAllMoves().PrintMoveList();
+    MoveGenerator.GenerateAllMoves(gameWithPromotion.CurrentPosition).PrintMoveList();
 
     GeneralMoveTest(gameWithPromotion);
 
     static void GeneralMoveTest(Game game)
     {
-        foreach (var move in game.GetAllMoves())
+        foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
         {
             game.CurrentPosition.Print();
 
@@ -493,7 +493,7 @@ static void _32_Make_Move()
 
     static void CastlingRightsTest(Game game)
     {
-        foreach (var move in game.GetAllMoves())
+        foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
         {
             if (move.Piece() == (int)Piece.R || (move.Piece() == (int)Piece.r)
              || move.Piece() == (int)Piece.K || (move.Piece() == (int)Piece.k))

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -677,7 +677,7 @@ static void ZobristTable()
     var pos = new Position(KillerPosition);
     var zobristTable = InitializeZobristTable();
     var hash = CalculatePositionHash(zobristTable, pos);
-    var updatedHash = UpdatePositionHash(zobristTable, hash, pos.AllPossibleMoves()[0]);
+    var updatedHash = UpdatePositionHash(zobristTable, hash, pos.AllPossibleMoves().First());
 
     Console.WriteLine(updatedHash);
 }

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -393,7 +393,7 @@ static void _23_Castling_Moves()
     var position = new Position("rn2k2r/pppppppp/8/8/8/8/PPPPPPPP/RN2K2R w KQkq - 0 1");
     position.Print();
 
-    var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side)).ToList();
+    var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side)).ToList();
 
     foreach (var move in moves)
     {

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -359,4 +359,11 @@ public static class Constants
             15, 15, 15, 15, 15, 15, 15, 15,
             13, 15, 15, 15, 12, 15, 15, 14
     };
+
+    /// <summary>
+    /// 218 or 224 seems to be the known limit
+    /// https://www.reddit.com/r/chess/comments/9j70dc/position_with_the_most_number_of_legal_moves/
+    /// </summary>
+    public const int MaxNumberOfPossibleMovesInAPosition = 250;
+
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -6,6 +6,8 @@ public sealed class Game
 {
     private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
+    public Move[] MovePool { get; } = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+
     public List<Move> MoveHistory { get; }
     public List<Position> PositionHistory { get; }
     public Dictionary<long, int> PositionHashHistory { get; }
@@ -33,10 +35,10 @@ public sealed class Game
 
     public Game(string fen, List<string> movesUCIString) : this(fen)
     {
-        var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
-
         foreach (var moveString in movesUCIString)
         {
+            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, MovePool);
+
             if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
             {
                 _logger.Error($"Error parsing game with fen {fen} and moves {string.Join(' ', movesUCIString)}: error detected in {moveString}");

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -35,7 +35,7 @@ public sealed class Game
     {
         foreach (var moveString in movesUCIString)
         {
-            if (!Move.TryParseFromUCIString(moveString, GetAllMoves(), out var parsedMove))
+            if (!MoveExtensions.TryParseFromUCIString(moveString, GetAllMoves(), out var parsedMove))
             {
                 _logger.Error($"Error parsing game with fen {fen} and moves {string.Join(' ', movesUCIString)}: error detected in {moveString}");
                 break;

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -33,9 +33,11 @@ public sealed class Game
 
     public Game(string fen, List<string> movesUCIString) : this(fen)
     {
+        var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
+
         foreach (var moveString in movesUCIString)
         {
-            if (!MoveExtensions.TryParseFromUCIString(moveString, GetAllMoves(), out var parsedMove))
+            if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
             {
                 _logger.Error($"Error parsing game with fen {fen} and moves {string.Join(' ', movesUCIString)}: error detected in {moveString}");
                 break;
@@ -44,9 +46,6 @@ public sealed class Game
             MakeMove(parsedMove.Value);
         }
     }
-
-    public List<Move> GetAllMoves() => MoveGenerator.GenerateAllMoves(CurrentPosition);
-    public List<Move> GetAllMovesWithCaptures() => MoveGenerator.GenerateAllMoves(CurrentPosition, capturesOnly: true);
 
     public bool MakeMove(Move moveToPlay)
     {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -64,7 +64,7 @@ public static class MoveExtensions
     /// <exception cref="InvalidOperationException"></exception>
     /// <exception cref="IndexOutOfRangeException"></exception>
     /// <returns></returns>
-    public static bool TryParseFromUCIString(string UCIString, List<Move> moveList, [NotNullWhen(true)] out Move? move)
+    public static bool TryParseFromUCIString(string UCIString, IEnumerable<Move> moveList, [NotNullWhen(true)] out Move? move)
     {
         Utils.Assert(UCIString.Length == 4 || UCIString.Length == 5);
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -5,27 +5,29 @@ using System.Text;
 
 namespace Lynx.Model;
 
-public readonly struct Move
+/// <summary>
+/// <para>int Value:</para>
+/// <para>
+///     Binary move bits            Hexadecimal
+/// 0000 0000 0000 0000 0000 0011 1111      0x3F        Source square (63 bits)
+/// 0000 0000 0000 0000 1111 1100 0000      0xFC0       Target Square (63 bits)
+/// 0000 0000 0000 1111 0000 0000 0000      0xF000      Piece (11 bits)
+/// 0000 0000 1111 0000 0000 0000 0000      0xF0000     Promoted piece (~11 bits)
+/// 0000 0001 0000 0000 0000 0000 0000      0x10_0000   Capture flag
+/// 0000 0010 0000 0000 0000 0000 0000      0x20_0000   Double pawn push flag
+/// 0000 0100 0000 0000 0000 0000 0000      0x40_0000   Enpassant flag
+/// 0000 1000 0000 0000 0000 0000 0000      0x80_0000   Short castling flag
+/// 0001 0000 0000 0000 0000 0000 0000      0x100_0000  Long castling flag
+/// Total: 24 bits -> fits an int
+/// Could be reduced to 16 bits -> see https://www.chessprogramming.org/Encoding_Moves
+/// </para>
+/// </summary>
+/// </summary>
+public static class MoveExtensions
 {
     public const int CaptureBaseScore = 100_000;
 
     private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
-
-    /// <summary>
-    ///     Binary move bits            Hexadecimal
-    /// 0000 0000 0000 0000 0000 0011 1111      0x3F        Source square (63 bits)
-    /// 0000 0000 0000 0000 1111 1100 0000      0xFC0       Target Square (63 bits)
-    /// 0000 0000 0000 1111 0000 0000 0000      0xF000      Piece (11 bits)
-    /// 0000 0000 1111 0000 0000 0000 0000      0xF0000     Promoted piece (~11 bits)
-    /// 0000 0001 0000 0000 0000 0000 0000      0x10_0000   Capture flag
-    /// 0000 0010 0000 0000 0000 0000 0000      0x20_0000   Double pawn push flag
-    /// 0000 0100 0000 0000 0000 0000 0000      0x40_0000   Enpassant flag
-    /// 0000 1000 0000 0000 0000 0000 0000      0x80_0000   Short castling flag
-    /// 0001 0000 0000 0000 0000 0000 0000      0x100_0000  Long castling flag
-    /// Total: 24 bits -> fits an int
-    /// Could be reduced to 16 bits -> see https://www.chessprogramming.org/Encoding_Moves
-    /// </summary>
-    public int EncodedMove { get; }
 
     /// <summary>
     /// 'Encode' constractor
@@ -40,12 +42,12 @@ public readonly struct Move
     /// <param name="isShortCastle"></param>
     /// <param name="isLongCastle"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Move(
+    public static Move New(
         int sourceSquare, int targetSquare, int piece, int promotedPiece = default,
         int isCapture = default, int isDoublePawnPush = default, int isEnPassant = default,
         int isShortCastle = default, int isLongCastle = default)
     {
-        EncodedMove = sourceSquare | (targetSquare << 6) | (piece << 12) | (promotedPiece << 16)
+        return sourceSquare | (targetSquare << 6) | (piece << 12) | (promotedPiece << 16)
             | (isCapture << 20)
             | (isDoublePawnPush << 21)
             | (isEnPassant << 22)
@@ -113,34 +115,34 @@ public readonly struct Move
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int SourceSquare() => EncodedMove & 0x3F;
+    public static int SourceSquare(this Move move) => move & 0x3F;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int TargetSquare() => (EncodedMove & 0xFC0) >> 6;
+    public static int TargetSquare(this Move move) => (move & 0xFC0) >> 6;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int Piece() => (EncodedMove & 0xF000) >> 12;
+    public static int Piece(this Move move) => (move & 0xF000) >> 12;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int PromotedPiece() => (EncodedMove & 0xF0000) >> 16;
+    public static int PromotedPiece(this Move move) => (move & 0xF0000) >> 16;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsCapture() => (EncodedMove & 0x10_0000) >> 20 != default;
+    public static bool IsCapture(this Move move) => (move & 0x10_0000) >> 20 != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsDoublePawnPush() => (EncodedMove & 0x20_0000) >> 21 != default;
+    public static bool IsDoublePawnPush(this Move move) => (move & 0x20_0000) >> 21 != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsEnPassant() => (EncodedMove & 0x40_0000) >> 22 != default;
+    public static bool IsEnPassant(this Move move) => (move & 0x40_0000) >> 22 != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsShortCastle() => (EncodedMove & 0x80_0000) >> 23 != default;
+    public static bool IsShortCastle(this Move move) => (move & 0x80_0000) >> 23 != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsLongCastle() => (EncodedMove & 0x100_0000) >> 24 != default;
+    public static bool IsLongCastle(this Move move) => (move & 0x100_0000) >> 24 != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly bool IsCastle() => (EncodedMove & 0x180_0000) >> 23 != default;
+    public static bool IsCastle(this Move move) => (move & 0x180_0000) >> 23 != default;
 
     /// <summary>
     /// Returns the score evaluation of a move taking into account <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
@@ -151,16 +153,16 @@ public readonly struct Move
     /// <param name="historyMoves"></param>
     /// <returns>The higher the score is, the more valuable is the captured piece and the less valuable is the piece that makes the such capture</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public readonly int Score(Position position, int[,]? killerMoves = null, int? plies = null, int[,]? historyMoves = null)
+    public static int Score(this Move move, Position position, int[,]? killerMoves = null, int? plies = null, int[,]? historyMoves = null)
     {
         int score = 0;
 
-        if (IsCapture())
+        if (move.IsCapture())
         {
-            var sourcePiece = Piece();
+            var sourcePiece = move.Piece();
             int targetPiece = (int)Model.Piece.P;    // Important to initialize to P or p, due to en-passant captures
 
-            var targetSquare = TargetSquare();
+            var targetSquare = move.TargetSquare();
             var oppositeSide = Utils.OppositeSide(position.Side);
             var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
             var oppositePawnIndex = (int)Model.Piece.P + oppositeSideOffset;
@@ -182,13 +184,13 @@ public readonly struct Move
             if (killerMoves is not null && plies is not null)
             {
                 // 1st killer move
-                if (killerMoves[0, plies.Value] == EncodedMove)
+                if (killerMoves[0, plies.Value] == move)
                 {
                     return EvaluationConstants.FirstKillerMoveValue;
                 }
 
                 // 2nd killer move
-                else if (killerMoves[1, plies.Value] == EncodedMove)
+                else if (killerMoves[1, plies.Value] == move)
                 {
                     return EvaluationConstants.SecondKillerMoveValue;
                 }
@@ -196,7 +198,7 @@ public readonly struct Move
                 // History move
                 else if (historyMoves is not null)
                 {
-                    return historyMoves[Piece(), TargetSquare()];
+                    return historyMoves[move.Piece(), move.TargetSquare()];
                 }
             }
         }
@@ -204,18 +206,18 @@ public readonly struct Move
         return score;
     }
 
-    public override string ToString()
+    public static string ToString(this Move move)
     {
 #pragma warning disable S3358 // Ternary operators should not be nested
-        return IsCastle() == default
+        return move.IsCastle() == default
             ?
-                Constants.AsciiPieces[Piece()] +
-                Constants.Coordinates[SourceSquare()] +
-                (IsCapture() == default ? "" : "x") +
-                Constants.Coordinates[TargetSquare()] +
-                (PromotedPiece() == default ? "" : $"={Constants.AsciiPieces[PromotedPiece()]}") +
-                (IsEnPassant() == default ? "" : "e.p.")
-            : (IsShortCastle() ? "O-O" : "O-O-O");
+                Constants.AsciiPieces[move.Piece()] +
+                Constants.Coordinates[move.SourceSquare()] +
+                (move.IsCapture() == default ? "" : "x") +
+                Constants.Coordinates[move.TargetSquare()] +
+                (move.PromotedPiece() == default ? "" : $"={Constants.AsciiPieces[move.PromotedPiece()]}") +
+                (move.IsEnPassant() == default ? "" : "e.p.")
+            : (move.IsShortCastle() ? "O-O" : "O-O-O");
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
 
@@ -223,35 +225,35 @@ public readonly struct Move
     /// Typical format when humans write moves
     /// </summary>
     /// <returns></returns>
-    public string ToEPDString()
+    public static string ToEPDString(this Move move)
     {
-        var piece = Piece();
+        var piece = move.Piece();
 #pragma warning disable S3358 // Ternary operators should not be nested
-        return IsCastle() == default
+        return move.IsCastle() == default
             ?
-                ((piece == (int)Model.Piece.P || piece == (int)Model.Piece.p) && !IsCapture() ? "" : char.ToUpperInvariant(Constants.AsciiPieces[Piece()])) +
-                (IsCapture() == default ? "" : "x") +
-                Constants.Coordinates[TargetSquare()] +
-                (PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[PromotedPiece()])}") +
-                (IsEnPassant() == default ? "" : "e.p.")
-            : (IsShortCastle() ? "O-O" : "O-O-O");
+                ((piece == (int)Model.Piece.P || piece == (int)Model.Piece.p) && !move.IsCapture() ? "" : char.ToUpperInvariant(Constants.AsciiPieces[move.Piece()])) +
+                (move.IsCapture() == default ? "" : "x") +
+                Constants.Coordinates[move.TargetSquare()] +
+                (move.PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[move.PromotedPiece()])}") +
+                (move.IsEnPassant() == default ? "" : "e.p.")
+            : (move.IsShortCastle() ? "O-O" : "O-O-O");
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
 
-    public readonly void Print()
+    public static void Print(this Move move)
     {
-        Console.WriteLine(ToString());
+        Console.WriteLine(move.ToString());
     }
 
-    public string UCIString()
+    public static string UCIString(this Move move)
     {
         return
-            Constants.Coordinates[SourceSquare()] +
-            Constants.Coordinates[TargetSquare()] +
-            (PromotedPiece() == default ? "" : $"{Constants.AsciiPieces[PromotedPiece()].ToString().ToLowerInvariant()}");
+            Constants.Coordinates[move.SourceSquare()] +
+            Constants.Coordinates[move.TargetSquare()] +
+            (move.PromotedPiece() == default ? "" : $"{Constants.AsciiPieces[move.PromotedPiece()].ToString().ToLowerInvariant()}");
     }
 
-    public static void PrintMoveList(IEnumerable<Move> moves)
+    public static void PrintMoveList(this IEnumerable<Move> moves)
     {
         Console.WriteLine($"{"#",-3}{"Pc",-3}{"src",-4}{"x",-2}{"tgt",-4}{"DPP",-4}{"ep",-3}{"O-O",-4}{"O-O-O",-7}\n");
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -42,7 +42,7 @@ public static class MoveExtensions
     /// <param name="isShortCastle"></param>
     /// <param name="isLongCastle"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Move New(
+    public static Move Encode(
         int sourceSquare, int targetSquare, int piece, int promotedPiece = default,
         int isCapture = default, int isDoublePawnPush = default, int isEnPassant = default,
         int isShortCastle = default, int isLongCastle = default)

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -450,10 +450,10 @@ public sealed class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public List<Move> AllPossibleMoves() => MoveGenerator.GenerateAllMoves(this);
+    public IEnumerable<Move> AllPossibleMoves() => MoveGenerator.GenerateAllMoves(this);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public List<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
+    public IEnumerable<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
 
     /// <summary>
     /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -450,10 +450,10 @@ public sealed class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllPossibleMoves() => MoveGenerator.GenerateAllMoves(this);
+    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllCapturesMoves() => MoveGenerator.GenerateAllMoves(this, capturesOnly: true);
+    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
     /// <summary>
     /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -95,14 +95,14 @@ public static class MoveGenerator
                 var targetRank = (singlePushSquare / 8) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
-                    yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                    yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                    yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                    yield return new Move(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                 }
                 else if (!capturesOnly)
                 {
-                    yield return new Move(sourceSquare, singlePushSquare, piece);
+                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece);
                 }
 
                 // Double pawn push
@@ -113,7 +113,7 @@ public static class MoveGenerator
                     if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
                         && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
                     {
-                        yield return new Move(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                        yield return MoveExtensions.New(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
                     }
                 }
             }
@@ -124,7 +124,7 @@ public static class MoveGenerator
             if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
             // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
             {
-                yield return new Move(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+                yield return MoveExtensions.New(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
             }
 
             // Captures
@@ -137,14 +137,14 @@ public static class MoveGenerator
                 var targetRank = (targetSquare / 8) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
-                    yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-                    yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-                    yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-                    yield return new Move(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
                 }
                 else
                 {
-                    yield return new Move(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
             }
         }
@@ -178,7 +178,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
                 {
-                    yield return new Move(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
 
                 if (((position.Castle & (int)CastlingRights.WQ) != default)
@@ -189,7 +189,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
                 {
-                    yield return new Move(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
             }
             else
@@ -202,7 +202,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
                 {
-                    yield return new Move(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
 
                 if (((position.Castle & (int)CastlingRights.BQ) != default)
@@ -213,7 +213,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
                 {
-                    yield return new Move(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
             }
         }
@@ -247,11 +247,11 @@ public static class MoveGenerator
 
                 if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
                 {
-                    yield return new Move(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
                 else if (!capturesOnly)
                 {
-                    yield return new Move(sourceSquare, targetSquare, piece);
+                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece);
                 }
             }
         }

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -10,6 +10,11 @@ public static class MoveGenerator
 
     private const int TRUE = 1;
 
+    private static int MoveIndex;
+    private static Move[] MovePool { get; } = new Move[218];
+
+    public static IEnumerable<Move> GeneratedMoves => MovePool.Take(MoveIndex);
+
     /// <summary>
     /// Indexed by <see cref="Piece"/>.
     /// Checks are not considered
@@ -50,20 +55,224 @@ public static class MoveGenerator
 #endif
         var offset = Utils.PieceOffset(position.Side);
 
-        var moves = new List<Move>(150);
-        moves.AddRange(GeneratePawnMoves(position, offset, capturesOnly));
-        moves.AddRange(GenerateCastlingMoves(position, offset));
-        moves.AddRange(GeneratePieceMoves((int)Piece.K + offset, position, capturesOnly));
-        moves.AddRange(GeneratePieceMoves((int)Piece.N + offset, position, capturesOnly));
-        moves.AddRange(GeneratePieceMoves((int)Piece.B + offset, position, capturesOnly));
-        moves.AddRange(GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly));
-        moves.AddRange(GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly));
+        MoveIndex = 0;
+        GeneratePawnMoves(position, offset, capturesOnly);
+        GenerateCastlingMoves(position, offset);
+        GeneratePieceMoves((int)Piece.K + offset, position, capturesOnly);
+        GeneratePieceMoves((int)Piece.N + offset, position, capturesOnly);
+        GeneratePieceMoves((int)Piece.B + offset, position, capturesOnly);
+        GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly);
+        GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly);
 
-        return moves;
+        return GeneratedMoves.ToList();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GeneratePawnMoves(Position position, int offset, bool capturesOnly = false)
+    internal static void GeneratePawnMoves(Position position, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece].Board;
+
+        while (bitboard != default)
+        {
+            sourceSquare = BitBoard.GetLS1BIndex(bitboard);
+            bitboard = BitBoard.ResetLS1B(bitboard);
+
+            var sourceRank = (sourceSquare / 8) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn($"There's a non-promoted {position.Side} pawn in rank {sourceRank}");
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                    {
+                        MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            ulong attackedSquares = attacks.Board & position.OccupancyBitBoards[oppositeSide].Board;
+            while (attackedSquares != default)
+            {
+                targetSquare = BitBoard.GetLS1BIndex(attackedSquares);
+                attackedSquares = BitBoard.ResetLS1B(attackedSquares);
+
+                var targetRank = (targetSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceMoves(int piece, Position position, bool capturesOnly = false)
+    {
+        var bitboard = position.PieceBitBoards[piece].Board;
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = BitBoard.GetLS1BIndex(bitboard);
+            bitboard = BitBoard.ResetLS1B(bitboard);
+
+            ulong attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side].Board;
+
+            while (attacks != default)
+            {
+                targetSquare = BitBoard.GetLS1BIndex(attacks);
+                attacks = BitBoard.ResetLS1B(attacks);
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    MovePool[MoveIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
+    #region Only for reference, but unused
+
+    /// <summary>
+    /// Sames as <see cref="GeneratePawnMoves(Position, int, bool)"/> but returning them
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GeneratePawnMovesForReference(Position position, int offset, bool capturesOnly = false)
     {
         int sourceSquare, targetSquare;
 
@@ -151,14 +360,13 @@ public static class MoveGenerator
     }
 
     /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// Same as <see cref="GenerateCastlingMoves(Position, int)"/> but returning them
     /// </summary>
     /// <param name="position"></param>
     /// <param name="offset"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateCastlingMoves(Position position, int offset)
+    internal static IEnumerable<Move> GenerateCastlingMovesForReference(Position position, int offset)
     {
         var piece = (int)Piece.K + offset;
         var oppositeSide = (Side)Utils.OppositeSide(position.Side);
@@ -219,15 +427,55 @@ public static class MoveGenerator
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GenerateKingMoves(Position position, bool capturesOnly = false)
+    {
+        var offset = Utils.PieceOffset(position.Side);
+
+        return GeneratePieceMovesForReference((int)Piece.K + offset, position, capturesOnly);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GenerateKnightMoves(Position position, bool capturesOnly = false)
+    {
+        var offset = Utils.PieceOffset(position.Side);
+
+        return GeneratePieceMovesForReference((int)Piece.N + offset, position, capturesOnly);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GenerateBishopMoves(Position position, bool capturesOnly = false)
+    {
+        var offset = Utils.PieceOffset(position.Side);
+
+        return GeneratePieceMovesForReference((int)Piece.B + offset, position, capturesOnly);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GenerateRookMoves(Position position, bool capturesOnly = false)
+    {
+        var offset = Utils.PieceOffset(position.Side);
+
+        return GeneratePieceMovesForReference((int)Piece.R + offset, position, capturesOnly);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static IEnumerable<Move> GenerateQueenMoves(Position position, bool capturesOnly = false)
+    {
+        var offset = Utils.PieceOffset(position.Side);
+
+        return GeneratePieceMovesForReference((int)Piece.Q + offset, position, capturesOnly);
+    }
+
     /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
+    /// Same as <see cref="GeneratePieceMoves(int, Position, bool)"/> but returning them
     /// </summary>
     /// <param name="piece"><see cref="Piece"/></param>
     /// <param name="position"></param>
     /// <param name="capturesOnly"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GeneratePieceMoves(int piece, Position position, bool capturesOnly = false)
+    internal static IEnumerable<Move> GeneratePieceMovesForReference(int piece, Position position, bool capturesOnly = false)
     {
         var bitboard = position.PieceBitBoards[piece].Board;
         int sourceSquare, targetSquare;
@@ -255,48 +503,6 @@ public static class MoveGenerator
                 }
             }
         }
-    }
-
-    #region Only for reference, but unused
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateKingMoves(Position position, bool capturesOnly = false)
-    {
-        var offset = Utils.PieceOffset(position.Side);
-
-        return GeneratePieceMoves((int)Piece.K + offset, position, capturesOnly);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateKnightMoves(Position position, bool capturesOnly = false)
-    {
-        var offset = Utils.PieceOffset(position.Side);
-
-        return GeneratePieceMoves((int)Piece.N + offset, position, capturesOnly);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateBishopMoves(Position position, bool capturesOnly = false)
-    {
-        var offset = Utils.PieceOffset(position.Side);
-
-        return GeneratePieceMoves((int)Piece.B + offset, position, capturesOnly);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateRookMoves(Position position, bool capturesOnly = false)
-    {
-        var offset = Utils.PieceOffset(position.Side);
-
-        return GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static IEnumerable<Move> GenerateQueenMoves(Position position, bool capturesOnly = false)
-    {
-        var offset = Utils.PieceOffset(position.Side);
-
-        return GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly);
     }
 
     #endregion

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -95,14 +95,14 @@ public static class MoveGenerator
                 var targetRank = (singlePushSquare / 8) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
-                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                    yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                 }
                 else if (!capturesOnly)
                 {
-                    yield return MoveExtensions.New(sourceSquare, singlePushSquare, piece);
+                    yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
                 }
 
                 // Double pawn push
@@ -113,7 +113,7 @@ public static class MoveGenerator
                     if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
                         && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
                     {
-                        yield return MoveExtensions.New(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                        yield return MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
                     }
                 }
             }
@@ -124,7 +124,7 @@ public static class MoveGenerator
             if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
             // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
             {
-                yield return MoveExtensions.New(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+                yield return MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
             }
 
             // Captures
@@ -137,14 +137,14 @@ public static class MoveGenerator
                 var targetRank = (targetSquare / 8) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
                 }
                 else
                 {
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
             }
         }
@@ -178,7 +178,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
                 {
-                    yield return MoveExtensions.New(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
 
                 if (((position.Castle & (int)CastlingRights.WQ) != default)
@@ -189,7 +189,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
                 {
-                    yield return MoveExtensions.New(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
             }
             else
@@ -202,7 +202,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
                 {
-                    yield return MoveExtensions.New(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
 
                 if (((position.Castle & (int)CastlingRights.BQ) != default)
@@ -213,7 +213,7 @@ public static class MoveGenerator
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
                     && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
                 {
-                    yield return MoveExtensions.New(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
             }
         }
@@ -247,11 +247,11 @@ public static class MoveGenerator
 
                 if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
                 {
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
                 else if (!capturesOnly)
                 {
-                    yield return MoveExtensions.New(sourceSquare, targetSquare, piece);
+                    yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece);
                 }
             }
         }

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -45,7 +45,7 @@ public static class MoveGenerator
     /// <param name="capturesOnly">Filters out all moves but captures</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static List<Move> GenerateAllMoves(Position position, bool capturesOnly = false)
+    public static IEnumerable<Move> GenerateAllMoves(Position position, bool capturesOnly = false)
     {
 #if DEBUG
         if (position.Side == Side.Both)
@@ -64,7 +64,7 @@ public static class MoveGenerator
         GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly);
         GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly);
 
-        return GeneratedMoves.ToList();
+        return GeneratedMoves;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -96,7 +96,7 @@ public sealed partial class Engine
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               position.AllPossibleMoves(),
+               position.AllPossibleMoves(Game.MovePool),
                out _))
             {
                 var message = $"Unexpected PV move {move.UCIString()} from position {position.FEN}";

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -35,7 +35,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int moveIndex = 0; moveIndex < moves.Count; ++moveIndex)
             {
-                if (moves[moveIndex].EncodedMove == _pVTable[depth].EncodedMove)
+                if (moves[moveIndex] == _pVTable[depth])
                 {
                     _isFollowingPV = true;
                     _isScoringPV = true;
@@ -49,7 +49,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int Score(Move move, Position position, int depth)
     {
-        if (_isScoringPV && move.EncodedMove == _pVTable[depth].EncodedMove)
+        if (_isScoringPV && move == _pVTable[depth])
         {
             _isScoringPV = false;
 
@@ -65,7 +65,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
     {
-        if (_pVTable[source].EncodedMove == default)
+        if (_pVTable[source] == default)
         {
             Array.Clear(_pVTable, target, _pVTable.Length - target);
             return;
@@ -84,17 +84,17 @@ public sealed partial class Engine
         var position = Game.CurrentPosition;
         for (int i = 0; i < PVTable.Indexes[1]; ++i)
         {
-            if (_pVTable[i].EncodedMove == default)
+            if (_pVTable[i] == default)
             {
                 for (int j = i + 1; j < PVTable.Indexes[1]; ++j)
                 {
-                    Utils.Assert(_pVTable[j].EncodedMove == default, $"Not expecting a move in _pvTable[{j}]");
+                    Utils.Assert(_pVTable[j] == default, $"Not expecting a move in _pvTable[{j}]");
                 }
                 break;
             }
             var move = _pVTable[i];
 
-            if (!Move.TryParseFromUCIString(
+            if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
                position.AllPossibleMoves(),
                out _))

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -28,14 +28,14 @@ public sealed partial class Engine
     private const int MaxValue = +2 * EvaluationConstants.CheckMateEvaluation;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private List<Move> SortMoves(List<Move> moves, Position currentPosition, int depth)
+    private List<Move> SortMoves(IEnumerable<Move> moves, Position currentPosition, int depth)
     {
         if (_isFollowingPV)
         {
             _isFollowingPV = false;
-            for (int moveIndex = 0; moveIndex < moves.Count; ++moveIndex)
+            foreach (var move in moves)
             {
-                if (moves[moveIndex] == _pVTable[depth])
+                if (move == _pVTable[depth])
                 {
                     _isFollowingPV = true;
                     _isScoringPV = true;
@@ -60,7 +60,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IOrderedEnumerable<Move> SortCaptures(List<Move> moves, Position currentPosition, int depth) => moves.OrderByDescending(move => Score(move, currentPosition, depth));
+    private IOrderedEnumerable<Move> SortCaptures(IEnumerable<Move> moves, Position currentPosition, int depth) => moves.OrderByDescending(move => Score(move, currentPosition, depth));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -50,9 +50,9 @@ public sealed partial class Engine
 
         if (Game.MoveHistory.Count >= 2
             && _previousSearchResult?.Moves.Count >= 2
-            && _previousSearchResult.BestMove.EncodedMove != default
-            && Game.MoveHistory[^2].EncodedMove == _previousSearchResult.Moves[0].EncodedMove
-            && Game.MoveHistory[^1].EncodedMove == _previousSearchResult.Moves[1].EncodedMove)
+            && _previousSearchResult.BestMove != default
+            && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
+            && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
         {
             _logger.Debug("Ponder hit");
 
@@ -114,7 +114,7 @@ public sealed partial class Engine
                 //PrintPvTable();
                 ValidatePVTable();
 
-                var pvMoves = _pVTable.TakeWhile(m => m.EncodedMove != default).ToList();
+                var pvMoves = _pVTable.TakeWhile(m => m != default).ToList();
                 var maxDepthReached = _maxDepthReached.LastOrDefault(item => item != default);
 
                 int mate = default;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -173,7 +173,7 @@ public sealed partial class Engine
                 if (!move.IsCapture())
                 {
                     _killerMoves[1, depth] = _killerMoves[0, depth];
-                    _killerMoves[0, depth] = move.EncodedMove;
+                    _killerMoves[0, depth] = move;
                 }
                 return beta;    // TODO return evaluation?
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -40,7 +40,7 @@ public sealed partial class Engine
 
         if (depth >= maxDepth)
         {
-            foreach (var candidateMove in position.AllPossibleMoves())
+            foreach (var candidateMove in position.AllPossibleMoves(Game.MovePool))
             {
                 if (new Position(position, candidateMove).WasProduceByAValidMove())
                 {
@@ -89,7 +89,7 @@ public sealed partial class Engine
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 
-        var pseudoLegalMoves = SortMoves(position.AllPossibleMoves(), position, depth);
+        var pseudoLegalMoves = SortMoves(position.AllPossibleMoves(Game.MovePool), position, depth);
 
         foreach (var move in pseudoLegalMoves)
         {
@@ -260,7 +260,7 @@ public sealed partial class Engine
         // Quiescence search limitation
         //if (depth >= Configuration.EngineSettings.QuiescenceSearchDepth) return alpha;
 
-        var generatedMoves = position.AllCapturesMoves();
+        var generatedMoves = position.AllCapturesMoves(Game.MovePool);
         if (!generatedMoves.Any())
         {
             return staticEvaluation;  // TODO check if in check or drawn position
@@ -312,7 +312,7 @@ public sealed partial class Engine
 
         if (bestMove is null)
         {
-            return isAnyMoveValid || position.AllPossibleMoves().Any(move => new Position(position, move).WasProduceByAValidMove())
+            return isAnyMoveValid || position.AllPossibleMoves(Game.MovePool).Any(move => new Position(position, move).WasProduceByAValidMove())
                 ? alpha
                 : Position.EvaluateFinalPosition(depth, position.IsInCheck(), Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -261,7 +261,7 @@ public sealed partial class Engine
         //if (depth >= Configuration.EngineSettings.QuiescenceSearchDepth) return alpha;
 
         var generatedMoves = position.AllCapturesMoves();
-        if (generatedMoves.Count == 0)
+        if (!generatedMoves.Any())
         {
             return staticEvaluation;  // TODO check if in check or drawn position
         }

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Lynx.UCI.Commands.Engine;
+﻿using Lynx.Model;
+
+namespace Lynx.UCI.Commands.Engine;
 
 /// <summary>
 /// info

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -65,7 +65,7 @@ public sealed class PositionCommand : GUIBaseCommand
 
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            game.CurrentPosition.AllPossibleMoves(),
+            game.CurrentPosition.AllPossibleMoves(game.MovePool),
             out lastMove))
         {
             _logger.Warn($"Error parsing last move {lastMove} from position command {positionCommand}");

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -63,7 +63,7 @@ public sealed class PositionCommand : GUIBaseCommand
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Last();
 
-        if (!Move.TryParseFromUCIString(
+        if (!MoveExtensions.TryParseFromUCIString(
             moveString,
             game.CurrentPosition.AllPossibleMoves(),
             out lastMove))

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -37,15 +37,15 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                new ((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
-                new ((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
-                new ((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K),
-                new ((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                new ((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K)
+                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
+                MoveExtensions.New((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K)
             };
 
-        Move movesThatAllowsRepetition = new((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
+        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         foreach (var move in repeatedMoves)
@@ -83,16 +83,16 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                new ((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k),
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
             };
 
-        Move movesThatAllowsRepetition = new((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k);
+        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         foreach (var move in repeatedMoves)
@@ -132,13 +132,13 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                new ((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                new ((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
-                new ((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
-                new ((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K)
+                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
+                MoveExtensions.New((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K)
             };
 
-        Move movesThatAllowsRepetition = new((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
+        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         for (int i = 0; i < 98; ++i)
@@ -179,13 +179,13 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                new ((int)BoardSquare.h5, (int)BoardSquare.h6, (int)Piece.k),
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k)
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h6, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k)
             };
 
-        Move movesThatAllowsRepetition = new((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k);
+        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         for (int i = 0; i < 98; ++i)

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -37,15 +37,15 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
-                MoveExtensions.New((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K)
+                MoveExtensions.Encode((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.Encode((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
+                MoveExtensions.Encode((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.Encode((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K)
             };
 
-        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
+        Move movesThatAllowsRepetition = MoveExtensions.Encode((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         foreach (var move in repeatedMoves)
@@ -83,16 +83,16 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h6, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
             };
 
-        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k);
+        Move movesThatAllowsRepetition = MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h6, (int)Piece.k);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         foreach (var move in repeatedMoves)
@@ -132,13 +132,13 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
-                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
-                MoveExtensions.New((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K)
+                MoveExtensions.Encode((int)BoardSquare.d6, (int)BoardSquare.c7, (int)Piece.q),
+                MoveExtensions.Encode((int)BoardSquare.h5, (int)BoardSquare.h4, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q),
+                MoveExtensions.Encode((int)BoardSquare.h4, (int)BoardSquare.h5, (int)Piece.K)
             };
 
-        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
+        Move movesThatAllowsRepetition = MoveExtensions.Encode((int)BoardSquare.c7, (int)BoardSquare.d6, (int)Piece.q);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         for (int i = 0; i < 98; ++i)
@@ -179,13 +179,13 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h5, (int)BoardSquare.h6, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k)
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h5, (int)BoardSquare.h6, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k)
             };
 
-        Move movesThatAllowsRepetition = MoveExtensions.New((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k);
+        Move movesThatAllowsRepetition = MoveExtensions.Encode((int)BoardSquare.h6, (int)BoardSquare.h5, (int)Piece.k);
 
         var sb = new StringBuilder($"position fen {fen} moves");
         for (int i = 0; i < 98; ++i)

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -1,4 +1,5 @@
-﻿using Lynx.UCI.Commands.GUI;
+﻿using Lynx.Model;
+using Lynx.UCI.Commands.GUI;
 using NUnit.Framework;
 
 namespace Lynx.Test.BestMove;
@@ -273,6 +274,6 @@ public class RegressionTest : BaseTest
 
         searchResult = engine.BestMove();
 
-        Assert.NotZero(searchResult.BestMove.EncodedMove);
+        Assert.NotZero(searchResult.BestMove);
     }
 }

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -1,5 +1,6 @@
 ﻿// WACData source: http://www.talkchess.com/forum3/viewtopic.php?f=2&t=67469",
 
+using Lynx.Model;
 using Lynx.UCI.Commands.GUI;
 using NUnit.Framework;
 

--- a/tests/Lynx.Test/Commands/StopCommandTest.cs
+++ b/tests/Lynx.Test/Commands/StopCommandTest.cs
@@ -30,7 +30,7 @@ public class StopCommandTest
         engine.StopSearching();
 
         // Assert
-        Assert.AreNotEqual(default, (await resultTask).BestMove.EncodedMove);
+        Assert.AreNotEqual(default, (await resultTask).BestMove);
 
         Assert.AreEqual(initialPositionFEN, engine.Game.CurrentPosition.FEN);
         Assert.IsEmpty(engine.Game.MoveHistory);

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -64,6 +64,6 @@ public class MoveScoreTest
         var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(position)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(Move.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(position));
+        Assert.AreEqual(MoveExtensions.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(position));
     }
 }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -96,7 +96,7 @@ public class PositionTest
     public void CustomIsValid()
     {
         var origin = new Position("r2k4/1K6/8/8/8/8/8/8 b - - 0 1");
-        var move = new Move((int)BoardSquare.b7, (int)BoardSquare.a8, (int)Piece.K, isCapture: 1);
+        var move = MoveExtensions.New((int)BoardSquare.b7, (int)BoardSquare.a8, (int)Piece.K, isCapture: 1);
 
         Assert.NotNull(new Position(origin, move));
     }
@@ -167,17 +167,17 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                new ((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                new ((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),   // Triple position repetition
-                new ((int)BoardSquare.f2, (int)BoardSquare.a2, (int)Piece.R),   // Other random move
-                new ((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)    // Mate
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),   // Triple position repetition
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.a2, (int)Piece.R),   // Other random move
+                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)    // Mate
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -197,14 +197,14 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                new ((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                new ((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                new ((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
-                new ((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                new ((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                new ((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                new ((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -225,14 +225,14 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
-                new ((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                new ((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
-                new ((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
-                new ((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
-                new ((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                new ((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
-                new ((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
+                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
+                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -247,14 +247,14 @@ public class PositionTest
         game = new Game(winningPosition);
         repeatedMoves = new List<Move>
             {
-                new ((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
-                new ((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                new ((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
-                new ((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
-                new ((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
-                new ((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                new ((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
-                new ((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
+                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
+                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.New((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
             };
 
         // Act
@@ -283,10 +283,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                new ((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                new ((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                new ((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                new ((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k)
+                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k)
             };
 
         for (int i = 0; i < 98; ++i)
@@ -296,7 +296,7 @@ public class PositionTest
 
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[2]));
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[3]));
-        Assert.True(game.MakeMove(new Move((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)));   // Mate on move 51
+        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)));   // Mate on move 51
 
         Assert.AreEqual(101, game.MoveHistory.Count);
 
@@ -313,10 +313,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                new ((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                new ((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                new ((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                new ((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
+                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
             };
 
         for (int i = 0; i < 100; ++i)
@@ -339,10 +339,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                new ((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                new ((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                new ((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                new ((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
+                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
             };
 
         for (int i = 0; i < 48; ++i)
@@ -350,8 +350,8 @@ public class PositionTest
             Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[i % nonCaptureOrPawnMoveMoves.Count]));
         }
 
-        Assert.True(game.MakeMove(new((int)BoardSquare.h2, (int)BoardSquare.h1, (int)Piece.p, promotedPiece: (int)(Piece.q))));   // Promotion
-        Assert.True(game.MakeMove(new((int)BoardSquare.b3, (int)BoardSquare.c4, (int)Piece.K)));
+        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.h2, (int)BoardSquare.h1, (int)Piece.p, promotedPiece: (int)(Piece.q))));   // Promotion
+        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.c4, (int)Piece.K)));
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[2]));
 
         Assert.AreEqual(51, game.MoveHistory.Count);

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -96,7 +96,7 @@ public class PositionTest
     public void CustomIsValid()
     {
         var origin = new Position("r2k4/1K6/8/8/8/8/8/8 b - - 0 1");
-        var move = MoveExtensions.New((int)BoardSquare.b7, (int)BoardSquare.a8, (int)Piece.K, isCapture: 1);
+        var move = MoveExtensions.Encode((int)BoardSquare.b7, (int)BoardSquare.a8, (int)Piece.K, isCapture: 1);
 
         Assert.NotNull(new Position(origin, move));
     }
@@ -167,17 +167,17 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),   // Triple position repetition
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.a2, (int)Piece.R),   // Other random move
-                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)    // Mate
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),   // Triple position repetition
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.a2, (int)Piece.R),   // Other random move
+                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)    // Mate
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -197,14 +197,14 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K),
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -225,14 +225,14 @@ public class PositionTest
         var game = new Game(winningPosition);
         var repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
-                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
-                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
+                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
+                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
             };
 
         repeatedMoves.ForEach(move => Assert.True(game.MakeMove(move)));
@@ -247,14 +247,14 @@ public class PositionTest
         game = new Game(winningPosition);
         repeatedMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
-                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
-                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.New((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
+                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
+                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+                MoveExtensions.Encode((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)
             };
 
         // Act
@@ -283,10 +283,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.New((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.New((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k)
+                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
+                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
+                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k)
             };
 
         for (int i = 0; i < 98; ++i)
@@ -296,7 +296,7 @@ public class PositionTest
 
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[2]));
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[3]));
-        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)));   // Mate on move 51
+        Assert.True(game.MakeMove(MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.h2, (int)Piece.R)));   // Mate on move 51
 
         Assert.AreEqual(101, game.MoveHistory.Count);
 
@@ -313,10 +313,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
+                MoveExtensions.Encode((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
             };
 
         for (int i = 0; i < 100; ++i)
@@ -339,10 +339,10 @@ public class PositionTest
         var game = new Game(winningPosition);
         var nonCaptureOrPawnMoveMoves = new List<Move>
             {
-                MoveExtensions.New((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
-                MoveExtensions.New((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
-                MoveExtensions.New((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
+                MoveExtensions.Encode((int)BoardSquare.a1, (int)BoardSquare.b1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.b3, (int)BoardSquare.a2, (int)Piece.K),
+                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.a1, (int)Piece.r),
+                MoveExtensions.Encode((int)BoardSquare.a2, (int)BoardSquare.b3, (int)Piece.K)
             };
 
         for (int i = 0; i < 48; ++i)
@@ -350,8 +350,8 @@ public class PositionTest
             Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[i % nonCaptureOrPawnMoveMoves.Count]));
         }
 
-        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.h2, (int)BoardSquare.h1, (int)Piece.p, promotedPiece: (int)(Piece.q))));   // Promotion
-        Assert.True(game.MakeMove(MoveExtensions.New((int)BoardSquare.b3, (int)BoardSquare.c4, (int)Piece.K)));
+        Assert.True(game.MakeMove(MoveExtensions.Encode((int)BoardSquare.h2, (int)BoardSquare.h1, (int)Piece.p, promotedPiece: (int)(Piece.q))));   // Promotion
+        Assert.True(game.MakeMove(MoveExtensions.Encode((int)BoardSquare.b3, (int)BoardSquare.c4, (int)Piece.K)));
         Assert.True(game.MakeMove(nonCaptureOrPawnMoveMoves[2]));
 
         Assert.AreEqual(51, game.MoveHistory.Count);

--- a/tests/Lynx.Test/MoveGeneration/EncodeDecodeMoveTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/EncodeDecodeMoveTest.cs
@@ -27,7 +27,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.b8, BoardSquare.c6, Piece.n, false)]
     public void SourceSquare_TargetSquare_Piece_Capture(BoardSquare sourceSquare, BoardSquare targetSquare, Piece piece, bool isCapture)
     {
-        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)piece, isCapture: isCapture ? 1 : 0);
+        var move = MoveExtensions.Encode((int)sourceSquare, (int)targetSquare, (int)piece, isCapture: isCapture ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -51,7 +51,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.a2, BoardSquare.a1, Piece.n)]
     public void Promotion(BoardSquare sourceSquare, BoardSquare targetSquare, Piece promotedPiece)
     {
-        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, promotedPiece: (int)promotedPiece);
+        var move = MoveExtensions.Encode((int)sourceSquare, (int)targetSquare, (int)Piece.P, promotedPiece: (int)promotedPiece);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -64,7 +64,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.e4, BoardSquare.d3, true)]
     public void EnPassant(BoardSquare sourceSquare, BoardSquare targetSquare, bool enPassant)
     {
-        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, isEnPassant: enPassant ? 1 : 0);
+        var move = MoveExtensions.Encode((int)sourceSquare, (int)targetSquare, (int)Piece.P, isEnPassant: enPassant ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -79,7 +79,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.e8, BoardSquare.e7, false, false)]
     public void Castling(BoardSquare sourceSquare, BoardSquare targetSquare, bool isShortCastle, bool isLongCastle)
     {
-        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.K,
+        var move = MoveExtensions.Encode((int)sourceSquare, (int)targetSquare, (int)Piece.K,
             isShortCastle: isShortCastle ? 1 : 0, isLongCastle: isLongCastle ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
@@ -96,7 +96,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.g7, BoardSquare.g5)]
     public void DoublePawnPush(BoardSquare sourceSquare, BoardSquare targetSquare)
     {
-        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, isDoublePawnPush: 1);
+        var move = MoveExtensions.Encode((int)sourceSquare, (int)targetSquare, (int)Piece.P, isDoublePawnPush: 1);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());

--- a/tests/Lynx.Test/MoveGeneration/EncodeDecodeMoveTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/EncodeDecodeMoveTest.cs
@@ -27,7 +27,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.b8, BoardSquare.c6, Piece.n, false)]
     public void SourceSquare_TargetSquare_Piece_Capture(BoardSquare sourceSquare, BoardSquare targetSquare, Piece piece, bool isCapture)
     {
-        var move = new Move((int)sourceSquare, (int)targetSquare, (int)piece, isCapture: isCapture ? 1 : 0);
+        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)piece, isCapture: isCapture ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -51,7 +51,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.a2, BoardSquare.a1, Piece.n)]
     public void Promotion(BoardSquare sourceSquare, BoardSquare targetSquare, Piece promotedPiece)
     {
-        var move = new Move((int)sourceSquare, (int)targetSquare, (int)Piece.P, promotedPiece: (int)promotedPiece);
+        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, promotedPiece: (int)promotedPiece);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -64,7 +64,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.e4, BoardSquare.d3, true)]
     public void EnPassant(BoardSquare sourceSquare, BoardSquare targetSquare, bool enPassant)
     {
-        var move = new Move((int)sourceSquare, (int)targetSquare, (int)Piece.P, isEnPassant: enPassant ? 1 : 0);
+        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, isEnPassant: enPassant ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());
@@ -79,7 +79,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.e8, BoardSquare.e7, false, false)]
     public void Castling(BoardSquare sourceSquare, BoardSquare targetSquare, bool isShortCastle, bool isLongCastle)
     {
-        var move = new Move((int)sourceSquare, (int)targetSquare, (int)Piece.K,
+        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.K,
             isShortCastle: isShortCastle ? 1 : 0, isLongCastle: isLongCastle ? 1 : 0);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
@@ -96,7 +96,7 @@ public class EncodeDecodeMoveTest
     [TestCase(BoardSquare.g7, BoardSquare.g5)]
     public void DoublePawnPush(BoardSquare sourceSquare, BoardSquare targetSquare)
     {
-        var move = new Move((int)sourceSquare, (int)targetSquare, (int)Piece.P, isDoublePawnPush: 1);
+        var move = MoveExtensions.New((int)sourceSquare, (int)targetSquare, (int)Piece.P, isDoublePawnPush: 1);
 
         Assert.AreEqual((int)sourceSquare, move.SourceSquare());
         Assert.AreEqual((int)targetSquare, move.TargetSquare());

--- a/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
@@ -17,7 +17,7 @@ public class GenerateBishopMovesTest
     {
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
-        var moves = MoveGenerator.GeneratePieceMoves((int)Piece.B + offset, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference((int)Piece.B + offset, position);
 
         Assert.AreEqual(expectedMoves, moves.Count());
 
@@ -44,7 +44,7 @@ public class GenerateBishopMovesTest
         var position = new Position(Constants.TrickyTestPositionFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.B + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(11, moves.Count(m => m.Piece() == piece));
 
@@ -113,7 +113,7 @@ public class GenerateBishopMovesTest
         var position = new Position(Constants.TrickyTestPositionReversedFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.B + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(8, moves.Count(m => m.Piece() == piece));
 
@@ -170,7 +170,7 @@ public class GenerateBishopMovesTest
         var position = new Position(Constants.TrickyTestPositionFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.B + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(1, moves.Count(m => m.Piece() == piece && m.IsCapture()));
 
@@ -199,7 +199,7 @@ public class GenerateBishopMovesTest
         var position = new Position(Constants.TrickyTestPositionReversedFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.B + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(1, moves.Count(m => m.Piece() == piece && m.IsCapture()));
 

--- a/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
@@ -15,7 +15,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.True(1 == moves.Count(m => m.IsCastle()));
         Assert.True(1 == moves.Count(m => m.IsShortCastle()));
@@ -32,7 +32,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.True(1 == moves.Count(m => m.IsCastle()));
         Assert.True(1 == moves.Count(m => m.IsLongCastle()));
@@ -57,7 +57,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -80,7 +80,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }
@@ -101,7 +101,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -127,7 +127,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }
@@ -142,7 +142,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -157,7 +157,7 @@ public class GenerateCastlingMovesTest
     {
         var position = new Position(fen);
 
-        var moves = MoveGenerator.GenerateCastlingMoves(position, Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GenerateCastlingMovesForReference(position, Utils.PieceOffset(position.Side));
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }

--- a/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
@@ -20,7 +20,7 @@ public class GenerateKingMovesTest
     {
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
-        var moves = MoveGenerator.GeneratePieceMoves((int)Piece.K + offset, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference((int)Piece.K + offset, position);
 
         Assert.AreEqual(expectedMoves, moves.Count());
 
@@ -47,7 +47,7 @@ public class GenerateKingMovesTest
         var position = new Position("8/6nQ/6k1/5PB1/8/2N5/nKr5/bp6 w - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.K + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(7, moves.Count(m => m.Piece() == piece));
 
@@ -100,7 +100,7 @@ public class GenerateKingMovesTest
         var position = new Position("8/6nQ/6k1/5PB1/8/2N5/nKr5/bp6 b - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.K + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(7, moves.Count(m => m.Piece() == piece));
 
@@ -153,7 +153,7 @@ public class GenerateKingMovesTest
         var position = new Position("8/6nQ/6k1/5PB1/8/2N5/nKr5/bp6 w - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.K + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(4, moves.Count(m => m.Piece() == piece));
 
@@ -194,7 +194,7 @@ public class GenerateKingMovesTest
         var position = new Position("8/6nQ/6k1/5PB1/8/2N5/nKr5/bp6 b - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.K + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(3, moves.Count(m => m.Piece() == piece));
 
@@ -230,7 +230,7 @@ public class GenerateKingMovesTest
     //    var position = new Position(fen);
     //    var offset = Utils.PieceOffset(position.Side);
     //    var piece = (int)Piece.K + offset;
-    //    var moves = MovesGenerator.GeneratePieceMoves(piece, position);
+    //    var moves = MovesGenerator.GeneratePieceMovesForReference(piece, position);
 
     //    Assert.AreEqual(expectedMoves, moves.Count(m => m.Piece() == piece));
     //}

--- a/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
@@ -17,7 +17,7 @@ public class GenerateKnightMovesTest
     {
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
-        var moves = MoveGenerator.GeneratePieceMoves((int)Piece.N + offset, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference((int)Piece.N + offset, position);
 
         Assert.AreEqual(expectedMoves, moves.Count());
 
@@ -44,7 +44,7 @@ public class GenerateKnightMovesTest
         var position = new Position(Constants.TrickyTestPositionFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.N + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(11, moves.Count(m => m.Piece() == piece));
 
@@ -113,7 +113,7 @@ public class GenerateKnightMovesTest
         var position = new Position(Constants.TrickyTestPositionReversedFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.N + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(10, moves.Count(m => m.Piece() == piece));
 
@@ -178,7 +178,7 @@ public class GenerateKnightMovesTest
         var position = new Position(Constants.TrickyTestPositionFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.N + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(3, moves.Count(m => m.Piece() == piece && m.IsCapture()));
 
@@ -215,7 +215,7 @@ public class GenerateKnightMovesTest
         var position = new Position(Constants.TrickyTestPositionReversedFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.N + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(3, moves.Count(m => m.Piece() == piece && m.IsCapture()));
 

--- a/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
@@ -12,7 +12,7 @@ public class GeneratePawnMovesTest
     {
         var position = new Position(Constants.InitialPositionFEN);
 
-        var whiteMoves = MoveGenerator.GeneratePawnMoves(position, offset: 0);
+        var whiteMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: 0);
 
         for (int square = (int)BoardSquare.a2; square <= (int)BoardSquare.h2; ++square)
         {
@@ -28,7 +28,7 @@ public class GeneratePawnMovesTest
         }
 
         position = new Position("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1");
-        var blackMoves = MoveGenerator.GeneratePawnMoves(position, offset: 6);
+        var blackMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: 6);
 
         for (int square = (int)BoardSquare.a7; square <= (int)BoardSquare.h7; ++square)
         {
@@ -55,7 +55,7 @@ public class GeneratePawnMovesTest
     public void QuietMoves_NoDoublePush(string fen, int expectedMoves)
     {
         var position = new Position(fen);
-        var moves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side));
         Assert.AreEqual(expectedMoves, moves.Count());
     }
 
@@ -64,7 +64,7 @@ public class GeneratePawnMovesTest
     {
         var position = new Position("8/8/8/8/8/1n6/PPP5/8 w - - 0 1");
 
-        var whiteMoves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side)).ToList();
+        var whiteMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side)).ToList();
 
         Assert.AreEqual(6, whiteMoves.Count);
         Assert.True(1 == whiteMoves.Count(m =>
@@ -79,7 +79,7 @@ public class GeneratePawnMovesTest
 
         position = new Position("8/ppp/1B6/8/8/8/8/8 b - - 0 1");
 
-        var blackMoves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side)).ToList();
+        var blackMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side)).ToList();
         Assert.AreEqual(6, whiteMoves.Count);
         Assert.True(1 == blackMoves.Count(m =>
             m.SourceSquare() == (int)BoardSquare.a7
@@ -97,7 +97,7 @@ public class GeneratePawnMovesTest
     {
         var position = new Position("8/P6P/8/8/8/8/p6p/8 w - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
-        var whiteMoves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side)).ToList();
+        var whiteMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side)).ToList();
 
         Assert.AreEqual(8, whiteMoves.Count);
         Assert.AreEqual(2, whiteMoves.Count(m => m.PromotedPiece() == (int)Piece.B + offset && !m.IsCapture()));
@@ -109,7 +109,7 @@ public class GeneratePawnMovesTest
 
         position = new Position("8/P6P/8/8/8/8/p6p/8 b - - 0 1");
         offset = Utils.PieceOffset(position.Side);
-        var blackMoves = MoveGenerator.GeneratePawnMoves(position, offset: 6).ToList();
+        var blackMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: 6).ToList();
 
         Assert.AreEqual(8, blackMoves.Count);
         Assert.AreEqual(2, blackMoves.Count(m => m.PromotedPiece() == (int)Piece.B + offset));
@@ -125,7 +125,7 @@ public class GeneratePawnMovesTest
     {
         var position = new Position("BqB2BqB/P6P/8/8/8/8/p6p/bQb2bQb w - - 0 1");
         var offset = Utils.PieceOffset(position.Side);
-        var whiteMoves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side)).ToList();
+        var whiteMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side)).ToList();
 
         Assert.AreEqual(8, whiteMoves.Count);
         Assert.AreEqual(2, whiteMoves.Count(m => m.PromotedPiece() == (int)Piece.B + offset && m.IsCapture()));
@@ -137,7 +137,7 @@ public class GeneratePawnMovesTest
 
         position = new Position("BqB2BqB/P6P/8/8/8/8/p6p/bQb2bQb b - - 0 1");
         offset = Utils.PieceOffset(position.Side);
-        var blackMoves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side)).ToList();
+        var blackMoves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side)).ToList();
 
         Assert.AreEqual(8, blackMoves.Count);
         Assert.AreEqual(2, blackMoves.Count(m => m.PromotedPiece() == (int)Piece.B + offset && m.IsCapture()));
@@ -155,7 +155,7 @@ public class GeneratePawnMovesTest
     public void EnPassant(string fen)
     {
         var position = new Position(fen);
-        var moves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side));
         Assert.True(1 == moves.Count());
         Assert.True(1 == moves.Count(m => m.IsEnPassant() && m.IsCapture()));
     }
@@ -165,7 +165,7 @@ public class GeneratePawnMovesTest
     public void DoubleEnPassant(string fen)
     {
         var position = new Position(fen);
-        var moves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side));
         Assert.AreEqual(2, moves.Count(m => m.IsEnPassant() && m.IsCapture()));
     }
 
@@ -182,7 +182,7 @@ public class GeneratePawnMovesTest
     public void ShouldNotGenerateMoves(string fen)
     {
         var position = new Position(fen);
-        var moves = MoveGenerator.GeneratePawnMoves(position, offset: Utils.PieceOffset(position.Side));
+        var moves = MoveGenerator.GeneratePawnMovesForReference(position, offset: Utils.PieceOffset(position.Side));
         Assert.IsEmpty(moves);
     }
 

--- a/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
@@ -21,7 +21,7 @@ public class GenerateQueenMovesTest
     {
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
-        var moves = MoveGenerator.GeneratePieceMoves((int)Piece.Q + offset, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference((int)Piece.Q + offset, position);
 
         Assert.AreEqual(expectedMoves, moves.Count());
 
@@ -48,7 +48,7 @@ public class GenerateQueenMovesTest
         var position = new Position(Constants.TrickyTestPositionFEN);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.Q + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(9, moves.Count(m => m.Piece() == piece));
 
@@ -109,7 +109,7 @@ public class GenerateQueenMovesTest
         var position = new Position("r3kR1r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R b KQkq - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.Q + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(4, moves.Count(m => m.Piece() == piece));
 
@@ -139,7 +139,7 @@ public class GenerateQueenMovesTest
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.Q + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(expectedCaptures, moves.Count(m => m.Piece() == piece && m.IsCapture()));
     }

--- a/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
@@ -17,7 +17,7 @@ public class GenerateRookMovesTest
     {
         var position = new Position(fen);
         var offset = Utils.PieceOffset(position.Side);
-        var moves = MoveGenerator.GeneratePieceMoves((int)Piece.R + offset, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference((int)Piece.R + offset, position);
 
         Assert.AreEqual(expectedMoves, moves.Count());
 
@@ -44,7 +44,7 @@ public class GenerateRookMovesTest
         var position = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1P/1PPBBPP1/R3K2R w KQkq - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.R + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(11, moves.Count(m => m.Piece() == piece));
 
@@ -113,7 +113,7 @@ public class GenerateRookMovesTest
         var position = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1P/1PPBBPP1/R3K2R b KQkq - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.R + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position);
 
         Assert.AreEqual(10, moves.Count(m => m.Piece() == piece));
 
@@ -178,7 +178,7 @@ public class GenerateRookMovesTest
         var position = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1P/1PPBBPP1/R3K2R w KQkq - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.R + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(1, moves.Count(m => m.Piece() == piece));
 
@@ -208,7 +208,7 @@ public class GenerateRookMovesTest
         var position = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1P/1PPBBPP1/R3K2R b KQkq - 0 1");
         var offset = Utils.PieceOffset(position.Side);
         var piece = (int)Piece.R + offset;
-        var moves = MoveGenerator.GeneratePieceMoves(piece, position, capturesOnly: true);
+        var moves = MoveGenerator.GeneratePieceMovesForReference(piece, position, capturesOnly: true);
 
         Assert.AreEqual(1, moves.Count(m => m.Piece() == piece));
 

--- a/tests/Lynx.Test/MoveGeneration/TryParseFromUCIStringTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/TryParseFromUCIStringTest.cs
@@ -41,7 +41,7 @@ public class TryParseFromUCIStringTest
         var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         // Act
-        Assert.True(Move.TryParseFromUCIString(UCIString, moves, out var move));
+        Assert.True(MoveExtensions.TryParseFromUCIString(UCIString, moves, out var move));
 
         // Assert
         Assert.AreEqual((int)sourceSquare, move!.Value.SourceSquare());
@@ -85,7 +85,7 @@ public class TryParseFromUCIStringTest
         var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         // Act
-        Assert.True(Move.TryParseFromUCIString(UCIString, moves, out var move));
+        Assert.True(MoveExtensions.TryParseFromUCIString(UCIString, moves, out var move));
 
         // Assert
         Assert.AreEqual((int)sourceSquare, move!.Value.SourceSquare());
@@ -102,7 +102,7 @@ public class TryParseFromUCIStringTest
         var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         // Act & Assert
-        Assert.False(Move.TryParseFromUCIString(UCIString, moves, out var result));
+        Assert.False(MoveExtensions.TryParseFromUCIString(UCIString, moves, out var result));
         Assert.Null(result);
     }
 }


### PR DESCRIPTION
* Replace `Move` class with `MoveExtensions` and apply global `using Move =System.Int32`
* Rename `MoveExtensions.New`, simplify `Game` by removing intermediate move generating methods, optimize `Game` constructor
* Modify `MoveGenerator` to use a pool of `Move`s rather than instantiating lists every time1
* `.ToList()` optimization