### PR TITLE
⚡  Add `MoveGenerator.CanGenerateAtLeastAValidMove`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -593,6 +593,9 @@ public class Position
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool HasValidMoves() => MoveGenerator.CanGenerateAtLeastAValidMove(this);
+
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 
     /// <summary>


### PR DESCRIPTION
Add `MoveGenerator.CanGenerateAtLeastAValidMove` to check move validity on the fly instead of generating all moves first

We use this in NegaMax to see if we can trigger QSearch and to validate the outcome in case no best move is found during QSearch

```
Score of Lynx 1291 - hasvalidmoves vs Lynx 1287 - main: 1108 - 934 - 666  [0.532] 2708
...      Lynx 1291 - hasvalidmoves playing White: 644 - 370 - 339  [0.601] 1353
...      Lynx 1291 - hasvalidmoves playing Black: 464 - 564 - 327  [0.463] 1355
...      White vs Black: 1208 - 834 - 666  [0.569] 2708
Elo difference: 22.4 +/- 11.4, LOS: 100.0 %, DrawRatio: 24.6 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```