### PR TITLE
🔍 Transposition table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,10 @@ global.json
 
 # VS diagnostic sessions
 *.diagsession
+
+# VS Code settings
+.vscode/
+
+# Infersharp
+.infersharpconfig
+infer-out/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <Nullable>Enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
@@ -10,6 +11,7 @@
   <ItemGroup>
     <Using Include="System.Int32" Alias="Move" />
     <Using Include="System.UInt64" Alias="BitBoard" />
+    <Using Include="Lynx.Model.TranspositionTableElement[]" Alias="TranspositionTable" />
   </ItemGroup >
 
   <PropertyGroup>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -52,11 +52,11 @@ catch (AggregateException ae)
     {
         if (e is TaskCanceledException taskCanceledException)
         {
-            Console.WriteLine("Cancellation requested: {taskCanceledException.Message}");
+            Console.WriteLine("Cancellation requested: {0}", taskCanceledException.Message);
         }
         else
         {
-            Console.WriteLine("Exception: " + e.GetType().Name);
+            Console.WriteLine("Exception: {0}", e.GetType().Name);
         }
     }
 }

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -19,7 +19,7 @@
     "MinSecurityTime": 1000,
     "CoefficientSecurityTime": 0.9,
     "MinDepth": 4,
-    "MaxDepth": 64,
+    "MaxDepth": 128,
     "MinMoveTime": 1000,
     "DepthWhenLessThanMinMoveTime": 5,
     "MinElapsedTimeToConsiderStopSearching": 900,
@@ -49,7 +49,8 @@
     "OpenFileKingPenalty": 15,
     "KingShieldBonus": 5,
     "BishopMobilityBonus": 1,
-    "QueenMobilityBonus": 1
+    "QueenMobilityBonus": 1,
+    "TranspositionTableSize": "0x10000000" // 256 MB
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -1,13 +1,18 @@
-﻿namespace Lynx;
+﻿using Lynx.Model;
+using System.Runtime.InteropServices;
+
+namespace Lynx;
 
 public static class Configuration
 {
+    public static EngineSettings EngineSettings { get; set; } = new EngineSettings();
+    public static GeneralSettings GeneralSettings { get; set; } = new GeneralSettings();
+
     private static int _isDebug = 0;
 #pragma warning disable IDE1006 // Naming Styles
     private static int _UCI_AnalyseMode = 0;
 #pragma warning restore IDE1006 // Naming Styles
     private static int _ponder = 0;
-    private static int _hash = 0;
 
     public static bool IsDebug
     {
@@ -59,13 +64,9 @@ public static class Configuration
 
     public static int Hash
     {
-        get => _hash;
-        set => Interlocked.Exchange(ref _hash, value);
+        get => EngineSettings.TranspositionTableSize;
+        set => EngineSettings.TranspositionTableSize = value;
     }
-
-    public static EngineSettings EngineSettings { get; set; } = new EngineSettings();
-
-    public static GeneralSettings GeneralSettings { get; set; } = new GeneralSettings();
 }
 
 public sealed class GeneralSettings
@@ -139,7 +140,8 @@ public sealed class EngineSettings
 
     public int MinDepth { get; set; } = 4;
 
-    public int MaxDepth { get; set; } = 32;
+    private int _maxDepth = 64;
+    public int MaxDepth { get => _maxDepth; set => _maxDepth = Math.Clamp(value, 1, Constants.AbsoluteMaxDepth); }
 
     public int MinMoveTime { get; set; } = 1_000;
 
@@ -180,4 +182,9 @@ public sealed class EngineSettings
     public int BishopMobilityBonus { get; set; } = 1;
 
     public int QueenMobilityBonus { get; set; } = 1;
+
+    /// <summary>
+    /// 64 MB
+    /// </summary>
+    public int TranspositionTableSize { get; set; } = 64 * 1024 * 1024;
 }

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -299,6 +299,9 @@ public static class Constants
 
     public const string ComplexPositionFEN = "rq2k2r/ppp2pb1/2n1pnpp/1Q1p1b2/3P1B2/2N1PNP1/PPP2PBP/R3K2R w KQkq - 0 1";
 
+    // https://www.chessprogramming.org/Lasker-Reichhelm_Position
+    public const string TTPositionFEN = "8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - - 0 1";
+
     public const string EmptyBoardFEN = "8/8/8/8/8/8/8/8 w - - 0 1";
 
     public const int WhiteShortCastleKingSquare = (int)BoardSquare.g1;
@@ -391,4 +394,6 @@ public static class Constants
         0, 1, 2, 3, 4, 5, 6, 7,
         0, 1, 2, 3, 4, 5, 6, 7
     };
+
+    public const int AbsoluteMaxDepth = 255;
 }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -51,6 +51,7 @@ public sealed partial class Engine
         AverageDepth = 0;
         _isNewGameComing = true;
         _isNewGameCommandSupported = true;
+        //_transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
     }
 
     public void AdjustPosition(string rawPositionCommand)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -51,7 +51,7 @@ public sealed partial class Engine
         AverageDepth = 0;
         _isNewGameComing = true;
         _isNewGameCommandSupported = true;
-        //_transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
+        _transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
     }
 
     public void AdjustPosition(string rawPositionCommand)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -276,11 +276,36 @@ public static class EvaluationConstants
             { 100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600 }
     };
 
-    public const int CheckMateEvaluation = 1_000_000_000;
+    /// <summary>
+    /// Base absolute checkmate evaluation value. Actual absolute evaluations are lower than this one by a number of <see cref="Position.DepthCheckmateFactor"/>
+    /// </summary>
+    public const int CheckMateBaseEvaluation = 30_000;
+
+    /// <summary>
+    /// This value combined with <see cref="PositiveCheckmateDetectionLimit"/> and <see cref="NegativeCheckmateDetectionLimit"/> should allows mates up to in <see cref="Constants.AbsoluteMaxDepth"/> moves.
+    /// </summary>
+    public const int DepthCheckmateFactor = 10;
+
+    /// <summary>
+    /// Minimum evaluation for a position to be White checkmate
+    /// </summary>
+    public const int PositiveCheckmateDetectionLimit = 27_000; // CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
+
+    /// <summary>
+    /// Minimum evaluation for a position to be Black checkmate
+    /// </summary>
+    public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     public const int FirstKillerMoveValue = 9_000;
 
     public const int SecondKillerMoveValue = 8_000;
 
-    public const int PVMoveValue = 20_000;
+    public const int PVMoveScoreValue = 20_000;
+
+    public const int TTMoveScoreValue = 19_000;
+
+    /// <summary>
+    /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
+    /// </summary>
+    public const int NoHashEntry = 25_000;
 }

--- a/src/Lynx/LinxDriver.cs
+++ b/src/Lynx/LinxDriver.cs
@@ -195,9 +195,8 @@ public sealed class LinxDriver
                 {
                     if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
                     {
-                        Configuration.Hash = value;
+                        Configuration.Hash = value * 1024 * 1024;
                     }
-                    _logger.Warn("Hash size modification not supported yet");
                     break;
                 }
             case "uci_opponent":

--- a/src/Lynx/Model/PVTable.cs
+++ b/src/Lynx/Model/PVTable.cs
@@ -8,7 +8,7 @@ public static class PVTable
 
     private static ImmutableArray<int> Initialize()
     {
-        var indexes = new int [Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2];
+        var indexes = new int[Configuration.EngineSettings.MaxDepth + 1];
         int previousPVIndex = 0;
         indexes[0] = previousPVIndex;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -7,8 +7,6 @@ namespace Lynx.Model;
 
 public readonly struct Position
 {
-    internal const int DepthFactor = 1_000_000;
-
     private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
 
     public string FEN() => CalculateFEN();
@@ -346,6 +344,12 @@ public readonly struct Position
         return sb.ToString();
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
+
     /// <summary>
     /// Evaluates material and position in a NegaMax style.
     /// That is, positive scores always favour playing <see cref="Side"/>.
@@ -356,12 +360,23 @@ public readonly struct Position
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int StaticEvaluation(Dictionary<long, int> positionHistory, int movesWithoutCaptureOrPawnMove)
     {
-        var eval = 0;
-
-        if (positionHistory.Values.Any(val => val >= 3) || movesWithoutCaptureOrPawnMove >= 100)
+        if (IsThreefoldRepetition(positionHistory) || Is50MovesRepetition(movesWithoutCaptureOrPawnMove))
         {
-            return eval;
+            return 0;
         }
+
+        return StaticEvaluation();
+    }
+
+    /// <summary>
+    /// Evaluates material and position in a NegaMax style.
+    /// That is, positive scores always favour playing <see cref="Side"/>.
+    /// </summary>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int StaticEvaluation()
+    {
+        var eval = 0;
 
         int whiteMaterialEval = 0, blackMaterialEval = 0;
         var pieceCount = new int[PieceBitBoards.Length];
@@ -457,6 +472,55 @@ public readonly struct Position
             ? eval
             : -eval;
     }
+
+    /// <summary>
+    /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),
+    /// this method determines if a position is a result of either a loss by Checkmate or a draw by stalemate.
+    /// NegaMax style
+    /// </summary>
+    /// <param name="depth">Modulates the output, favouring positions with lower depth left (i.e. Checkmate in less moves)</param>
+    /// <param name="positionHistory"></param>
+    /// <param name="movesWithoutCaptureOrPawnMove"></param>
+    /// <returns>At least <see cref="CheckMateEvaluation"/> if Position.Side lost (more extreme values when <paramref name="depth"/> increases)
+    /// or 0 if Position.Side was stalemated</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int EvaluateFinalPosition(int depth, bool isInCheck, Dictionary<long, int> positionHistory, int movesWithoutCaptureOrPawnMove)
+    {
+        if (IsThreefoldRepetition(positionHistory) || Is50MovesRepetition(movesWithoutCaptureOrPawnMove))
+        {
+            return 0;
+        }
+
+        return EvaluateFinalPosition(depth, isInCheck);
+    }
+
+    /// <summary>
+    /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),
+    /// this method determines if a position is a result of either a loss by Checkmate or a draw by stalemate.
+    /// NegaMax style
+    /// </summary>
+    /// <param name="depth">Modulates the output, favouring positions with lower depth left (i.e. Checkmate in less moves)</param>
+    /// <returns>At least <see cref="CheckMateEvaluation"/> if Position.Side lost (more extreme values when <paramref name="depth"/> increases)
+    /// or 0 if Position.Side was stalemated</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int EvaluateFinalPosition(int depth, bool isInCheck)
+    {
+        if (isInCheck)
+        {
+            // Checkmate evaluation, but not as bad/shallow as it looks like since we're already searching at a certain depth
+            return -EvaluationConstants.CheckMateBaseEvaluation + (EvaluationConstants.DepthCheckmateFactor * depth);
+        }
+        else
+        {
+            return default;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsThreefoldRepetition(Dictionary<long, int> positionHistory) => positionHistory.Values.Any(val => val >= 3);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool Is50MovesRepetition(int movesWithoutCaptureOrPawnMove) => movesWithoutCaptureOrPawnMove >= 100;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int CustomPieceEvaluation(int pieceSquareIndex, int pieceIndex)
@@ -558,42 +622,8 @@ public readonly struct Position
             }
         }
 
-        return bonus += Configuration.EngineSettings.KingShieldBonus *
+        return bonus + Configuration.EngineSettings.KingShieldBonus *
             (Attacks.KingAttacks[squareIndex] & OccupancyBitBoards[(int)pieceSide]).CountBits();
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
-
-    /// <summary>
-    /// Assuming a current position has no legal moves (<see cref="AllPossibleMoves"/> doesn't produce any <see cref="IsValid"/> position),
-    /// this method determines if a position is a result of either a loss by Checkmate or a draw by stalemate.
-    /// NegaMax style
-    /// </summary>
-    /// <param name="depth">Modulates the output, favouring positions with lower depth left (i.e. Checkmate in less moves)</param>
-    /// <param name="positionHistory"></param>
-    /// <param name="movesWithoutCaptureOrPawnMove"></param>
-    /// <returns>At least <see cref="CheckMateEvaluation"/> if Position.Side lost (more extreme values when <paramref name="depth"/> increases)
-    /// or 0 if Position.Side was stalemated</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int EvaluateFinalPosition(int depth, bool isInCheck, Dictionary<long, int> positionHistory, int movesWithoutCaptureOrPawnMove)
-    {
-        if (positionHistory.Values.Any(val => val >= 3) || movesWithoutCaptureOrPawnMove >= 100)
-        {
-            return 0;
-        }
-
-        if (isInCheck)
-        {
-            return -EvaluationConstants.CheckMateEvaluation + (DepthFactor * depth);
-        }
-        else
-        {
-            return default;
-        }
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,0 +1,219 @@
+﻿using NLog;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Lynx.Model;
+
+public enum NodeType : byte
+{
+    Unknown,    // Making it 0 instead of -1 because of default struct initialization
+    Exact,
+    Alpha,
+    Beta
+}
+
+public struct TranspositionTableElement
+{
+    private byte _depth;
+    //private byte _age;
+    private short _score;
+
+    /// <summary>
+    /// Full Zobrist key
+    /// </summary>
+    public long Key { get; set; }
+
+    /// <summary>
+    /// Node (position) type:
+    /// <see cref="NodeType.Exact"/>: == <see cref="Score"/>,
+    /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
+    /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
+    /// </summary>
+    public NodeType Type { get; set; }
+
+    /// <summary>
+    /// Position evaluation
+    /// </summary>
+    public int Score { readonly get => _score; set => _score = (short)value; }
+
+    /// <summary>
+    /// Best move found in a position. 0 if the position failed low (score <= alpha)
+    /// </summary>
+    public Move Move { get; set; }
+
+    /// <summary>
+    /// How deep the recorded search went. For us this numberis targetDepth - ply
+    /// </summary>
+    public int Depth { readonly get => _depth; set => _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref value, 1))[0]; }
+
+    //public int Age { readonly get => _age; set => _age = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref value, 1))[0]; }
+
+    public void Clear()
+    {
+        Key = 0;
+        Score = 0;
+        Depth = 0;
+        Move = 0;
+        Type = NodeType.Unknown;
+    }
+}
+
+public static class TranspositionTableExtensions
+{
+    private static readonly ILogger _logger = LogManager.GetCurrentClassLogger();
+
+    public static int TranspositionTableArrayLength => Configuration.EngineSettings.TranspositionTableSize / Marshal.SizeOf(typeof(TranspositionTableElement));
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int TranspositionTableIndex(Position position, TranspositionTable transpositionTable) =>
+        (int)(position.UniqueIdentifier % transpositionTable.Length);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ClearTranspositionTable(this TranspositionTable transpositionTable)
+    {
+        foreach (var element in transpositionTable)
+        {
+            element.Clear();
+        }
+    }
+
+    /// <summary>
+    /// Checks the transposition table and, if there's a eval value that can be deducted from it of there's a previously recorded <paramref name="position"/>, it's returned. <see cref="EvaluationConstants.NoHashEntry"/> is returned otherwise
+    /// </summary>
+    /// <param name="transpositionTable"></param>
+    /// <param name="position"></param>
+    /// <param name="targetDepth"></param>
+    /// <param name="ply">Ply</param>
+    /// <param name="alpha"></param>
+    /// <param name="beta"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (int Evaluation, Move BestMove) ProbeHash(this TranspositionTable transpositionTable, Position position, int targetDepth, int ply, int alpha, int beta)
+    {
+        var entry = transpositionTable[TranspositionTableIndex(position, transpositionTable)];
+
+        if (position.UniqueIdentifier != entry.Key)
+        {
+            return (EvaluationConstants.NoHashEntry, default);
+        }
+
+        var eval = EvaluationConstants.NoHashEntry;
+
+        if (entry.Depth >= (targetDepth - ply))    // TODO is this conditon correct? In BBC depth is passed, but BBC depth decreases when going deeper
+        {
+            // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
+            // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
+            var score = RecalculateMateScores(entry.Score, ply);
+
+            eval = entry.Type switch
+            {
+                NodeType.Exact => score,
+                NodeType.Alpha when score <= alpha => alpha,
+                NodeType.Beta when score >= beta => beta,
+                _ => EvaluationConstants.NoHashEntry
+            };
+        }
+
+        return (eval, entry.Move);
+    }
+
+    /// <summary>
+    /// Adds a <see cref="TranspositionTableElement"/> to the transposition tabke
+    /// </summary>
+    /// <param name="transpositionTable"></param>
+    /// <param name="position"></param>
+    /// <param name="targetDepth"></param>
+    /// <param name="ply">Ply</param>
+    /// <param name="eval"></param>
+    /// <param name="nodeType"></param>
+    /// <param name="move"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void RecordHash(this TranspositionTable transpositionTable, Position position, int targetDepth, int ply, int eval, NodeType nodeType, Move? move = 0)
+    {
+        ref var entry = ref transpositionTable[TranspositionTableIndex(position, transpositionTable)];
+
+        //if (entry.Key != default && entry.Key != position.UniqueIdentifier)
+        //{
+        //    _logger.Warn("TT collision");
+        //}
+
+        // We want to store the distance to the checkmate position relative to the current node, independently from the root
+        // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
+        var score = RecalculateMateScores(eval, -ply);
+
+        entry.Key = position.UniqueIdentifier;
+        entry.Score = score;
+        entry.Depth = targetDepth - ply;
+        entry.Move = move ?? 0;
+        entry.Type = nodeType;
+    }
+
+    /// <summary>
+    /// If playing side is giving checkmate, decrease checkmate score (increase n in checkmate in n moves) due to being searching at a given depth already when this position is found.
+    /// The opposite if the playing side is getting checkmated.
+    /// Logic for when to pass +depth or -depth for the desired effect in https://www.talkchess.com/forum3/viewtopic.php?f=7&t=74411 and https://talkchess.com/forum3/viewtopic.php?p=861852#p861852
+    /// </summary>
+    /// <param name="score"></param>
+    /// <param name="depth"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int RecalculateMateScores(int score, int depth) => score +
+            score switch
+            {
+                > EvaluationConstants.PositiveCheckmateDetectionLimit => -EvaluationConstants.DepthCheckmateFactor * depth,
+                < EvaluationConstants.NegativeCheckmateDetectionLimit => EvaluationConstants.DepthCheckmateFactor * depth,
+                _ => 0
+            };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PopulatedItemsCount(this TranspositionTable transpositionTable)
+    {
+        int items = 0;
+        for (int i = 0; i < transpositionTable.Length; ++i)
+        {
+            if (transpositionTable[i].Key != default)
+            {
+                ++items;
+            }
+        }
+
+        return items;
+    }
+
+    /// <summary>
+    /// TT occupancy per mill
+    /// </summary>
+    /// <param name="transpositionTable"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int HashfullPermill(this TranspositionTable transpositionTable) => 1000 * transpositionTable.PopulatedItemsCount() / transpositionTable.Length;
+
+    [Conditional("DEBUG")]
+    internal static void Stats(this TranspositionTable transpositionTable)
+    {
+        int items = 0;
+        for (int i = 0; i < transpositionTable.Length; ++i)
+        {
+            if (transpositionTable[i].Key != default)
+            {
+                ++items;
+            }
+        }
+        _logger.Info($"TT Occupancy:\t{100 * transpositionTable.PopulatedItemsCount() / transpositionTable.Length}% ({transpositionTable.Length * Marshal.SizeOf(typeof(TranspositionTableElement)) / 1024 / 1024}MB)");
+    }
+
+    [Conditional("DEBUG")]
+    internal static void Print(this TranspositionTable transpositionTable)
+    {
+        Console.WriteLine("Transposition table content:");
+        for (int i = 0; i < transpositionTable.Length; ++i)
+        {
+            if (transpositionTable[i].Key != default)
+            {
+                Console.WriteLine($"{i}: Key = {transpositionTable[i].Key}, Depth: {transpositionTable[i].Depth}, Score: {transpositionTable[i].Score}, Move: {(transpositionTable[i].Move != 0 ? transpositionTable[i].Move.ToMoveString() : "-")} {transpositionTable[i].Type}");
+            }
+        }
+        Console.WriteLine("");
+    }
+}

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -5,9 +5,19 @@ using System.Text;
 
 namespace Lynx;
 
-public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, int DepthReached, int Nodes, long Time, long NodesPerSecond, List<Move> Moves, int Alpha, int Beta, int Mate = default)
+public sealed record SearchResult(Move BestMove, double Evaluation, int TargetDepth, List<Move> Moves, int Alpha, int Beta, int Mate = default)
 {
+    public int DepthReached { get; set; }
+
+    public int Nodes { get; set; }
+
+    public long Time { get; set; }
+
+    public long NodesPerSecond { get; set; }
+
     public bool IsCancelled { get; set; }
+
+    public int HashfullPermill { get; set; }
 
     public SearchResult(SearchResult previousSearchResult)
     {
@@ -24,11 +34,11 @@ public record SearchResult(Move BestMove, double Evaluation, int TargetDepth, in
 
 public sealed partial class Engine
 {
-    private const int MinValue = -2 * EvaluationConstants.CheckMateEvaluation;
-    private const int MaxValue = +2 * EvaluationConstants.CheckMateEvaluation;
+    private const int MinValue = short.MinValue;
+    private const int MaxValue = short.MaxValue;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private List<Move> SortMoves(IEnumerable<Move> moves, in Position currentPosition, int depth)
+    private List<Move> SortMoves(IEnumerable<Move> moves, in Position currentPosition, int depth, Move bestMoveTTCandidate)
     {
         if (_isFollowingPV)
         {
@@ -45,17 +55,22 @@ public sealed partial class Engine
         }
 
         var localPosition = currentPosition;
-        return moves.OrderByDescending(move => Score(move, in localPosition, depth)).ToList();
+        return moves.OrderByDescending(move => Score(move, in localPosition, depth, bestMoveTTCandidate)).ToList();
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int Score(Move move, in Position position, int depth)
+    private int Score(Move move, in Position position, int depth, Move bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[depth])
         {
             _isScoringPV = false;
 
-            return EvaluationConstants.PVMoveValue;
+            return EvaluationConstants.PVMoveScoreValue;
+        }
+
+        if (move == bestMoveTTCandidate)
+        {
+            return EvaluationConstants.TTMoveScoreValue;
         }
 
         return move.Score(in position, _killerMoves, depth, _historyMoves);
@@ -123,63 +138,75 @@ public sealed partial class Engine
     [Conditional("DEBUG")]
     private static void PrintPreMove(in Position position, int plies, Move move, bool isQuiescence = false)
     {
-        var sb = new StringBuilder();
-        for (int i = 0; i <= plies; ++i)
+        if (_logger.IsTraceEnabled)
         {
-            sb.Append("\t\t");
-        }
-        string depthStr = sb.ToString();
+            var sb = new StringBuilder();
+            for (int i = 0; i <= plies; ++i)
+            {
+                sb.Append("\t\t");
+            }
+            string depthStr = sb.ToString();
 
-        //if (plies < Configuration.Parameters.Depth - 1)
-        {
-            //Console.WriteLine($"{Environment.NewLine}{depthStr}{move} ({position.Side}, {depth})");
-            _logger.Trace($"{Environment.NewLine}{depthStr}{(isQuiescence ? "[Qui] " : "")}{move} ({position.Side}, {plies})");
+            //if (plies < Configuration.Parameters.Depth - 1)
+            {
+                //Console.WriteLine($"{Environment.NewLine}{depthStr}{move} ({position.Side}, {depth})");
+                _logger.Trace($"{Environment.NewLine}{depthStr}{(isQuiescence ? "[Qui] " : "")}{move} ({position.Side}, {plies})");
+            }
         }
     }
 
     [Conditional("DEBUG")]
     private static void PrintMove(int plies, Move move, int evaluation, bool isQuiescence = false, bool prune = false)
     {
-        var sb = new StringBuilder();
-        for (int i = 0; i <= plies; ++i)
+        if (_logger.IsTraceEnabled)
         {
-            sb.Append("\t\t");
+            var sb = new StringBuilder();
+            for (int i = 0; i <= plies; ++i)
+            {
+                sb.Append("\t\t");
+            }
+            string depthStr = sb.ToString();
+
+            //Console.ForegroundColor = depth switch
+            //{
+            //    0 => ConsoleColor.Red,
+            //    1 => ConsoleColor.Blue,
+            //    2 => ConsoleColor.Green,
+            //    3 => ConsoleColor.White,
+            //    _ => ConsoleColor.White
+            //};
+            //Console.WriteLine($"{depthStr}{move} ({position.Side}, {depthLeft}) | {evaluation}");
+            //Console.WriteLine($"{depthStr}{move} | {evaluation}");
+
+            _logger.Trace($"{depthStr}{(isQuiescence ? "[Qui] " : "")}{move,-6} | {evaluation}{(prune ? " | prunning" : "")}");
+
+            //Console.ResetColor();
         }
-        string depthStr = sb.ToString();
-
-        //Console.ForegroundColor = depth switch
-        //{
-        //    0 => ConsoleColor.Red,
-        //    1 => ConsoleColor.Blue,
-        //    2 => ConsoleColor.Green,
-        //    3 => ConsoleColor.White,
-        //    _ => ConsoleColor.White
-        //};
-        //Console.WriteLine($"{depthStr}{move} ({position.Side}, {depthLeft}) | {evaluation}");
-        //Console.WriteLine($"{depthStr}{move} | {evaluation}");
-
-        _logger.Trace($"{depthStr}{(isQuiescence ? "[Qui] " : "")}{move,-6} | {evaluation}{(prune ? " | prunning" : "")}");
-
-        //Console.ResetColor();
     }
 
     [Conditional("DEBUG")]
     private static void PrintMessage(int plies, string message)
     {
-        var sb = new StringBuilder();
-        for (int i = 0; i <= plies; ++i)
+        if (_logger.IsTraceEnabled)
         {
-            sb.Append("\t\t");
-        }
-        string depthStr = sb.ToString();
+            var sb = new StringBuilder();
+            for (int i = 0; i <= plies; ++i)
+            {
+                sb.Append("\t\t");
+            }
+            string depthStr = sb.ToString();
 
-        _logger.Trace(depthStr + message);
+            _logger.Trace(depthStr + message);
+        }
     }
 
     [Conditional("DEBUG")]
     private static void PrintMessage(string message)
     {
-        _logger.Trace(message);
+        if (_logger.IsTraceEnabled)
+        {
+            _logger.Trace(message);
+        }
     }
 
     [Conditional("DEBUG")]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -12,7 +12,7 @@ public sealed partial class Engine
     private readonly int[,] _killerMoves = new int[2, Configuration.EngineSettings.MaxDepth];
     private readonly int[,] _historyMoves = new int[12, 64];
     private readonly int[] _maxDepthReached = new int[Constants.AbsoluteMaxDepth];
-    //private TranspositionTable _transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
+    private TranspositionTable _transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
 
     private int _nodes;
     private bool _isFollowingPV;
@@ -59,7 +59,7 @@ public sealed partial class Engine
 
             lastSearchResult = new SearchResult(_previousSearchResult)
             {
-                //HashfullPermill = _transpositionTable.HashfullPermill()
+                HashfullPermill = _transpositionTable.HashfullPermill()
             };
             Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
 
@@ -136,7 +136,7 @@ public sealed partial class Engine
                     Nodes = _nodes,
                     Time = elapsedTime,
                     NodesPerSecond = Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * elapsedTime) + 1), 0, long.MaxValue)),
-                    //HashfullPermill = _transpositionTable.HashfullPermill()
+                    HashfullPermill = _transpositionTable.HashfullPermill()
                 };
 
                 Task.Run(async () => await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult)));
@@ -171,7 +171,7 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = _stopWatch.ElapsedMilliseconds;
         finalSearchResult.NodesPerSecond = Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * _stopWatch.ElapsedMilliseconds) + 1), 0, long.MaxValue));
-        //finalSearchResult.HashfullPermill = _transpositionTable.HashfullPermill();
+        finalSearchResult.HashfullPermill = _transpositionTable.HashfullPermill();
 
         return finalSearchResult;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -8,10 +8,11 @@ namespace Lynx;
 public sealed partial class Engine
 {
     private readonly Stopwatch _stopWatch = new();
-    private readonly Move[] _pVTable = new Move[((Configuration.EngineSettings.MaxDepth * Configuration.EngineSettings.MaxDepth) + Configuration.EngineSettings.MaxDepth) / 2];
+    private readonly Move[] _pVTable = new Move[Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2];
     private readonly int[,] _killerMoves = new int[2, Configuration.EngineSettings.MaxDepth];
     private readonly int[,] _historyMoves = new int[12, 64];
-    private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth];
+    private readonly int[] _maxDepthReached = new int[Constants.AbsoluteMaxDepth];
+    //private TranspositionTable _transpositionTable = new TranspositionTableElement[TranspositionTableExtensions.TranspositionTableArrayLength];
 
     private int _nodes;
     private bool _isFollowingPV;
@@ -56,7 +57,10 @@ public sealed partial class Engine
         {
             _logger.Debug("Ponder hit");
 
-            lastSearchResult = new SearchResult(_previousSearchResult);
+            lastSearchResult = new SearchResult(_previousSearchResult)
+            {
+                //HashfullPermill = _transpositionTable.HashfullPermill()
+            };
             Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
 
             Task.Run(async () => await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult)));
@@ -96,7 +100,7 @@ public sealed partial class Engine
                 bestEvaluation = NegaMax(Game.CurrentPosition, minDepth, maxDepth: depth, depth: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
 
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
-                isMateDetected = bestEvaluationAbs > 0.1 * EvaluationConstants.CheckMateEvaluation;
+                isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;
 
                 // 🔍 Aspiration Windows
                 if (!isMateDetected && ((bestEvaluation <= alpha) || (bestEvaluation >= beta)))
@@ -120,14 +124,20 @@ public sealed partial class Engine
                 int mate = default;
                 if (isMateDetected)
                 {
-                    mate = (int)Math.Ceiling(0.5 * ((EvaluationConstants.CheckMateEvaluation - bestEvaluationAbs) / Position.DepthFactor));
-                    mate = (int)Math.CopySign(mate, bestEvaluation);
+                    mate = Utils.CalculateMateInX(bestEvaluation, bestEvaluationAbs);
                 }
 
                 var elapsedTime = _stopWatch.ElapsedMilliseconds;
 
                 _previousSearchResult = lastSearchResult;
-                lastSearchResult = new SearchResult(pvMoves.FirstOrDefault(), bestEvaluation, depth, maxDepthReached, _nodes, elapsedTime, Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * elapsedTime) + 1), 0, Int64.MaxValue)), pvMoves, alpha, beta, mate);
+                lastSearchResult = new SearchResult(pvMoves.FirstOrDefault(), bestEvaluation, depth, pvMoves, alpha, beta, mate)
+                {
+                    DepthReached = maxDepthReached,
+                    Nodes = _nodes,
+                    Time = elapsedTime,
+                    NodesPerSecond = Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * elapsedTime) + 1), 0, long.MaxValue)),
+                    //HashfullPermill = _transpositionTable.HashfullPermill()
+                };
 
                 Task.Run(async () => await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult)));
 
@@ -154,15 +164,16 @@ public sealed partial class Engine
             _stopWatch.Stop();
         }
 
-        if (lastSearchResult is not null)
-        {
-            lastSearchResult.IsCancelled = isCancelled;
-            return lastSearchResult;
-        }
-        else
-        {
-            return new(default, bestEvaluation, depth, depth, _nodes, _stopWatch.ElapsedMilliseconds, Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * _stopWatch.ElapsedMilliseconds) + 1), 0, Int64.MaxValue)), new List<Move>(), alpha, beta);
-        }
+        var finalSearchResult = lastSearchResult ??= new(default, bestEvaluation, depth, new List<Move>(), alpha, beta);
+
+        finalSearchResult.IsCancelled = isCancelled;
+        finalSearchResult.DepthReached = Math.Max(finalSearchResult.DepthReached, _maxDepthReached.LastOrDefault(item => item != default));
+        finalSearchResult.Nodes = _nodes;
+        finalSearchResult.Time = _stopWatch.ElapsedMilliseconds;
+        finalSearchResult.NodesPerSecond = Convert.ToInt64(Math.Clamp(_nodes / ((0.001 * _stopWatch.ElapsedMilliseconds) + 1), 0, long.MaxValue));
+        //finalSearchResult.HashfullPermill = _transpositionTable.HashfullPermill();
+
+        return finalSearchResult;
 
         static bool stopSearchCondition(int depth, int? maxDepth, bool isMateDetected, int nodes, int? decisionTime, Stopwatch stopWatch, ILogger logger)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -34,16 +34,16 @@ public sealed partial class Engine
 
         Move ttBestMove = default;
 
-        //bool isPvNode = beta - alpha == 1;
-        //if (!isPvNode && depth > 0)
-        //{
-        //    var ttProbeResult = _transpositionTable.ProbeHash(position, maxDepth, depth, alpha, beta);
-        //    if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
-        //    {
-        //        return ttProbeResult.Evaluation;
-        //    }
-        //    ttBestMove = ttProbeResult.BestMove;
-        //}
+        bool isPvNode = beta - alpha == 1;
+        if (!isPvNode && depth > 0)
+        {
+            var ttProbeResult = _transpositionTable.ProbeHash(position, maxDepth, depth, alpha, beta);
+            if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
+            {
+                return ttProbeResult.Evaluation;
+            }
+            ttBestMove = ttProbeResult.BestMove;
+        }
 
         if (depth > minDepth)
         {
@@ -208,7 +208,7 @@ public sealed partial class Engine
                     _killerMoves[0, depth] = move;
                 }
 
-                //_transpositionTable.RecordHash(position, maxDepth, depth, beta, NodeType.Beta, bestMove);
+                _transpositionTable.RecordHash(position, maxDepth, depth, beta, NodeType.Beta, bestMove);
 
                 return beta;    // TODO return evaluation?
             }
@@ -245,11 +245,11 @@ public sealed partial class Engine
         {
             var eval = Position.EvaluateFinalPosition(depth, isInCheck);
 
-            //_transpositionTable.RecordHash(position, maxDepth, depth, eval, NodeType.Exact);
+            _transpositionTable.RecordHash(position, maxDepth, depth, eval, NodeType.Exact);
             return eval;
         }
 
-        //_transpositionTable.RecordHash(position, maxDepth, depth, alpha, nodeType, bestMove);
+        _transpositionTable.RecordHash(position, maxDepth, depth, alpha, nodeType, bestMove);
 
         // Node fails low
         return alpha;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -27,10 +27,10 @@ public sealed partial class Engine
         _maxDepthReached[depth] = depth;
         _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-        //if (Position.IsThreefoldRepetition(Game.PositionHashHistory) || Position.Is50MovesRepetition(_halfMovesWithoutCaptureOrPawnMove))
-        //{
-        //    return 0;
-        //}
+        if (Position.IsThreefoldRepetition(Game.PositionHashHistory) || Position.Is50MovesRepetition(_halfMovesWithoutCaptureOrPawnMove))
+        {
+            return 0;
+        }
 
         Move ttBestMove = default;
 
@@ -62,7 +62,7 @@ public sealed partial class Engine
                 }
             }
 
-            var finalPositionEvaluation = Position.EvaluateFinalPosition(depth, isInCheck, Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+            var finalPositionEvaluation = Position.EvaluateFinalPosition(depth, isInCheck);
             //_transpositionTable.RecordHash(position, maxDepth, depth, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
@@ -71,7 +71,7 @@ public sealed partial class Engine
         if (depth >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Warn("####################### prevents runtime failure ###########################3");
-            return position.StaticEvaluation(Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation();
             //_transpositionTable.RecordHash(position, targetDepth, ply, null, staticEval, NodeType.Exact);         // This seems to create bugs for multiple people
         }
 
@@ -243,7 +243,7 @@ public sealed partial class Engine
 
         if (bestMove is null && !isAnyMoveValid)
         {
-            var eval = Position.EvaluateFinalPosition(depth, isInCheck, Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+            var eval = Position.EvaluateFinalPosition(depth, isInCheck);
 
             //_transpositionTable.RecordHash(position, maxDepth, depth, eval, NodeType.Exact);
             return eval;
@@ -274,14 +274,14 @@ public sealed partial class Engine
         _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
         //_cancellationToken.Token.ThrowIfCancellationRequested();
 
-        //if (Position.IsThreefoldRepetition(Game.PositionHashHistory) || Position.Is50MovesRepetition(_halfMovesWithoutCaptureOrPawnMove))
-        //{
-        //    return 0;
-        //}
+        if (Position.IsThreefoldRepetition(Game.PositionHashHistory) || Position.Is50MovesRepetition(_halfMovesWithoutCaptureOrPawnMove))
+        {
+            return 0;
+        }
 
         if (depth >= Configuration.EngineSettings.MaxDepth)
         {
-            return position.StaticEvaluation(Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation();
         }
 
         ++_nodes;
@@ -291,7 +291,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[depth + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var staticEvaluation = position.StaticEvaluation(Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+        var staticEvaluation = position.StaticEvaluation();
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)
@@ -371,7 +371,7 @@ public sealed partial class Engine
                 }
             }
 
-            return Position.EvaluateFinalPosition(depth, position.IsInCheck(), Game.PositionHashHistory, _halfMovesWithoutCaptureOrPawnMove);
+            return Position.EvaluateFinalPosition(depth, position.IsInCheck());
         }
 
         // Node fails low

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -82,10 +82,11 @@ public sealed class InfoCommand : EngineBaseCommand
             $" depth {searchResult.TargetDepth}" +
             $" seldepth {searchResult.DepthReached}" +
             $" multipv 1" +
-            $" score cp {searchResult.Evaluation}" + (searchResult.Mate == default ? "" : $" mate {searchResult.Mate}") +
+            $" score {(searchResult.Mate == default ? $"cp {searchResult.Evaluation}" : $"mate {searchResult.Mate}")}" +
             $" nodes {searchResult.Nodes}" +
             $" nps {searchResult.NodesPerSecond}" +
             $" time {searchResult.Time}" +
+            $" hashfull {searchResult.HashfullPermill}" +
             $" pv {string.Join(" ", searchResult.Moves.Select(move => move.UCIString()))}";
 #pragma warning restore RCS1214 // Unnecessary interpolated string.
     }

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -123,7 +123,8 @@ public sealed class OptionCommand : EngineBaseCommand
 
     public static readonly ImmutableArray<string> AvailableOptions = ImmutableArray.Create<string>(
         "option name UCI_Opponent type string",
-        "option name UCI_EngineAbout type string default Lynx by Eduardo Cáceres, see https://github.com/lynx-chess/Lynx");
+        "option name UCI_EngineAbout type string default Lynx by Eduardo Cáceres, see https://github.com/lynx-chess/Lynx",
+        $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize / 1024 / 1024} min 1 max 131072");
 
     //"option name Hash type spin default 1 min 1 max 128",
     //"option name UCI_AnalyseMode type check",

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -151,6 +151,20 @@ public static class Utils
         }
     }
 
+    /// <summary>
+    /// Providing there's a checkmate detected in <paramref name="bestEvaluation"/>, returns in how many moves
+    /// </summary>
+    /// <param name="bestEvaluation"></param>
+    /// <param name="bestEvaluationAbs"></param>
+    /// <returns>Positive value if white is checkmating, negative value if black is</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CalculateMateInX(int bestEvaluation, int bestEvaluationAbs)
+    {
+        int mate = (int)Math.Ceiling(0.5 * ((EvaluationConstants.CheckMateBaseEvaluation - bestEvaluationAbs) / EvaluationConstants.DepthCheckmateFactor));
+
+        return (int)Math.CopySign(mate, bestEvaluation);
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -62,7 +62,7 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         // Assert
         Assert.AreNotEqual(movesThatAllowsRepetition.UCIString(), bestMoveFound.UCIString(), "No threefold repetition avoided");
-        Assert.Less(searchResult.Evaluation, EvaluationConstants.CheckMateEvaluation - (20 * Position.DepthFactor), "Mate not detected");
+        Assert.Less(searchResult.Evaluation, EvaluationConstants.CheckMateBaseEvaluation - (20 * EvaluationConstants.DepthCheckmateFactor), "Mate not detected");
     }
 
     [Test]
@@ -158,7 +158,7 @@ public class ForceOrAvoidDrawTest : BaseTest
 
         // Assert
         Assert.AreNotEqual(movesThatAllowsRepetition.UCIString(), bestMoveFound.UCIString(), "No 50 moves rule avoided");
-        Assert.Less(searchResult.Evaluation, EvaluationConstants.CheckMateEvaluation - (20 * Position.DepthFactor), "Mate not detected");
+        Assert.Less(searchResult.Evaluation, EvaluationConstants.CheckMateBaseEvaluation - (20 * EvaluationConstants.DepthCheckmateFactor), "Mate not detected");
     }
 
     [Test]

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -1,0 +1,52 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+using static Lynx.EvaluationConstants;
+
+namespace Lynx.Test;
+public class EvaluationConstantsTest
+{
+    /// <summary>
+    /// Shy from 14k
+    /// </summary>
+    private readonly int _sensibleEvaluation =
+        2 * (MaterialScore[(int)Piece.B] + PositionalScore[(int)Piece.B].Max() + Configuration.EngineSettings.BishopMobilityBonus * 64) +
+        2 * (MaterialScore[(int)Piece.N] + PositionalScore[(int)Piece.N].Max()) +
+        2 * (MaterialScore[(int)Piece.R] + PositionalScore[(int)Piece.R].Max() + Configuration.EngineSettings.OpenFileRookBonus + Configuration.EngineSettings.SemiOpenFileRookBonus) +
+        9 * (MaterialScore[(int)Piece.Q] + PositionalScore[(int)Piece.Q].Max() + Configuration.EngineSettings.QueenMobilityBonus * 64) +
+        Configuration.EngineSettings.KingShieldBonus * 8 +
+        MaterialScore[(int)Piece.Q]; // just in case
+
+    [TestCase(PositiveCheckmateDetectionLimit)]
+    [TestCase(-NegativeCheckmateDetectionLimit)]
+    public void CheckmateDetectionLimitConstants(int checkmateDetectionLimit)
+    {
+        Assert.Greater(CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth * DepthCheckmateFactor,
+            checkmateDetectionLimit);
+
+        Assert.Greater(checkmateDetectionLimit, _sensibleEvaluation);
+
+        Assert.Greater(checkmateDetectionLimit, PVMoveScoreValue);
+        Assert.Greater(checkmateDetectionLimit, FirstKillerMoveValue);
+        Assert.Greater(checkmateDetectionLimit, SecondKillerMoveValue);
+    }
+
+    [Test]
+    public void NoHashEntryConstant()
+    {
+        Assert.Greater(NoHashEntry, _sensibleEvaluation);
+        Assert.Greater(PositiveCheckmateDetectionLimit, NoHashEntry);
+        Assert.Greater(-NegativeCheckmateDetectionLimit, NoHashEntry);
+
+        Assert.Greater(NoHashEntry, PVMoveScoreValue);
+        Assert.Greater(NoHashEntry, FirstKillerMoveValue);
+        Assert.Greater(NoHashEntry, SecondKillerMoveValue);
+    }
+
+    [Test]
+    public void EvaluationFitsIntoDepth16()
+    {
+        Assert.Greater(short.MaxValue, PositiveCheckmateDetectionLimit);
+        Assert.Greater(short.MaxValue, NoHashEntry);
+        Assert.Greater(short.MaxValue, _sensibleEvaluation);
+    }
+}

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -136,8 +136,8 @@ public class PositionTest
     [TestCase("7K/8/8/8/8/3b4/1k6/6q1 w - - 0 1", 0)]
     [TestCase("8/5K2/7p/6pk/6p1/6P1/7P/8 b - - 0 1", 0)]
     [TestCase("8/7p/6p1/6P1/6PK/5k1P/8/8 w - - 0 1", 0)]
-    [TestCase("7k/8/8/8/8/8/1K5R/6R1 b - - 0 1", -EvaluationConstants.CheckMateEvaluation)]
-    [TestCase("7K/8/8/8/8/8/1k5r/6r1 w - - 0 1", -EvaluationConstants.CheckMateEvaluation)]
+    [TestCase("7k/8/8/8/8/8/1K5R/6R1 b - - 0 1", -EvaluationConstants.CheckMateBaseEvaluation)]
+    [TestCase("7K/8/8/8/8/8/1k5r/6r1 w - - 0 1", -EvaluationConstants.CheckMateBaseEvaluation)]
     public void EvaluateFinalPosition(string fen, int expectedEvaluationValue)
     {
         // Arrange

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -1,0 +1,67 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+using static Lynx.EvaluationConstants;
+
+namespace Lynx.Test;
+public class TranspositionTableTests
+{
+    [TestCase(10_000, 1, 10_000)]
+    [TestCase(10_000, 5, 10_000)]
+    [TestCase(10_000, 3, 10_000)]
+    [TestCase(PositiveCheckmateDetectionLimit - 1, 5, PositiveCheckmateDetectionLimit - 1)]
+    [TestCase(-10_000, 1, -10_000)]
+    [TestCase(-10_000, 3, -10_000)]
+    [TestCase(-10_000, 5, -10_000)]
+    [TestCase(NegativeCheckmateDetectionLimit + 1, 5, NegativeCheckmateDetectionLimit + 1)]
+
+    [TestCase(CheckMateBaseEvaluation - 5 * DepthCheckmateFactor, 2, CheckMateBaseEvaluation - 7 * DepthCheckmateFactor)]
+    [TestCase(CheckMateBaseEvaluation - 2 * DepthCheckmateFactor, 4, CheckMateBaseEvaluation - 6 * DepthCheckmateFactor)]
+
+    [TestCase(-CheckMateBaseEvaluation + 5 * DepthCheckmateFactor, 2, -CheckMateBaseEvaluation + 7 * DepthCheckmateFactor)]
+    [TestCase(-CheckMateBaseEvaluation + 2 * DepthCheckmateFactor, 4, -CheckMateBaseEvaluation + 6 * DepthCheckmateFactor)]
+    public void RecalculateMateScores(int evaluation, int depth, int expectedEvaluation)
+    {
+        Assert.AreEqual(expectedEvaluation, TranspositionTableExtensions.RecalculateMateScores(evaluation, depth));
+    }
+
+    [TestCase(+19, NodeType.Alpha, +20, +30, 20)]
+    [TestCase(+21, NodeType.Alpha, +20, +30, NoHashEntry)]
+    [TestCase(+29, NodeType.Beta, +20, +30, NoHashEntry)]
+    [TestCase(+31, NodeType.Beta, +20, +30, 30)]
+    public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
+    {
+        var position = new Position(Constants.InitialPositionFEN);
+        var transpositionTable = new TranspositionTableElement[Configuration.EngineSettings.TranspositionTableSize];
+
+        transpositionTable.RecordHash(position, targetDepth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
+
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(position, targetDepth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
+    }
+
+    [TestCase(CheckMateBaseEvaluation - 8 * DepthCheckmateFactor)]
+    [TestCase(-CheckMateBaseEvaluation + 3 * DepthCheckmateFactor)]
+    public void RecordHash_ProbeHash_CheckmateSameDepth(int recordedEval)
+    {
+        const int sharedDepth = 5;
+        var position = new Position(Constants.InitialPositionFEN);
+        var transpositionTable = new TranspositionTableElement[Configuration.EngineSettings.TranspositionTableSize];
+
+        transpositionTable.RecordHash(position, targetDepth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+
+        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(position, targetDepth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
+    }
+
+    [TestCase(CheckMateBaseEvaluation - 8 * DepthCheckmateFactor, 5, 4, CheckMateBaseEvaluation - 7 * DepthCheckmateFactor)]
+    [TestCase(CheckMateBaseEvaluation - 8 * DepthCheckmateFactor, 5, 6, CheckMateBaseEvaluation - 9 * DepthCheckmateFactor)]
+    [TestCase(-CheckMateBaseEvaluation + 8 * DepthCheckmateFactor, 5, 4, -CheckMateBaseEvaluation + 7 * DepthCheckmateFactor)]
+    [TestCase(-CheckMateBaseEvaluation + 8 * DepthCheckmateFactor, 5, 6, -CheckMateBaseEvaluation + 9 * DepthCheckmateFactor)]
+    public void RecordHash_ProbeHash_CheckmateDifferentDepth(int recordedEval, int recordedDeph, int probeDepth, int expectedProbeEval)
+    {
+        var position = new Position(Constants.InitialPositionFEN);
+        var transpositionTable = new TranspositionTableElement[Configuration.EngineSettings.TranspositionTableSize];
+
+        transpositionTable.RecordHash(position, targetDepth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(position, targetDepth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
+    }
+}


### PR DESCRIPTION
Implement transposition table.

Results.. suggest there's something clearly wrong, since no improvement is detected (or even small regression), but I rather merge it and investigate later.

2+1
```log
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black 
   0 Lynx 894 - TT                  99      36     304     163      79      62    194.0   63.8%   20.4%   66.1%   61.5% 
   1 Lynx 893 - draw check          98      36     317     174      87      56    202.0   63.7%   17.7%   65.4%   62.0% 
   2 Lynx 892 - eval const         131      35     320     181      66      73    217.5   68.0%   22.8%   76.3%   59.7% 
   3 Lynx 889 - pre TT             137      36     320     188      68      64    220.0   68.8%   20.0%   73.1%   64.4% 
   4 Lynx 841 - ropos               99      35     320     170      81      69    204.5   63.9%   21.6%   65.3%   62.5% 
   5 Walleye 1.6.0                   4      45     197      86      84      27     99.5   50.5%   13.7%   58.7%   42.4% 
   6 Lynx 0.13.0                     0      40     196      65      65      66     98.0   50.0%   33.7%   56.1%   43.9% 
   7 Celestial 1.0                 -55      45     198      69     100      29     83.5   42.2%   14.6%   44.4%   39.9% 
   8 Vapor 0.01-r1                 -68      39     198      44      82      72     80.0   40.4%   36.4%   39.4%   41.4% 
   9 Rustic 1.1                   -122      48     198      52     119      27     65.5   33.1%   13.6%   39.4%   26.8% 
  10 Darky 0.5d                   -236      55     198      29     146      23     40.5   20.5%   11.6%   18.2%   22.7% 
  11 Princhess 0.5.1              -247      47     198      12     133      53     38.5   19.4%   26.8%   25.3%   13.6% 
  12 Piranha 0.5                  -253      55     198      24     147      27     37.5   18.9%   13.6%   22.7%   15.2% 

1581 of 40000 games finished.
```

1+1
```log
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black 
   0 Lynx 894 - TT                  45      41     224     103      74      47    126.5   56.5%   21.0%   57.6%   55.4% 
   1 Lynx 893 - draw checks         90      43     224     121      64      39    140.5   62.7%   17.4%   64.3%   61.2% 
   2 Lynx 892 - eval const          72      41     224     110      64      50    135.0   60.3%   22.3%   67.4%   53.1% 
   3 Lynx 889 - pre TT             108      42     226     124      56      46    147.0   65.0%   20.4%   65.9%   64.2% 
   4 Lynx 841 - ropos               41      40     238     112      84      42    133.0   55.9%   17.6%   61.8%   50.0% 
   5 Walleye 1.6.0                  52      49     162      77      53      32     93.0   57.4%   19.8%   60.5%   54.3% 
   6 Lynx 0.13.0                    30      45     162      63      49      50     88.0   54.3%   30.9%   54.9%   53.7% 
   7 Celestial1.0                  -45      49     164      58      79      27     71.5   43.6%   16.5%   53.0%   34.1% 
   8 Vapor 0.01-r1                 -70      44     162      37      69      56     65.0   40.1%   34.6%   38.3%   42.0% 
   9 Rustic 1.1                    -70      51     162      54      86      22     65.0   40.1%   13.6%   49.4%   30.9% 
  10 Darky 0.5d                   -166      55     162      34     106      22     45.0   27.8%   13.6%   29.0%   26.5% 
  11 Piranha 0.5                  -283      68     162      19     128      15     26.5   16.4%    9.3%   17.9%   14.8% 

1136 of 35000 games finished.
```

1+1
```log
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black 
   0 Lynx 894 - TT                  15      31     396     169     152      75    206.5   52.1%   18.9%   55.3%   49.0% 
   1 Lynx 893 - draw checks         14      31     396     175     159      62    206.0   52.0%   15.7%   55.1%   49.0% 
   2 Lynx 892 - eval constants      46      32     396     192     140      64    224.0   56.6%   16.2%   53.5%   59.6% 
   3 Lynx main 889 - pre TT         22      31     407     184     158      65    216.5   53.2%   16.0%   54.4%   52.0% 
   4 MinimalChess 0.4.1            166      51     178     114      35      29    128.5   72.2%   16.3%   69.1%   75.3% 
   5 Rustic 2                       58      47     176      87      58      31    102.5   58.2%   17.6%   60.8%   55.7% 
   6 Walleye 1.6.0                  50      48     176      88      63      25    100.5   57.1%   14.2%   63.1%   51.1% 
   7 Celestial 1.0                  -6      46     178      70      73      35     87.5   49.2%   19.7%   48.3%   50.0% 
   8 Rustic 1.1                    -20      49     177      74      84      19     83.5   47.2%   10.7%   49.4%   44.9% 
   9 Vapor 0.01-r1                 -48      44     176      51      75      50     76.0   43.2%   28.4%   39.2%   47.2% 
  10 Cecir 3.5                     -77      47     178      52      91      35     69.5   39.0%   19.7%   37.1%   41.0% 
  11 Darky 0.5d                    -98      50     178      53     102      23     64.5   36.2%   12.9%   43.3%   29.2% 
  12 Piranha 0.5                  -281      63     178      20     139      19     29.5   16.6%   10.7%   18.5%   14.6% 

1595 of 36000 games finished.
``` 