### PR TITLE
Use !pvNode condition for TT cutoffs

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -33,10 +33,11 @@ public sealed partial class Engine
 
         Move ttBestMove = default;
 
+        bool pvNode = alpha != beta - 1;
         if (ply > 0)
         {
             var ttProbeResult = _transpositionTable.ProbeHash(position, targetDepth, ply, alpha, beta);
-            if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry) // TODO here we can try alpha == beta - 1 as requirement
+            if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry && !pvNode)
             {
                 return ttProbeResult.Evaluation;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -33,7 +33,9 @@ public sealed partial class Engine
 
         Move ttBestMove = default;
 
-        bool pvNode = alpha != beta - 1;
+        //bool pvNode = alpha != beta - 1;
+        bool pvNode = beta - alpha > 1;
+
         if (ply > 0)
         {
             var ttProbeResult = _transpositionTable.ProbeHash(position, targetDepth, ply, alpha, beta);


### PR DESCRIPTION
v1
```
Score of Lynx 1038 - tt-pv-node-v1 vs Lynx 1030 - main: 703 - 745 - 362  [0.488] 1810
...      Lynx 1038 - tt-pv-node-v1 playing White: 419 - 311 - 175  [0.560] 905
...      Lynx 1038 - tt-pv-node-v1 playing Black: 284 - 434 - 187  [0.417] 905
...      White vs Black: 853 - 595 - 362  [0.571] 1810
Elo difference: -8.1 +/- 14.3, LOS: 13.5 %, DrawRatio: 20.0 %
SPRT: llr -2.45 (-83.1%), lbound -2.94, ubound 2.94
```

v2
```
Score of Lynx 1039 - tt-pv-node-v2 vs Lynx 1030 - main: 1589 - 1596 - 935  [0.499] 4120
...      Lynx 1039 - tt-pv-node-v2 playing White: 928 - 673 - 459  [0.562] 2060
...      Lynx 1039 - tt-pv-node-v2 playing Black: 661 - 923 - 476  [0.436] 2060
...      White vs Black: 1851 - 1334 - 935  [0.563] 4120
Elo difference: -0.6 +/- 9.3, LOS: 45.1 %, DrawRatio: 22.7 %
SPRT: llr -2.47 (-83.8%), lbound -2.94, ubound 2.94
```

```
Score of Lynx 1046 - tune-no-pv vs Lynx 1030 - main: 2953 - 2902 - 1554  [0.503] 7409
...      Lynx 1046 - tune-no-pv playing White: 1741 - 1187 - 777  [0.575] 3705
...      Lynx 1046 - tune-no-pv playing Black: 1212 - 1715 - 777  [0.432] 3704
...      White vs Black: 3456 - 2399 - 1554  [0.571] 7409
Elo difference: 2.4 +/- 7.0, LOS: 74.7 %, DrawRatio: 21.0 %
SPRT: llr -2.03 (-68.8%), lbound -2.94, ubound 2.94
```