### PR TITLE
Avoid creating `ProbeOnlineTablebase` task if requirements for tb probing are not met

### DIFF
--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -45,6 +45,7 @@ public static class OnlineTablebaseProber
 
     public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, HashSet<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
+        // TODO remove? Redundant
         if (!Configuration.EngineSettings.UseOnlineTablebaseInRootPositions || position.CountPieces() > Configuration.EngineSettings.OnlineTablebaseMaxSupportedPieces)
         {
             return (NoResult, default);


### PR DESCRIPTION
Avoid creating `ProbeOnlineTablebase` task and using `WhenAll` if requirements for tb probing are not met

```
Score of Lynx-perf-avoid-probeonlinetablebase-task-when-not-applicable-1199-win-x64 vs Lynx 0.15.0: 1916 - 2038 - 1164  [0.488] 5118
...      Lynx-perf-avoid-probeonlinetablebase-task-when-not-applicable-1199-win-x64 playing White: 1166 - 843 - 550  [0.563] 2559
...      Lynx-perf-avoid-probeonlinetablebase-task-when-not-applicable-1199-win-x64 playing Black: 750 - 1195 - 614  [0.413] 2559
...      White vs Black: 2361 - 1593 - 1164  [0.575] 5118
Elo difference: -8.3 +/- 8.4, LOS: 2.6 %, DrawRatio: 22.7 %
SPRT: llr -2.96 (-100.5%), lbound -2.94, ubound 2.94 - H0 was accepted
```