### PR TITLE
⚡  Make NLog targets `async `

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -67,7 +67,7 @@
       "archiveLogDirectory": "${basedir}/logs/archives"
     },
     "targets": {
-      "async": false,
+      "async": true,
       "errors": {
         "type": "File",
         "layout": "${longdate}|${event-properties:item=EventId_Id:whenEmpty=0}|${processid}|${uppercase:${level}}|${logger}|${message} ${exception:format=tostring}",


### PR DESCRIPTION
```
Score of Lynx 1178 - nlog async targets vs Lynx 1176 - main: 5029 - 4779 - 2789  [0.510] 12597
...      Lynx 1178 - nlog async targets playing White: 2923 - 2010 - 1367  [0.572] 6300
...      Lynx 1178 - nlog async targets playing Black: 2106 - 2769 - 1422  [0.447] 6297
...      White vs Black: 5692 - 4116 - 2789  [0.563] 12597
Elo difference: 6.9 +/- 5.3, LOS: 99.4 %, DrawRatio: 22.1 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```