### PR TITLE
👷🏽‍♂️ Fix `git push` step in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
       if: github.event.inputs.should_commit_new_version == 'true'
       continue-on-error: true
       run: |
-        git switch ${{ env.GITHUB_REF_SLUG }}
+        git switch ${{ env.GITHUB_REF_NAME }}
         git status
         git commit -am "🚀 Release v${{ github.event.inputs.new_engine_version }}"
         git push
@@ -181,7 +181,7 @@ jobs:
     - name: Create git tag
       if: github.event.inputs.should_tag_new_version == 'true'
       run: |
-        git switch ${{ env.GITHUB_REF_SLUG }}
+        git switch ${{ env.GITHUB_REF_NAME }}
         git status
         git tag -a v${{ github.event.inputs.new_engine_version }} -m "v${{ github.event.inputs.new_engine_version }}"
         git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.GH_RELEASE }}
 
     - name: Configure git user
       run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </ItemGroup >
 
   <PropertyGroup>
-    <Version>0.15.0</Version>
+    <Version>0.15.1-alpha.1</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </ItemGroup >
 
   <PropertyGroup>
-    <Version>0.14.1</Version>
+    <Version>0.15.1-alpha.1</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </ItemGroup >
 
   <PropertyGroup>
-    <Version>0.15.1-alpha.1</Version>
+    <Version>0.14.1</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,7 +15,7 @@
   </ItemGroup >
 
   <PropertyGroup>
-    <Version>0.15.1-alpha.1</Version>
+    <Version>0.15.0</Version>
     <Authors>Eduardo Cáceres</Authors>
     <ApplicationIcon>$(MSBuildThisFileDirectory)resources\icon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/lynx-chess/Lynx</RepositoryUrl>


### PR DESCRIPTION
Due to having enabled branch protection for `main`, step required for using the new 'Merge when ready' feature, `git push` isn't allowed with default, implicit token, so a PAT is used.

Two articles about this:

- https://www.paulmowat.co.uk/blog/resolve-github-action-gh006-protected-branch-update-failed
- https://til.cazzulino.com/devops-ci-cd/push-to-protected-branch-from-github-actions