### PR TITLE
⚖ Improve positional scores

### DIFF
--- a/src/Lynx.Benchmark/EnumCasting.cs
+++ b/src/Lynx.Benchmark/EnumCasting.cs
@@ -1,0 +1,66 @@
+﻿/*
+ *  |   Method | iterations |           Mean |         Error |        StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------- |----------- |---------------:|--------------:|--------------:|------:|--------:|----------:|------------:|
+ *  | Constant |          1 |       4.663 ns |     0.1549 ns |     0.1449 ns |  1.00 |    0.00 |         - |          NA |
+ *  |     Cast |          1 |       4.122 ns |     0.1462 ns |     0.1795 ns |  0.88 |    0.07 |         - |          NA |
+ *  |          |            |                |               |               |       |         |           |             |
+ *  | Constant |         10 |      22.844 ns |     0.5169 ns |     0.5077 ns |  1.00 |    0.00 |         - |          NA |
+ *  |     Cast |         10 |      23.195 ns |     0.4863 ns |     0.7714 ns |  1.02 |    0.04 |         - |          NA |
+ *  |          |            |                |               |               |       |         |           |             |
+ *  | Constant |       1000 |   2,754.421 ns |    14.6464 ns |    12.9836 ns |  1.00 |    0.00 |         - |          NA |
+ *  |     Cast |       1000 |   2,768.868 ns |    16.7819 ns |    14.8767 ns |  1.01 |    0.01 |         - |          NA |
+ *  |          |            |                |               |               |       |         |           |             |
+ *  | Constant |      10000 |  27,710.451 ns |   165.8820 ns |   138.5190 ns |  1.00 |    0.00 |         - |          NA |
+ *  |     Cast |      10000 |  28,080.178 ns |   289.2892 ns |   270.6013 ns |  1.01 |    0.01 |         - |          NA |
+ *  |          |            |                |               |               |       |         |           |             |
+ *  | Constant |     100000 | 277,720.653 ns | 2,782.1333 ns | 2,602.4092 ns |  1.00 |    0.00 |         - |          NA |
+ *  |     Cast |     100000 | 278,077.362 ns | 2,431.3312 ns | 2,274.2687 ns |  1.00 |    0.01 |         - |          NA |
+ */
+
+using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+
+namespace Lynx.Benchmark;
+
+public class EnumCasting : BaseBenchmark
+{
+    public static IEnumerable<int> Data => new[] { 1, 10, 1_000, 10_000, 100_000 };
+
+    private const int Pawn = (int)Piece.P;
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public int Constant(int iterations)
+    {
+        var sum = 0;
+        for (int i = 0; i < iterations; ++i)
+        {
+            sum += EvaluationConstants.MaterialScore[Pawn];
+            sum += EvaluationConstants.MaterialScore[Pawn];
+            sum += EvaluationConstants.MaterialScore[Pawn];
+            sum += EvaluationConstants.MaterialScore[Pawn];
+            sum += EvaluationConstants.MaterialScore[Pawn];
+            sum += EvaluationConstants.MaterialScore[Pawn];
+        }
+
+        return sum;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public int Cast(int iterations)
+    {
+        var sum = 0;
+        for (int i = 0; i < iterations; ++i)
+        {
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+            sum += EvaluationConstants.MaterialScore[(int)Piece.P];
+        }
+
+        return sum;
+    }
+}

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -366,4 +366,5 @@ public static class Constants
     /// </summary>
     public const int MaxNumberOfPossibleMovesInAPosition = 250;
 
+    public static readonly int SideLimit = Enum.GetValues(typeof(Piece)).Length / 2;
 }

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -40,65 +40,74 @@ public static class EvaluationConstants
 
     private static readonly int[] _knightPositionalScore = new int[64]
     {
-            -10,   0,   0,   0,   0,   0,   0,  -10,
-            -5,   0,   0,  10,  10,   0,   0,  -5,
-            -5,   5,  20,  20,  20,  20,   5,  -5,
-            -5,  10,  20,  30,  30,  20,  10,  -5,
-            -5,  10,  20,  30,  30,  20,  10,  -5,
-            -5,   5,  20,  10,  10,  20,   5,  -5,
-            -5,   0,   0,   0,   0,   0,   0,  -5,
-            -10, -10,   0,   0,   0,   0, -10,  -10
+            -60,    -20,    -10,    -3,     -3,     -10,    -20,    -60,
+            -15,    -5,      0,     10,     10,     0,      -5,     -15,
+            -5,     5,      20,     20,     20,     20,     5,      -5,
+            -5,     10,     20,     30,     30,     20,     10,     -5,
+            -5,     10,     20,     30,     30,     20,     10,     -5,
+            -5,     5,      20,     10,     10,     20,     5,      -5,
+            -15,    -5,      0,      5,      5,      0,     -5,     -15,
+            -30,    -20,    -10,    -5,     -5,     -10,    -20,    -30
      };
 
     private static readonly int[] _bishopPositionalScore = new int[64]
     {
-             0,   0,   0,   0,   0,   0,   0,   0,
-             0,   0,   0,   0,   0,   0,   0,   0,
-             0,   0,   0,  10,  10,   0,   0,   0,
-             0,   0,  10,  20,  20,  10,   0,   0,
-             0,   0,  10,  20,  20,  10,   0,   0,
-             0,  10,   0,   0,   0,   0,  10,   0,
-             0,  30,   0,   0,   0,   0,  30,   0,
-             0,   0, -10,   0,   0, -10,   0,   0
+             -0,   -10,    -10,     -10,    -10,    -10,    -10,    0,
+             -5,    10,      0,     0,      0,      0,      10,     -5,
+             -5,    0,      20,     10,     10,     20,     0,      -5,
+             0,     5,      10,     30,     30,     10,     5,      0,
+             0,     5,      10,     30,     30,     10,     5,      0,
+             -5,    0,      20,     10,     10,     20,     0,      -5,
+             -5,     10,     0,      0,      0,      0,     10,    -5,
+             0,     -10,    -20,    -10,    -10,    -20,    -10,    0
     };
 
     private static readonly int[] _rookPositionalScore = new int[64]
     {
             50,  50,  50,  50,  50,  50,  50,  50,
-            50,  50,  50,  50,  50,  50,  50,  50,
+            70,  70,  70,  70,  70,  70,  70,  70,
              0,   0,  10,  20,  20,  10,   0,   0,
              0,   0,  10,  20,  20,  10,   0,   0,
              0,   0,  10,  20,  20,  10,   0,   0,
              0,   0,  10,  20,  20,  10,   0,   0,
              0,   0,  10,  20,  20,  10,   0,   0,
-             0,   0,   0,  20,  20,   0,   0,   0
+             5,   5,   5,  20,  20,   5,   5,   5
     };
 
     private static readonly int[] _queenPositionalScore = new int[64]
     {
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0,
-             0,  0,  0,  0,  0,  0,  0,  0
+             -10,   -10,    5,      5,      5,      5,      -10,    -10,
+             -10,   5,      5,      5,      5,      5,      5,      -10,
+             5,     5,      10,     10,     10,     5,      5,      5,
+             5,     5,      10,     20,     20,     10,     5,      5,
+             5,     5,      10,     20,     20,     10,     5,      5,
+             5,     5,      5,      10,     10,     5,      5,      5,
+             -10,   5,      5,      5,      5,      5,      5,      -10,
+             -10,   -10,    -5,     0,      0,      -5,     -10,    -10
     };
 
-    /// <summary>
-    /// Could have two: one for opening/middle game, avoiding the center, and another one for endgames, seeking the center
-    /// </summary>
     private static readonly int[] _kingPositionalScore = new int[64]
     {
-             0,   0,   0,   0,   0,   0,   0,   0,
-             0,   0,   5,   5,   5,   5,   0,   0,
-             0,   5,   5,  10,  10,   5,   5,   0,
-             0,   5,  10,  20,  20,  10,   5,   0,
-             0,   5,  10,  20,  20,  10,   5,   0,
-             0,   0,   5,  10,  10,   5,   0,   0,
-             0,   5,   5,  -5,  -5,   0,   5,   0,
-             0,   0,   10,  0, -15,   0,  15,   0
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             -50,   -50,    -50,    -50,    -50,    -50,    -50,    -50,
+             +15,    +20,   -10,    -20,    -20,    -30,    +30,    +25,
+             +20,    +20,   +20,    -10,    +10,    -40,    +30,    +30
+    };
+
+    private static readonly int[] _kingEndgamePositionalScore = new int[64]
+    {
+             0,     5,      10,     12,     12,     10,     5,      0,
+             5,     10,     15,     20,     20,     15,     10,     5,
+             10,    15,     20,     30,     30,     20,     15,     10,
+             15,    20,     30,     50,     50,     30,     20,     15,
+             15,    20,     30,     50,     50,     30,     20,     15,
+             10,    15,     20,     30,     30,     20,     15,     10,
+             5,     10,     15,     20,     20,     15,     10,     5,
+             0,     5,      10,     12,     12,     10,     5,      0
     };
 
     private static readonly int[] _mirrorScore = new int[64]
@@ -118,6 +127,8 @@ public static class EvaluationConstants
     private static int BPS(BoardSquare square) => -_bishopPositionalScore[_mirrorScore[(int)square]];
     private static int RPS(BoardSquare square) => -_rookPositionalScore[_mirrorScore[(int)square]];
     private static int KPS(BoardSquare square) => -_kingPositionalScore[_mirrorScore[(int)square]];
+
+    private static int KEPS(BoardSquare square) => -_kingEndgamePositionalScore[_mirrorScore[(int)square]];
 
     private static readonly int[] _pawnPositionalScore_Black = new int[64]
     {
@@ -179,21 +190,50 @@ public static class EvaluationConstants
             KPS(a1), KPS(b1), KPS(c1), KPS(d1), KPS(e1), KPS(f1), KPS(g1), KPS(h1)
     };
 
+    private static readonly int[] _kingEndgamePositionalScore_Black = new int[64]
+    {
+            KEPS(a8), KEPS(b8), KEPS(c8), KEPS(d8), KEPS(e8), KEPS(f8), KEPS(g8), KEPS(h8),
+            KEPS(a7), KEPS(b7), KEPS(c7), KEPS(d7), KEPS(e7), KEPS(f7), KEPS(g7), KEPS(h7),
+            KEPS(a6), KEPS(b6), KEPS(c6), KEPS(d6), KEPS(e6), KEPS(f6), KEPS(g6), KEPS(h6),
+            KEPS(a5), KEPS(b5), KEPS(c5), KEPS(d5), KEPS(e5), KEPS(f5), KEPS(g5), KEPS(h5),
+            KEPS(a4), KEPS(b4), KEPS(c4), KEPS(d4), KEPS(e4), KEPS(f4), KEPS(g4), KEPS(h4),
+            KEPS(a3), KEPS(b3), KEPS(c3), KEPS(d3), KEPS(e3), KEPS(f3), KEPS(g3), KEPS(h3),
+            KEPS(a2), KEPS(b2), KEPS(c2), KEPS(d2), KEPS(e2), KEPS(f2), KEPS(g2), KEPS(h2),
+            KEPS(a1), KEPS(b1), KEPS(c1), KEPS(d1), KEPS(e1), KEPS(f1), KEPS(g1), KEPS(h1)
+    };
+
     public static readonly int[][] PositionalScore = new int[12][]
     {
-            _pawnPositionalScore,
-            _knightPositionalScore,
-            _bishopPositionalScore,
-            _rookPositionalScore,
-            _queenPositionalScore,
-            _kingPositionalScore,
+        _pawnPositionalScore,
+        _knightPositionalScore,
+        _bishopPositionalScore,
+        _rookPositionalScore,
+        _queenPositionalScore,
+        _kingPositionalScore,
 
-            _pawnPositionalScore_Black,
-            _knightPositionalScore_Black,
-            _bishopPositionalScore_Black,
-            _rookPositionalScore_Black,
-            _queenPositionalScore,
-            _kingPositionalScore_Black,
+        _pawnPositionalScore_Black,
+        _knightPositionalScore_Black,
+        _bishopPositionalScore_Black,
+        _rookPositionalScore_Black,
+        _queenPositionalScore,
+        _kingPositionalScore_Black,
+    };
+
+    public static readonly int[][] EndgamePositionalScore = new int[12][]
+    {
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        _kingEndgamePositionalScore,
+
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        Array.Empty<int>(),
+        _kingEndgamePositionalScore_Black
     };
 
     /// <summary>


### PR DESCRIPTION
* Differentiate King positional score during the endgames from the rest of the game.
  For now endgame detection is done using the existence of opponent's queen
* Adjust Bishop, Knight and Rook positional scores.
* Add Queen positional scores.

Gauntlet comparing [Lynx-enhance-positional-scores-637-win-x64](https://github.com/lynx-chess/Lynx/suites/8617079006/artifacts/386677181) vs [Lynx 0.11.0](https://github.com/lynx-chess/Lynx/releases/tag/v0.11.0).
Conditions:
 - `Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz, 2594 Mhz, 1 Core(s), 2 Logical Processor(s)`
 - 3'+2''
 - 2 games per encounter, 2 games per opening


```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black 
   0 Lynx 0.11.0                   -35      99      40      14      18       8     18.0   45.0%   20.0%   45.0%   45.0% 
   1 Lynx 637                       53     100      40      19      13       8     23.0   57.5%   20.0%   60.0%   55.0% 
   2 Walleye 1.6.0                 338     323      20      16       1       3     17.5   87.5%   15.0%  100.0%   75.0% 
   3 Rustic 1.1                     35     145      20       9       7       4     11.0   55.0%   20.0%   45.0%   65.0% 
   4 Darky 0.5d                    -89     144      20       5      10       5      7.5   37.5%   25.0%   35.0%   40.0% 
   5 Princhess 0.5.1              -301     222      20       1      15       4      3.0   15.0%   20.0%   20.0%   10.0% 

80 of 80 games finished.
```

[Lynx-enhance-positional-scores-637-win-x64](https://github.com/lynx-chess/Lynx/suites/8617079006/artifacts/386677181) vs [Lynx 0.11.0](https://github.com/lynx-chess/Lynx/releases/tag/v0.11.0) match.
Conditions:
 - `Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz, 2594 Mhz, 1 Core(s), 2 Logical Processor(s)`
 - 1'+1''
 - 2 games per encounter, 2 games per opening

```
Score of Lynx 637 vs Lynx 0.11.0: 21 - 13 - 6 [0.600]
...      Lynx 637 playing White: 13 - 3 - 4  [0.750] 20
...      Lynx 637 playing Black: 8 - 10 - 2  [0.450] 20
...      White vs Black: 23 - 11 - 6  [0.650] 40
Elo difference: 70.4 +/- 104.2, LOS: 91.5 %, DrawRatio: 15.0 %
40 of 40 games finished.
```