### PR TITLE
⚡  Use `Bmi1.X64.TrailingZeroCount` and `Popcnt.X64.PopCount` hardware intrinsics

### DIFF
--- a/src/Lynx/Model/BitBoard.cs
+++ b/src/Lynx/Model/BitBoard.cs
@@ -1,5 +1,6 @@
 ﻿using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 
 #pragma warning disable S4136
 
@@ -121,6 +122,11 @@ public static class BitBoardExtensions
     {
         Utils.Assert(board != default);
 
+        if (Bmi1.X64.IsSupported)
+        {
+            return (int)Bmi1.X64.TrailingZeroCount(board);
+        }
+
         return BitOperations.TrailingZeroCount(board);
     }
 
@@ -149,6 +155,11 @@ public static class BitBoardExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int CountBits(this BitBoard board)
     {
+        if (Popcnt.X64.IsSupported)
+        {
+            return (int)Popcnt.X64.PopCount(board);
+        }
+
         return BitOperations.PopCount(board);
     }
 


### PR DESCRIPTION
Use `Bmi1.X64.TrailingZeroCount` and `Popcnt.X64.PopCount` hardware intrinsics when available

Result: disappointment after 20k games
```
Score of Lynx 1177 - hw intrinsics vs Lynx 1176 - main: 7983 - 7884 - 4503  [0.502] 20370
...      Lynx 1177 - hw intrinsics playing White: 4760 - 3168 - 2257  [0.578] 10185
...      Lynx 1177 - hw intrinsics playing Black: 3223 - 4716 - 2246  [0.427] 10185
...      White vs Black: 9476 - 6391 - 4503  [0.576] 20370
Elo difference: 1.7 +/- 4.2, LOS: 78.4 %, DrawRatio: 22.1 %
SPRT: llr -0.879 (-29.9%), lbound -2.94, ubound 2.94
```