### PR TITLE
Use `Array.Sort` to sort moves (values array override)

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -588,10 +588,10 @@ public class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
+    public Move[] AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
+    public Move[] AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -40,12 +40,12 @@ public static class MoveGenerator
     /// <param name="capturesOnly">Filters out all moves but captures</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+    public static Move[] GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
     {
 #if DEBUG
         if (position.Side == Side.Both)
         {
-            return new List<Move>();
+            return Array.Empty<Move>();
         }
 #endif
 
@@ -62,7 +62,7 @@ public static class MoveGenerator
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
 
-        return movePool.Take(localIndex);
+        return movePool[..localIndex];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -56,32 +56,6 @@ public sealed partial class Engine
     private const int MinValue = short.MinValue;
     private const int MaxValue = short.MaxValue;
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private List<Move> SortMoves(IEnumerable<Move> moves, int depth, Move bestMoveTTCandidate)
-    {
-        if (_isFollowingPV)
-        {
-            _isFollowingPV = false;
-            foreach (var move in moves)
-            {
-                if (move == _pVTable[depth])
-                {
-                    _isFollowingPV = true;
-                    _isScoringPV = true;
-                    break;
-                }
-            }
-        }
-
-        var orderedMoves = moves
-            .OrderByDescending(move => ScoreMove(move, depth, true, bestMoveTTCandidate))
-            .ToList();
-
-        PrintMessage($"For position {Game.CurrentPosition.FEN()}:\n{string.Join(", ", orderedMoves.Select(m => $"{m.ToEPDString()} ({ScoreMove(m, depth, true, bestMoveTTCandidate)})"))})");
-
-        return orderedMoves;
-    }
-
     /// <summary>
     /// Returns the score evaluation of a move taking into account <see cref="_isScoringPV"/>, <paramref name="bestMoveTTCandidate"/>, <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_historyMoves"/>
     /// </summary>


### PR DESCRIPTION
What was attempted in https://github.com/lynx-chess/Lynx/pull/333, but using another `Array.Sort` override.

```
Score of Lynx 1281 - array sort vs Lynx 1279 - main: 1713 - 1836 - 1096  [0.487] 4645
...      Lynx 1281 - array sort playing White: 1048 - 720 - 555  [0.571] 2323
...      Lynx 1281 - array sort playing Black: 665 - 1116 - 541  [0.403] 2322
...      White vs Black: 2164 - 1385 - 1096  [0.584] 4645
Elo difference: -9.2 +/- 8.7, LOS: 1.9 %, DrawRatio: 23.6 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```