### PR TITLE
🐛 Fix illegal moves potentially sent when the previous search line is hit

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -532,10 +532,10 @@ public readonly struct Position
         }
     }
 
-    public static int NumberOfTwoFoldRepetitions(Dictionary<long, int> positionHistory) => positionHistory.Values.Count(val => val >= 2);
+    public static int NumberOfTwoFoldRepetitions(Dictionary<long, int> positionHistory) => positionHistory.Count(pair => pair.Value >= 2);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsThreefoldRepetition(Dictionary<long, int> positionHistory) => positionHistory.Values.Any(val => val >= 3);
+    public static bool IsThreefoldRepetition(Dictionary<long, int> positionHistory) => positionHistory.Any(pair => pair.Value >= 3);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Is50MovesRepetition(int movesWithoutCaptureOrPawnMove) => movesWithoutCaptureOrPawnMove >= 100;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -532,10 +532,10 @@ public readonly struct Position
         }
     }
 
-    public static int NumberOfTwoFoldRepetitions(Dictionary<long, int> positionHistory) => positionHistory.Count(pair => pair.Value >= 2);
+    public static int NumberOfTwoFoldRepetitions(Dictionary<long, int> positionHistory) => positionHistory.Values.Count(val => val >= 2);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsThreefoldRepetition(Dictionary<long, int> positionHistory) => positionHistory.Any(pair => pair.Value >= 3);
+    public static bool IsThreefoldRepetition(Dictionary<long, int> positionHistory) => positionHistory.Values.Any(val => val >= 3);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Is50MovesRepetition(int movesWithoutCaptureOrPawnMove) => movesWithoutCaptureOrPawnMove >= 100;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -52,7 +52,7 @@ public sealed partial class Engine
         bool isMateDetected = false;
 
         if (Game.MoveHistory.Count >= 2
-            && _previousSearchResult?.Moves.Count >= 2
+            && _previousSearchResult?.Moves.Count > 2
             && _previousSearchResult.BestMove != default
             && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
             && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -27,6 +27,10 @@ public sealed partial class Engine
         _maxDepthReached[ply] = ply;
         _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
+        var pvIndex = PVTable.Indexes[ply];
+        var nextPvIndex = PVTable.Indexes[ply + 1];
+        _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
+
         if (Position.IsThreefoldRepetition(Game.PositionHashHistory) || Position.Is50MovesRepetition(_halfMovesWithoutCaptureOrPawnMove))
         {
             return 0;
@@ -80,10 +84,6 @@ public sealed partial class Engine
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
             return position.StaticEvaluation(_halfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
         }
-
-        var pvIndex = PVTable.Indexes[ply];
-        var nextPvIndex = PVTable.Indexes[ply + 1];
-        _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
         ++_nodes;
 


### PR DESCRIPTION
* https://github.com/lynx-chess/Lynx/commit/e4fa879f5203f11ca9737559cc79311e82e855f9 should prevent some `bestmove a1a1` situations
* https://github.com/lynx-chess/Lynx/commit/eff7c5c0b48aa95c03cb34216a005118e7872fff should prevent some illegal, nonsensical moves in PVs from previous searches

```
Score of Lynx 1006 - basefixes vs Lynx 987 - main: 728 - 731 - 351  [0.499] 1810
...      Lynx 1006 - basefixes playing White: 324 - 404 - 177  [0.456] 905
...      Lynx 1006 - basefixes playing Black: 404 - 327 - 174  [0.543] 905
...      White vs Black: 651 - 808 - 351  [0.457] 1810
Elo difference: -0.6 +/- 14.4, LOS: 46.9 %, DrawRatio: 19.4 %
SPRT: llr -1.04 (-35.2%), lbound -2.94, ubound 2.94
```