### PR TITLE
Disable logging in published version

### DIFF
--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -13,6 +13,12 @@
       }
     },
     "rules": {
+      // Generates logs-{date}*.log files
+      "1": {
+        "logger": "*",
+        "minLevel": "Debug",
+        "writeTo": "logs"
+      },
       //"99": {
       //  "logger": "*",
       //  "minLevel": "Trace",

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -169,11 +169,11 @@
       },
 
       // Generates logs-{date}*.log files
-      "1": {
-        "logger": "*",
-        "minLevel": "Debug",
-        "writeTo": "logs"
-      },
+      //"1": {
+      //  "logger": "*",
+      //  "minLevel": "Debug",
+      //  "writeTo": "logs"
+      //},
 
       // Logs to console
       "100": {


### PR DESCRIPTION
No clear improvement detected, so keeping it for now.

```log
Score of Lynx disable-logging vs Lynx 0.14.0: 662 - 666 - 532  [0.499] 1860
...      Lynx disable-logging playing White: 335 - 315 - 280  [0.511] 930
...      Lynx disable-logging playing Black: 327 - 351 - 252  [0.487] 930
...      White vs Black: 686 - 642 - 532  [0.512] 1860
Elo difference: -0.7 +/- 13.3, LOS: 45.6 %, DrawRatio: 28.6 %
SPRT: llr -1.24 (-42.1%), lbound -2.94, ubound 2.94
```