### PR TITLE
⚡  Disable NLog autoreload

### DIFF
--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -68,6 +68,7 @@ finally
     engineChannel.Writer.TryComplete();
     uciChannel.Writer.TryComplete();
     //source.Cancel();
+    NLog.LogManager.Shutdown(); // Flush and close down internal threads and timers
 }
 
 Thread.Sleep(2_000);

--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -1,11 +1,13 @@
 ﻿{
   "EngineSettings": {
     "DefaultMaxDepth": 3,
-    "TranspositionTableEnabled": false,
+    "TranspositionTableEnabled": true,
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false
   },
   "NLog": {
+    "internalLogLevel": "Warn",
+    "throwExceptions": true,
     "targets": {
       "console": {
         "type": "ColoredConsole",

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -61,12 +61,13 @@
     "autoreload": false,
     "internalLogLevel": "Error",
     "internalLogFile": "${basedir}/logs/internal-nlog.txt",
-    "throwExceptions": true,
+    "throwExceptions": false,
     "variables": {
       "logDirectory": "${basedir}/logs",
       "archiveLogDirectory": "${basedir}/logs/archives"
     },
     "targets": {
+      "async": true,
       "errors": {
         "type": "File",
         "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${processid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -58,7 +58,7 @@
 
   // Logging settings
   "NLog": {
-    "autoreload": true,
+    "autoreload": false,
     "internalLogLevel": "Error",
     "internalLogFile": "${basedir}/logs/internal-nlog.txt",
     "throwExceptions": true,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -67,7 +67,7 @@
       "archiveLogDirectory": "${basedir}/logs/archives"
     },
     "targets": {
-      "async": true,
+      "async": false,
       "errors": {
         "type": "File",
         "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${processid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",


### PR DESCRIPTION
Disabling NLog autoreload might save some filewatchers.
I'm also invoking Flush at the end of `Program.cs`, as recommended.

[1167](https://github.com/lynx-chess/Lynx/pull/329/commits/6dea228ae566a2de4b0b75e5b8cc52c4d2aaca54)
[-4, 1]
```
Score of Lynx-perf-nlog-config-1167-win-x64 vs Lynx 1150 - main: 2506 - 2542 - 1462  [0.497] 6510
...      Lynx-perf-nlog-config-1167-win-x64 playing White: 1483 - 1045 - 727  [0.567] 3255
...      Lynx-perf-nlog-config-1167-win-x64 playing Black: 1023 - 1497 - 735  [0.427] 3255
...      White vs Black: 2980 - 2068 - 1462  [0.570] 6510
Elo difference: -1.9 +/- 7.4, LOS: 30.6 %, DrawRatio: 22.5 %
SPRT: llr -0.146 (-5.0%), lbound -2.94, ubound 2.94
```

[0,10]
```
Score of Lynx-perf-nlog-config-1167-win-x64 vs Lynx 1150 - main: 896 - 897 - 527  [0.500] 2320
...      Lynx-perf-nlog-config-1167-win-x64 playing White: 535 - 372 - 253  [0.570] 1160
...      Lynx-perf-nlog-config-1167-win-x64 playing Black: 361 - 525 - 274  [0.429] 1160
...      White vs Black: 1060 - 733 - 527  [0.570] 2320
Elo difference: -0.1 +/- 12.4, LOS: 49.1 %, DrawRatio: 22.7 %
SPRT: llr -1.28 (-43.5%), lbound -2.94, ubound 2.94
```