### PR TITLE
⚡ Optimize divisions by power of two

### DIFF
--- a/src/Lynx/AttackGenerator.cs
+++ b/src/Lynx/AttackGenerator.cs
@@ -418,8 +418,7 @@ public static class AttackGenerator
         int rank, file;
 
         // Next target square within the attack ray of a sliding piece
-        int targetRank = squareIndex / 8;
-        int targetFile = squareIndex % 8;
+        int targetRank = Math.DivRem(squareIndex, 8, out int targetFile);
 
         // Mask relevant bishop occupancy bits (squares)
 
@@ -489,8 +488,7 @@ public static class AttackGenerator
         int rank, file;
 
         // Next target square within the attack ray of a sliding piece
-        int targetRank = squareIndex / 8;
-        int targetFile = squareIndex % 8;
+        int targetRank = Math.DivRem(squareIndex, 8, out int targetFile);
 
         // Mask relevant rook occupancy bits (squares)
 
@@ -585,8 +583,7 @@ public static class AttackGenerator
         int rank, file;
 
         // Next target square within the attack ray of a sliding piece
-        int targetRank = squareIndex / 8;
-        int targetFile = squareIndex % 8;
+        int targetRank = Math.DivRem(squareIndex, 8, out int targetFile);
 
         // Generate bishop attacks
 
@@ -673,8 +670,7 @@ public static class AttackGenerator
         int rank, file;
 
         // Next target square within the attack ray of a sliding piece
-        int targetRank = squareIndex / 8;
-        int targetFile = squareIndex % 8;
+        int targetRank = Math.DivRem(squareIndex, 8, out int targetFile);
 
         // Generate rook attacks
 

--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -169,7 +169,7 @@ public static partial class FENParser
         {
             enPassant = result;
 
-            var rank = 1 + (int)enPassant / 8;
+            var rank = 1 + (int)enPassant >> 3;
             if (rank != 3 && rank != 6)
             {
                 success = false;

--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -169,7 +169,7 @@ public static partial class FENParser
         {
             enPassant = result;
 
-            var rank = 1 + (int)enPassant >> 3;
+            var rank = 1 + ((int)enPassant >> 3);
             if (rank != 3 && rank != 6)
             {
                 success = false;

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -80,7 +80,7 @@ public static class MoveGenerator
             sourceSquare = bitboard.GetLS1BIndex();
             bitboard.ResetLS1B();
 
-            var sourceRank = (sourceSquare / 8) + 1;
+            var sourceRank = (sourceSquare >> 3) + 1;
 
 #if DEBUG
             if (sourceRank == 1 || sourceRank == 8)
@@ -95,7 +95,7 @@ public static class MoveGenerator
             if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
             {
                 // Single pawn push
-                var targetRank = (singlePushSquare / 8) + 1;
+                var targetRank = (singlePushSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
@@ -137,7 +137,7 @@ public static class MoveGenerator
                 targetSquare = attackedSquares.GetLS1BIndex();
                 attackedSquares.ResetLS1B();
 
-                var targetRank = (targetSquare / 8) + 1;
+                var targetRank = (targetSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
@@ -284,7 +284,7 @@ public static class MoveGenerator
             sourceSquare = bitboard.GetLS1BIndex();
             bitboard.ResetLS1B();
 
-            var sourceRank = (sourceSquare / 8) + 1;
+            var sourceRank = (sourceSquare >> 3) + 1;
 
 #if DEBUG
             if (sourceRank == 1 || sourceRank == 8)
@@ -299,7 +299,7 @@ public static class MoveGenerator
             if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
             {
                 // Single pawn push
-                var targetRank = (singlePushSquare / 8) + 1;
+                var targetRank = (singlePushSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
                     yield return MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
@@ -341,7 +341,7 @@ public static class MoveGenerator
                 targetSquare = attackedSquares.GetLS1BIndex();
                 attackedSquares.ResetLS1B();
 
-                var targetRank = (targetSquare / 8) + 1;
+                var targetRank = (targetSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
                     yield return MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);


### PR DESCRIPTION
* [`a / 8` -> `a >> 3`](https://github.com/lynx-chess/Lynx/commit/0c7847bd5ce4a3c5fc7450111d15e6770279abf6)
* [Use `Math.DivRem`](https://github.com/lynx-chess/Lynx/commit/639b7d566cbed5e7f4b9d16a8a89f85d35f2d698)

```
Score of Lynx 1256 - perf div vs Lynx 1247 - main: 3432 - 3436 - 2052  [0.500] 8920
...      Lynx 1256 - perf div playing White: 2043 - 1400 - 1017  [0.572] 4460
...      Lynx 1256 - perf div playing Black: 1389 - 2036 - 1035  [0.427] 4460
...      White vs Black: 4079 - 2789 - 2052  [0.572] 8920
Elo difference: -0.2 +/- 6.3, LOS: 48.1 %, DrawRatio: 23.0 %
SPRT: llr -1.27 (-43.3%), lbound -2.94, ubound 2.94
```