### PR TITLE
Stop potentially sending uci `info` commands after `bestmove` one

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -165,8 +165,6 @@ public sealed partial class Engine
         {
             _logger.Info("Search evaluation result - eval: {0}, mate: {1}, depth: {2}, refutation: {3}",
                 searchResult.Evaluation, searchResult.Mate, searchResult.TargetDepth, string.Join(", ", searchResult.Moves.Select(m => m.ToMoveString())));
-
-            Task.Run(async () => await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult)));
         }
 
         if (tbResult is not null)
@@ -182,11 +180,9 @@ public sealed partial class Engine
             }
         }
 
-        var result = tbResult ?? searchResult ?? throw new AssertException("Both search and online tb proving results are null. At least search one is always expected to have a value");
-
-        Task.Run(async () => await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(result)));
-
-        return result;
+        return tbResult
+            ?? searchResult
+                ?? throw new AssertException("Both search and online tb proving results are null. At least search one is always expected to have a value");
     }
 
     internal double CalculateDecisionTime(int movesToGo, int millisecondsLeft, int millisecondsIncrement)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -92,7 +92,7 @@ public sealed partial class Engine
             {
                 _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                 if (minDepth == maxDepth    // go depth n commands
-                    ||  depth - 1 > minDepth)
+                    || depth - 1 > minDepth)
                 {
                     _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                 }


### PR DESCRIPTION
I tried to be clever to prevent some GUIs from choosing the wrong `info` command as the best one in case online tb probing was on, but that causes a big annoyance while testing in cutechess-cli due to constant warnings about illegal pv moves (which should probs be unexpected output ones, as suggested in https://github.com/cutechess/cutechess/issues/472).