### PR TITLE
Add `osx.13-arm64` to release runtime list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        runtime-identifier: [win-x64, win-arm64, linux-x64, linux-arm64, linux-arm, osx-x64, osx.11.0-arm64, osx.12-arm64]
+        runtime-identifier: [win-x64, win-arm64, linux-x64, linux-arm64, linux-arm, osx-x64, osx.11.0-arm64, osx.12-arm64, osx.13-arm64]
         include:
           - runtime-identifier: win-x64
             os: windows-latest


### PR DESCRIPTION
Although it seems to be deducted from the include below, so no need for 0.13.1