### PR TITLE
🔍 Enhance depth extension on check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -49,6 +49,10 @@ public sealed partial class Engine
 
         bool isInCheck = position.IsInCheck();
 
+        if (isInCheck)
+        {
+            ++targetDepth;
+        }
         if (ply >= targetDepth)
         {
             foreach (var candidateMove in position.AllPossibleMoves(Game.MovePool))
@@ -121,10 +125,6 @@ public sealed partial class Engine
             isAnyMoveValid = true;
 
             PrintPreMove(in position, ply, move);
-            if (newPosition.IsInCheck())
-            {
-                ++targetDepth;
-            }
 
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -49,10 +49,6 @@ public sealed partial class Engine
 
         bool isInCheck = position.IsInCheck();
 
-        if (isInCheck)
-        {
-            ++targetDepth;
-        }
         if (ply >= targetDepth)
         {
             foreach (var candidateMove in position.AllPossibleMoves(Game.MovePool))
@@ -125,6 +121,10 @@ public sealed partial class Engine
             isAnyMoveValid = true;
 
             PrintPreMove(in position, ply, move);
+            if (newPosition.IsInCheck())
+            {
+                ++targetDepth;
+            }
 
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -49,26 +49,23 @@ public sealed partial class Engine
 
         bool isInCheck = position.IsInCheck();
 
+        if (isInCheck)
+        {
+            ++targetDepth;
+        }
         if (ply >= targetDepth)
         {
-            if (isInCheck)
+            foreach (var candidateMove in position.AllPossibleMoves(Game.MovePool))
             {
-                ++targetDepth;
-            }
-            else
-            {
-                foreach (var candidateMove in position.AllPossibleMoves(Game.MovePool))
+                if (new Position(in position, candidateMove).WasProduceByAValidMove())
                 {
-                    if (new Position(in position, candidateMove).WasProduceByAValidMove())
-                    {
-                        return QuiescenceSearch(in position, ply, alpha, beta);
-                    }
+                    return QuiescenceSearch(in position, ply, alpha, beta);
                 }
-
-                var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-                _transpositionTable.RecordHash(position, targetDepth, ply, finalPositionEvaluation, NodeType.Exact);
-                return finalPositionEvaluation;
             }
+
+            var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
+            _transpositionTable.RecordHash(position, targetDepth, ply, finalPositionEvaluation, NodeType.Exact);
+            return finalPositionEvaluation;
         }
 
         // Prevents runtime failure, in case targetDepth is increased due to check extension


### PR DESCRIPTION
Extend depth when searching on any depth, not only in the last one.
8+0.08 👍🏽
```
Score of Lynx 1091 - depth extension any depth vs Lynx 1067 - main: 3588 - 3380 - 1823  [0.512] 8791
...      Lynx 1091 - depth extension any depth playing White: 2047 - 1449 - 900  [0.568] 4396
...      Lynx 1091 - depth extension any depth playing Black: 1541 - 1931 - 923  [0.456] 4395
...      White vs Black: 3978 - 2990 - 1823  [0.556] 8791
Elo difference: 8.2 +/- 6.5, LOS: 99.4 %, DrawRatio: 20.7 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
40+0.4 👍🏽
![image](https://github.com/lynx-chess/Lynx/assets/11148519/bf4f9628-83d5-4536-a341-6c21c83a5039)