### PR TITLE
🐛 Fix TT probing condition and TT moves score

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -299,6 +299,7 @@ public static class Constants
 
     public const string ComplexPositionFEN = "rq2k2r/ppp2pb1/2n1pnpp/1Q1p1b2/3P1B2/2N1PNP1/PPP2PBP/R3K2R w KQkq - 0 1";
 
+    // 'Search explosion'
     // https://www.chessprogramming.org/Lasker-Reichhelm_Position
     public const string TTPositionFEN = "8/k7/3p4/p2P1p2/P2P1P2/8/8/K7 w - - 0 1";
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -300,9 +300,14 @@ public static class EvaluationConstants
 
     public const int SecondKillerMoveValue = 8_000;
 
-    public const int PVMoveScoreValue = 20_000;
+    public const int PVMoveScoreValue = 200_000;
 
-    public const int TTMoveScoreValue = 19_000;
+    public const int TTMoveScoreValue = 190_000;
+
+    /// <summary>
+    /// For MVVLVA
+    /// </summary>
+    public const int CaptureMoveBaseScoreValue = 100_000;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -25,8 +25,6 @@ namespace Lynx.Model;
 /// </summary>
 public static class MoveExtensions
 {
-    public const int CaptureBaseScore = 100_000;
-
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
     /// <summary>
@@ -177,7 +175,7 @@ public static class MoveExtensions
                 }
             }
 
-            score += CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
+            score += EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }
         else
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -33,14 +33,11 @@ public sealed partial class Engine
 
         Move ttBestMove = default;
 
-        bool isPvNode = beta - alpha == 1;
-        if (!isPvNode && ply > 0)
+        if (ply > 0)
         {
             var ttProbeResult = _transpositionTable.ProbeHash(position, targetDepth, ply, alpha, beta);
-            if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
+            if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry) // TODO here we can try alpha == beta - 1 as requirement
             {
-                _logger.Trace("Taking move {0} from tt with eval {1}", ttProbeResult.BestMove, ttProbeResult.Evaluation);
-
                 return ttProbeResult.Evaluation;
             }
             ttBestMove = ttProbeResult.BestMove;

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -24,10 +24,6 @@ public class EvaluationConstantsTest
             checkmateDetectionLimit);
 
         Assert.Greater(checkmateDetectionLimit, _sensibleEvaluation);
-
-        Assert.Greater(checkmateDetectionLimit, PVMoveScoreValue);
-        Assert.Greater(checkmateDetectionLimit, FirstKillerMoveValue);
-        Assert.Greater(checkmateDetectionLimit, SecondKillerMoveValue);
     }
 
     [Test]
@@ -36,10 +32,6 @@ public class EvaluationConstantsTest
         Assert.Greater(NoHashEntry, _sensibleEvaluation);
         Assert.Greater(PositiveCheckmateDetectionLimit, NoHashEntry);
         Assert.Greater(-NegativeCheckmateDetectionLimit, NoHashEntry);
-
-        Assert.Greater(NoHashEntry, PVMoveScoreValue);
-        Assert.Greater(NoHashEntry, FirstKillerMoveValue);
-        Assert.Greater(NoHashEntry, SecondKillerMoveValue);
     }
 
     [Test]
@@ -48,5 +40,85 @@ public class EvaluationConstantsTest
         Assert.Greater(short.MaxValue, PositiveCheckmateDetectionLimit);
         Assert.Greater(short.MaxValue, NoHashEntry);
         Assert.Greater(short.MaxValue, _sensibleEvaluation);
+    }
+
+    [Test]
+    public void TTMoveScoreValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+        Assert.Greater(TTMoveScoreValue, maxMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+    }
+
+    [Test]
+    public void PVMoveScoreValueConstant()
+    {
+        Assert.Greater(PVMoveScoreValue, TTMoveScoreValue);
+    }
+
+    [Test]
+    public void FirstKillerMoveValueConstant()
+    {
+        var minMVVLVAMoveValue = int.MaxValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] < minMVVLVAMoveValue)
+                {
+                    minMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        checked
+        {
+#pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
+            Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+#pragma warning restore S3949 // Calculations should not overflow
+        }
+
+        Assert.Less(FirstKillerMoveValue, TTMoveScoreValue);
+
+        Assert.Greater(FirstKillerMoveValue, SecondKillerMoveValue);
+    }
+
+    [Test]
+    public void SecondKillerMoveValueConstant()
+    {
+        var minMVVLVAMoveValue = int.MaxValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] < minMVVLVAMoveValue)
+                {
+                    minMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        checked
+        {
+#pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
+            Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+#pragma warning restore S3949 // Calculations should not overflow
+        }
+
+        Assert.Less(SecondKillerMoveValue, FirstKillerMoveValue);
+
+        Assert.Greater(SecondKillerMoveValue, default);
     }
 }

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -64,6 +64,6 @@ public class MoveScoreTest
         var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(in position)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(MoveExtensions.CaptureBaseScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(in position));
+        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(in position));
     }
 }


### PR DESCRIPTION
```
Score of Lynx 1019 - tt-exp vs Lynx 1016 - main: 303 - 214 - 152  [0.567] 669
...      Lynx 1019 - tt-exp playing White: 163 - 107 - 65  [0.584] 335
...      Lynx 1019 - tt-exp playing Black: 140 - 107 - 87  [0.549] 334
...      White vs Black: 270 - 247 - 152  [0.517] 669
Elo difference: 46.5 +/- 23.3, LOS: 100.0 %, DrawRatio: 22.7 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```