### PR TITLE
⚡ Remove UCI `hashfull` command for performance reasons

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -52,10 +52,7 @@ public sealed partial class Engine
         {
             _logger.Debug("Ponder hit");
 
-            lastSearchResult = new SearchResult(_previousSearchResult)
-            {
-                HashfullPermill = _transpositionTable.HashfullPermill()
-            };
+            lastSearchResult = new SearchResult(_previousSearchResult);
 
             Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
 
@@ -132,8 +129,7 @@ public sealed partial class Engine
                     DepthReached = maxDepthReached,
                     Nodes = _nodes,
                     Time = elapsedTime,
-                    NodesPerSecond = Utils.CalculateNps(_nodes, elapsedTime),
-                    HashfullPermill = _transpositionTable.HashfullPermill()
+                    NodesPerSecond = Utils.CalculateNps(_nodes, elapsedTime)
                 };
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
@@ -168,7 +164,6 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = _stopWatch.ElapsedMilliseconds;
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, _stopWatch.ElapsedMilliseconds);
-        finalSearchResult.HashfullPermill = _transpositionTable.HashfullPermill();
 
         if (isMateDetected && finalSearchResult.Mate + Game.HalfMovesWithoutCaptureOrPawnMove < 96)
         {

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -20,8 +20,7 @@ public sealed partial class Engine
                     DepthReached = 0,
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = stopWatch.ElapsedMilliseconds,
-                    NodesPerSecond = 0,
-                    HashfullPermill = _transpositionTable.HashfullPermill()
+                    NodesPerSecond = 0
                 };
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult));

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -86,7 +86,6 @@ public sealed class InfoCommand : EngineBaseCommand
             $" nodes {searchResult.Nodes}" +
             $" nps {searchResult.NodesPerSecond}" +
             $" time {searchResult.Time}" +
-            $" hashfull {searchResult.HashfullPermill}" +
             $" pv {string.Join(" ", searchResult.Moves.Select(move => move.UCIString()))}";
 #pragma warning restore RCS1214 // Unnecessary interpolated string.
     }


### PR DESCRIPTION
```
Score of Lynx 1217 - no hashfull vs Lynx 0.15.0: 592 - 426 - 308  [0.563] 1326
...      Lynx 1217 - no hashfull playing White: 352 - 158 - 153  [0.646] 663
...      Lynx 1217 - no hashfull playing Black: 240 - 268 - 155  [0.479] 663
...      White vs Black: 620 - 398 - 308  [0.584] 1326
Elo difference: 43.7 +/- 16.5, LOS: 100.0 %, DrawRatio: 23.2 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```