### PR TITLE
🐛 Fix PV table bug which keeps extra moves in PV after the move where a draw is detected

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -274,12 +274,15 @@ public sealed partial class Engine
 
         Console.WriteLine(
 (target != -1 ? $"src: {source}, tgt: {target}" + Environment.NewLine : "") +
-$" {0,-3} {_pVTable[0].ToEPDString(),-6} {_pVTable[1].ToEPDString(),-6} {_pVTable[2].ToEPDString(),-6} {_pVTable[3].ToEPDString(),-6} {_pVTable[4].ToEPDString(),-6} {_pVTable[5].ToEPDString(),-6} {_pVTable[6].ToEPDString(),-6} {_pVTable[7].ToEPDString(),-6}" + Environment.NewLine +
-$" {64,-3}        {_pVTable[64].ToEPDString(),-6} {_pVTable[65].ToEPDString(),-6} {_pVTable[66].ToEPDString(),-6} {_pVTable[67].ToEPDString(),-6} {_pVTable[68].ToEPDString(),-6} {_pVTable[69].ToEPDString(),-6} {_pVTable[70].ToEPDString(),-6}" + Environment.NewLine +
-$" {127,-3}               {_pVTable[127].ToEPDString(),-6} {_pVTable[128].ToEPDString(),-6} {_pVTable[129].ToEPDString(),-6} {_pVTable[130].ToEPDString(),-6} {_pVTable[131].ToEPDString(),-6} {_pVTable[132].ToEPDString(),-6}" + Environment.NewLine +
-$" {189,-3}                      {_pVTable[189].ToEPDString(),-6} {_pVTable[190].ToEPDString(),-6} {_pVTable[191].ToEPDString(),-6} {_pVTable[192].ToEPDString(),-6} {_pVTable[193].ToEPDString(),-6}" + Environment.NewLine +
-$" {250,-3}                             {_pVTable[250].ToEPDString(),-6} {_pVTable[251].ToEPDString(),-6} {_pVTable[252].ToEPDString(),-6} {_pVTable[253].ToEPDString(),-6}" + Environment.NewLine +
-$" {310,-3}                                    {_pVTable[310].ToEPDString(),-6} {_pVTable[311].ToEPDString(),-6} {_pVTable[312].ToEPDString(),-6}" + Environment.NewLine +
+$" {0,-3} {_pVTable[0].ToEPDString(),-6} {_pVTable[1].ToEPDString(),-6} {_pVTable[2].ToEPDString(),-6} {_pVTable[3].ToEPDString(),-6} {_pVTable[4].ToEPDString(),-6} {_pVTable[5].ToEPDString(),-6} {_pVTable[6].ToEPDString(),-6} {_pVTable[7].ToEPDString(),-6} {_pVTable[8].ToEPDString(),-6} {_pVTable[9].ToEPDString(),-6} {_pVTable[10].ToEPDString(),-6}" + Environment.NewLine +
+$" {64,-3}        {_pVTable[64].ToEPDString(),-6} {_pVTable[65].ToEPDString(),-6} {_pVTable[66].ToEPDString(),-6} {_pVTable[67].ToEPDString(),-6} {_pVTable[68].ToEPDString(),-6} {_pVTable[69].ToEPDString(),-6} {_pVTable[70].ToEPDString(),-6} {_pVTable[71].ToEPDString(),-6} {_pVTable[72].ToEPDString(),-6} {_pVTable[73].ToEPDString(),-6}" + Environment.NewLine +
+$" {127,-3}               {_pVTable[127].ToEPDString(),-6} {_pVTable[128].ToEPDString(),-6} {_pVTable[129].ToEPDString(),-6} {_pVTable[130].ToEPDString(),-6} {_pVTable[131].ToEPDString(),-6} {_pVTable[132].ToEPDString(),-6} {_pVTable[133].ToEPDString(),-6} {_pVTable[134].ToEPDString(),-6} {_pVTable[135].ToEPDString(),-6}" + Environment.NewLine +
+$" {189,-3}                      {_pVTable[189].ToEPDString(),-6} {_pVTable[190].ToEPDString(),-6} {_pVTable[191].ToEPDString(),-6} {_pVTable[192].ToEPDString(),-6} {_pVTable[193].ToEPDString(),-6} {_pVTable[194].ToEPDString(),-6} {_pVTable[195].ToEPDString(),-6} {_pVTable[196].ToEPDString(),-6}" + Environment.NewLine +
+$" {250,-3}                             {_pVTable[250].ToEPDString(),-6} {_pVTable[251].ToEPDString(),-6} {_pVTable[252].ToEPDString(),-6} {_pVTable[253].ToEPDString(),-6} {_pVTable[254].ToEPDString(),-6} {_pVTable[255].ToEPDString(),-6} {_pVTable[256].ToEPDString(),-6}" + Environment.NewLine +
+$" {310,-3}                                    {_pVTable[310].ToEPDString(),-6} {_pVTable[311].ToEPDString(),-6} {_pVTable[312].ToEPDString(),-6} {_pVTable[313].ToEPDString(),-6} {_pVTable[314].ToEPDString(),-6} {_pVTable[315].ToEPDString(),-6}" + Environment.NewLine +
+$" {369,-3}                                           {_pVTable[369].ToEPDString(),-6} {_pVTable[370].ToEPDString(),-6} {_pVTable[371].ToEPDString(),-6} {_pVTable[372].ToEPDString(),-6} {_pVTable[373].ToEPDString(),-6}" + Environment.NewLine +
+$" {427,-3}                                                  {_pVTable[427].ToEPDString(),-6} {_pVTable[428].ToEPDString(),-6} {_pVTable[429].ToEPDString(),-6} {_pVTable[430].ToEPDString(),-6}" + Environment.NewLine +
+$" {484,-3}                                                         {_pVTable[484].ToEPDString(),-6} {_pVTable[485].ToEPDString(),-6} {_pVTable[486].ToEPDString(),-6}" + Environment.NewLine +
 (target == -1 ? "------------------------------------------------------------------------------------" + Environment.NewLine : ""));
     }
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -112,13 +112,31 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
     {
+        // When asked to copy an incomplete PV one level ahead, clears the rest of the PV Table+
+        // PV Table at depth 3
+        // Copying 60 moves
+        // src: 250, tgt: 190
+        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+        //  189                      Qxb1   Qxb1   Qxb1   a8     a8
+        //  250                             a8     Qxb1   a8     a8
+        //  310                                    a8     a8     a8
+        //
+        // PV Table at depth 3
+        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+        //  189                      Qxb1   a8     a8     a8     a8
+        //  250                             a8     a8     a8     a8
+        //  310                                    a8     a8     a8
         if (_pVTable[source] == default)
         {
             Array.Clear(_pVTable, target, _pVTable.Length - target);
             return;
         }
 
-        //PrintPvTable(target, source);
+        //PrintPvTable(target: target, source: source, movesToCopy: moveCountToCopy);
         Array.Copy(_pVTable, source, _pVTable, target, moveCountToCopy);
         //PrintPvTable();
     }
@@ -235,17 +253,33 @@ public sealed partial class Engine
         }
     }
 
+    /// <summary>
+    /// Assumes Configuration.EngineSettings.MaxDepth = 64
+    /// </summary>
+    /// <param name="target"></param>
+    /// <param name="source"></param>
+    /// <param name="movesToCopy"></param>
+    /// <param name="depth"></param>
     [Conditional("DEBUG")]
-    private void PrintPvTable(int target = -1, int source = -1)
+    private void PrintPvTable(int target = -1, int source = -1, int movesToCopy = 0, int depth = 0)
     {
+        if (depth != default)
+        {
+            Console.WriteLine($"PV Table at depth {depth}");
+        }
+        if (movesToCopy != default)
+        {
+            Console.WriteLine($"Copying {movesToCopy} moves");
+        }
+
         Console.WriteLine(
 (target != -1 ? $"src: {source}, tgt: {target}" + Environment.NewLine : "") +
-$" {0,-3} {_pVTable[0],-6} {_pVTable[1],-6} {_pVTable[2],-6} {_pVTable[3],-6} {_pVTable[4],-6} {_pVTable[5],-6} {_pVTable[6],-6} {_pVTable[7],-6}" + Environment.NewLine +
-$" {64,-3}        {_pVTable[64],-6} {_pVTable[65],-6} {_pVTable[66],-6} {_pVTable[67],-6} {_pVTable[68],-6} {_pVTable[69],-6} {_pVTable[70],-6}" + Environment.NewLine +
-$" {127,-3}               {_pVTable[127],-6} {_pVTable[128],-6} {_pVTable[129],-6} {_pVTable[130],-6} {_pVTable[131],-6} {_pVTable[132],-6}" + Environment.NewLine +
-$" {189,-3}                      {_pVTable[189],-6} {_pVTable[190],-6} {_pVTable[191],-6} {_pVTable[192],-6} {_pVTable[193],-6}" + Environment.NewLine +
-$" {250,-3}                             {_pVTable[250],-6} {_pVTable[251],-6} {_pVTable[252],-6} {_pVTable[253],-6}" + Environment.NewLine +
-$" {310,-3}                                    {_pVTable[310],-6} {_pVTable[311],-6} {_pVTable[312],-6}" + Environment.NewLine +
+$" {0,-3} {_pVTable[0].ToEPDString(),-6} {_pVTable[1].ToEPDString(),-6} {_pVTable[2].ToEPDString(),-6} {_pVTable[3].ToEPDString(),-6} {_pVTable[4].ToEPDString(),-6} {_pVTable[5].ToEPDString(),-6} {_pVTable[6].ToEPDString(),-6} {_pVTable[7].ToEPDString(),-6}" + Environment.NewLine +
+$" {64,-3}        {_pVTable[64].ToEPDString(),-6} {_pVTable[65].ToEPDString(),-6} {_pVTable[66].ToEPDString(),-6} {_pVTable[67].ToEPDString(),-6} {_pVTable[68].ToEPDString(),-6} {_pVTable[69].ToEPDString(),-6} {_pVTable[70].ToEPDString(),-6}" + Environment.NewLine +
+$" {127,-3}               {_pVTable[127].ToEPDString(),-6} {_pVTable[128].ToEPDString(),-6} {_pVTable[129].ToEPDString(),-6} {_pVTable[130].ToEPDString(),-6} {_pVTable[131].ToEPDString(),-6} {_pVTable[132].ToEPDString(),-6}" + Environment.NewLine +
+$" {189,-3}                      {_pVTable[189].ToEPDString(),-6} {_pVTable[190].ToEPDString(),-6} {_pVTable[191].ToEPDString(),-6} {_pVTable[192].ToEPDString(),-6} {_pVTable[193].ToEPDString(),-6}" + Environment.NewLine +
+$" {250,-3}                             {_pVTable[250].ToEPDString(),-6} {_pVTable[251].ToEPDString(),-6} {_pVTable[252].ToEPDString(),-6} {_pVTable[253].ToEPDString(),-6}" + Environment.NewLine +
+$" {310,-3}                                    {_pVTable[310].ToEPDString(),-6} {_pVTable[311].ToEPDString(),-6} {_pVTable[312].ToEPDString(),-6}" + Environment.NewLine +
 (target == -1 ? "------------------------------------------------------------------------------------" + Environment.NewLine : ""));
     }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -112,7 +112,7 @@ public sealed partial class Engine
                 alpha = bestEvaluation - Configuration.EngineSettings.AspirationWindowAlpha;
                 beta = bestEvaluation + Configuration.EngineSettings.AspirationWindowBeta;
 
-                //PrintPvTable();
+                //PrintPvTable(depth: depth);
                 ValidatePVTable();
 
                 var pvMoves = _pVTable.TakeWhile(m => m != default).ToList();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -140,6 +140,11 @@ public sealed partial class Engine
             if (isThreFoldRepetition || Game.Is50MovesRepetition())
             {
                 evaluation = 0;
+
+                // We don't need to evaluate further down to know it's a draw.
+                // Since we won't be evaluating further down, we need to clear the PV table because those moves there
+                // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
+                Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
             }
             else if (movesSearched == 0)
             {
@@ -279,8 +284,8 @@ public sealed partial class Engine
         //_searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         var pvIndex = PVTable.Indexes[ply];
-        _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
         var nextPvIndex = PVTable.Indexes[ply + 1];
+        _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
         ++_nodes;
         _maxDepthReached[ply] = ply;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -134,10 +134,10 @@ public sealed partial class Engine
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
             Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-            var isThreFoldRepetition = !Game.PositionHashHistory.Add(newPosition.UniqueIdentifier);
+            var isThreeFoldRepetition = !Game.PositionHashHistory.Add(newPosition.UniqueIdentifier);
 
             int evaluation;
-            if (isThreFoldRepetition || Game.Is50MovesRepetition())
+            if (isThreeFoldRepetition || Game.Is50MovesRepetition())
             {
                 evaluation = 0;
 
@@ -197,7 +197,7 @@ public sealed partial class Engine
 
             // After making a move
             Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-            if (!isThreFoldRepetition)
+            if (!isThreeFoldRepetition)
             {
                 Game.PositionHashHistory.Remove(newPosition.UniqueIdentifier);
             }
@@ -330,17 +330,26 @@ public sealed partial class Engine
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
             Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-            var isNotThreFoldRepetition = Game.PositionHashHistory.Add(newPosition.UniqueIdentifier);
+            var isThreeFoldRepetition = !Game.PositionHashHistory.Add(newPosition.UniqueIdentifier);
 
-            int evaluation = 0;
-            if (isNotThreFoldRepetition && !Game.Is50MovesRepetition())
+            int evaluation;
+            if (isThreeFoldRepetition || Game.Is50MovesRepetition())
+            {
+                evaluation = 0;
+
+                // We don't need to evaluate further down to know it's a draw.
+                // Since we won't be evaluating further down, we need to clear the PV table because those moves there
+                // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
+                Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
+            }
+            else
             {
                 evaluation = -QuiescenceSearch(in newPosition, ply + 1, -beta, -alpha);
             }
 
             // After making a move
             Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-            if (isNotThreFoldRepetition)
+            if (!isThreeFoldRepetition)
             {
                 Game.PositionHashHistory.Remove(newPosition.UniqueIdentifier);
             }

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -229,6 +229,47 @@ public class RegressionTest : BaseTest
         Assert.NotZero(bestMove.Evaluation);
     }
 
+    // 8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1 - || PV Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6, with b1=Q as the first invalid move there
+    [TestCase("position startpos moves d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1f4 e8g8" +
+        " e2e3 c7c5 d4c5 e7c5 a2a3 a7a6 d1d2 d5c4 f1c4 b7b5 c4d3 c8b7 b2b4 b7f3 b4c5 f3g2" +
+        " h1g1 g2f3 g1g3 f3c6 f4h6 g7g6 h6f8 d8f8 a3a4 b5b4 c3a2 b4b3 a2c1 f8c5 c1b3 c5d5" +
+        " b3a5 d5h1 d3f1 c6d5 d2c3 b8d7 c3c7 h1e4 f1c4 e4c2 a1a2 c2c1 e1e2 d7e5 c7e5 d5c4" +
+        " a5c4 c1c4 e2f3 c4a2 e5f6 a2a4 f3g2 a8c8 g3f3 a4d7 f6e5 d7b5 e5d6 a6a5 d6e7 c8f8" +
+        " e7d6 a5a4 e3e4 b5c4 f3e3 f8c8 h2h3 c4b5 e3f3 b5g5 f3g3 g5a5 g3d3 a5g5 d3g3 g5b5" +
+        " g3f3 b5a5 f3d3 a5a8 d6b4 c8b8 b4c4 a4a3 d3d2 b8b2 d2b2 a3b2 c4b4 a8a2 b4b8 g8g7" +
+        " b8e5 g7g8 e5b8 g8g7 b8e5 f7f6 e5c7 g7g8 c7b8 g8f7 b8c7 f7g8 c7b8 g8g7")]
+    public void InvalidPV(string positionCommand)
+    {
+        var engine = GetEngine();
+        engine.AdjustPosition(positionCommand);
+
+        var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
+        Assert.Zero(bestMove.Evaluation);
+        Assert.AreEqual(1, bestMove.Moves.Count);
+        Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
+    }
+
+    // pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
+    [TestCase("position startpos moves e2e4 c7c6 d2d4 d7d5 e4e5 c8f5 g1f3 e7e6 f1e2 c6c5 c1e3" +
+        " c5d4 f3d4 g8e7 b1c3 f5g6 h2h4 h7h5 e2b5 b8d7 e3f4 a7a6 b5d3 g6d3 d1d3 e7g6 d4e6 g6f4" +
+        " e6f4 d7e5 d3e2 d8d6 c3d5 g7g6 e1c1 f8h6 h1e1 f7f6 d5f6 d6f6 e2e5 f6e5 e1e5 e8f8 g2g3" +
+        " a8e8 e5e3 h6f4 g3f4 h8h7 d1d6 h7f7 e3e8 f8e8 d6g6 f7f4 g6g8 e8f7 g8b8 b7b5 b8b6 f4a4" +
+        " f2f3 a4h4 b6a6 h4h1 c1d2 h1h2 d2c3 h2f2 b2b3 h5h4 a6h6 f2f3 c3b4 f3f4 b4b5 f7g7 h6h5" +
+        " g7f6 c2c4 f4f5 h5f5 f6f5 c4c5 f5e6 a2a4 h4h3 b5b6 h3h2 b3b4 h2h1q a4a5")]
+
+    public void InvalidPV2(string positionCommand)
+    {
+        var engine = GetEngine();
+        engine.AdjustPosition(positionCommand[..^10]);
+
+        var bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+        Assert.AreEqual("h2h1q", bestMove.BestMove.UCIString());
+
+        engine.AdjustPosition(positionCommand);
+        bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+        Assert.AreNotEqual("h2h1q", bestMove.BestMove.UCIString());
+    }
+
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCase(Constants.KillerTestPositionFEN)]


### PR DESCRIPTION
Since I've moved draw detection to the move-evaluation loop, the search doesn't go into NegaMax again and the pv table first node for that depth isn't cleared (which I ensured in #294)

Example of the issue:

Given `8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1`, PV spitted out at depth 5 was: `Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6`, where `b1=Q` is an illegal move, since before searching Qc7, Qb7 was being searched with the correct PV `Qb7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6`

----

First commit (only NegaMax method):
```
Score of Lynx 1014 - pvtable fix vs Lynx 1012 - main: 131 - 120 - 100  [0.516] 351
...      Lynx 1014 - pvtable fix playing White: 69 - 58 - 49  [0.531] 176
...      Lynx 1014 - pvtable fix playing Black: 62 - 62 - 51  [0.500] 175
...      White vs Black: 131 - 120 - 100  [0.516] 351
Elo difference: 10.9 +/- 30.8, LOS: 75.6 %, DrawRatio: 28.5 %
SPRT: llr 0.24 (8.1%), lbound -2.94, ubound 2.94
```

Both together:
```
Score of Lynx 1015 - pvtable fix vs Lynx 1012 - main: 97 - 86 - 77  [0.521] 260
...      Lynx 1015 - pvtable fix playing White: 60 - 36 - 34  [0.592] 130
...      Lynx 1015 - pvtable fix playing Black: 37 - 50 - 43  [0.450] 130
...      White vs Black: 110 - 73 - 77  [0.571] 260
Elo difference: 14.7 +/- 35.5, LOS: 79.2 %, DrawRatio: 29.6 %
```