### PR TITLE
Prevent NUnit from doing non-explicit test runs

### DIFF
--- a/Lynx.sln
+++ b/Lynx.sln
@@ -25,7 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lynx.Cli", "src\Lynx.Cli\Ly
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "dev_test", "dev_test", "{D656F9EF-DEF3-42C9-BB12-09961D43B844}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lynx.Test", "tests\Lynx.Test\Lynx.Test.csproj", "{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Lynx.Test", "tests\Lynx.Test\Lynx.Test.csproj", "{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -49,10 +49,10 @@ Global
 		{465383BC-C4CB-478B-A5D1-3C9C1E425534}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{465383BC-C4CB-478B-A5D1-3C9C1E425534}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{465383BC-C4CB-478B-A5D1-3C9C1E425534}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,7 +60,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{4288CBA1-156C-435D-845F-4D60A20B10A4} = {D656F9EF-DEF3-42C9-BB12-09961D43B844}
 		{25C9C733-F43B-4E8D-BD89-FC0D9CDFED36} = {D656F9EF-DEF3-42C9-BB12-09961D43B844}
-		{BAC43BBF-9EB6-4BB2-AF2B-50AEAAB8C34A} = {D656F9EF-DEF3-42C9-BB12-09961D43B844}
+		{A8D2A6F0-BDE8-4562-8B94-4638D1ABE359} = {D656F9EF-DEF3-42C9-BB12-09961D43B844}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {44D1B1AC-75A9-4AB8-9FF9-A4A182D84F0F}

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -29,9 +29,6 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
       <_Parameter1>$(AssemblyName).Test</_Parameter1>
     </AssemblyAttribute>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
-      <_Parameter1>$(AssemblyName).NUnit.Test</_Parameter1>
-    </AssemblyAttribute>
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
@@ -24,7 +24,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3), Category = Categories.NoPruning)]
+    [Category(Categories.NoPruning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
     public void Mate_in_Exactly_3(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 5);
@@ -32,7 +33,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4), Category = Categories.NoPruning)]
+    [Category(Categories.NoPruning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4))]
     public void Mate_in_Exactly_4(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
@@ -40,7 +42,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection), Category = Categories.NoPruning)]
+    [Category(Categories.NoPruning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection))]
     public void Mate_in_Exactly_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
@@ -48,7 +51,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5), Category = Categories.NoPruning)]
+    [Category(Categories.NoPruning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5))]
     public void Mate_in_Exactly_5(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 10);
@@ -56,7 +60,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6), Category = Categories.NoPruning)]
+    [Category(Categories.NoPruning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6))]
     public void Mate_in_Exactly_6(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 12);
@@ -64,7 +69,8 @@ public class MatesInExactlyXTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7), Category = Categories.TooLong)]
+    [Category(Categories.TooLong)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7))]
     public void Mate_in_Exactly_7(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 14);

--- a/tests/Lynx.Test/BestMove/MatesTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesTest.cs
@@ -28,7 +28,8 @@ public class MatesTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4), Category = Categories.LongRunning)]
+    [Category(Categories.LongRunning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4))]
     public void Mate_in_4(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = SearchBestMove(fen);
@@ -41,7 +42,8 @@ public class MatesTest : BaseTest
     /// <param name="fen"></param>
     /// <param name="allowedUCIMoveString"></param>
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection), Category = Categories.LongRunning)]
+    [Category(Categories.LongRunning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection))]
     public void Mate_in_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = SearchBestMove(fen);
@@ -49,7 +51,8 @@ public class MatesTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5), Category = Categories.LongRunning)]
+    [Category(Categories.LongRunning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5))]
     public void Mate_in_5(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = SearchBestMove(fen);
@@ -57,7 +60,8 @@ public class MatesTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6), Category = Categories.LongRunning)]
+    [Category(Categories.LongRunning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6))]
     public void Mate_in_6(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = SearchBestMove(fen);
@@ -65,7 +69,8 @@ public class MatesTest : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7), Category = Categories.LongRunning)]
+    [Category(Categories.LongRunning)]
+    [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7))]
     public void Mate_in_7(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = SearchBestMove(fen, depth: 14);

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -23,13 +23,13 @@ public class RegressionTest : BaseTest
 
     [TestCase("8/n2k4/bpr4p/1q1p4/4pp1b/P3P1Pr/R2K4/1r2n1Nr w - - 0 1", new[]
     {
-            "a3a4",
-            "a2a1", "a2b2", "a2c2",
-            "e3f4", "f3g4",
-            "g3f4", "g3g4", "g3h4",
-            "g3f4", "g3g4", "g3h4",
-            "g1h3", "g1f3", "g1e2"
-        }, Description = "Used to return an illegal move in the very first versions")]
+                "a3a4",
+                "a2a1", "a2b2", "a2c2",
+                "e3f4", "f3g4",
+                "g3f4", "g3g4", "g3h4",
+                "g3f4", "g3g4", "g3h4",
+                "g1h3", "g1f3", "g1e2"
+            }, Description = "Used to return an illegal move in the very first versions")]
 
     public void GeneralRegression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
@@ -43,9 +43,10 @@ public class RegressionTest : BaseTest
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
     }
 
+    [Explicit]
+    [Category(Categories.NotGoodEnough)]
     [TestCase("6k1/1R6/5Kn1/3p1N2/1P6/8/8/3r4 b - - 10 37", new[] { "g6f8" }, new[] { "g6f4" },
-        Category = Categories.LongRunning, Explicit = true, Description = "Avoid mate in 4 https://lichess.org/XkZsoXLA#74",
-        Ignore = "Not good enough yet")]
+        Description = "Avoid mate in 4 https://lichess.org/XkZsoXLA#74")]
     public void AvoidMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
@@ -102,15 +103,14 @@ public class RegressionTest : BaseTest
         Assert.DoesNotThrow(() => engine.BestMove(goCommand));
     }
 
+    [Explicit]
+    [Category(Categories.NotGoodEnough)]
     [TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
-        Category = Categories.LongRunning, Explicit = true, Description = "At depth 3 White takes the pawn",
-        Ignore = "Not good enough yet")]
+        Description = "At depth 3 White takes the pawn")]
     [TestCase("r1bqk2r/ppp2ppp/2n1p3/8/Q1pP4/2b2NP1/P3PPBP/1RB2RK1 b kq - 1 10", null, new[] { "c3d4" },
-        Category = Categories.LongRunning, Explicit = true, Description = "It failed at depth 6 in https://lichess.org/nZVw6G5D/black#19",
-        Ignore = "Not good enough yet")]
+        Description = "It failed at depth 6 in https://lichess.org/nZVw6G5D/black#19")]
     [TestCase("r1bqkb1r/ppp2ppp/2n1p3/3pP3/3Pn3/5P2/PPP1N1PP/R1BQKBNR b KQkq - 0 1", null, new[] { "f8b4" },
-        Category = Categories.LongRunning, Explicit = true, Description = "It failed at depth 5 in https://lichess.org/rtTsj9Sr/black",
-        Ignore = "Not good enough yet")]
+        Description = "It failed at depth 5 in https://lichess.org/rtTsj9Sr/black")]
     public void GeneralFailures(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
@@ -228,6 +228,8 @@ public class RegressionTest : BaseTest
         Assert.NotZero(bestMove.Evaluation);
     }
 
+    [Explicit]
+    [Category(Categories.LongRunning)]
     [TestCase(Constants.KillerTestPositionFEN)]
     [TestCase(Constants.TrickyTestPositionFEN)]
     public void PVTableCrash(string fen)
@@ -235,10 +237,12 @@ public class RegressionTest : BaseTest
         const int depthWhenMaxDepthInQuiescenceIsReached = 7;
         var engine = GetEngine(fen);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached }"));
+        var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
         Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.TargetDepth);
     }
 
+    [Explicit]
+    [Category(Categories.LongRunning)]
     [Test]
     public void PonderingCrash()
     {

--- a/tests/Lynx.Test/BestMove/SacrificesTest.cs
+++ b/tests/Lynx.Test/BestMove/SacrificesTest.cs
@@ -4,8 +4,10 @@ namespace Lynx.Test.BestMove;
 
 public class SacrificesTest : BaseTest
 {
+    [Explicit]
+    [Category(Categories.LongRunning)]
     [TestCase("4n3/1p2k2p/p2p2pP/P1bP1pP1/2P2P2/2BB4/3K4/8 w - - 0 43", new[] { "d3f5" },
-        Category = Categories.LongRunning, Explicit = true, Description = "Actual Bishop sacrifice - https://lichess.org/VaY6zfHI/white#84")]
+        Description = "Actual Bishop sacrifice - https://lichess.org/VaY6zfHI/white#84")]
     public void Sacrifices(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 12);

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -9,7 +9,8 @@ namespace Lynx.Test.BestMove;
 public class WACSilver200 : BaseTest
 {
     [Explicit]
-    [TestCaseSource(typeof(WACData), nameof(WACData.Data), Category = nameof(WinningAtChess_10seconds))]
+    [Category(nameof(WinningAtChess_10seconds))]
+    [TestCaseSource(typeof(WACData), nameof(WACData.Data))]
     /// <summary>
     /// 10s, see first case of <see cref="TimeManagementTest"/>
     /// </summary>
@@ -21,7 +22,8 @@ public class WACSilver200 : BaseTest
     }
 
     [Explicit]
-    [TestCaseSource(typeof(WACData), nameof(WACData.Data), Category = nameof(WinningAtChess_DefaultSearchDepth))]
+    [Category(nameof(WinningAtChess_DefaultSearchDepth))]
+    [TestCaseSource(typeof(WACData), nameof(WACData.Data))]
     /// <summary>
     /// 10s, see first case of <see cref="TimeManagementTest"/>
     /// </summary>

--- a/tests/Lynx.Test/Categories.cs
+++ b/tests/Lynx.Test/Categories.cs
@@ -9,4 +9,6 @@ public static class Categories
     public const string TooLong = "TooLongToBeRun";
 
     public const string NoPruning = "RequireNoPruning";
+
+    public const string NotGoodEnough = "NotGoodEnough";
 }

--- a/tests/Lynx.Test/ZobristHashGenerationTest.cs
+++ b/tests/Lynx.Test/ZobristHashGenerationTest.cs
@@ -36,8 +36,10 @@ public class ZobristHashGenerationTest
         TransversePosition(originalPosition, fenDictionary);
     }
 
-    [TestCase(Constants.TrickyTestPositionFEN, Category = Categories.LongRunning, Explicit = true)]
-    [TestCase(Constants.KillerTestPositionFEN, Category = Categories.LongRunning, Explicit = true)]
+    [Explicit]
+    [Category(Categories.LongRunning)]
+    [TestCase(Constants.TrickyTestPositionFEN)]
+    [TestCase(Constants.KillerTestPositionFEN)]
     public void EnPassant(string fen)
     {
         var originalPosition = new Position(fen);


### PR DESCRIPTION
Prevent NUnit from doing non-explicit test runs, which was in practice skipping a bunch of tests from being run in CI.