### PR TITLE
🐛 Fix nlog concurrency issue when accessing log files

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -69,43 +69,46 @@
     "targets": {
       "errors": {
         "type": "File",
-        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${threadid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
-        "fileName": "${logDirectory}/errors-${date:format=yyyy-MM-dd}.log",
+        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${processid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
+        "fileName": "${logDirectory}/errors-${date:format=yyyy-MM-dd}-${processid}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
         "archiveFileName": "${archiveLogDirectory}/archived-errors-{#}.log",
         "archiveEvery": "Monday",
         "archiveNumbering": "Date",
         "archiveDateFormat": "yyyy-MM-dd",
-        "maxArchiveFiles": 100
+        "maxArchiveFiles": 100,
+        "enableArchiveFileCompression": true
       },
       "logs": {
         "type": "File",
-        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${threadid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
-        "fileName": "${logDirectory}/logs-${date:format=yyyy-MM-dd}.log",
+        "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${processid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",
+        "fileName": "${logDirectory}/logs-${date:format=yyyy-MM-dd}-${processid}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
         "archiveFileName": "${archiveLogDirectory}/archived-logs-{#}.log",
         "archiveEvery": "Monday",
-        "archiveNumbering": "Date",
+        "archiveNumbering": "DateAndSequence",
         "archiveDateFormat": "yyyy-MM-dd",
-        "maxArchiveFiles": 100
+        "maxArchiveFiles": 100,
+        "enableArchiveFileCompression": true
       },
       "moves": {
         "type": "File",
         "layout": "${message}",
-        "fileName": "${logDirectory}/moves-${date:format=yyyy-MM-dd}.log",
+        "fileName": "${logDirectory}/moves-${date:format=yyyy-MM-dd}-${processid}.log",
         "concurrentWrites": true,
         "keepFileOpen": false,
         "archiveFileName": "${archiveLogDirectory}/archived-moves-{#}.log",
         "archiveEvery": "Monday",
         "archiveNumbering": "Date",
         "archiveDateFormat": "yyyy-MM-dd",
-        "maxArchiveFiles": 100
+        "maxArchiveFiles": 100,
+        "enableArchiveFileCompression": true
       },
       "console": {
         "type": "ColoredConsole",
-        "layout": "${date:format=HH\\:mm\\:ss} | ${threadid} | [${uppercase:${level}}] ${message} ${exception:format=tostring}",
+        "layout": "${date:format=HH\\:mm\\:ss} | [${uppercase:${level}}] ${message} ${exception:format=tostring}",
         "rowHighlightingRules": [
           {
             "condition": "level == LogLevel.Fatal",


### PR DESCRIPTION
Make different instances write to different log files by adding process id to the file name
This should fix `Exception: System.IO.IOException: The process cannot access the file logs-2023-07-30.log' because it is being used by another process.` and allow more parallelizable testing (before concurrency limit was around 6 on a good day)