### PR TITLE
Use `Array.Sort` to sort moves

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -579,10 +579,10 @@ public class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
+    public Move[] AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
+    public Move[] AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -45,7 +45,7 @@ public static class MoveGenerator
 #if DEBUG
         if (position.Side == Side.Both)
         {
-            return new List<Move>();
+            return Array.Empty<Move>();
         }
 #endif
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -40,7 +40,7 @@ public static class MoveGenerator
     /// <param name="capturesOnly">Filters out all moves but captures</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+    public static Move[] GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
     {
 #if DEBUG
         if (position.Side == Side.Both)
@@ -62,7 +62,7 @@ public static class MoveGenerator
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
 
-        return movePool.Take(localIndex);
+        return movePool[..localIndex];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -57,14 +57,14 @@ public sealed partial class Engine
     private const int MaxValue = short.MaxValue;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void SortMoves(Move[] moves, int depth, Move bestMoveTTCandidate)
+    private void SortMoves(Move[] moves, int ply, Move bestMoveTTCandidate)
     {
         if (_isFollowingPV)
         {
             _isFollowingPV = false;
             foreach (var move in moves)
             {
-                if (move == _pVTable[depth])
+                if (move == _pVTable[ply])
                 {
                     _isFollowingPV = true;
                     _isScoringPV = true;
@@ -73,7 +73,13 @@ public sealed partial class Engine
             }
         }
 
-        Array.Sort(moves, (a, b) => ScoreMove(a, depth, true, bestMoveTTCandidate) > ScoreMove(b, depth, true, bestMoveTTCandidate) ? 1 : 0);
+        Array.Sort(moves, (moveA, moveB) =>
+        {
+            var scoreA = ScoreMove(moveA, ply, true, bestMoveTTCandidate);
+            var scoreB = ScoreMove(moveB, ply, true, bestMoveTTCandidate);
+
+            return scoreA == scoreB ? 0 : (scoreA > scoreB ? -1 : 1);
+        });
     }
 
     /// <summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -57,7 +57,7 @@ public sealed partial class Engine
     private const int MaxValue = short.MaxValue;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private List<Move> SortMoves(IEnumerable<Move> moves, int depth, Move bestMoveTTCandidate)
+    private void SortMoves(Move[] moves, int depth, Move bestMoveTTCandidate)
     {
         if (_isFollowingPV)
         {
@@ -73,13 +73,7 @@ public sealed partial class Engine
             }
         }
 
-        var orderedMoves = moves
-            .OrderByDescending(move => ScoreMove(move, depth, true, bestMoveTTCandidate))
-            .ToList();
-
-        PrintMessage($"For position {Game.CurrentPosition.FEN()}:\n{string.Join(", ", orderedMoves.Select(m => $"{m.ToEPDString()} ({ScoreMove(m, depth, true, bestMoveTTCandidate)})"))})");
-
-        return orderedMoves;
+        Array.Sort(moves, (a, b) => ScoreMove(a, depth, true, bestMoveTTCandidate) > ScoreMove(b, depth, true, bestMoveTTCandidate) ? 1 : 0);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -120,7 +120,8 @@ public sealed partial class Engine
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 
-        var pseudoLegalMoves = SortMoves(position.AllPossibleMoves(Game.MovePool), ply, ttBestMove);
+        var pseudoLegalMoves = position.AllPossibleMoves(Game.MovePool);
+        SortMoves(pseudoLegalMoves, ply, ttBestMove);
 
         foreach (var move in pseudoLegalMoves)
         {
@@ -311,13 +312,13 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        var generatedMoves = position.AllCapturesMoves(Game.MovePool);
-        if (!generatedMoves.Any())
+        var movesToEvaluate = position.AllCapturesMoves(Game.MovePool);
+        if (movesToEvaluate.Length == 0)
         {
             return staticEvaluation;  // TODO check if in check or drawn position
         }
 
-        var movesToEvaluate = generatedMoves.OrderByDescending(move => ScoreMove(move, ply, false));
+        Array.Sort(movesToEvaluate, (a, b) => ScoreMove(a, ply, false) > ScoreMove(b, ply, false) ? 1 : 0);
 
         Move? bestMove = null;
         bool isAnyMoveValid = false;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -318,7 +318,13 @@ public sealed partial class Engine
             return staticEvaluation;  // TODO check if in check or drawn position
         }
 
-        Array.Sort(movesToEvaluate, (a, b) => ScoreMove(a, ply, false) > ScoreMove(b, ply, false) ? 1 : 0);
+        Array.Sort(movesToEvaluate, (moveA, moveB) =>
+        {
+            var scoreA = ScoreMove(moveA, ply, false);
+            var scoreB = ScoreMove(moveB, ply, false);
+
+            return scoreA == scoreB ? 0 : (scoreA > scoreB ? -1 : 1);
+        });
 
         Move? bestMove = null;
         bool isAnyMoveValid = false;


### PR DESCRIPTION
Use `Array.Sort` instead of `IEnumerable.OrderByDescending`, taking advantage that pseulegal moves can return in form of an array

```
Score of Lynx 1182 - array sort vs Lynx 1176 - main: 1728 - 1743 - 1013  [0.498] 4484
...      Lynx 1182 - array sort playing White: 1030 - 692 - 520  [0.575] 2242
...      Lynx 1182 - array sort playing Black: 698 - 1051 - 493  [0.421] 2242
...      White vs Black: 2081 - 1390 - 1013  [0.577] 4484
Elo difference: -1.2 +/- 8.9, LOS: 40.0 %, DrawRatio: 22.6 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```

```
Score of Lynx 1182 - array sort vs Lynx 1176 - main: 9214 - 9203 - 5290  [0.500] 23707
...      Lynx 1182 - array sort playing White: 5370 - 3800 - 2684  [0.566] 11854
...      Lynx 1182 - array sort playing Black: 3844 - 5403 - 2606  [0.434] 11853
...      White vs Black: 10773 - 7644 - 5290  [0.566] 23707
Elo difference: 0.2 +/- 3.9, LOS: 53.2 %, DrawRatio: 22.3 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```