### PR TITLE
[Experimental] Passed pawn bonusc

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -171,7 +171,7 @@ public sealed class EngineSettings
 
     public int DoubledPawnPenalty { get; set; } = 10;
 
-    public int[] PassedPawnBonus { get; set; } = new[] { 0, 10, 30, 50, 75, 100, 150, 200 };
+    public int[] PassedPawnBonus { get; set; } = new[] { 0, 5, 15, 25, 37, 50, 75, 100 };
 
     public int SemiOpenFileRookBonus { get; set; } = 10;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -523,15 +523,15 @@ public readonly struct Position
         }
 
         //bool IsPassedPawn() => (PieceBitBoards[(int)Piece.p - pieceIndex] & Masks.PassedPawns[pieceIndex][squareIndex]) == default;
-        if ((PieceBitBoards[(int)Piece.p - pieceIndex] & Masks.PassedPawns[pieceIndex][squareIndex]) == default)
-        {
-            var rank = Constants.Rank[squareIndex];
-            if (pieceIndex == (int)Piece.p)
-            {
-                rank = 7 - rank;
-            }
-            bonus += Configuration.EngineSettings.PassedPawnBonus[rank];
-        }
+        //if ((PieceBitBoards[(int)Piece.p - pieceIndex] & Masks.PassedPawns[pieceIndex][squareIndex]) == default)
+        //{
+        //    var rank = Constants.Rank[squareIndex];
+        //    if (pieceIndex == (int)Piece.p)
+        //    {
+        //        rank = 7 - rank;
+        //    }
+        //    bonus += Configuration.EngineSettings.PassedPawnBonus[rank];
+        //}
 
         return bonus;
     }


### PR DESCRIPTION
Removing it fails

```
Score of Lynx 1069 - no-passed-pawn-bonus vs Lynx 1067 - main: 309 - 385 - 118  [0.453] 812
...      Lynx 1069 - no-passed-pawn-bonus playing White: 171 - 171 - 65  [0.500] 407
...      Lynx 1069 - no-passed-pawn-bonus playing Black: 138 - 214 - 53  [0.406] 405
...      White vs Black: 385 - 309 - 118  [0.547] 812
Elo difference: -32.6 +/- 22.2, LOS: 0.2 %, DrawRatio: 14.5 %
SPRT: llr -2.96 (-100.5%), lbound -2.94, ubound 2.94 - H0 was accepted
```

Splitting each value in half as well
```
Score of Lynx 1068 - passed-pawns-bonus vs Lynx 1067 - main: 1118 - 1160 - 544  [0.493] 2822
...      Lynx 1068 - passed-pawns-bonus playing White: 645 - 478 - 287  [0.559] 1410
...      Lynx 1068 - passed-pawns-bonus playing Black: 473 - 682 - 257  [0.426] 1412
...      White vs Black: 1327 - 951 - 544  [0.567] 2822
Elo difference: -5.2 +/- 11.5, LOS: 18.9 %, DrawRatio: 19.3 %
SPRT: llr -2.95 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```