### PR TITLE
⚗ LMR tuning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -157,7 +157,7 @@ public sealed class EngineSettings
 
     public int LMR_FullDepthMoves { get; set; } = 4;
 
-    public int LMR_ReductionLimit { get; set; } = 4;
+    public int LMR_ReductionLimit { get; set; } = 2;
 
     public int LMR_DepthReduction { get; set; } = 1;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -155,7 +155,7 @@ public sealed class EngineSettings
 
     public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
 
-    public int LMR_FullDepthMoves { get; set; } = 5;
+    public int LMR_FullDepthMoves { get; set; } = 3;
 
     public int LMR_ReductionLimit { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -155,7 +155,7 @@ public sealed class EngineSettings
 
     public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
 
-    public int LMR_FullDepthMoves { get; set; } = 4;
+    public int LMR_FullDepthMoves { get; set; } = 5;
 
     public int LMR_ReductionLimit { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -157,9 +157,9 @@ public sealed class EngineSettings
 
     public int LMR_FullDepthMoves { get; set; } = 4;
 
-    public int LMR_ReductionLimit { get; set; } = 2;
+    public int LMR_ReductionLimit { get; set; } = 3;
 
-    public int LMR_DepthReduction { get; set; } = 1;
+    public int LMR_DepthReduction { get; set; } = 2;
 
     public int NullMovePruning_R { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,7 +159,7 @@ public sealed class EngineSettings
 
     public int LMR_ReductionLimit { get; set; } = 3;
 
-    public int LMR_DepthReduction { get; set; } = 2;
+    public int LMR_DepthReduction { get; set; } = 3;
 
     public int NullMovePruning_R { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -155,9 +155,9 @@ public sealed class EngineSettings
 
     public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
 
-    public int LMR_FullDepthMoves { get; set; } = 3;
+    public int LMR_FullDepthMoves { get; set; } = 4;
 
-    public int LMR_ReductionLimit { get; set; } = 3;
+    public int LMR_ReductionLimit { get; set; } = 4;
 
     public int LMR_DepthReduction { get; set; } = 1;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -94,7 +94,7 @@ public sealed partial class Engine
                 AspirationWindows_SearchAgain:
 
                 _isFollowingPV = true;
-                bestEvaluation = NegaMax(Game.CurrentPosition, minDepth, targetDepth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                bestEvaluation = NegaMax(Game.CurrentPosition, minDepth, targetDepth: depth, ply: 0, alpha, beta/*, isVerifyingNullMoveCutOff: true*/);
 
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
                 isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -149,47 +149,47 @@ public sealed partial class Engine
             }
             else
             {
-                //// 🔍 Late Move Reduction (LMR)
-                //if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
-                //    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-                //    && !_isFollowingPV
-                //    && !isInCheck
-                //    //&& !newPosition.IsInCheck()
-                //    && !move.IsCapture()
-                //    && move.PromotedPiece() == default)
-                //{
-                //    // Search with reduced depth
-                //    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
-                //}
-                //else
-                //{
-                //    // Ensuring full depth search takes place
-                //    evaluation = alpha + 1;
-                //}
-
-                //if (evaluation > alpha)
-                //{
-                // 🔍 Principal Variation Search (PVS)
-                if (bestMove is not null)
+                // 🔍 Late Move Reduction (LMR)
+                if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
+                    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
+                    && !_isFollowingPV
+                    && !isInCheck
+                    //&& !newPosition.IsInCheck()
+                    && !move.IsCapture()
+                    && move.PromotedPiece() == default)
                 {
-                    // Optimistic search, validating that the rest of the moves are worse than bestmove.
-                    // It should produce more cutoffs and therefore be faster.
-                    // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
-
-                    // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha);
-
-                    if (evaluation > alpha && evaluation < beta)
-                    {
-                        // Hipothesis invalidated -> search with full depth and full score bandwidth
-                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha);
-                    }
+                    // Search with reduced depth
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
                 }
                 else
                 {
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha);
+                    // Ensuring full depth search takes place
+                    evaluation = alpha + 1;
                 }
-                //}
+
+                if (evaluation > alpha)
+                {
+                    // 🔍 Principal Variation Search (PVS)
+                    if (bestMove is not null)
+                    {
+                        // Optimistic search, validating that the rest of the moves are worse than bestmove.
+                        // It should produce more cutoffs and therefore be faster.
+                        // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+
+                        // Search with full depth but narrowed score bandwidth
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
+
+                        if (evaluation > alpha && evaluation < beta)
+                        {
+                            // Hipothesis invalidated -> search with full depth and full score bandwidth
+                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
+                        }
+                    }
+                    else
+                    {
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
+                    }
+                }
             }
 
             // After making a move

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -31,6 +31,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
+        bool pvNode = beta - alpha > 1;
         Move ttBestMove = default;
 
         if (ply > 0)
@@ -152,7 +153,7 @@ public sealed partial class Engine
                 // 🔍 Late Move Reduction (LMR)
                 if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
                     && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-                    && !_isFollowingPV
+                    && !pvNode
                     && !isInCheck
                     //&& !newPosition.IsInCheck()
                     && !move.IsCapture()

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -153,11 +153,12 @@ public sealed partial class Engine
                 // 🔍 Late Move Reduction (LMR)
                 if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
                     && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-                    && !pvNode
+                    && !_isFollowingPV
                     && !isInCheck
                     //&& !newPosition.IsInCheck()
-                    && !move.IsCapture()
-                    && move.PromotedPiece() == default)
+                    //&& !move.IsCapture()
+                    //&& move.PromotedPiece() == default
+                    )
                 {
                     // Search with reduced depth
                     evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -22,7 +22,7 @@ public sealed partial class Engine
     /// <param name="isVerifyingNullMoveCutOff">Indicates if the search is verifying an ancestors null-move that failed high, or the root node</param>
     /// <param name="ancestorWasNullMove">Indicates whether the immediate ancestor node was a null move</param>
     /// <returns></returns>
-    private int NegaMax(in Position position, int minDepth, int targetDepth, int ply, int alpha, int beta, bool isVerifyingNullMoveCutOff, bool ancestorWasNullMove = false)
+    private int NegaMax(in Position position, int minDepth, int targetDepth, int ply, int alpha, int beta/*, bool isVerifyingNullMoveCutOff, bool ancestorWasNullMove = false*/)
     {
         _maxDepthReached[ply] = ply;
         _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
@@ -79,35 +79,35 @@ public sealed partial class Engine
 
         ++_nodes;
 
-        // 🔍 Null-move pruning
-        bool isFailHigh = false;    // In order to detect zugzwangs
-        if (ply > Configuration.EngineSettings.NullMovePruning_R
-            && !isInCheck
-            && !ancestorWasNullMove
-            && (!isVerifyingNullMoveCutOff || ply < targetDepth - 1))    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
-                                                                         // following pv?
-        {
-            var newPosition = new Position(in position, nullMove: true);
+        //// 🔍 Null-move pruning
+        //bool isFailHigh = false;    // In order to detect zugzwangs
+        //if (ply > Configuration.EngineSettings.NullMovePruning_R
+        //    && !isInCheck
+        //    && !ancestorWasNullMove
+        //    && (!isVerifyingNullMoveCutOff || ply < targetDepth - 1))    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
+        //                                                                 // following pv?
+        //{
+        //    var newPosition = new Position(in position, nullMove: true);
 
-            var evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.NullMovePruning_R, -beta, -beta + 1, isVerifyingNullMoveCutOff, ancestorWasNullMove: true);
+        //    var evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.NullMovePruning_R, -beta, -beta + 1, isVerifyingNullMoveCutOff, ancestorWasNullMove: true);
 
-            if (evaluation >= beta) // Fail high
-            {
-                if (isVerifyingNullMoveCutOff)
-                {
-                    ++ply;
-                    isVerifyingNullMoveCutOff = false;
-                    isFailHigh = true;
-                }
-                else
-                {
-                    // cutoff in a sub-tree with fail-high report
-                    return evaluation;
-                }
-            }
-        }
+        //    if (evaluation >= beta) // Fail high
+        //    {
+        //        if (isVerifyingNullMoveCutOff)
+        //        {
+        //            ++ply;
+        //            isVerifyingNullMoveCutOff = false;
+        //            isFailHigh = true;
+        //        }
+        //        else
+        //        {
+        //            // cutoff in a sub-tree with fail-high report
+        //            return evaluation;
+        //        }
+        //    }
+        //}
 
-        VerifiedNullMovePruning_SearchAgain:
+        //VerifiedNullMovePruning_SearchAgain:
 
         var nodeType = NodeType.Alpha;
 
@@ -145,7 +145,7 @@ public sealed partial class Engine
             }
             else if (movesSearched == 0)
             {
-                evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*a, isVerifyingNullMoveCutOff*/);
             }
             else
             {
@@ -177,17 +177,17 @@ public sealed partial class Engine
                         // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                         // Search with full depth but narrowed score bandwidth
-                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
 
                         if (evaluation > alpha && evaluation < beta)
                         {
                             // Hipothesis invalidated -> search with full depth and full score bandwidth
-                            evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
                         }
                     }
                     else
                     {
-                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
                     }
                 }
             }
@@ -239,13 +239,13 @@ public sealed partial class Engine
         }
 
         // [Null-move pruning] If there is a fail-high report, but no cutoff was found, the position is a zugzwang and has to be re-searched with the original depth
-        if (isFailHigh && alpha < beta)
-        {
-            --ply;
-            isFailHigh = false;
-            isVerifyingNullMoveCutOff = true;
-            goto VerifiedNullMovePruning_SearchAgain;
-        }
+        //if (isFailHigh && alpha < beta)
+        //{
+        //    --ply;
+        //    isFailHigh = false;
+        //    isVerifyingNullMoveCutOff = true;
+        //    goto VerifiedNullMovePruning_SearchAgain;
+        //}
 
         if (bestMove is null && !isAnyMoveValid)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -159,7 +159,7 @@ public sealed partial class Engine
                     && move.PromotedPiece() == default)
                 {
                     // Search with reduced depth
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
                 }
                 else
                 {
@@ -177,17 +177,17 @@ public sealed partial class Engine
                         // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                         // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
+                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
 
                         if (evaluation > alpha && evaluation < beta)
                         {
                             // Hipothesis invalidated -> search with full depth and full score bandwidth
-                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
+                            evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
                         }
                     }
                     else
                     {
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
+                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
                     }
                 }
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -149,47 +149,47 @@ public sealed partial class Engine
             }
             else
             {
-                // 🔍 Late Move Reduction (LMR)
-                if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
-                    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-                    && !_isFollowingPV
-                    && !isInCheck
-                    //&& !newPosition.IsInCheck()
-                    && !move.IsCapture()
-                    && move.PromotedPiece() == default)
+                //// 🔍 Late Move Reduction (LMR)
+                //if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
+                //    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
+                //    && !_isFollowingPV
+                //    && !isInCheck
+                //    //&& !newPosition.IsInCheck()
+                //    && !move.IsCapture()
+                //    && move.PromotedPiece() == default)
+                //{
+                //    // Search with reduced depth
+                //    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                //}
+                //else
+                //{
+                //    // Ensuring full depth search takes place
+                //    evaluation = alpha + 1;
+                //}
+
+                //if (evaluation > alpha)
+                //{
+                // 🔍 Principal Variation Search (PVS)
+                if (bestMove is not null)
                 {
-                    // Search with reduced depth
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                    // Optimistic search, validating that the rest of the moves are worse than bestmove.
+                    // It should produce more cutoffs and therefore be faster.
+                    // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+
+                    // Search with full depth but narrowed score bandwidth
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha);
+
+                    if (evaluation > alpha && evaluation < beta)
+                    {
+                        // Hipothesis invalidated -> search with full depth and full score bandwidth
+                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha);
+                    }
                 }
                 else
                 {
-                    // Ensuring full depth search takes place
-                    evaluation = alpha + 1;
+                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha);
                 }
-
-                if (evaluation > alpha)
-                {
-                    // 🔍 Principal Variation Search (PVS)
-                    if (bestMove is not null)
-                    {
-                        // Optimistic search, validating that the rest of the moves are worse than bestmove.
-                        // It should produce more cutoffs and therefore be faster.
-                        // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
-
-                        // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -alpha - 1, -alpha/*, isVerifyingNullMoveCutOff*/);
-
-                        if (evaluation > alpha && evaluation < beta)
-                        {
-                            // Hipothesis invalidated -> search with full depth and full score bandwidth
-                        evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
-                        }
-                    }
-                    else
-                    {
-                    evaluation = -NegaMax(in newPosition, minDepth, targetDepth, ply + 1, -beta, -alpha/*, isVerifyingNullMoveCutOff*/);
-                    }
-                }
+                //}
             }
 
             // After making a move

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -156,8 +156,8 @@ public sealed partial class Engine
                     && !_isFollowingPV
                     && !isInCheck
                     //&& !newPosition.IsInCheck()
-                    //&& !move.IsCapture()
-                    //&& move.PromotedPiece() == default
+                    && !move.IsCapture()
+                    && move.PromotedPiece() == default
                     )
                 {
                     // Search with reduced depth


### PR DESCRIPTION
First things first:

```
Score of Lynx 1074 - disable LMR vs Lynx 1075 - disable nmp: 225 - 299 - 120  [0.443] 644
...      Lynx 1074 - disable LMR playing White: 144 - 122 - 56  [0.534] 322
...      Lynx 1074 - disable LMR playing Black: 81 - 177 - 64  [0.351] 322
...      White vs Black: 321 - 203 - 120  [0.592] 644
Elo difference: -40.1 +/- 24.3, LOS: 0.1 %, DrawRatio: 18.6 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```

Using pvNode 👍🏽
```
Score of Lynx 1078 - pvnode vs Lynx-exp-lmr-tuning-1076-base-win-x64: 2733 - 2560 - 1357  [0.513] 6650
...      Lynx 1078 - pvnode playing White: 1622 - 1017 - 686  [0.591] 3325
...      Lynx 1078 - pvnode playing Black: 1111 - 1543 - 671  [0.435] 3325
...      White vs Black: 3165 - 2128 - 1357  [0.578] 6650
Elo difference: 9.0 +/- 7.4, LOS: 99.1 %, DrawRatio: 20.4 %
SPRT: llr 2.8 (95.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Removing captures and check conditions 👎🏽 (try individually?)
```
Score of Lynx 1080 - no-captures-or-check-conditions vs Lynx 1076 - LMR base: 3234 - 3198 - 1697  [0.502] 8129
...      Lynx 1080 - no-captures-or-check-conditions playing White: 1886 - 1301 - 878  [0.572] 4065
...      Lynx 1080 - no-captures-or-check-conditions playing Black: 1348 - 1897 - 819  [0.432] 4064
...      White vs Black: 3783 - 2649 - 1697  [0.570] 8129
Elo difference: 1.5 +/- 6.7, LOS: 67.3 %, DrawRatio: 20.9 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```

LMR_FullDepthMoves 5 👎🏽
```
Score of Lynx 1081 - LMR_FullDepthMoves 5 vs Lynx-exp-lmr-tuning-1076-base-win-x64: 1233 - 1269 - 652  [0.494] 3154
...      Lynx 1081 - LMR_FullDepthMoves 5 playing White: 732 - 516 - 329  [0.568] 1577
...      Lynx 1081 - LMR_FullDepthMoves 5 playing Black: 501 - 753 - 323  [0.420] 1577
...      White vs Black: 1485 - 1017 - 652  [0.574] 3154
Elo difference: -4.0 +/- 10.8, LOS: 23.6 %, DrawRatio: 20.7 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```

LMR_FullDepthMoves 3 👎🏽
```
Score of Lynx 1082 - LMR_FullDepthMoves 3 vs Lynx 1076 - LMR base: 2709 - 2692 - 1427  [0.501] 6828
...      Lynx 1082 - LMR_FullDepthMoves 3 playing White: 1612 - 1093 - 709  [0.576] 3414
...      Lynx 1082 - LMR_FullDepthMoves 3 playing Black: 1097 - 1599 - 718  [0.426] 3414
...      White vs Black: 3211 - 2190 - 1427  [0.575] 6828
Elo difference: 0.9 +/- 7.3, LOS: 59.1 %, DrawRatio: 20.9 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepte
```

LMR_ReductionLimit 4 👎🏽
```
Score of Lynx 1083 - LMR_ReductionLimit 4 vs Lynx 1076 - LMR base: 285 - 355 - 140  [0.455] 780
...      Lynx 1083 - LMR_ReductionLimit 4 playing White: 169 - 147 - 75  [0.528] 391
...      Lynx 1083 - LMR_ReductionLimit 4 playing Black: 116 - 208 - 65  [0.382] 389
...      White vs Black: 377 - 263 - 140  [0.573] 780
Elo difference: -31.3 +/- 22.2, LOS: 0.3 %, DrawRatio: 17.9 %
SPRT: llr -2.85 (-96.9%), lbound -2.94, ubound 2.94
```

LMR_ReductionLimit 2 STC👍🏽
```
Score of Lynx 1085 - LMR_DepthReduction 2 vs Lynx-exp-lmr-tuning-1076-base-win-x64: 3888 - 3668 - 2121  [0.511] 9677
...      Lynx 1085 - LMR_DepthReduction 2 playing White: 2307 - 1495 - 1036  [0.584] 4838
...      Lynx 1085 - LMR_DepthReduction 2 playing Black: 1581 - 2173 - 1085  [0.439] 4839
...      White vs Black: 4480 - 3076 - 2121  [0.573] 9677
Elo difference: 7.9 +/- 6.1, LOS: 99.4 %, DrawRatio: 21.9 %
SPRT: llr 2.98 (101.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```

LMR_ReductionLimit 2 LTC👎🏽
````
Score of Lynx 1088 - LMR_DepthReduction 2 vs Lynx 1067 - main: 608 - 660 - 434  [0.485] 1702
...      Lynx 1088 - LMR_DepthReduction 2 playing White: 382 - 246 - 223  [0.580] 851
...      Lynx 1088 - LMR_DepthReduction 2 playing Black: 226 - 414 - 211  [0.390] 851
...      White vs Black: 796 - 472 - 434  [0.595] 1702
Elo difference: -10.6 +/- 14.2, LOS: 7.2 %, DrawRatio: 25.5 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
````

LMR_ReductionLimit 3 👎🏽
```
Score of Lynx 1086 - LMR_DepthReduction 3 vs Lynx-exp-lmr-tuning-1076-base-win-x64: 338 - 404 - 212  [0.465] 954
...      Lynx 1086 - LMR_DepthReduction 3 playing White: 188 - 186 - 103  [0.502] 477
...      Lynx 1086 - LMR_DepthReduction 3 playing Black: 150 - 218 - 109  [0.429] 477
...      White vs Black: 406 - 336 - 212  [0.537] 954
Elo difference: -24.1 +/- 19.5, LOS: 0.8 %, DrawRatio: 22.2 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```