### PR TITLE
🔍 Exclude promotions from killer moves and take them into account in move ordering

### DIFF
--- a/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
+++ b/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
@@ -54,5 +54,65 @@ public class LocalVariableIn_vs_NoIn : BaseBenchmark
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int Score(Move move, in Position position) => move.Score(in position);
+    private int Score(Move move, in Position position) => move.OldScore(in position);
+}
+
+public static class BenchmarkLegacyMoveExtensions
+{
+    /// <summary>
+    /// Returns the score evaluation of a move taking into account <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
+    /// </summary>
+    /// <param name="position">The position that precedes a move</param>
+    /// <param name="killerMoves"></param>
+    /// <param name="plies"></param>
+    /// <param name="historyMoves"></param>
+    /// <returns>The higher the score is, the more valuable is the captured piece and the less valuable is the piece that makes the such capture</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int OldScore(this Move move, in Position position, int[,]? killerMoves = null, int? plies = null, int[,]? historyMoves = null)
+    {
+        if (move.IsCapture())
+        {
+            var sourcePiece = move.Piece();
+            int targetPiece = (int)Model.Piece.P;    // Important to initialize to P or p, due to en-passant captures
+
+            var targetSquare = move.TargetSquare();
+            var oppositeSide = Utils.OppositeSide(position.Side);
+            var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
+            var oppositePawnIndex = (int)Model.Piece.P + oppositeSideOffset;
+
+            var limit = (int)Model.Piece.K + oppositeSideOffset;
+            for (int pieceIndex = oppositePawnIndex; pieceIndex < limit; ++pieceIndex)
+            {
+                if (position.PieceBitBoards[pieceIndex].GetBit(targetSquare))
+                {
+                    targetPiece = pieceIndex;
+                    break;
+                }
+            }
+
+            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
+        }
+        else if (killerMoves is not null && plies is not null)
+        {
+            // 1st killer move
+            if (killerMoves[0, plies.Value] == move)
+            {
+                return EvaluationConstants.FirstKillerMoveValue;
+            }
+
+            // 2nd killer move
+            else if (killerMoves[1, plies.Value] == move)
+            {
+                return EvaluationConstants.SecondKillerMoveValue;
+            }
+
+            // History move
+            else if (historyMoves is not null)
+            {
+                return historyMoves[move.Piece(), move.TargetSquare()];
+            }
+        }
+
+        return default;
+    }
 }

--- a/src/Lynx.Benchmark/MoveGeneratorParallel.cs
+++ b/src/Lynx.Benchmark/MoveGeneratorParallel.cs
@@ -120,7 +120,7 @@ public class MoveGeneratorParallel : BaseBenchmark
             moves.AddRange(GeneratePieceMoves((int)Piece.R + offset, position, capturesOnly));
             moves.AddRange(GeneratePieceMoves((int)Piece.Q + offset, position, capturesOnly));
 
-            return moves.OrderByDescending(move => move.Score(in position, killerMoves, plies));
+            return moves.OrderByDescending(move => move.OldScore(in position, killerMoves, plies));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -141,7 +141,7 @@ public class MoveGeneratorParallel : BaseBenchmark
 
             var result = await Task.WhenAll(taskList);
 
-            return result.SelectMany(i => i).OrderByDescending(move => move.Score(in position, killerMoves, plies));
+            return result.SelectMany(i => i).OrderByDescending(move => move.OldScore(in position, killerMoves, plies));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -170,7 +170,7 @@ public class MoveGeneratorParallel : BaseBenchmark
                 }
             });
 
-            return concurrentBag.OrderByDescending(move => move.Score(in position, killerMoves, plies));
+            return concurrentBag.OrderByDescending(move => move.OldScore(in position, killerMoves, plies));
         }
 
         #region Other stuff

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -2,9 +2,11 @@
 using Lynx.Internal;
 using Lynx.Model;
 using System.Diagnostics;
+using System.Net.Http.Headers;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading.Channels;
 
 //_2_GettingStarted();
 //_3_PawnAttacks();
@@ -662,9 +664,10 @@ static void _54_ScoreMove()
     var position = new Position(KillerPosition);
     position.Print();
 
+    var engine = new Engine(Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
     foreach (var move in position.AllCapturesMoves())
     {
-        Console.WriteLine($"{move} {move.Score(in position)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, in position, default, default)}");
     }
 
     position = new Position(TrickyPosition);
@@ -672,7 +675,7 @@ static void _54_ScoreMove()
 
     foreach (var move in position.AllCapturesMoves())
     {
-        Console.WriteLine($"{move} {move.Score(in position)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, in position, default, default)}");
     }
 }
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -305,11 +305,11 @@ public static class EvaluationConstants
     /// </summary>
     public const int CaptureMoveBaseScoreValue = 100_000;
 
-    public const int PromotionMoveScoreValue = 10_000;
-
     public const int FirstKillerMoveValue = 9_000;
 
     public const int SecondKillerMoveValue = 8_000;
+
+    public const int PromotionMoveScoreValue = 7_000;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -304,7 +304,7 @@ public static class EvaluationConstants
 
     public const int TTMoveScoreValue = 190_000;
 
-    public const int PromotionMoveScoreValue = 10_000;
+    public const int PromotionMoveScoreValue = 7000;
 
     /// <summary>
     /// For MVVLVA

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -304,7 +304,7 @@ public static class EvaluationConstants
 
     public const int TTMoveScoreValue = 190_000;
 
-    public const int PromotionMoveScoreValue = 7000;
+    public const int PromotionMoveScoreValue = 150_000;
 
     /// <summary>
     /// For MVVLVA

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -304,6 +304,8 @@ public static class EvaluationConstants
 
     public const int TTMoveScoreValue = 190_000;
 
+    public const int PromotionMoveScoreValue = 10_000;
+
     /// <summary>
     /// For MVVLVA
     /// </summary>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -296,20 +296,20 @@ public static class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
-    public const int FirstKillerMoveValue = 9_000;
-
-    public const int SecondKillerMoveValue = 8_000;
-
     public const int PVMoveScoreValue = 200_000;
 
     public const int TTMoveScoreValue = 190_000;
-
-    public const int PromotionMoveScoreValue = 150_000;
 
     /// <summary>
     /// For MVVLVA
     /// </summary>
     public const int CaptureMoveBaseScoreValue = 100_000;
+
+    public const int PromotionMoveScoreValue = 10_000;
+
+    public const int FirstKillerMoveValue = 9_000;
+
+    public const int SecondKillerMoveValue = 8_000;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -153,9 +153,11 @@ public static class MoveExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int Score(this Move move, in Position position, int[,]? killerMoves = null, int? plies = null, int[,]? historyMoves = null)
     {
-        int score = 0;
-
-        if (move.IsCapture())
+        if (move.PromotedPiece() != default)
+        {
+            return EvaluationConstants.PromotionMoveScoreValue;
+        }
+        else if (move.IsCapture())
         {
             var sourcePiece = move.Piece();
             int targetPiece = (int)Model.Piece.P;    // Important to initialize to P or p, due to en-passant captures
@@ -175,11 +177,7 @@ public static class MoveExtensions
                 }
             }
 
-            score += EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
-        }
-        else if (move.PromotedPiece() != default)
-        {
-            return EvaluationConstants.PromotionMoveScoreValue;
+            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }
         else if (killerMoves is not null && plies is not null)
         {
@@ -202,7 +200,7 @@ public static class MoveExtensions
             }
         }
 
-        return score;
+        return default;
     }
 
     public static string ToMoveString(this Move move)

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -177,27 +177,28 @@ public static class MoveExtensions
 
             score += EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }
-        else
+        else if (move.PromotedPiece() != default)
         {
-            if (killerMoves is not null && plies is not null)
+            return EvaluationConstants.PromotionMoveScoreValue;
+        }
+        else if (killerMoves is not null && plies is not null)
+        {
+            // 1st killer move
+            if (killerMoves[0, plies.Value] == move)
             {
-                // 1st killer move
-                if (killerMoves[0, plies.Value] == move)
-                {
-                    return EvaluationConstants.FirstKillerMoveValue;
-                }
+                return EvaluationConstants.FirstKillerMoveValue;
+            }
 
-                // 2nd killer move
-                else if (killerMoves[1, plies.Value] == move)
-                {
-                    return EvaluationConstants.SecondKillerMoveValue;
-                }
+            // 2nd killer move
+            else if (killerMoves[1, plies.Value] == move)
+            {
+                return EvaluationConstants.SecondKillerMoveValue;
+            }
 
-                // History move
-                else if (historyMoves is not null)
-                {
-                    return historyMoves[move.Piece(), move.TargetSquare()];
-                }
+            // History move
+            else if (historyMoves is not null)
+            {
+                return historyMoves[move.Piece(), move.TargetSquare()];
             }
         }
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -142,67 +142,6 @@ public static class MoveExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsCastle(this Move move) => (move & 0x180_0000) >> 23 != default;
 
-    /// <summary>
-    /// Returns the score evaluation of a move taking into account <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
-    /// </summary>
-    /// <param name="position">The position that precedes a move</param>
-    /// <param name="killerMoves"></param>
-    /// <param name="plies"></param>
-    /// <param name="historyMoves"></param>
-    /// <returns>The higher the score is, the more valuable is the captured piece and the less valuable is the piece that makes the such capture</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int Score(this Move move, in Position position, int[,]? killerMoves = null, int? plies = null, int[,]? historyMoves = null)
-    {
-        if (move.PromotedPiece() != default)
-        {
-            return EvaluationConstants.PromotionMoveScoreValue;
-        }
-        else if (move.IsCapture())
-        {
-            var sourcePiece = move.Piece();
-            int targetPiece = (int)Model.Piece.P;    // Important to initialize to P or p, due to en-passant captures
-
-            var targetSquare = move.TargetSquare();
-            var oppositeSide = Utils.OppositeSide(position.Side);
-            var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
-            var oppositePawnIndex = (int)Model.Piece.P + oppositeSideOffset;
-
-            var limit = (int)Model.Piece.K + oppositeSideOffset;
-            for (int pieceIndex = oppositePawnIndex; pieceIndex < limit; ++pieceIndex)
-            {
-                if (position.PieceBitBoards[pieceIndex].GetBit(targetSquare))
-                {
-                    targetPiece = pieceIndex;
-                    break;
-                }
-            }
-
-            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
-        }
-        else if (killerMoves is not null && plies is not null)
-        {
-            // 1st killer move
-            if (killerMoves[0, plies.Value] == move)
-            {
-                return EvaluationConstants.FirstKillerMoveValue;
-            }
-
-            // 2nd killer move
-            else if (killerMoves[1, plies.Value] == move)
-            {
-                return EvaluationConstants.SecondKillerMoveValue;
-            }
-
-            // History move
-            else if (historyMoves is not null)
-            {
-                return historyMoves[move.Piece(), move.TargetSquare()];
-            }
-        }
-
-        return default;
-    }
-
     public static string ToMoveString(this Move move)
     {
 #pragma warning disable S3358 // Ternary operators should not be nested

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -76,16 +76,25 @@ public sealed partial class Engine
         var localPosition = currentPosition;
 
         var orderedMoves = moves
-            .OrderByDescending(move => Score(move, in localPosition, depth, bestMoveTTCandidate))
+            .OrderByDescending(move => ScoreMove(move, in localPosition, depth, true, bestMoveTTCandidate))
             .ToList();
 
-        PrintMessage($"For position {currentPosition.FEN()}:\n{string.Join(", ", orderedMoves.Select(m => $"{m.ToEPDString()} ({Score(m, in localPosition, depth, bestMoveTTCandidate)})"))})");
+        PrintMessage($"For position {currentPosition.FEN()}:\n{string.Join(", ", orderedMoves.Select(m => $"{m.ToEPDString()} ({ScoreMove(m, in localPosition, depth, true, bestMoveTTCandidate)})"))})");
 
         return orderedMoves;
     }
 
+    /// <summary>
+    /// Returns the score evaluation of a move taking into account <see cref="_isScoringPV"/>, <paramref name="bestMoveTTCandidate"/>, <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_historyMoves"/>
+    /// </summary>
+    /// <param name="move"></param>
+    /// <param name="position"></param>
+    /// <param name="depth"></param>
+    /// <param name="useKillerAndPositionMoves"></param>
+    /// <param name="bestMoveTTCandidate"></param>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int Score(Move move, in Position position, int depth, Move bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, in Position position, int depth, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[depth])
         {
@@ -99,14 +108,61 @@ public sealed partial class Engine
             return EvaluationConstants.TTMoveScoreValue;
         }
 
-        return move.Score(in position, _killerMoves, depth, _historyMoves);
-    }
+        var promotedPiece = move.PromotedPiece();
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IOrderedEnumerable<Move> SortCaptures(IEnumerable<Move> moves, in Position currentPosition, int depth)
-    {
-        var localPosition = currentPosition;
-        return moves.OrderByDescending(move => Score(move, in localPosition, depth));
+        //// Queen promotion
+        //if ((promotedPiece + 2) % 6 == 0)
+        //{
+        //    return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.PromotionMoveScoreValue;
+        //}
+
+        if (move.IsCapture())
+        {
+            var sourcePiece = move.Piece();
+            int targetPiece = (int)Piece.P;    // Important to initialize to P or p, due to en-passant captures
+
+            var targetSquare = move.TargetSquare();
+            var oppositeSide = Utils.OppositeSide(position.Side);
+            var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
+            var oppositePawnIndex = (int)Piece.P + oppositeSideOffset;
+
+            var limit = (int)Piece.K + oppositeSideOffset;
+            for (int pieceIndex = oppositePawnIndex; pieceIndex < limit; ++pieceIndex)
+            {
+                if (position.PieceBitBoards[pieceIndex].GetBit(targetSquare))
+                {
+                    targetPiece = pieceIndex;
+                    break;
+                }
+            }
+
+            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
+        }
+
+        if (promotedPiece != default)
+        {
+            return EvaluationConstants.PromotionMoveScoreValue;
+        }
+
+        if (useKillerAndPositionMoves)
+        {
+            // 1st killer move
+            if (_killerMoves[0, depth] == move)
+            {
+                return EvaluationConstants.FirstKillerMoveValue;
+            }
+
+            // 2nd killer move
+            if (_killerMoves[1, depth] == move)
+            {
+                return EvaluationConstants.SecondKillerMoveValue;
+            }
+
+            // History move or 0 if not found
+            return _historyMoves[move.Piece(), move.TargetSquare()];
+        }
+
+        return default;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -111,10 +111,10 @@ public sealed partial class Engine
         var promotedPiece = move.PromotedPiece();
 
         //// Queen promotion
-        //if ((promotedPiece + 2) % 6 == 0)
-        //{
-        //    return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.PromotionMoveScoreValue;
-        //}
+        if ((promotedPiece + 2) % 6 == 0)
+        {
+            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.PromotionMoveScoreValue;
+        }
 
         if (move.IsCapture())
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -207,7 +207,7 @@ public sealed partial class Engine
                 PrintMessage($"Pruning: {move} is enough");
 
                 // 🔍 Killer moves
-                if (!move.IsCapture())
+                if (!move.IsCapture() && move.PromotedPiece() == default)
                 {
                     _killerMoves[1, ply] = _killerMoves[0, ply];
                     _killerMoves[0, ply] = move;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -308,7 +308,8 @@ public sealed partial class Engine
             return staticEvaluation;  // TODO check if in check or drawn position
         }
 
-        var movesToEvaluate = SortCaptures(generatedMoves, in position, ply);
+        var localPosition = position;
+        var movesToEvaluate = generatedMoves.OrderByDescending(move => ScoreMove(move, in localPosition, ply, false));
 
         Move? bestMove = null;
         bool isAnyMoveValid = false;

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 namespace Lynx.Test.Model;
 
-public class MoveScoreTest
+public class MoveScoreTest : BaseTest
 {
     /// <summary>
     /// 'Tricky position'
@@ -22,9 +22,10 @@ public class MoveScoreTest
     [TestCase(Constants.TrickyTestPositionFEN)]
     public void MoveScore(string fen)
     {
+        var engine = GetEngine();
         var position = new Position(fen);
 
-        var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(in position)).ToList();
+        var allMoves = position.AllPossibleMoves().OrderByDescending(move => engine.ScoreMove(move, in position, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("f3f6", allMoves[1].UCIString());     // QxN
@@ -37,7 +38,7 @@ public class MoveScoreTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {
-            Assert.AreEqual(0, move.Score(in position));
+            Assert.AreEqual(0, engine.ScoreMove(move, in position, default, default));
         }
     }
 
@@ -59,11 +60,12 @@ public class MoveScoreTest
     [TestCase("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", "d4e3")]
     public void MoveScoreEnPassant(string fen, string moveWithHighestScore)
     {
-        Position position = new(fen);
+        var engine = GetEngine();
+        var position = new Position(fen);
 
-        var allMoves = position.AllPossibleMoves().OrderByDescending(move => move.Score(in position)).ToList();
+        var allMoves = position.AllPossibleMoves().OrderByDescending(move => engine.ScoreMove(move, in position, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], allMoves[0].Score(in position));
+        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], in position, default, default));
     }
 }


### PR DESCRIPTION
```
Score of Lynx 1036 - killers-over-promotions vs Lynx 1030 - main: 1334 - 1366 - 729  [0.495] 3429
...      Lynx 1036 - killers-over-promotions playing White: 789 - 559 - 367  [0.567] 1715
...      Lynx 1036 - killers-over-promotions playing Black: 545 - 807 - 362  [0.424] 1714
...      White vs Black: 1596 - 1104 - 729  [0.572] 3429
Elo difference: -3.2 +/- 10.3, LOS: 26.9 %, DrawRatio: 21.3 %
SPRT: llr -2.97 (-101.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```


```
Score of Lynx 1047 - prom-over-capt vs Lynx 1030 - main: 678 - 702 - 346  [0.493] 1726
...      Lynx 1047 - prom-over-capt playing White: 408 - 282 - 173  [0.573] 863
...      Lynx 1047 - prom-over-capt playing Black: 270 - 420 - 173  [0.413] 863
...      White vs Black: 828 - 552 - 346  [0.580] 1726
Elo difference: -4.8 +/- 14.6, LOS: 25.9 %, DrawRatio: 20.0 %
SPRT: llr -1.76 (-59.7%), lbound -2.94, ubound 2.94
```

```
Score of Lynx 1049 - queen promo vs Lynx 1030 - main: 2427 - 2420 - 1276  [0.501] 6123
...      Lynx 1049 - queen promo playing White: 1412 - 1018 - 631  [0.564] 3061
...      Lynx 1049 - queen promo playing Black: 1015 - 1402 - 645  [0.437] 3062
...      White vs Black: 2814 - 2033 - 1276  [0.564] 6123
Elo difference: 0.4 +/- 7.7, LOS: 54.0 %, DrawRatio: 20.8 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```