### PR TITLE
⚡🔍 Don't generate castling moves in QSearch

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -55,7 +55,10 @@ public static class MoveGenerator
         var offset = Utils.PieceOffset(position.Side);
 
         GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
-        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        if (!capturesOnly)
+        {
+            GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        }
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);


### PR DESCRIPTION
8+0.08
```
Score of Lynx 1290 - qsearch no castl vs Lynx 1287 - main: 3991 - 4073 - 2452  [0.496] 10516
...      Lynx 1290 - qsearch no castl playing White: 2377 - 1661 - 1221  [0.568] 5259
...      Lynx 1290 - qsearch no castl playing Black: 1614 - 2412 - 1231  [0.424] 5257
...      White vs Black: 4789 - 3275 - 2452  [0.572] 10516
Elo difference: -2.7 +/- 5.8, LOS: 18.1 %, DrawRatio: 23.3 %
SPRT: llr -2.96 (-100.5%), lbound -2.94, ubound 2.94 - H0 was accepted
```

40+0.4
```
Score of Lynx 1290 - qsearch no castl vs Lynx 1287 - main: 1268 - 1353 - 1087  [0.489] 3708
...      Lynx 1290 - qsearch no castl playing White: 779 - 534 - 541  [0.566] 1854
...      Lynx 1290 - qsearch no castl playing Black: 489 - 819 - 546  [0.411] 1854
...      White vs Black: 1598 - 1023 - 1087  [0.578] 3708
Elo difference: -8.0 +/- 9.4, LOS: 4.8 %, DrawRatio: 29.3 %
SPRT: llr -2.27 (-77.2%), lbound -2.94, ubound 2.94
```