### PR TITLE
Use reference variable (`ref`) when probing TT

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -96,7 +96,7 @@ public static class TranspositionTableExtensions
             return (EvaluationConstants.NoHashEntry, default);
         }
 
-        var entry = transpositionTable[TranspositionTableIndex(position, transpositionTable)];
+        ref var entry = ref transpositionTable[TranspositionTableIndex(position, transpositionTable)];
 
         if (position.UniqueIdentifier != entry.Key)
         {


### PR DESCRIPTION
```
Score of Lynx 1021 - tt ref vs Lynx 1020 - main: 920 - 969 - 467  [0.490] 2356
...      Lynx 1021 - tt ref playing White: 532 - 424 - 222  [0.546] 1178
...      Lynx 1021 - tt ref playing Black: 388 - 545 - 245  [0.433] 1178
...      White vs Black: 1077 - 812 - 467  [0.556] 2356
Elo difference: -7.2 +/- 12.6, LOS: 13.0 %, DrawRatio: 19.8 %
SPRT: llr -2.98 (-101.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```

No improvement detected whatsoever