### PR TITLE
⚡  Perf/make unmake general optimizations

### DIFF
--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -142,6 +142,7 @@ public static class MoveExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsCastle(this Move move) => (move & 0x180_0000) >> 23 != default;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string ToMoveString(this Move move)
     {
 #pragma warning disable S3358 // Ternary operators should not be nested
@@ -149,10 +150,10 @@ public static class MoveExtensions
             ?
                 Constants.AsciiPieces[move.Piece()] +
                 Constants.Coordinates[move.SourceSquare()] +
-                (move.IsCapture() == default ? "" : "x") +
+                (move.IsCapture() ? "x" : "") +
                 Constants.Coordinates[move.TargetSquare()] +
                 (move.PromotedPiece() == default ? "" : $"={Constants.AsciiPieces[move.PromotedPiece()]}") +
-                (move.IsEnPassant() == default ? "" : "e.p.")
+                (move.IsEnPassant() ? "e.p." : "")
             : (move.IsShortCastle() ? "O-O" : "O-O-O");
 #pragma warning restore S3358 // Ternary operators should not be nested
     }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -211,7 +211,7 @@ public class Position
         BoardSquare enpassantCopy = EnPassant;
         long uniqueIdentifierCopy = UniqueIdentifier;
 
-        var oldSide = Side;
+        var oldSide = (int)Side;
         var offset = Utils.PieceOffset(oldSide);
         var oppositeSide = Utils.OppositeSide(oldSide);
 
@@ -227,10 +227,10 @@ public class Position
         }
 
         PieceBitBoards[piece].PopBit(sourceSquare);
-        OccupancyBitBoards[(int)Side].PopBit(sourceSquare);
+        OccupancyBitBoards[oldSide].PopBit(sourceSquare);
 
         PieceBitBoards[newPiece].SetBit(targetSquare);
-        OccupancyBitBoards[(int)Side].SetBit(targetSquare);
+        OccupancyBitBoards[oldSide].SetBit(targetSquare);
 
         UniqueIdentifier ^=
             ZobristTable.SideHash()
@@ -242,8 +242,7 @@ public class Position
         EnPassant = BoardSquare.noSquare;
         if (move.IsCapture())
         {
-            var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
-            var oppositePawnIndex = (int)Piece.P + oppositeSideOffset;
+            var oppositePawnIndex = /*(int)Piece.P + */Utils.PieceOffset(oppositeSide);
 
             if (move.IsEnPassant())
             {
@@ -257,7 +256,7 @@ public class Position
             }
             else
             {
-                var limit = (int)Piece.K + oppositeSideOffset;
+                var limit = (int)Piece.K + oppositePawnIndex;
                 for (int pieceIndex = oppositePawnIndex; pieceIndex < limit; ++pieceIndex)
                 {
                     if (PieceBitBoards[pieceIndex].GetBit(targetSquare))
@@ -274,7 +273,7 @@ public class Position
         }
         else if (move.IsDoublePawnPush())
         {
-            var pawnPush = +8 - ((int)oldSide * 16);
+            var pawnPush = +8 - (oldSide * 16);
             var enPassantSquare = sourceSquare + pawnPush;
             Utils.Assert(Constants.EnPassantCaptureSquares.ContainsKey(enPassantSquare), $"Unexpected en passant square : {(BoardSquare)enPassantSquare}");
 
@@ -288,10 +287,10 @@ public class Position
             var rookIndex = (int)Piece.R + offset;
 
             PieceBitBoards[rookIndex].PopBit(rookSourceSquare);
-            OccupancyBitBoards[(int)Side].PopBit(rookSourceSquare);
+            OccupancyBitBoards[oldSide].PopBit(rookSourceSquare);
 
             PieceBitBoards[rookIndex].SetBit(rookTargetSquare);
-            OccupancyBitBoards[(int)Side].SetBit(rookTargetSquare);
+            OccupancyBitBoards[oldSide].SetBit(rookTargetSquare);
 
             UniqueIdentifier ^=
                 ZobristTable.PieceHash(rookSourceSquare, rookIndex)
@@ -304,10 +303,10 @@ public class Position
             var rookIndex = (int)Piece.R + offset;
 
             PieceBitBoards[rookIndex].PopBit(rookSourceSquare);
-            OccupancyBitBoards[(int)Side].PopBit(rookSourceSquare);
+            OccupancyBitBoards[oldSide].PopBit(rookSourceSquare);
 
             PieceBitBoards[rookIndex].SetBit(rookTargetSquare);
-            OccupancyBitBoards[(int)Side].SetBit(rookTargetSquare);
+            OccupancyBitBoards[oldSide].SetBit(rookTargetSquare);
 
             UniqueIdentifier ^=
                 ZobristTable.PieceHash(rookSourceSquare, rookIndex)
@@ -315,11 +314,11 @@ public class Position
         }
 
         Side = (Side)oppositeSide;
-        OccupancyBitBoards[(int)Side.Both] = OccupancyBitBoards[(int)Side.White] | OccupancyBitBoards[(int)Side.Black];
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
 
         // Updating castling rights
-        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare];
-        Castle &= Constants.CastlingRightsUpdateConstants[targetSquare];
+        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare]
+            & Constants.CastlingRightsUpdateConstants[targetSquare];
 
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
 
@@ -336,8 +335,9 @@ public class Position
     public void UnmakeMove(Move move, GameState gameState)
     {
         var oppositeSide = (int)Side;
-        Side = (Side)Utils.OppositeSide(Side);
-        var offset = Utils.PieceOffset(Side);
+        var side = Utils.OppositeSide(oppositeSide);
+        Side = (Side)side;
+        var offset = Utils.PieceOffset(side);
 
         int sourceSquare = move.SourceSquare();
         int targetSquare = move.TargetSquare();
@@ -351,15 +351,14 @@ public class Position
         }
 
         PieceBitBoards[newPiece].PopBit(targetSquare);
-        OccupancyBitBoards[(int)Side].PopBit(targetSquare);
+        OccupancyBitBoards[side].PopBit(targetSquare);
 
         PieceBitBoards[piece].SetBit(sourceSquare);
-        OccupancyBitBoards[(int)Side].SetBit(sourceSquare);
+        OccupancyBitBoards[side].SetBit(sourceSquare);
 
         if (move.IsCapture())
         {
-            var oppositeSideOffset = Utils.PieceOffset(oppositeSide);
-            var oppositePawnIndex = (int)Piece.P + oppositeSideOffset;
+            var oppositePawnIndex =/*(int)Piece.P +*/ Utils.PieceOffset(oppositeSide);
 
             if (move.IsEnPassant())
             {
@@ -378,30 +377,30 @@ public class Position
         }
         else if (move.IsShortCastle())
         {
-            var rookSourceSquare = Utils.ShortCastleRookSourceSquare(Side);
-            var rookTargetSquare = Utils.ShortCastleRookTargetSquare(Side);
+            var rookSourceSquare = Utils.ShortCastleRookSourceSquare(side);
+            var rookTargetSquare = Utils.ShortCastleRookTargetSquare(side);
             var rookIndex = (int)Piece.R + offset;
 
             PieceBitBoards[rookIndex].SetBit(rookSourceSquare);
-            OccupancyBitBoards[(int)Side].SetBit(rookSourceSquare);
+            OccupancyBitBoards[side].SetBit(rookSourceSquare);
 
             PieceBitBoards[rookIndex].PopBit(rookTargetSquare);
-            OccupancyBitBoards[(int)Side].PopBit(rookTargetSquare);
+            OccupancyBitBoards[side].PopBit(rookTargetSquare);
         }
         else if (move.IsLongCastle())
         {
-            var rookSourceSquare = Utils.LongCastleRookSourceSquare(Side);
-            var rookTargetSquare = Utils.LongCastleRookTargetSquare(Side);
+            var rookSourceSquare = Utils.LongCastleRookSourceSquare(side);
+            var rookTargetSquare = Utils.LongCastleRookTargetSquare(side);
             var rookIndex = (int)Piece.R + offset;
 
             PieceBitBoards[rookIndex].SetBit(rookSourceSquare);
-            OccupancyBitBoards[(int)Side].SetBit(rookSourceSquare);
+            OccupancyBitBoards[side].SetBit(rookSourceSquare);
 
             PieceBitBoards[rookIndex].PopBit(rookTargetSquare);
-            OccupancyBitBoards[(int)Side].PopBit(rookTargetSquare);
+            OccupancyBitBoards[side].PopBit(rookTargetSquare);
         }
 
-        OccupancyBitBoards[(int)Side.Both] = OccupancyBitBoards[(int)Side.White] | OccupancyBitBoards[(int)Side.Black];
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
 
         // Updating saved values
         Castle = gameState.Castle;
@@ -512,7 +511,6 @@ public class Position
     //        ZobristTable.CastleHash(Castle)
     //        ^ ZobristTable.EnPassantHash((int)EnPassant);
     //}
-
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeNullMove()

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -48,11 +48,20 @@ public static class Utils
     /// <param name="side"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int OppositeSide(Side side)
-    {
-        GuardAgainstSideBoth((int)side);
+    public static int OppositeSide(Side side) => OppositeSide((int)side);
 
-        return (int)side ^ 1;     // or  (int)Side.White - (int)side
+    /// <summary>
+    /// Side.Black -> Side.White
+    /// Side.White -> Side.Black
+    /// </summary>
+    /// <param name="side"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int OppositeSide(int side)
+    {
+        GuardAgainstSideBoth(side);
+
+        return side ^ 1;     // or  (int)Side.White - side
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,6 +102,26 @@ public static class Utils
         GuardAgainstSideBoth(side);
 
         return (int)BoardSquare.a8 + (7 * 8 * side);
+    }
+
+    public static (int Source, int Target) ShortCastleRookSourceAndTargetSquare(Side side) => ShortCastleRookSourceAndTargetSquare((int)side);
+    public static (int Source, int Target) ShortCastleRookSourceAndTargetSquare(int side)
+    {
+        GuardAgainstSideBoth(side);
+
+        return (
+            (int)BoardSquare.h8 + (7 * 8 * side),
+            Constants.BlackShortCastleRookSquare + (7 * 8 * side));
+    }
+
+    public static (int Source, int Target) LongCastleRookSourceAndTargetSquare(Side side) => LongCastleRookSourceAndTargetSquare((int)side);
+    public static (int Source, int Target) LongCastleRookSourceAndTargetSquare(int side)
+    {
+        GuardAgainstSideBoth(side);
+
+        return (
+            (int)BoardSquare.a8 + (7 * 8 * side),
+            Constants.BlackLongCastleRookSquare + (7 * 8 * side));
     }
 
     /// <summary>


### PR DESCRIPTION
It can't possibly be worse than before, so merging since no regression.

WIP runs
```
Score of Lynx 1143 - general opt vs Lynx 1140 - main: 1805 - 1726 - 1009  [0.509] 4540
...      Lynx 1143 - general opt playing White: 1060 - 703 - 507  [0.579] 2270
...      Lynx 1143 - general opt playing Black: 745 - 1023 - 502  [0.439] 2270
...      White vs Black: 2083 - 1448 - 1009  [0.570] 4540
Elo difference: 6.0 +/- 8.9, LOS: 90.8 %, DrawRatio: 22.2 %
SPRT: llr 0.506 (17.2%), lbound -2.94, ubound 2.94
```
```
Score of Lynx 1143 - general opt vs Lynx 1140 - main: 746 - 766 - 398  [0.495] 1910
...      Lynx 1143 - general opt playing White: 443 - 311 - 201  [0.569] 955
...      Lynx 1143 - general opt playing Black: 303 - 455 - 197  [0.420] 955
...      White vs Black: 898 - 614 - 398  [0.574] 1910
Elo difference: -3.6 +/- 13.9, LOS: 30.4 %, DrawRatio: 20.8 %
SPRT: llr -1.73 (-58.6%), lbound -2.94, ubound 2.94
```