### PR TITLE
Use non-alloc version of get moves instead of game move pool

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -45,7 +45,8 @@ using System.Runtime.InteropServices;
 //FileAndRankMasks();
 //EnhancedPawnEvaluation();
 //RookEvaluation();
-TranspositionTable();
+_42_Perft();
+//TranspositionTable();
 
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
 const string TrickyPosition = Constants.TrickyTestPositionFEN;
@@ -520,14 +521,20 @@ static void _42_Perft()
 
     var pos = new Position(TrickyPosition);
 
-    for (int depth = 0; depth < 7; ++depth)
+    for (int depth = 0; depth < 6; ++depth)
     {
         var sw = new Stopwatch();
         sw.Start();
-        var nodes = Perft.Results(in pos, depth);
+        var nodes = Perft.Results(in pos, depth, false);
         sw.Stop();
+    }
 
-        Console.WriteLine($"Depth {depth}\tNodes: {nodes}\tTime: {sw.ElapsedMilliseconds}ms");
+    for (int depth = 0; depth < 6; ++depth)
+    {
+        var sw = new Stopwatch();
+        sw.Start();
+        var nodes = Perft.Results(in pos, depth, true);
+        sw.Stop();
     }
 }
 

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -7,8 +7,6 @@ public sealed class Game
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    public Move[] MovePool { get; } = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-
     public List<Move> MoveHistory { get; }
     public List<Position> PositionHistory { get; }
     public HashSet<long> PositionHashHistory { get; }
@@ -46,9 +44,10 @@ public sealed class Game
     {
         foreach (var moveString in movesUCIString)
         {
-            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, MovePool);
+            Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            MoveGenerator.GenerateAllMoves(CurrentPosition, ref moveList);
 
-            if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
+            if (!MoveExtensions.TryParseFromUCIString(moveString, ref moveList, out var parsedMove))
             {
                 _logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', movesUCIString), moveString);
                 break;

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -70,6 +71,65 @@ public static class MoveExtensions
         var targetSquare = (UCIString[2] - 'a') + ((8 - (UCIString[3] - '0')) * 8);
 
         var candidateMoves = moveList.Where(move => move.SourceSquare() == sourceSquare && move.TargetSquare() == targetSquare);
+
+        if (UCIString.Length == 4)
+        {
+            move = candidateMoves.FirstOrDefault();
+
+            if (move.Equals(default(Move)))
+            {
+                _logger.Warn("Unable to link last move string {0} to a valid move in the current position. That move may have already been played", UCIString);
+                move = null;
+                return false;
+            }
+
+            Utils.Assert(move.Value.PromotedPiece() == default);
+            return true;
+        }
+        else
+        {
+            var promotedPiece = (int)Enum.Parse<Piece>(UCIString[4].ToString());
+
+            bool predicate(Move m)
+            {
+                var actualPromotedPiece = m.PromotedPiece();
+
+                return actualPromotedPiece == promotedPiece
+                || actualPromotedPiece == promotedPiece - 6;
+            }
+
+            move = candidateMoves.FirstOrDefault(predicate);
+            if (move.Equals(default(Move)))
+            {
+                _logger.Warn("Unable to link move {0} to a valid move in the current position. That move may have already been played", UCIString);
+                move = null;
+                return false;
+            }
+
+            Utils.Assert(candidateMoves.Count() == 4);
+            Utils.Assert(candidateMoves.Count(predicate) == 1);
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns the move from <paramref name="moveList"/> indicated by <paramref name="UCIString"/>
+    /// </summary>
+    /// <param name="UCIString"></param>
+    /// <param name="moveList"></param>
+    /// <param name="move"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IndexOutOfRangeException"></exception>
+    /// <returns></returns>
+    public static bool TryParseFromUCIString(string UCIString, ref Span<Move> moveList, [NotNullWhen(true)] out Move? move)
+    {
+        Utils.Assert(UCIString.Length == 4 || UCIString.Length == 5);
+
+        var sourceSquare = (UCIString[0] - 'a') + ((8 - (UCIString[1] - '0')) * 8);
+        var targetSquare = (UCIString[2] - 'a') + ((8 - (UCIString[3] - '0')) * 8);
+
+        var candidateMoves = moveList.ToImmutableArray().Where(move => move.SourceSquare() == sourceSquare && move.TargetSquare() == targetSquare);
 
         if (UCIString.Length == 4)
         {

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -353,6 +353,13 @@ public readonly struct Position
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AllPossibleMoves(ref Span<Move> movePool) => MoveGenerator.GenerateAllMoves(this, ref movePool);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AllCapturesMoves(ref Span<Move> movePool) => MoveGenerator.GenerateAllMoves(this, ref movePool, capturesOnly: true);
+
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 
     /// <summary>

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -260,6 +260,232 @@ public static class MoveGenerator
         }
     }
 
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GenerateAllMoves(in Position position, ref Span<Move> movePool, bool capturesOnly = false)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return;
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnMoves(ref localIndex, ref movePool, in position, offset, capturesOnly);
+        GenerateCastlingMoves(ref localIndex, ref movePool, in position, offset);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.K + offset, in position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.N + offset, in position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.B + offset, in position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.R + offset, in position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.Q + offset, in position, capturesOnly);
+
+        movePool = movePool.Slice(0, localIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnMoves(ref int localIndex, ref Span<Move> movePool, in Position position, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare / 8) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                    {
+                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, ref Span<Move> movePool, in Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, in position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, in position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, in position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, in position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, in position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, in position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, in position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, in position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, in position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, in position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceMoves(ref int localIndex, ref Span<Move> movePool, int piece, in Position position, bool capturesOnly = false)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
     #region Only for reference, but unused
 
     /// <summary>

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -9,11 +9,11 @@ namespace Lynx;
 /// </summary>
 public static class Perft
 {
-    public static long Results(in Position position, int depth)
+    public static long Results(in Position position, int depth, bool useSpan = false)
     {
         var sw = new Stopwatch();
         sw.Start();
-        var nodes = ResultsImpl(position, depth, 0);
+        var nodes = ResultsImpl(position, depth, 0, useSpan);
         sw.Stop();
 
         PrintPerftResult(depth, nodes, sw);
@@ -41,11 +41,23 @@ public static class Perft
     /// <param name="depth"></param>
     /// <param name="nodes"></param>
     /// <returns></returns>
-    internal static long ResultsImpl(in Position position, int depth, long nodes)
+    internal static long ResultsImpl(in Position position, int depth, long nodes, bool useSpan = false)
     {
         if (depth != 0)
         {
-            foreach (var move in MoveGenerator.GenerateAllMoves(in position))
+            Span<Move> moveList = useSpan
+                ? stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition]
+                : default;
+
+            if (useSpan)
+            {
+                MoveGenerator.GenerateAllMoves(in position, ref moveList);
+            }
+            else
+            {
+                moveList = new(MoveGenerator.GenerateAllMoves(in position).ToArray());
+            }
+            foreach (var move in moveList)
             {
                 var newPosition = new Position(in position, move);
 
@@ -65,7 +77,9 @@ public static class Perft
     {
         if (depth != 0)
         {
-            foreach (var move in MoveGenerator.GenerateAllMoves(in position))
+            Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            MoveGenerator.GenerateAllMoves(in position, ref moveList);
+            foreach (var move in moveList)
             {
                 var newPosition = new Position(in position, move);
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -159,9 +159,11 @@ public sealed partial class Engine
             }
             var move = _pVTable[i];
 
+            Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            MoveGenerator.GenerateAllMoves(in position, ref moveList);
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               position.AllPossibleMoves(Game.MovePool),
+               ref moveList,
                out _))
             {
                 var message = $"Unexpected PV move {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -63,9 +63,10 @@ public sealed partial class PositionCommand : GUIBaseCommand
         var moveString = positionCommand
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)[^1];
 
+        Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            game.CurrentPosition.AllPossibleMoves(game.MovePool),
+            ref moveList,
             out lastMove))
         {
             _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -249,7 +249,7 @@ public class RegressionTest : BaseTest
         Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
     }
 
-    // pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
+    // 1Q6/6kp/4ppp1/8/4P3/7P/qp3PK1/8 w - - 0 1 || pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
     [TestCase("position startpos moves e2e4 c7c6 d2d4 d7d5 e4e5 c8f5 g1f3 e7e6 f1e2 c6c5 c1e3" +
         " c5d4 f3d4 g8e7 b1c3 f5g6 h2h4 h7h5 e2b5 b8d7 e3f4 a7a6 b5d3 g6d3 d1d3 e7g6 d4e6 g6f4" +
         " e6f4 d7e5 d3e2 d8d6 c3d5 g7g6 e1c1 f8h6 h1e1 f7f6 d5f6 d6f6 e2e5 f6e5 e1e5 e8f8 g2g3" +


### PR DESCRIPTION
```
Score of Lynx 1031 - move-stackalloc vs Lynx 1030 - main: 773 - 767 - 460  [0.501] 2000
...      Lynx 1031 - move-stackalloc playing White: 446 - 316 - 238  [0.565] 1000
...      Lynx 1031 - move-stackalloc playing Black: 327 - 451 - 222  [0.438] 1000
...      White vs Black: 897 - 643 - 460  [0.564] 2000
Elo difference: 1.0 +/- 13.3, LOS: 56.1 %, DrawRatio: 23.0 %
SPRT: llr -0.852 (-28.9%), lbound -2.94, ubound 2.94
```

Move pool was a good trick apparently