### PR TITLE
Reduce `GameState` struct size 

### DIFF
--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration.cs
@@ -156,7 +156,7 @@ public class MakeUnmakeMove_integration : BaseBenchmark
             ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 4),
             ("3K4/8/8/8/8/8/4p3/2k2R2 b - - 0 1", 6),
             ("2K2r2/4P3/8/8/8/8/8/3k4 w - - 0 1", 6),
-            ("8/p7/8/1P6/K1k3p1/6P1/7P/8 w - -", 6),
+            ("8/p7/8/1P6/K1k3p1/6P1/7P/8 w - -", 6)
         };
 
     [Benchmark(Baseline = true)]

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -354,7 +354,7 @@ public static class Constants
     ///  Black kingside Rook moved      1111 & 1011  =  1011    11
     ///  Black queenside Rook moved     1111 & 0111  =  0111    7
     /// </summary>
-    public static readonly int[] CastlingRightsUpdateConstants = new int[64]
+    public static readonly byte[] CastlingRightsUpdateConstants = new byte[64]
     {
             7, 15, 15, 15,  3, 15, 15, 11,
             15, 15, 15, 15, 15, 15, 15, 15,

--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -13,7 +13,7 @@ public static partial class FENParser
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    public static (bool Success, BitBoard[] PieceBitBoards, BitBoard[] OccupancyBitBoards, Side Side, int Castle, BoardSquare EnPassant,
+    public static (bool Success, BitBoard[] PieceBitBoards, BitBoard[] OccupancyBitBoards, Side Side, byte Castle, BoardSquare EnPassant,
         int HalfMoveClock, int FullMoveCounter) ParseFEN(string fen)
     {
         fen = fen.Trim();
@@ -27,7 +27,7 @@ public static partial class FENParser
 
         bool success;
         Side side = Side.Both;
-        int castle = 0;
+        byte castle = 0;
         int halfMoveClock = 0, fullMoveCounter = 1;
         BoardSquare enPassant = BoardSquare.noSquare;
 
@@ -140,18 +140,18 @@ public static partial class FENParser
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
 
-    private static int ParseCastlingRights(string castleString)
+    private static byte ParseCastlingRights(string castleString)
     {
-        int castle = 0;
+        byte castle = 0;
 
         foreach (var ch in castleString)
         {
             castle |= ch switch
             {
-                'K' => (int)CastlingRights.WK,
-                'Q' => (int)CastlingRights.WQ,
-                'k' => (int)CastlingRights.BK,
-                'q' => (int)CastlingRights.BQ,
+                'K' => (byte)CastlingRights.WK,
+                'Q' => (byte)CastlingRights.WQ,
+                'k' => (byte)CastlingRights.BK,
+                'q' => (byte)CastlingRights.BQ,
                 '-' => castle,
                 _ => throw new($"Unrecognized castling char: {ch}")
             };

--- a/src/Lynx/Model/BoardSquare.cs
+++ b/src/Lynx/Model/BoardSquare.cs
@@ -13,7 +13,7 @@
 ///         SW       S      SE
 ///
 /// </summary>
-public enum BoardSquare
+public enum BoardSquare : sbyte
 {
     a8, b8, c8, d8, e8, f8, g8, h8,
     a7, b7, c7, d7, e7, f7, g7, h7,

--- a/src/Lynx/Model/CastlingRights.cs
+++ b/src/Lynx/Model/CastlingRights.cs
@@ -10,7 +10,7 @@
 /// * 1111      Both sides can castle both directions
 /// * 1001      Black king => only O-O-O; White king => only O-O
 /// </summary>
-public enum CastlingRights
+public enum CastlingRights : byte
 {
     WK = 1, WQ = 2, BK = 4, BQ = 8
 }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,7 +1,7 @@
 ﻿namespace Lynx.Model;
 public readonly struct GameState
 {
-    public readonly int CapturedPiece;
+    public readonly sbyte CapturedPiece;
 
     public readonly byte Castle;
 
@@ -11,7 +11,7 @@ public readonly struct GameState
 
     // TODO: save full Zobrist key?
 
-    public GameState(int capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
+    public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
     {
         CapturedPiece = capturedPiece;
         Castle = castle;

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,11 +1,21 @@
 ﻿namespace Lynx.Model;
-public readonly struct GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
+public readonly struct GameState
 {
-    public readonly sbyte CapturedPiece = capturedPiece;
+    public readonly sbyte CapturedPiece;
 
-    public readonly byte Castle = castle;
+    public readonly byte Castle;
 
-    public readonly BoardSquare EnPassant = enpassant;
+    public readonly BoardSquare EnPassant;
 
-    public readonly long ZobristKey = zobristKey;
+    public readonly long ZobristKey;
+
+    // TODO: save full Zobrist key?
+
+    public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
+    {
+        CapturedPiece = capturedPiece;
+        Castle = castle;
+        EnPassant = enpassant;
+        ZobristKey = zobristKey;
+    }
 }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,21 +1,11 @@
 ﻿namespace Lynx.Model;
-public readonly struct GameState
+public readonly struct GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
 {
-    public readonly sbyte CapturedPiece;
+    public readonly sbyte CapturedPiece = capturedPiece;
 
-    public readonly byte Castle;
+    public readonly byte Castle = castle;
 
-    public readonly BoardSquare EnPassant;
+    public readonly BoardSquare EnPassant = enpassant;
 
-    public readonly long ZobristKey;
-
-    // TODO: save full Zobrist key?
-
-    public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
-    {
-        CapturedPiece = capturedPiece;
-        Castle = castle;
-        EnPassant = enpassant;
-        ZobristKey = zobristKey;
-    }
+    public readonly long ZobristKey = zobristKey;
 }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -3,7 +3,7 @@ public readonly struct GameState
 {
     public readonly int CapturedPiece;
 
-    public readonly int Castle;
+    public readonly byte Castle;
 
     public readonly BoardSquare EnPassant;
 
@@ -11,7 +11,7 @@ public readonly struct GameState
 
     // TODO: save full Zobrist key?
 
-    public GameState(int capturedPiece, int castle, BoardSquare enpassant, long zobristKey)
+    public GameState(int capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
     {
         CapturedPiece = capturedPiece;
         Castle = castle;

--- a/src/Lynx/Model/Piece.cs
+++ b/src/Lynx/Model/Piece.cs
@@ -1,6 +1,6 @@
 ﻿namespace Lynx.Model;
 
-public enum Piece
+public enum Piece : sbyte
 {
     Unknown = -1,
     P, N, B, R, Q, K,   // White

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -209,7 +209,7 @@ public class Position
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move move)
     {
-        int capturedPiece = -1;
+        sbyte capturedPiece = -1;
         byte castleCopy = Castle;
         BoardSquare enpassantCopy = EnPassant;
         long uniqueIdentifierCopy = UniqueIdentifier;
@@ -255,7 +255,7 @@ public class Position
                 PieceBitBoards[oppositePawnIndex].PopBit(capturedPawnSquare);
                 OccupancyBitBoards[oppositeSide].PopBit(capturedPawnSquare);
                 UniqueIdentifier ^= ZobristTable.PieceHash(capturedPawnSquare, oppositePawnIndex);
-                capturedPiece = oppositePawnIndex;
+                capturedPiece = (sbyte)oppositePawnIndex;
             }
             else
             {
@@ -266,7 +266,7 @@ public class Position
                     {
                         PieceBitBoards[pieceIndex].PopBit(targetSquare);
                         UniqueIdentifier ^= ZobristTable.PieceHash(targetSquare, pieceIndex);
-                        capturedPiece = pieceIndex;
+                        capturedPiece = (sbyte)pieceIndex;
                         break;
                     }
                 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -26,13 +26,16 @@ public class Position
 
     public BoardSquare EnPassant { get; private set; }
 
-    public int Castle { get; private set; }
+    /// <summary>
+    /// See <see cref="<CastlingRights"/>
+    /// </summary>
+    public byte Castle { get; private set; }
 
     public Position(string fen) : this(FENParser.ParseFEN(fen))
     {
     }
 
-    public Position((bool Success, BitBoard[] PieceBitBoards, BitBoard[] OccupancyBitBoards, Side Side, int Castle, BoardSquare EnPassant,
+    public Position((bool Success, BitBoard[] PieceBitBoards, BitBoard[] OccupancyBitBoards, Side Side, byte Castle, BoardSquare EnPassant,
         int HalfMoveClock, int FullMoveCounter) parsedFEN)
     {
         PieceBitBoards = parsedFEN.PieceBitBoards;
@@ -207,7 +210,7 @@ public class Position
     public GameState MakeMove(Move move)
     {
         int capturedPiece = -1;
-        int castleCopy = Castle;
+        byte castleCopy = Castle;
         BoardSquare enpassantCopy = EnPassant;
         long uniqueIdentifierCopy = UniqueIdentifier;
 
@@ -420,7 +423,7 @@ public class Position
             ZobristTable.SideHash()
             ^ ZobristTable.EnPassantHash((int)oldEnPassant);
 
-        return new GameState(-1, -1, oldEnPassant, oldUniqueIdentifier);
+        return new GameState(-1, byte.MaxValue, oldEnPassant, oldUniqueIdentifier);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -320,8 +320,8 @@ public class Position
         OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
 
         // Updating castling rights
-        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare]
-            & Constants.CastlingRightsUpdateConstants[targetSquare];
+        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare];
+        Castle &= Constants.CastlingRightsUpdateConstants[targetSquare];
 
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
 


### PR DESCRIPTION
[GameState compression: make BoardSquare and sbyte enum](https://github.com/lynx-chess/Lynx/commit/8cfeeb7399f1b3656750d2493954da8848d3d446)


[GameState compression: make Position.Castle a byte](https://github.com/lynx-chess/Lynx/commit/dfad119924b4a26c106abf4787323208e5c75a0b)


[GameState compression: make Piece (and therefore `GameState.CapturedPiece`) a sbyte enum](https://github.com/lynx-chess/Lynx/commit/64394b19cf79676eb42ba85501aafbec743f7a2c)

```
Score of Lynx 1163 vs Lynx 1150 - main: 4468 - 4383 - 2578  [0.504] 11429
...      Lynx 1163 playing White: 2614 - 1804 - 1297  [0.571] 5715
...      Lynx 1163 playing Black: 1854 - 2579 - 1281  [0.437] 5714
...      White vs Black: 5193 - 3658 - 2578  [0.567] 11429
Elo difference: 2.6 +/- 5.6, LOS: 81.7 %, DrawRatio: 22.6 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```