### PR TITLE
Avoid unnecessary `IOrderedEnumerable.ToList()`

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -57,7 +57,7 @@ public sealed partial class Engine
     private const int MaxValue = short.MaxValue;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private List<Move> SortMoves(IEnumerable<Move> moves, int depth, Move bestMoveTTCandidate)
+    private IOrderedEnumerable<Move> SortMoves(IEnumerable<Move> moves, int depth, Move bestMoveTTCandidate)
     {
         if (_isFollowingPV)
         {
@@ -73,13 +73,8 @@ public sealed partial class Engine
             }
         }
 
-        var orderedMoves = moves
-            .OrderByDescending(move => ScoreMove(move, depth, true, bestMoveTTCandidate))
-            .ToList();
-
-        PrintMessage($"For position {Game.CurrentPosition.FEN()}:\n{string.Join(", ", orderedMoves.Select(m => $"{m.ToEPDString()} ({ScoreMove(m, depth, true, bestMoveTTCandidate)})"))})");
-
-        return orderedMoves;
+        return moves
+            .OrderByDescending(move => ScoreMove(move, depth, true, bestMoveTTCandidate));
     }
 
     /// <summary>


### PR DESCRIPTION
 Avoid unnecessary `IOrderedEnumerable.ToList()` before before iterating over it
10+0.1
```
Score of Lynx-perf-orederedenumerable-1188-win-x64 vs Lynx 1186 - main: 2631 - 2634 - 1665  [0.500] 6930
...      Lynx-perf-orederedenumerable-1188-win-x64 playing White: 1539 - 1059 - 867  [0.569] 3465
...      Lynx-perf-orederedenumerable-1188-win-x64 playing Black: 1092 - 1575 - 798  [0.430] 3465
...      White vs Black: 3114 - 2151 - 1665  [0.569] 6930
Elo difference: -0.2 +/- 7.1, LOS: 48.4 %, DrawRatio: 24.0 %
SPRT: llr -1 (-34.0%), lbound -2.94, ubound 2.94
```