### PR TITLE
Remove `<TrimMode>partial<TrimMode/>`

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -10,7 +10,6 @@
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
-    <TrimMode>partial</TrimMode>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!--In favour of tiered compilation-->


### PR DESCRIPTION
According to https://github.com/NLog/NLog/issues/5031#issuecomment-1235788566 from `v5.0.4` `NLog.Extensions.Logging` prevents the full trimming, and therefore there's not need to add `<TrimMode>partial<TrimMode/>`.