### PR TITLE
Replace `!_isFollowingPV` LMR condition with `!pvNode`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -31,6 +31,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
+        bool pvNode = beta - alpha > 1;
         Move ttBestMove = default;
 
         if (ply > 0)
@@ -152,7 +153,7 @@ public sealed partial class Engine
                 // 🔍 Late Move Reduction (LMR)
                 if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
                     && ply >= Configuration.EngineSettings.LMR_ReductionLimit
-                    && !_isFollowingPV
+                    && !pvNode
                     && !isInCheck
                     //&& !newPosition.IsInCheck()
                     && !move.IsCapture()


### PR DESCRIPTION
From https://github.com/lynx-chess/Lynx/pull/310

RTC (10+0.1/8+0.08):
```
Score of Lynx 1078 - pvnode vs Lynx-exp-lmr-tuning-1076-base-win-x64: 2733 - 2560 - 1357  [0.513] 6650
...      Lynx 1078 - pvnode playing White: 1622 - 1017 - 686  [0.591] 3325
...      Lynx 1078 - pvnode playing Black: 1111 - 1543 - 671  [0.435] 3325
...      White vs Black: 3165 - 2128 - 1357  [0.578] 6650
Elo difference: 9.0 +/- 7.4, LOS: 99.1 %, DrawRatio: 20.4 %
SPRT: llr 2.8 (95.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

STC (40+0.4):
```
Score of Lynx 1087 - LMR !pv vs Lynx 1067 - main: 2877 - 2692 - 2033  [0.512] 7602
...      Lynx 1087 - LMR !pv playing White: 1758 - 1063 - 980  [0.591] 3801
...      Lynx 1087 - LMR !pv playing Black: 1119 - 1629 - 1053  [0.433] 3801
...      White vs Black: 3387 - 2182 - 2033  [0.579] 7602
Elo difference: 8.5 +/- 6.7, LOS: 99.3 %, DrawRatio: 26.7 %
SPRT: llr 2.97 (100.9%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Keeping both seems pointless
```
Score of Lynx-lmr-pv-node-and-isfollowingpv-1089-win-x64 vs Lynx-lmr-pv-node-1087-win-x64: 2181 - 2189 - 944  [0.499] 5314
...      Lynx-lmr-pv-node-and-isfollowingpv-1089-win-x64 playing White: 1280 - 900 - 478  [0.571] 2658
...      Lynx-lmr-pv-node-and-isfollowingpv-1089-win-x64 playing Black: 901 - 1289 - 466  [0.427] 2656
...      White vs Black: 2569 - 1801 - 944  [0.572] 5314
Elo difference: -0.5 +/- 8.5, LOS: 45.2 %, DrawRatio: 17.8 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```