### PR TITLE
Use a big `Span<Move>` to save moves instead of move pool.

### DIFF
--- a/src/Lynx.Benchmark/TranspositionTableIndex.cs
+++ b/src/Lynx.Benchmark/TranspositionTableIndex.cs
@@ -122,9 +122,6 @@
  */
 
 using BenchmarkDotNet.Attributes;
-using Lynx.Model;
-using System.Numerics;
-using System.Runtime.CompilerServices;
 
 namespace Lynx.Benchmark;
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -3,6 +3,7 @@ using Lynx.Internal;
 using Lynx.Model;
 using System.Diagnostics;
 using System.Numerics;
+using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading.Channels;
@@ -46,8 +47,9 @@ using System.Threading.Channels;
 //FileAndRankMasks();
 //EnhancedPawnEvaluation();
 //RookEvaluation();
-TranspositionTable();
+//TranspositionTable();
 //UnmakeMove();
+ComparePerft();
 
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
 const string TrickyPosition = Constants.TrickyTestPositionFEN;
@@ -522,13 +524,26 @@ static void _42_Perft()
 
     var pos = new Position(TrickyPosition);
 
-    for (int depth = 0; depth < 7; ++depth)
+    //for (int depth = 0; depth < 6; ++depth)
+    //{
+    //    var sw = new Stopwatch();
+    //    sw.Start();
+    //    var result = Perft.Results(pos, depth);
+    //    sw.Stop();
+    //    Perft.PrintPerftResult(depth, result, Console.WriteLine);
+    //}
+
+    Console.WriteLine("**********************************************");
+    Console.WriteLine("Span");
+
+    Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition * Configuration.EngineSettings.MaxDepth];
+
+    for (int depth = 0; depth < 6; ++depth)
     {
         var sw = new Stopwatch();
         sw.Start();
-        var result = Perft.Results(pos, depth);
+        var result = Perft.Results(pos, depth, ref moveList);
         sw.Stop();
-
         Perft.PrintPerftResult(depth, result, Console.WriteLine);
     }
 }
@@ -1116,4 +1131,42 @@ static void UnmakeMove()
         Console.WriteLine();
     }
 
+}
+
+static void ComparePerft()
+{
+    var positions = new (string, int)[] {
+        (Constants.InitialPositionFEN, 6),
+        (Constants.TrickyTestPositionFEN, 5),
+        ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 5),
+        ("2K2r2/4P3/8/8/8/8/8/3k4 w - - 0 1", 8),
+        ("8/p7/8/1P6/K1k3p1/6P1/7P/8 w - -", 10)
+    };
+
+    Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition * Configuration.EngineSettings.MaxDepth];
+
+    foreach (var (fen, depth) in positions)
+    {
+        var startingDepth = Math.Clamp(0, depth, depth);
+        Console.WriteLine(fen);
+
+        for (int d = startingDepth; d <= depth; ++d)
+        {
+            var position = new Position(fen);
+            var result1 = Perft.Results(position, d);
+            Perft.PrintPerftResult(d, result1, Console.WriteLine);
+
+            position = new Position(fen);
+            var result2 = Perft.Results(position, d, ref moveList);
+            Perft.PrintPerftResult(d, result2, Console.WriteLine);
+
+            var percentage = 100 * (result1.ElapsedMilliseconds - result2.ElapsedMilliseconds) / result1.ElapsedMilliseconds;
+
+            Console.ForegroundColor = percentage > 0 ? ConsoleColor.Green : ConsoleColor.Red;
+            Console.WriteLine($"2 was {percentage:0.00}% faster than 1 at depth {d}");
+            Console.ResetColor();
+        }
+
+        Console.WriteLine("-------------------------------------------------------");
+    }
 }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -152,7 +152,7 @@ public sealed partial class Engine
     {
         if (!Configuration.EngineSettings.UseOnlineTablebaseInRootPositions || Game.CurrentPosition.CountPieces() > Configuration.EngineSettings.OnlineTablebaseMaxSupportedPieces)
         {
-            return (await IDDFS(minDepth, maxDepth, decisionTime))!;
+            return IDDFS(minDepth, maxDepth, decisionTime)!;
         }
 
         // Local copy of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove so that it doesn't interfere with regular search
@@ -161,7 +161,7 @@ public sealed partial class Engine
         var tasks = new Task<SearchResult?>[] {
                 // Other copies of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove (same reason)
                 ProbeOnlineTablebase(Game.CurrentPosition, new(Game.PositionHashHistory),  Game.HalfMovesWithoutCaptureOrPawnMove),
-                IDDFS(minDepth, maxDepth, decisionTime)
+                Task.Run(()=>IDDFS(minDepth, maxDepth, decisionTime))
             };
 
         var resultList = await Task.WhenAll(tasks);

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -7,8 +7,6 @@ public sealed class Game
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    public Move[] MovePool { get; } = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-
     public List<Move> MoveHistory { get; }
     public HashSet<long> PositionHashHistory { get; }
 
@@ -44,11 +42,13 @@ public sealed class Game
 
     public Game(string fen, List<string> movesUCIString) : this(fen)
     {
+        Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         foreach (var moveString in movesUCIString)
         {
-            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, MovePool);
+            var (start, end) = MoveGenerator.GenerateAllMoves(CurrentPosition, ref moveList, 0);
+            var slicedMoveList = moveList.Slice(start, end);
 
-            if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
+            if (!MoveExtensions.TryParseFromUCIString(moveString, ref slicedMoveList, out var parsedMove))
             {
                 _logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', movesUCIString), moveString);
                 break;

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -1,4 +1,5 @@
 ﻿using NLog;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -71,6 +72,65 @@ public static class MoveExtensions
         var targetSquare = (UCIString[2] - 'a') + ((8 - (UCIString[3] - '0')) * 8);
 
         var candidateMoves = moveList.Where(move => move.SourceSquare() == sourceSquare && move.TargetSquare() == targetSquare);
+
+        if (UCIString.Length == 4)
+        {
+            move = candidateMoves.FirstOrDefault();
+
+            if (move.Equals(default(Move)))
+            {
+                _logger.Warn("Unable to link last move string {0} to a valid move in the current position. That move may have already been played", UCIString);
+                move = null;
+                return false;
+            }
+
+            Utils.Assert(move.Value.PromotedPiece() == default);
+            return true;
+        }
+        else
+        {
+            var promotedPiece = (int)Enum.Parse<Piece>(UCIString[4].ToString());
+
+            bool predicate(Move m)
+            {
+                var actualPromotedPiece = m.PromotedPiece();
+
+                return actualPromotedPiece == promotedPiece
+                || actualPromotedPiece == promotedPiece - 6;
+            }
+
+            move = candidateMoves.FirstOrDefault(predicate);
+            if (move.Equals(default(Move)))
+            {
+                _logger.Warn("Unable to link move {0} to a valid move in the current position. That move may have already been played", UCIString);
+                move = null;
+                return false;
+            }
+
+            Utils.Assert(candidateMoves.Count() == 4);
+            Utils.Assert(candidateMoves.Count(predicate) == 1);
+
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Returns the move from <paramref name="moveList"/> indicated by <paramref name="UCIString"/>
+    /// </summary>
+    /// <param name="UCIString"></param>
+    /// <param name="moveList"></param>
+    /// <param name="move"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="IndexOutOfRangeException"></exception>
+    /// <returns></returns>
+    public static bool TryParseFromUCIString(string UCIString, ref Span<Move> moveList, [NotNullWhen(true)] out Move? move)
+    {
+        Utils.Assert(UCIString.Length == 4 || UCIString.Length == 5);
+
+        var sourceSquare = (UCIString[0] - 'a') + ((8 - (UCIString[1] - '0')) * 8);
+        var targetSquare = (UCIString[2] - 'a') + ((8 - (UCIString[3] - '0')) * 8);
+
+        var candidateMoves = moveList.ToImmutableArray().Where(move => move.SourceSquare() == sourceSquare && move.TargetSquare() == targetSquare);
 
         if (UCIString.Length == 4)
         {

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -593,6 +593,13 @@ public class Position
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AllPossibleMoves(ref Span<Move> movePool, int ply) => MoveGenerator.GenerateAllMoves(this, ref movePool, ply);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AllCapturesMoves(ref Span<Move> movePool, int ply) => MoveGenerator.GenerateAllMoves(this, ref movePool, ply, capturesOnly: true);
+
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 
     /// <summary>

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -260,6 +260,233 @@ public static class MoveGenerator
         }
     }
 
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static (int Start, int End) GenerateAllMoves(Position position, ref Span<Move> movePool, int ply, bool capturesOnly = false)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return (-1, -1);
+        }
+#endif
+
+        int initialLocalIndex = Constants.MaxNumberOfPossibleMovesInAPosition * ply;
+        int localIndex = initialLocalIndex;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnMoves(ref localIndex, ref movePool, position, offset, capturesOnly);
+        GenerateCastlingMoves(ref localIndex, ref movePool, position, offset);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.K + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.N + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.B + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.R + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, ref movePool, (int)Piece.Q + offset, position, capturesOnly);
+
+        return (initialLocalIndex, localIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnMoves(ref int localIndex, ref Span<Move> movePool, Position position, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare / 8) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                    {
+                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare / 8) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, ref Span<Move> movePool, Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceMoves(ref int localIndex, ref Span<Move> movePool, int piece, Position position, bool capturesOnly = false)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
     #region Only for reference, but unused
 
     /// <summary>

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -19,6 +19,16 @@ public static class Perft
         return (nodes, CalculateElapsedMilliseconds(sw));
     }
 
+    public static (long Nodes, double ElapsedMilliseconds) Results(Position position, int depth, ref Span<Move> moveList)
+    {
+        var sw = new Stopwatch();
+        sw.Start();
+        var nodes = ResultsImplSpan(position, depth, 0, ref moveList);
+        sw.Stop();
+
+        return (nodes, CalculateElapsedMilliseconds(sw));
+    }
+
     public static async Task<(long Nodes, double ElapsedMilliseconds)> Divide(Position position, int depth, Func<string, ValueTask> write)
     {
         var sw = new Stopwatch();
@@ -34,6 +44,16 @@ public static class Perft
         var sw = new Stopwatch();
         sw.Start();
         var nodes = DivideImpl(position, depth, 0, write);
+        sw.Stop();
+
+        return (nodes, CalculateElapsedMilliseconds(sw));
+    }
+
+    public static (long Nodes, double ElapsedMilliseconds) Divide(Position position, int depth, Action<string> write, ref Span<Move> moveList)
+    {
+        var sw = new Stopwatch();
+        sw.Start();
+        var nodes = DivideImplSpan(position, depth, 0, write, ref moveList);
         sw.Stop();
 
         return (nodes, CalculateElapsedMilliseconds(sw));
@@ -57,6 +77,38 @@ public static class Perft
                 if (position.WasProduceByAValidMove())
                 {
                     nodes = ResultsImpl(position, depth - 1, nodes);
+                }
+                position.UnmakeMove(move, state);
+            }
+
+            return nodes;
+        }
+
+        return nodes + 1;
+    }
+
+    /// <summary>
+    /// Proper implementation, used by <see cref="DivideImpl(Position, int, long)"/> as well
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="depth"></param>
+    /// <param name="nodes"></param>
+    /// <returns></returns>
+    internal static long ResultsImplSpan(Position position, int depth, long nodes, ref Span<Move> moveList, int ply = 0)
+    {
+        if (depth != 0)
+        {
+            var (start, end) = MoveGenerator.GenerateAllMoves(position, ref moveList, ply);
+
+            for (int i = start; i < end; ++i)
+            {
+                ref var move = ref moveList[i];
+
+                var state = position.MakeMove(move);
+
+                if (position.WasProduceByAValidMove())
+                {
+                    nodes = ResultsImplSpan(position, depth - 1, nodes, ref moveList, ply + 1);
                 }
                 position.UnmakeMove(move, state);
             }
@@ -106,6 +158,36 @@ public static class Perft
                 {
                     var accumulatedNodes = nodes;
                     nodes = ResultsImpl(position, depth - 1, nodes);
+
+                    write($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
+                }
+
+                position.UnmakeMove(move, state);
+            }
+
+            write(string.Empty);
+
+            return nodes;
+        }
+
+        return nodes + 1;
+    }
+
+    private static long DivideImplSpan(Position position, int depth, long nodes, Action<string> write, ref Span<Move> moveList, int ply = 0)
+    {
+        if (depth != 0)
+        {
+            var (start, end) = MoveGenerator.GenerateAllMoves(position, ref moveList, ply);
+
+            for (int i = start; i < end; ++i)
+            {
+                ref var move = ref moveList[i];
+                var state = position.MakeMove(move);
+
+                if (position.WasProduceByAValidMove())
+                {
+                    var accumulatedNodes = nodes;
+                    nodes = ResultsImplSpan(position, depth - 1, nodes, ref moveList, ply + 1);
 
                     write($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
                 }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -198,6 +198,8 @@ public sealed partial class Engine
     private void ValidatePVTable()
     {
         var position = Game.CurrentPosition;
+        Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+
         for (int i = 0; i < PVTable.Indexes[1]; ++i)
         {
             if (_pVTable[i] == default)
@@ -210,9 +212,12 @@ public sealed partial class Engine
             }
             var move = _pVTable[i];
 
+            var (start, end) = MoveGenerator.GenerateAllMoves(position, ref moveList, 0);
+            var slicedMoveList = moveList.Slice(start, end);
+
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               position.AllPossibleMoves(Game.MovePool),
+               ref slicedMoveList,
                out _))
             {
                 var message = $"Unexpected PV move {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -63,9 +63,10 @@ public sealed partial class PositionCommand : GUIBaseCommand
         var moveString = positionCommand
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)[^1];
 
+        Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            game.CurrentPosition.AllPossibleMoves(game.MovePool),
+            ref moveList,
             out lastMove))
         {
             _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -249,7 +249,7 @@ public class RegressionTest : BaseTest
         Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
     }
 
-    // pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
+    // 1Q6/6kp/4ppp1/8/4P3/7P/qp3PK1/8 w - - 0 1 || pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
     [TestCase("position startpos moves e2e4 c7c6 d2d4 d7d5 e4e5 c8f5 g1f3 e7e6 f1e2 c6c5 c1e3" +
         " c5d4 f3d4 g8e7 b1c3 f5g6 h2h4 h7h5 e2b5 b8d7 e3f4 a7a6 b5d3 g6d3 d1d3 e7g6 d4e6 g6f4" +
         " e6f4 d7e5 d3e2 d8d6 c3d5 g7g6 e1c1 f8h6 h1e1 f7f6 d5f6 d6f6 e2e5 f6e5 e1e5 e8f8 g2g3" +


### PR DESCRIPTION
A realPly variable is introduced, since we need to offset the moves every time we search deeper to avoid overriding previous, existing searches A different override of Span.Sort is used, the one that uses an array of keys instead of a comparison lambda
#355 but squashed, to preserve the changes in one single commit