### PR TITLE
⚡ Don't reload config on file changes

### DIFF
--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -12,8 +12,8 @@ Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
 var environmentName = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
 
 var config = new ConfigurationBuilder()
-    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-    .AddJsonFile($"appsettings.{environmentName}.json", optional: true, reloadOnChange: true)
+    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+    .AddJsonFile($"appsettings.{environmentName}.json", optional: true, reloadOnChange: false)
     .AddEnvironmentVariables()
     .Build();
 


### PR DESCRIPTION
This should avoid some threads with filewatchers monitoring the files

```
Score of Lynx 1029 - no-config-reload-on-change vs Lynx 1020 - main: 784 - 757 - 459  [0.507] 2000
...      Lynx 1029 - no-config-reload-on-change playing White: 452 - 307 - 241  [0.573] 1000
...      Lynx 1029 - no-config-reload-on-change playing Black: 332 - 450 - 218  [0.441] 1000
...      White vs Black: 902 - 639 - 459  [0.566] 2000
Elo difference: 4.7 +/- 13.4, LOS: 75.4 %, DrawRatio: 22.9 %
SPRT: llr -0.0673 (-2.3%), lbound -2.94, ubound 2.94
```