### PR TITLE
Add thread id to logs

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -69,7 +69,7 @@
     "targets": {
       "errors": {
         "type": "File",
-        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
+        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${threadid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
         "fileName": "${logDirectory}/errors-${date:format=yyyy-MM-dd}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
@@ -81,7 +81,7 @@
       },
       "logs": {
         "type": "File",
-        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
+        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${threadid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
         "fileName": "${logDirectory}/logs-${date:format=yyyy-MM-dd}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
@@ -105,7 +105,7 @@
       },
       "console": {
         "type": "ColoredConsole",
-        "layout": "${date:format=HH\\:mm\\:ss} | [${uppercase:${level}}] ${message} ${exception:format=tostring}",
+        "layout": "${date:format=HH\\:mm\\:ss} | ${threadid} | [${uppercase:${level}}] ${message} ${exception:format=tostring}",
         "rowHighlightingRules": [
           {
             "condition": "level == LogLevel.Fatal",


### PR DESCRIPTION
Add thread id to logs, useful when checking logs generated when testing an engine with concurrency > 1