### PR TITLE
Move non-static part of `MoveGenerator` into `Engine`

### DIFF
--- a/src/Lynx.Benchmark/FENGeneration.cs
+++ b/src/Lynx.Benchmark/FENGeneration.cs
@@ -212,7 +212,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string Struct_FENCalculatedOnTheFly(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new StructCustomPosition(fen);
         var newPosition = new StructCustomPosition(position, moves.First());
@@ -223,7 +223,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string Struct_FENCalculatedWithinTheMoveConstructor(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new StructCustomPosition(fen);
         var newPosition = new StructCustomPosition(position, moves.First(), default);
@@ -235,7 +235,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string ReadonlyStruct_FENCalculatedOnTheFly(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new ReadonlyStructCustomPosition(fen);
         var newPosition = new ReadonlyStructCustomPosition(position, moves.First());
@@ -247,7 +247,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string ReadonlyStruct_FENCalculatedWithinTheMoveConstructor(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new ReadonlyStructCustomPosition(fen);
         var newPosition = new ReadonlyStructCustomPosition(position, moves.First(), default);
@@ -259,7 +259,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string Class_FENCalculatedOnTheFly(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new ClassCustomPosition(fen);
         var newPosition = new ClassCustomPosition(position, moves.First());
@@ -271,7 +271,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string Class_FENCalculatedWithinTheMoveConstructor(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new ClassCustomPosition(fen);
         var newPosition = new ClassCustomPosition(position, moves.First(), default);
@@ -283,7 +283,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string RecordClass_FENCalculatedOnTheFly(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new RecordClassCustomPosition(fen);
         var newPosition = new RecordClassCustomPosition(position, moves.First());
@@ -295,7 +295,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string RecordClass_FENCalculatedWithinTheMoveConstructor(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new RecordClassCustomPosition(fen);
         var newPosition = new RecordClassCustomPosition(position, moves.First(), default);
@@ -307,7 +307,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string RecordStruct_FENCalculatedOnTheFly(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new RecordStructCustomPosition(fen);
         var newPosition = new RecordStructCustomPosition(position, moves.First());
@@ -319,7 +319,7 @@ public class FENGeneration : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public string RecordStruct_FENCalculatedWithinTheMoveConstructor(string fen)
     {
-        var moves = new Position(fen).AllPossibleMoves();
+        var moves = MoveGenerator.GenerateAllMoves(new Position(fen));
 
         var position = new RecordStructCustomPosition(fen);
         var newPosition = new RecordStructCustomPosition(position, moves.First(), default);

--- a/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
+++ b/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
@@ -23,7 +23,7 @@ public class LocalVariableIn_vs_NoIn : BaseBenchmark
         var moves = new List<Move>(50_000);
 
         for (int i = 0; i < 1000; ++i)
-            moves.AddRange(Sort_LocalVariableAndIn(position.AllPossibleMoves(), position));
+            moves.AddRange(Sort_LocalVariableAndIn(MoveGenerator.GenerateAllMoves(position), position));
 
         return Sort_LocalVariableAndIn(moves, position)[0];
     }
@@ -36,7 +36,7 @@ public class LocalVariableIn_vs_NoIn : BaseBenchmark
         var position = new Position(fen);
 
         for (int i = 0; i < 1000; ++i)
-            moves.AddRange(Sort_NoIn(position.AllPossibleMoves(), position));
+            moves.AddRange(Sort_NoIn(MoveGenerator.GenerateAllMoves(position), position));
 
         return Sort_NoIn(moves, position)[0];
     }

--- a/src/Lynx.Benchmark/PositionIdGeneration.cs
+++ b/src/Lynx.Benchmark/PositionIdGeneration.cs
@@ -62,10 +62,10 @@ public class PositionIdGeneration : BaseBenchmark
 
     public static IEnumerable<Position> Data => new[] {
             //Constants.EmptyBoardFEN,
-            new Position( Positions[0], Positions[0].AllPossibleMoves().First()),
-            new Position( Positions[1], Positions[1].AllPossibleMoves().First()),
-            new Position( Positions[2], Positions[2].AllPossibleMoves().First()),
-            new Position( Positions[3], Positions[3].AllPossibleMoves().First())
+            new Position( Positions[0], MoveGenerator.GenerateAllMoves(Positions[0]).First()),
+            new Position( Positions[1], MoveGenerator.GenerateAllMoves(Positions[1]).First()),
+            new Position( Positions[2], MoveGenerator.GenerateAllMoves(Positions[2]).First()),
+            new Position( Positions[3], MoveGenerator.GenerateAllMoves(Positions[3]).First())
         };
 }
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -668,7 +668,7 @@ static void _54_ScoreMove()
 
     var engine = new Engine(Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
     engine.SetGame(new(position));
-    foreach (var move in position.AllCapturesMoves())
+    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }
@@ -677,7 +677,7 @@ static void _54_ScoreMove()
     position.Print();
 
     engine.SetGame(new(position));
-    foreach (var move in position.AllCapturesMoves())
+    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }
@@ -688,7 +688,7 @@ static void ZobristTable()
     var pos = new Position(KillerPosition);
     var zobristTable = InitializeZobristTable();
     var hash = CalculatePositionHash(zobristTable, pos);
-    var updatedHash = UpdatePositionHash(zobristTable, hash, pos.AllPossibleMoves().First());
+    var updatedHash = UpdatePositionHash(zobristTable, hash, MoveGenerator.GenerateAllMoves(pos).First());
 
     Console.WriteLine(updatedHash);
 }
@@ -1084,7 +1084,7 @@ static void UnmakeMove()
         var position = new Position(fen);
         Console.WriteLine($"**Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}**");
 
-        var allMoves = position.AllPossibleMoves();
+        var allMoves = MoveGenerator.GenerateAllMoves(position);
 
         var oldZobristKey = position.UniqueIdentifier;
         foreach (var move in allMoves)

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -587,15 +587,6 @@ public class Position
         return sb.ToString();
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllPossibleMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public IEnumerable<Move> AllCapturesMoves(Move[]? movePool = null) => MoveGenerator.GenerateAllMoves(this, movePool, capturesOnly: true);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool HasValidMoves() => MoveGenerator.CanGenerateAtLeastAValidMove(this);
-
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
 
     /// <summary>

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -33,478 +33,478 @@ public static class MoveGenerator
             (int origin, BitBoard _) => Attacks.KingAttacks[origin],
     };
 
-//    /// <summary>
-//    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-//    /// </summary>
-//    /// <param name="position"></param>
-//    /// <param name="capturesOnly">Filters out all moves but captures</param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
-//    {
-//#if DEBUG
-//        if (position.Side == Side.Both)
-//        {
-//            return new List<Move>();
-//        }
-//#endif
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return new List<Move>();
+        }
+#endif
 
-//        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-//        int localIndex = 0;
+        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        int localIndex = 0;
 
-//        var offset = Utils.PieceOffset(position.Side);
+        var offset = Utils.PieceOffset(position.Side);
 
-//        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
-//        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
-//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
-//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
-//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
-//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
-//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
+        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
 
-//        return movePool.Take(localIndex);
-//    }
+        return movePool.Take(localIndex);
+    }
 
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
-//    {
-//        int sourceSquare, targetSquare;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
 
-//        var piece = (int)Piece.P + offset;
-//        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-//        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-//        var bitboard = position.PieceBitBoards[piece];
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
 
-//        while (bitboard != default)
-//        {
-//            sourceSquare = bitboard.GetLS1BIndex();
-//            bitboard.ResetLS1B();
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
 
-//            var sourceRank = (sourceSquare >> 3) + 1;
+            var sourceRank = (sourceSquare >> 3) + 1;
 
-//#if DEBUG
-//            if (sourceRank == 1 || sourceRank == 8)
-//            {
-//                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
-//                continue;
-//            }
-//#endif
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
 
-//            // Pawn pushes
-//            var singlePushSquare = sourceSquare + pawnPush;
-//            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
-//            {
-//                // Single pawn push
-//                var targetRank = (singlePushSquare >> 3) + 1;
-//                if (targetRank == 1 || targetRank == 8)  // Promotion
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
-//                }
-//                else if (!capturesOnly)
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
-//                }
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
 
-//                // Double pawn push
-//                // Inside of the if because singlePush square cannot be occupied either
-//                if (!capturesOnly)
-//                {
-//                    var doublePushSquare = sourceSquare + (2 * pawnPush);
-//                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-//                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
-//                    {
-//                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
-//                    }
-//                }
-//            }
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                    {
+                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
 
-//            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
 
-//            // En passant
-//            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
-//            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-//            {
-//                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
-//            }
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
 
-//            // Captures
-//            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
-//            while (attackedSquares != default)
-//            {
-//                targetSquare = attackedSquares.GetLS1BIndex();
-//                attackedSquares.ResetLS1B();
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
 
-//                var targetRank = (targetSquare >> 3) + 1;
-//                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
-//                }
-//                else
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
-//                }
-//            }
-//        }
-//    }
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
 
-//    /// <summary>
-//    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-//    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-//    /// </summary>
-//    /// <param name="position"></param>
-//    /// <param name="offset"></param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
-//    {
-//        var piece = (int)Piece.K + offset;
-//        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 
-//        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
 
-//        // Castles
-//        if (position.Castle != default)
-//        {
-//            if (position.Side == Side.White)
-//            {
-//                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
-//                if (((position.Castle & (int)CastlingRights.WK) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
-//                    && !ise1Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
-//                }
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
 
-//                if (((position.Castle & (int)CastlingRights.WQ) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
-//                    && !ise1Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
-//                }
-//            }
-//            else
-//            {
-//                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
-//                if (((position.Castle & (int)CastlingRights.BK) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
-//                    && !ise8Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
-//                }
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
 
-//                if (((position.Castle & (int)CastlingRights.BQ) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
-//                    && !ise8Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
-//                }
-//            }
-//        }
-//    }
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
 
-//    /// <summary>
-//    /// Generate Knight, Bishop, Rook and Queen moves
-//    /// </summary>
-//    /// <param name="piece"><see cref="Piece"/></param>
-//    /// <param name="position"></param>
-//    /// <param name="capturesOnly"></param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
-//    {
-//        var bitboard = position.PieceBitBoards[piece];
-//        int sourceSquare, targetSquare;
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
 
-//        while (bitboard != default)
-//        {
-//            sourceSquare = bitboard.GetLS1BIndex();
-//            bitboard.ResetLS1B();
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
 
-//            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-//                & ~position.OccupancyBitBoards[(int)position.Side];
+            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
 
-//            while (attacks != default)
-//            {
-//                targetSquare = attacks.GetLS1BIndex();
-//                attacks.ResetLS1B();
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
 
-//                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
-//                }
-//                else if (!capturesOnly)
-//                {
-//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
-//                }
-//            }
-//        }
-//    }
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
 
-//    /// <summary>
-//    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-//    /// </summary>
-//    /// <param name="position"></param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    public static bool CanGenerateAtLeastAValidMove(Position position)
-//    {
-//#if DEBUG
-//        if (position.Side == Side.Both)
-//        {
-//            return false;
-//        }
-//#endif
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CanGenerateAtLeastAValidMove(Position position)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return false;
+        }
+#endif
 
-//        var offset = Utils.PieceOffset(position.Side);
+        var offset = Utils.PieceOffset(position.Side);
 
-//        return IsAnyPawnMoveValid(position, offset)
-//            || IsAnyPieceMoveValid((int)Piece.K + offset, position)
-//            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
-//            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
-//            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
-//            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
-//            || IsAnyCastlingMoveValid(position, offset);
-//    }
+        return IsAnyPawnMoveValid(position, offset)
+            || IsAnyPieceMoveValid((int)Piece.K + offset, position)
+            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
+            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
+            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
+            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
+            || IsAnyCastlingMoveValid(position, offset);
+    }
 
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    private static bool IsAnyPawnMoveValid(Position position, int offset)
-//    {
-//        int sourceSquare, targetSquare;
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPawnMoveValid(Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
 
-//        var piece = (int)Piece.P + offset;
-//        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-//        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-//        var bitboard = position.PieceBitBoards[piece];
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
 
-//        while (bitboard != default)
-//        {
-//            sourceSquare = bitboard.GetLS1BIndex();
-//            bitboard.ResetLS1B();
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
 
-//            var sourceRank = (sourceSquare >> 3) + 1;
+            var sourceRank = (sourceSquare >> 3) + 1;
 
-//#if DEBUG
-//            if (sourceRank == 1 || sourceRank == 8)
-//            {
-//                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
-//                continue;
-//            }
-//#endif
-//            // Pawn pushes
-//            var singlePushSquare = sourceSquare + pawnPush;
-//            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
-//            {
-//                // Single pawn push
-//                var targetRank = (singlePushSquare >> 3) + 1;
-//                if (targetRank == 1 || targetRank == 8)  // Promotion
-//                {
-//                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset)))
-//                    {
-//                        return true;
-//                    }
-//                }
-//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
-//                {
-//                    return true;
-//                }
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset)))
+                    {
+                        return true;
+                    }
+                }
+                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+                {
+                    return true;
+                }
 
-//                // Double pawn push
-//                // Inside of the if because singlePush square cannot be occupied either
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
 
-//                var doublePushSquare = sourceSquare + (2 * pawnPush);
-//                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-//                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE)))
-//                {
-//                    return true;
-//                }
-//            }
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE)))
+                {
+                    return true;
+                }
+            }
 
-//            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
 
-//            // En passant
-//            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
-//            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-//                && IsValidMove(position, MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE)))
-//            {
-//                return true;
-//            }
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+                && IsValidMove(position, MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE)))
+            {
+                return true;
+            }
 
-//            // Captures
-//            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
-//            while (attackedSquares != default)
-//            {
-//                targetSquare = attackedSquares.GetLS1BIndex();
-//                attackedSquares.ResetLS1B();
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
 
-//                var targetRank = (targetSquare >> 3) + 1;
-//                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-//                {
-//                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE))
-//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE)))
-//                    {
-//                        return true;
-//                    }
-//                }
-//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
-//                {
-//                    return true;
-//                }
-//            }
-//        }
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE))
+                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE)))
+                    {
+                        return true;
+                    }
+                }
+                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+                {
+                    return true;
+                }
+            }
+        }
 
-//        return false;
-//    }
+        return false;
+    }
 
-//    /// <summary>
-//    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-//    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-//    /// </summary>
-//    /// <param name="position"></param>
-//    /// <param name="offset"></param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    private static bool IsAnyCastlingMoveValid(Position position, int offset)
-//    {
-//        var piece = (int)Piece.K + offset;
-//        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyCastlingMoveValid(Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 
-//        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
 
-//        // Castles
-//        if (position.Castle != default)
-//        {
-//            if (position.Side == Side.White)
-//            {
-//                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
-//                if (((position.Castle & (int)CastlingRights.WK) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
-//                    && !ise1Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide)
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
-//                {
-//                    return true;
-//                }
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide)
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
+                {
+                    return true;
+                }
 
-//                if (((position.Castle & (int)CastlingRights.WQ) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
-//                    && !ise1Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide)
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
-//                {
-//                    return true;
-//                }
-//            }
-//            else
-//            {
-//                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
-//                if (((position.Castle & (int)CastlingRights.BK) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
-//                    && !ise8Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide)
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
-//                {
-//                    return true;
-//                }
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide)
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide)
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
+                {
+                    return true;
+                }
 
-//                if (((position.Castle & (int)CastlingRights.BQ) != default)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
-//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
-//                    && !ise8Attacked
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide)
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
-//                {
-//                    return true;
-//                }
-//            }
-//        }
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide)
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
+                {
+                    return true;
+                }
+            }
+        }
 
-//        return false;
-//    }
+        return false;
+    }
 
-//    /// <summary>
-//    /// Generate Knight, Bishop, Rook and Queen moves
-//    /// </summary>
-//    /// <param name="piece"><see cref="Piece"/></param>
-//    /// <param name="position"></param>
-//    /// <returns></returns>
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    private static bool IsAnyPieceMoveValid(int piece, Position position)
-//    {
-//        var bitboard = position.PieceBitBoards[piece];
-//        int sourceSquare, targetSquare;
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPieceMoveValid(int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
 
-//        while (bitboard != default)
-//        {
-//            sourceSquare = bitboard.GetLS1BIndex();
-//            bitboard.ResetLS1B();
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
 
-//            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-//                & ~position.OccupancyBitBoards[(int)position.Side];
+            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
 
-//            while (attacks != default)
-//            {
-//                targetSquare = attacks.GetLS1BIndex();
-//                attacks.ResetLS1B();
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
 
-//                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
-//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
-//                {
-//                    return true;
-//                }
-//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
-//                {
-//                    return true;
-//                }
-//            }
-//        }
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
+                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+                {
+                    return true;
+                }
+                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
 
-//        return false;
-//    }
+        return false;
+    }
 
-//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-//    private static bool IsValidMove(Position position, Move move)
-//    {
-//        var gameState = position.MakeMove(move);
-//        bool result = position.WasProduceByAValidMove();
-//        position.UnmakeMove(move, gameState);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsValidMove(Position position, Move move)
+    {
+        var gameState = position.MakeMove(move);
+        bool result = position.WasProduceByAValidMove();
+        position.UnmakeMove(move, gameState);
 
-//        return result;
-//    }
+        return result;
+    }
 
     #region Only for reference, but unused
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -8,13 +8,13 @@ public static class MoveGenerator
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    private const int TRUE = 1;
+    public const int TRUE = 1;
 
     /// <summary>
     /// Indexed by <see cref="Piece"/>.
     /// Checks are not considered
     /// </summary>
-    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks = new Func<int, BitBoard, BitBoard>[]
+    public static readonly Func<int, BitBoard, BitBoard>[] PieceAttacks = new Func<int, BitBoard, BitBoard>[]
     {
             (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White, origin],
             (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
@@ -33,478 +33,478 @@ public static class MoveGenerator
             (int origin, BitBoard _) => Attacks.KingAttacks[origin],
     };
 
-    /// <summary>
-    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-    /// </summary>
-    /// <param name="position"></param>
-    /// <param name="capturesOnly">Filters out all moves but captures</param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
-    {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return new List<Move>();
-        }
-#endif
+//    /// <summary>
+//    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+//    /// </summary>
+//    /// <param name="position"></param>
+//    /// <param name="capturesOnly">Filters out all moves but captures</param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+//    {
+//#if DEBUG
+//        if (position.Side == Side.Both)
+//        {
+//            return new List<Move>();
+//        }
+//#endif
 
-        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        int localIndex = 0;
+//        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+//        int localIndex = 0;
 
-        var offset = Utils.PieceOffset(position.Side);
+//        var offset = Utils.PieceOffset(position.Side);
 
-        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
-        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
+//        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
+//        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
+//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
+//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
+//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
+//        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
 
-        return movePool.Take(localIndex);
-    }
+//        return movePool.Take(localIndex);
+//    }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
-    {
-        int sourceSquare, targetSquare;
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
+//    {
+//        int sourceSquare, targetSquare;
 
-        var piece = (int)Piece.P + offset;
-        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-        var bitboard = position.PieceBitBoards[piece];
+//        var piece = (int)Piece.P + offset;
+//        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+//        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+//        var bitboard = position.PieceBitBoards[piece];
 
-        while (bitboard != default)
-        {
-            sourceSquare = bitboard.GetLS1BIndex();
-            bitboard.ResetLS1B();
+//        while (bitboard != default)
+//        {
+//            sourceSquare = bitboard.GetLS1BIndex();
+//            bitboard.ResetLS1B();
 
-            var sourceRank = (sourceSquare >> 3) + 1;
+//            var sourceRank = (sourceSquare >> 3) + 1;
 
-#if DEBUG
-            if (sourceRank == 1 || sourceRank == 8)
-            {
-                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
-                continue;
-            }
-#endif
+//#if DEBUG
+//            if (sourceRank == 1 || sourceRank == 8)
+//            {
+//                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+//                continue;
+//            }
+//#endif
 
-            // Pawn pushes
-            var singlePushSquare = sourceSquare + pawnPush;
-            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
-            {
-                // Single pawn push
-                var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
-                }
-                else if (!capturesOnly)
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
-                }
+//            // Pawn pushes
+//            var singlePushSquare = sourceSquare + pawnPush;
+//            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+//            {
+//                // Single pawn push
+//                var targetRank = (singlePushSquare >> 3) + 1;
+//                if (targetRank == 1 || targetRank == 8)  // Promotion
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+//                }
+//                else if (!capturesOnly)
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+//                }
 
-                // Double pawn push
-                // Inside of the if because singlePush square cannot be occupied either
-                if (!capturesOnly)
-                {
-                    var doublePushSquare = sourceSquare + (2 * pawnPush);
-                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
-                    {
-                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
-                    }
-                }
-            }
+//                // Double pawn push
+//                // Inside of the if because singlePush square cannot be occupied either
+//                if (!capturesOnly)
+//                {
+//                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+//                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+//                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+//                    {
+//                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+//                    }
+//                }
+//            }
 
-            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+//            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
 
-            // En passant
-            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
-            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-            {
-                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
-            }
+//            // En passant
+//            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+//            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+//            {
+//                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+//            }
 
-            // Captures
-            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
-            while (attackedSquares != default)
-            {
-                targetSquare = attackedSquares.GetLS1BIndex();
-                attackedSquares.ResetLS1B();
+//            // Captures
+//            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+//            while (attackedSquares != default)
+//            {
+//                targetSquare = attackedSquares.GetLS1BIndex();
+//                attackedSquares.ResetLS1B();
 
-                var targetRank = (targetSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
-                }
-                else
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
-                }
-            }
-        }
-    }
+//                var targetRank = (targetSquare >> 3) + 1;
+//                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+//                }
+//                else
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+//                }
+//            }
+//        }
+//    }
 
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    /// <param name="position"></param>
-    /// <param name="offset"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
-    {
-        var piece = (int)Piece.K + offset;
-        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+//    /// <summary>
+//    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+//    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+//    /// </summary>
+//    /// <param name="position"></param>
+//    /// <param name="offset"></param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
+//    {
+//        var piece = (int)Piece.K + offset;
+//        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 
-        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+//        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
 
-        // Castles
-        if (position.Castle != default)
-        {
-            if (position.Side == Side.White)
-            {
-                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
-                if (((position.Castle & (int)CastlingRights.WK) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
-                    && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
-                }
+//        // Castles
+//        if (position.Castle != default)
+//        {
+//            if (position.Side == Side.White)
+//            {
+//                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+//                if (((position.Castle & (int)CastlingRights.WK) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+//                    && !ise1Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+//                }
 
-                if (((position.Castle & (int)CastlingRights.WQ) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
-                    && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
-                }
-            }
-            else
-            {
-                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
-                if (((position.Castle & (int)CastlingRights.BK) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
-                    && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
-                }
+//                if (((position.Castle & (int)CastlingRights.WQ) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+//                    && !ise1Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+//                }
+//            }
+//            else
+//            {
+//                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+//                if (((position.Castle & (int)CastlingRights.BK) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+//                    && !ise8Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+//                }
 
-                if (((position.Castle & (int)CastlingRights.BQ) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
-                    && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
-                }
-            }
-        }
-    }
+//                if (((position.Castle & (int)CastlingRights.BQ) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+//                    && !ise8Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+//                }
+//            }
+//        }
+//    }
 
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="position"></param>
-    /// <param name="capturesOnly"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
-    {
-        var bitboard = position.PieceBitBoards[piece];
-        int sourceSquare, targetSquare;
+//    /// <summary>
+//    /// Generate Knight, Bishop, Rook and Queen moves
+//    /// </summary>
+//    /// <param name="piece"><see cref="Piece"/></param>
+//    /// <param name="position"></param>
+//    /// <param name="capturesOnly"></param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
+//    {
+//        var bitboard = position.PieceBitBoards[piece];
+//        int sourceSquare, targetSquare;
 
-        while (bitboard != default)
-        {
-            sourceSquare = bitboard.GetLS1BIndex();
-            bitboard.ResetLS1B();
+//        while (bitboard != default)
+//        {
+//            sourceSquare = bitboard.GetLS1BIndex();
+//            bitboard.ResetLS1B();
 
-            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-                & ~position.OccupancyBitBoards[(int)position.Side];
+//            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+//                & ~position.OccupancyBitBoards[(int)position.Side];
 
-            while (attacks != default)
-            {
-                targetSquare = attacks.GetLS1BIndex();
-                attacks.ResetLS1B();
+//            while (attacks != default)
+//            {
+//                targetSquare = attacks.GetLS1BIndex();
+//                attacks.ResetLS1B();
 
-                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
-                }
-                else if (!capturesOnly)
-                {
-                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
-                }
-            }
-        }
-    }
+//                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+//                }
+//                else if (!capturesOnly)
+//                {
+//                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+//                }
+//            }
+//        }
+//    }
 
-    /// <summary>
-    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-    /// </summary>
-    /// <param name="position"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool CanGenerateAtLeastAValidMove(Position position)
-    {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return false;
-        }
-#endif
+//    /// <summary>
+//    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+//    /// </summary>
+//    /// <param name="position"></param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    public static bool CanGenerateAtLeastAValidMove(Position position)
+//    {
+//#if DEBUG
+//        if (position.Side == Side.Both)
+//        {
+//            return false;
+//        }
+//#endif
 
-        var offset = Utils.PieceOffset(position.Side);
+//        var offset = Utils.PieceOffset(position.Side);
 
-        return IsAnyPawnMoveValid(position, offset)
-            || IsAnyPieceMoveValid((int)Piece.K + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
-            || IsAnyCastlingMoveValid(position, offset);
-    }
+//        return IsAnyPawnMoveValid(position, offset)
+//            || IsAnyPieceMoveValid((int)Piece.K + offset, position)
+//            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
+//            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
+//            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
+//            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
+//            || IsAnyCastlingMoveValid(position, offset);
+//    }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyPawnMoveValid(Position position, int offset)
-    {
-        int sourceSquare, targetSquare;
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    private static bool IsAnyPawnMoveValid(Position position, int offset)
+//    {
+//        int sourceSquare, targetSquare;
 
-        var piece = (int)Piece.P + offset;
-        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-        var bitboard = position.PieceBitBoards[piece];
+//        var piece = (int)Piece.P + offset;
+//        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+//        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+//        var bitboard = position.PieceBitBoards[piece];
 
-        while (bitboard != default)
-        {
-            sourceSquare = bitboard.GetLS1BIndex();
-            bitboard.ResetLS1B();
+//        while (bitboard != default)
+//        {
+//            sourceSquare = bitboard.GetLS1BIndex();
+//            bitboard.ResetLS1B();
 
-            var sourceRank = (sourceSquare >> 3) + 1;
+//            var sourceRank = (sourceSquare >> 3) + 1;
 
-#if DEBUG
-            if (sourceRank == 1 || sourceRank == 8)
-            {
-                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
-                continue;
-            }
-#endif
-            // Pawn pushes
-            var singlePushSquare = sourceSquare + pawnPush;
-            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
-            {
-                // Single pawn push
-                var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
-                {
-                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset)))
-                    {
-                        return true;
-                    }
-                }
-                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
-                {
-                    return true;
-                }
+//#if DEBUG
+//            if (sourceRank == 1 || sourceRank == 8)
+//            {
+//                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+//                continue;
+//            }
+//#endif
+//            // Pawn pushes
+//            var singlePushSquare = sourceSquare + pawnPush;
+//            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+//            {
+//                // Single pawn push
+//                var targetRank = (singlePushSquare >> 3) + 1;
+//                if (targetRank == 1 || targetRank == 8)  // Promotion
+//                {
+//                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset)))
+//                    {
+//                        return true;
+//                    }
+//                }
+//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+//                {
+//                    return true;
+//                }
 
-                // Double pawn push
-                // Inside of the if because singlePush square cannot be occupied either
+//                // Double pawn push
+//                // Inside of the if because singlePush square cannot be occupied either
 
-                var doublePushSquare = sourceSquare + (2 * pawnPush);
-                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE)))
-                {
-                    return true;
-                }
-            }
+//                var doublePushSquare = sourceSquare + (2 * pawnPush);
+//                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+//                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE)))
+//                {
+//                    return true;
+//                }
+//            }
 
-            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+//            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
 
-            // En passant
-            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
-            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-                && IsValidMove(position, MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE)))
-            {
-                return true;
-            }
+//            // En passant
+//            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
+//            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+//                && IsValidMove(position, MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE)))
+//            {
+//                return true;
+//            }
 
-            // Captures
-            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
-            while (attackedSquares != default)
-            {
-                targetSquare = attackedSquares.GetLS1BIndex();
-                attackedSquares.ResetLS1B();
+//            // Captures
+//            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+//            while (attackedSquares != default)
+//            {
+//                targetSquare = attackedSquares.GetLS1BIndex();
+//                attackedSquares.ResetLS1B();
 
-                var targetRank = (targetSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-                {
-                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE))
-                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE)))
-                    {
-                        return true;
-                    }
-                }
-                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
-                {
-                    return true;
-                }
-            }
-        }
+//                var targetRank = (targetSquare >> 3) + 1;
+//                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+//                {
+//                    if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE))
+//                        || IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE)))
+//                    {
+//                        return true;
+//                    }
+//                }
+//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+//                {
+//                    return true;
+//                }
+//            }
+//        }
 
-        return false;
-    }
+//        return false;
+//    }
 
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    /// <param name="position"></param>
-    /// <param name="offset"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyCastlingMoveValid(Position position, int offset)
-    {
-        var piece = (int)Piece.K + offset;
-        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+//    /// <summary>
+//    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+//    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+//    /// </summary>
+//    /// <param name="position"></param>
+//    /// <param name="offset"></param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    private static bool IsAnyCastlingMoveValid(Position position, int offset)
+//    {
+//        var piece = (int)Piece.K + offset;
+//        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 
-        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+//        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
 
-        // Castles
-        if (position.Castle != default)
-        {
-            if (position.Side == Side.White)
-            {
-                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
-                if (((position.Castle & (int)CastlingRights.WK) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
-                    && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide)
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
-                {
-                    return true;
-                }
+//        // Castles
+//        if (position.Castle != default)
+//        {
+//            if (position.Side == Side.White)
+//            {
+//                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+//                if (((position.Castle & (int)CastlingRights.WK) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+//                    && !ise1Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide)
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
+//                {
+//                    return true;
+//                }
 
-                if (((position.Castle & (int)CastlingRights.WQ) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
-                    && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide)
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
-                if (((position.Castle & (int)CastlingRights.BK) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
-                    && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide)
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
-                {
-                    return true;
-                }
+//                if (((position.Castle & (int)CastlingRights.WQ) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+//                    && !ise1Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide)
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
+//                {
+//                    return true;
+//                }
+//            }
+//            else
+//            {
+//                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+//                if (((position.Castle & (int)CastlingRights.BK) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+//                    && !ise8Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide)
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
+//                {
+//                    return true;
+//                }
 
-                if (((position.Castle & (int)CastlingRights.BQ) != default)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
-                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
-                    && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide)
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
-                {
-                    return true;
-                }
-            }
-        }
+//                if (((position.Castle & (int)CastlingRights.BQ) != default)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+//                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+//                    && !ise8Attacked
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+//                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide)
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
+//                {
+//                    return true;
+//                }
+//            }
+//        }
 
-        return false;
-    }
+//        return false;
+//    }
 
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="position"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyPieceMoveValid(int piece, Position position)
-    {
-        var bitboard = position.PieceBitBoards[piece];
-        int sourceSquare, targetSquare;
+//    /// <summary>
+//    /// Generate Knight, Bishop, Rook and Queen moves
+//    /// </summary>
+//    /// <param name="piece"><see cref="Piece"/></param>
+//    /// <param name="position"></param>
+//    /// <returns></returns>
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    private static bool IsAnyPieceMoveValid(int piece, Position position)
+//    {
+//        var bitboard = position.PieceBitBoards[piece];
+//        int sourceSquare, targetSquare;
 
-        while (bitboard != default)
-        {
-            sourceSquare = bitboard.GetLS1BIndex();
-            bitboard.ResetLS1B();
+//        while (bitboard != default)
+//        {
+//            sourceSquare = bitboard.GetLS1BIndex();
+//            bitboard.ResetLS1B();
 
-            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-                & ~position.OccupancyBitBoards[(int)position.Side];
+//            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+//                & ~position.OccupancyBitBoards[(int)position.Side];
 
-            while (attacks != default)
-            {
-                targetSquare = attacks.GetLS1BIndex();
-                attacks.ResetLS1B();
+//            while (attacks != default)
+//            {
+//                targetSquare = attacks.GetLS1BIndex();
+//                attacks.ResetLS1B();
 
-                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
-                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
-                {
-                    return true;
-                }
-                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
-                {
-                    return true;
-                }
-            }
-        }
+//                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
+//                    && IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+//                {
+//                    return true;
+//                }
+//                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+//                {
+//                    return true;
+//                }
+//            }
+//        }
 
-        return false;
-    }
+//        return false;
+//    }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsValidMove(Position position, Move move)
-    {
-        var gameState = position.MakeMove(move);
-        bool result = position.WasProduceByAValidMove();
-        position.UnmakeMove(move, gameState);
+//    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+//    private static bool IsValidMove(Position position, Move move)
+//    {
+//        var gameState = position.MakeMove(move);
+//        bool result = position.WasProduceByAValidMove();
+//        position.UnmakeMove(move, gameState);
 
-        return result;
-    }
+//        return result;
+//    }
 
     #region Only for reference, but unused
 
@@ -729,7 +729,7 @@ public static class MoveGenerator
             sourceSquare = bitboard.GetLS1BIndex();
             bitboard.ResetLS1B();
 
-            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+            var attacks = PieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
                 & ~position.OccupancyBitBoards[(int)position.Side];
 
             while (attacks != default)

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -114,7 +114,7 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
-                    allPossibleMoves ??= position.AllPossibleMoves();
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -172,7 +172,7 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
-                    allPossibleMoves ??= position.AllPossibleMoves();
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -232,7 +232,7 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
-                    allPossibleMoves ??= position.AllPossibleMoves();
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -289,7 +289,7 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
-                    allPossibleMoves ??= position.AllPossibleMoves();
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
                     foreach (var move in bestMoveList)
                     {
                         if (!MoveExtensions.TryParseFromUCIString(move!.Uci, allPossibleMoves, out var moveCandidate))
@@ -329,7 +329,7 @@ public static class OnlineTablebaseProber
         }
 
         Move? parsedMove = 0;
-        if (bestMove?.Uci is not null && !MoveExtensions.TryParseFromUCIString(bestMove.Uci, position.AllPossibleMoves(), out parsedMove))
+        if (bestMove?.Uci is not null && !MoveExtensions.TryParseFromUCIString(bestMove.Uci, MoveGenerator.GenerateAllMoves(position), out parsedMove))
         {
             throw new AssertException($"{bestMove.Uci} should be parsable from position {fen}");
         }

--- a/src/Lynx/Search/GenerateMoves.cs
+++ b/src/Lynx/Search/GenerateMoves.cs
@@ -1,0 +1,481 @@
+﻿using Lynx.Model;
+using NLog;
+using System.Runtime.CompilerServices;
+namespace Lynx;
+
+using static MoveGenerator;
+
+public sealed partial class Engine
+{
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="Game.CurrentPosition"/>, ordered by <see cref="Move.Score(Game.CurrentPosition)"/>
+    /// </summary>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <param name="capturesOnly">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public IEnumerable<Move> GenerateAllMoves(bool capturesOnly = false)
+    {
+#if DEBUG
+        if (Game.CurrentPosition.Side == Side.Both)
+        {
+            return new List<Move>();
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(Game.CurrentPosition.Side);
+
+        GeneratePawnMoves(ref localIndex, offset, capturesOnly);
+        GenerateCastlingMoves(ref localIndex, offset);
+        GeneratePieceMoves(ref localIndex, (int)Piece.K + offset, capturesOnly);
+        GeneratePieceMoves(ref localIndex, (int)Piece.N + offset, capturesOnly);
+        GeneratePieceMoves(ref localIndex, (int)Piece.B + offset, capturesOnly);
+        GeneratePieceMoves(ref localIndex, (int)Piece.R + offset, capturesOnly);
+        GeneratePieceMoves(ref localIndex, (int)Piece.Q + offset, capturesOnly);
+
+        return Game.MovePool.Take(localIndex);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void GeneratePawnMoves(ref int localIndex, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)Game.CurrentPosition.Side * 16);          // Game.CurrentPosition.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(Game.CurrentPosition.Side);   // Game.CurrentPosition.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = Game.CurrentPosition.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", Game.CurrentPosition.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!Game.CurrentPosition.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!Game.CurrentPosition.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && Game.CurrentPosition.Side == Side.Black) || (sourceRank == 7 && Game.CurrentPosition.Side == Side.White)))
+                    {
+                        Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)Game.CurrentPosition.Side, sourceSquare];
+
+            // En passant
+            if (Game.CurrentPosition.EnPassant != BoardSquare.noSquare && attacks.GetBit(Game.CurrentPosition.EnPassant))
+            // We assume that Game.CurrentPosition.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)Game.CurrentPosition.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & Game.CurrentPosition.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN Game.CurrentPosition "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void GenerateCastlingMoves(ref int localIndex, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(Game.CurrentPosition.Side);
+
+        int sourceSquare = Game.CurrentPosition.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (Game.CurrentPosition.Castle != default)
+        {
+            if (Game.CurrentPosition.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, Game.CurrentPosition, oppositeSide);
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.WK) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, Game.CurrentPosition, oppositeSide))
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.WQ) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, Game.CurrentPosition, oppositeSide))
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, Game.CurrentPosition, oppositeSide);
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.BK) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, Game.CurrentPosition, oppositeSide))
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.BQ) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, Game.CurrentPosition, oppositeSide))
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal void GeneratePieceMoves(ref int localIndex, int piece, bool capturesOnly = false)
+    {
+        var bitboard = Game.CurrentPosition.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = PieceAttacks[piece](sourceSquare, Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both])
+                & ~Game.CurrentPosition.OccupancyBitBoards[(int)Game.CurrentPosition.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    Game.MovePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="Game.CurrentPosition"/>, ordered by <see cref="Move.Score(Game.CurrentPosition)"/>
+    /// </summary>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsThereAnyValidMove()
+    {
+#if DEBUG
+        if (Game.CurrentPosition.Side == Side.Both)
+        {
+            return false;
+        }
+#endif
+
+        var offset = Utils.PieceOffset(Game.CurrentPosition.Side);
+
+        return IsAnyPawnMoveValid(offset)
+            || IsAnyPieceMoveValid((int)Piece.K + offset)
+            || IsAnyPieceMoveValid((int)Piece.Q + offset)
+            || IsAnyPieceMoveValid((int)Piece.B + offset)
+            || IsAnyPieceMoveValid((int)Piece.N + offset)
+            || IsAnyPieceMoveValid((int)Piece.R + offset)
+            || IsAnyCastlingMoveValid(offset);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsAnyPawnMoveValid(int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)Game.CurrentPosition.Side * 16);          // Game.CurrentPosition.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(Game.CurrentPosition.Side);   // Game.CurrentPosition.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = Game.CurrentPosition.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", Game.CurrentPosition.Side, sourceRank);
+                continue;
+            }
+#endif
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!Game.CurrentPosition.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    if (IsValidMove(MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset)))
+                    {
+                        return true;
+                    }
+                }
+                else if (IsValidMove(MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+                {
+                    return true;
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!Game.CurrentPosition.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && Game.CurrentPosition.Side == Side.Black) || (sourceRank == 7 && Game.CurrentPosition.Side == Side.White))
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE)))
+                {
+                    return true;
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)Game.CurrentPosition.Side, sourceSquare];
+
+            // En passant
+            if (Game.CurrentPosition.EnPassant != BoardSquare.noSquare && attacks.GetBit(Game.CurrentPosition.EnPassant)
+            // We assume that Game.CurrentPosition.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+                && IsValidMove(MoveExtensions.Encode(sourceSquare, (int)Game.CurrentPosition.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE)))
+            {
+                return true;
+            }
+
+            // Captures
+            var attackedSquares = attacks & Game.CurrentPosition.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    if (IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE))
+                        || IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE)))
+                    {
+                        return true;
+                    }
+                }
+                else if (IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN Game.CurrentPosition "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsAnyCastlingMoveValid(int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(Game.CurrentPosition.Side);
+
+        int sourceSquare = Game.CurrentPosition.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (Game.CurrentPosition.Castle != default)
+        {
+            if (Game.CurrentPosition.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, Game.CurrentPosition, oppositeSide);
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.WK) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, Game.CurrentPosition, oppositeSide)
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
+                {
+                    return true;
+                }
+
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.WQ) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, Game.CurrentPosition, oppositeSide)
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e8, Game.CurrentPosition, oppositeSide);
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.BK) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, Game.CurrentPosition, oppositeSide)
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
+                {
+                    return true;
+                }
+
+                if (((Game.CurrentPosition.Castle & (int)CastlingRights.BQ) != default)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, Game.CurrentPosition, oppositeSide)
+                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, Game.CurrentPosition, oppositeSide)
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="Game.CurrentPosition"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsAnyPieceMoveValid(int piece)
+    {
+        var bitboard = Game.CurrentPosition.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = PieceAttacks[piece](sourceSquare, Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both])
+                & ~Game.CurrentPosition.OccupancyBitBoards[(int)Game.CurrentPosition.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (Game.CurrentPosition.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
+                    && IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE)))
+                {
+                    return true;
+                }
+                else if (IsValidMove(MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsValidMove(Move move)
+    {
+        var gameState = Game.CurrentPosition.MakeMove(move);
+        bool result = Game.CurrentPosition.WasProduceByAValidMove();
+        Game.CurrentPosition.UnmakeMove(move, gameState);
+
+        return result;
+    }
+}

--- a/src/Lynx/Search/GenerateMoves.cs
+++ b/src/Lynx/Search/GenerateMoves.cs
@@ -128,9 +128,8 @@ public sealed partial class Engine
 
     /// <summary>
     /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN Game.CurrentPosition "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// see FEN pos "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
     /// </summary>
-    /// <param name="Game.CurrentPosition"></param>
     /// <param name="offset"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -199,7 +198,6 @@ public sealed partial class Engine
     /// Generate Knight, Bishop, Rook and Queen moves
     /// </summary>
     /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="Game.CurrentPosition"></param>
     /// <param name="capturesOnly"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -236,7 +234,6 @@ public sealed partial class Engine
     /// <summary>
     /// Generates all psuedo-legal moves from <paramref name="Game.CurrentPosition"/>, ordered by <see cref="Move.Score(Game.CurrentPosition)"/>
     /// </summary>
-    /// <param name="Game.CurrentPosition"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsThereAnyValidMove()
@@ -356,9 +353,8 @@ public sealed partial class Engine
 
     /// <summary>
     /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN Game.CurrentPosition "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// see FEN pos "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
     /// </summary>
-    /// <param name="Game.CurrentPosition"></param>
     /// <param name="offset"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -433,7 +429,6 @@ public sealed partial class Engine
     /// Generate Knight, Bishop, Rook and Queen moves
     /// </summary>
     /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="Game.CurrentPosition"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsAnyPieceMoveValid(int piece)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -212,10 +212,10 @@ public sealed partial class Engine
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               GenerateAllMoves(),
+               MoveGenerator.GenerateAllMoves(position, Game.MovePool),
                out _))
             {
-                var message = $"Unexpected PV move {move.UCIString()} from position {position.FEN()}";
+                var message = $"Unexpected PV move {i}: {move.UCIString()} from position {position.FEN()}";
                 _logger.Error(message);
                 throw new AssertException(message);
             }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -212,7 +212,7 @@ public sealed partial class Engine
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               position.AllPossibleMoves(Game.MovePool),
+               GenerateAllMoves(),
                out _))
             {
                 var message = $"Unexpected PV move {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -63,7 +63,7 @@ public sealed partial class Engine
         }
         if (ply >= targetDepth)
         {
-            if (position.HasValidMoves())
+            if (IsThereAnyValidMove())
             {
                 return QuiescenceSearch(ply, alpha, beta);
             }
@@ -111,7 +111,7 @@ public sealed partial class Engine
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 
-        var pseudoLegalMoves = SortMoves(position.AllPossibleMoves(Game.MovePool), ply, ttBestMove);
+        var pseudoLegalMoves = SortMoves(GenerateAllMoves(), ply, ttBestMove);
 
         foreach (var move in pseudoLegalMoves)
         {
@@ -309,7 +309,7 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        var generatedMoves = position.AllCapturesMoves(Game.MovePool);
+        var generatedMoves = GenerateAllMoves(capturesOnly: true);
         if (!generatedMoves.Any())
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358
@@ -319,7 +319,7 @@ public sealed partial class Engine
         var movesToEvaluate = generatedMoves.OrderByDescending(move => ScoreMove(move, ply, false));
 
         Move? bestMove = null;
-        bool isAnyMoveValid = false;
+        bool isThereAnyValidCapture = false;
 
         foreach (var move in movesToEvaluate)
         {
@@ -331,7 +331,7 @@ public sealed partial class Engine
             }
 
             ++_nodes;
-            isAnyMoveValid = true;
+            isThereAnyValidCapture = true;
 
             PrintPreMove(position, ply, move, isQuiescence: true);
 
@@ -384,7 +384,7 @@ public sealed partial class Engine
 
         if (bestMove is null)
         {
-            return isAnyMoveValid || position.HasValidMoves()
+            return isThereAnyValidCapture || IsThereAnyValidMove()
                 ? alpha
                 : Position.EvaluateFinalPosition(ply, position.IsInCheck());
         }

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -58,20 +58,20 @@ public sealed partial class PositionCommand : GUIBaseCommand
         }
     }
 
-    public static bool TryParseLastMove(string positionCommand, Game game, [NotNullWhen(true)] out Move? lastMove)
-    {
-        var moveString = positionCommand
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries)[^1];
+    //public static bool TryParseLastMove(string positionCommand, Game game, [NotNullWhen(true)] out Move? lastMove)
+    //{
+    //    var moveString = positionCommand
+    //            .Split(' ', StringSplitOptions.RemoveEmptyEntries)[^1];
 
-        if (!MoveExtensions.TryParseFromUCIString(
-            moveString,
-            game.CurrentPosition.AllPossibleMoves(game.MovePool),
-            out lastMove))
-        {
-            _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);
-            return false;
-        }
+    //    if (!MoveExtensions.TryParseFromUCIString(
+    //        moveString,
+    //        game.CurrentPosition.AllPossibleMoves(game.MovePool),
+    //        out lastMove))
+    //    {
+    //        _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);
+    //        return false;
+    //    }
 
-        return true;
-    }
+    //    return true;
+    //}
 }

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -24,7 +24,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = engine.Game.CurrentPosition.AllPossibleMoves().OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("f3f6", allMoves[1].UCIString());     // QxN
@@ -61,7 +61,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = engine.Game.CurrentPosition.AllPossibleMoves().OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
         Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -142,7 +142,7 @@ public class PositionTest
     {
         // Arrange
         var position = new Position(fen);
-        Assert.IsEmpty(position.AllPossibleMoves().Where(move => new Position(position, move).IsValid()));
+        Assert.IsEmpty(MoveGenerator.GenerateAllMoves(position).Where(move => new Position(position, move).IsValid()));
         var isInCheck = position.IsInCheck();
 
         // Act

--- a/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
@@ -12,7 +12,7 @@ public class GeneralMoveGeneratorTest
     public void DiscoveredCheckAfterEnPassantCapture()
     {
         var originalPosition = new Position("8/8/8/k1pP3R/8/8/8/n4K2 w - c6 0 1");
-        var enPassantMove = originalPosition.AllPossibleMoves().Single(m => m.IsEnPassant());
+        var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition).Single(m => m.IsEnPassant());
         var positionAferEnPassant = new Position(originalPosition, enPassantMove);
 
         foreach (var move in MoveGenerator.GenerateAllMoves(positionAferEnPassant))

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -88,7 +88,7 @@ public class OnlineTablebaseProberTest
         var position = new Position(fen);
         var result = await OnlineTablebaseProber.RootSearch(position, new(), 0, default);
         Assert.AreEqual(distanceToMate, result.MateScore);
-        Assert.Contains(result.BestMove, position.AllPossibleMoves().ToList());
+        Assert.Contains(result.BestMove, MoveGenerator.GenerateAllMoves(position).ToList());
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public class OnlineTablebaseProberTest
         var position = new Position(fen);
         var result = await OnlineTablebaseProber.RootSearch(position, new(), 0, default);
         Assert.AreEqual(distanceToMate, result.MateScore);
-        Assert.Contains(result.BestMove, position.AllPossibleMoves().ToList());
+        Assert.Contains(result.BestMove, MoveGenerator.GenerateAllMoves(position).ToList());
     }
 
     [TestCase("8/8/8/8/8/2B3K1/8/6k1 b - - 1 1", 0)]   // B

--- a/tests/Lynx.Test/ZobristHashGenerationTest.cs
+++ b/tests/Lynx.Test/ZobristHashGenerationTest.cs
@@ -10,10 +10,10 @@ public class ZobristHashGenerationTest
     {
         var originalPosition = new Position(Constants.InitialPositionFEN);
 
-        var position = new Position(originalPosition, originalPosition.AllPossibleMoves().Single(m => m.UCIString() == "g1f3"));
-        position = new Position(position, position.AllPossibleMoves().Single(m => m.UCIString() == "g8f6"));
-        position = new Position(position, position.AllPossibleMoves().Single(m => m.UCIString() == "f3g1"));
-        position = new Position(position, position.AllPossibleMoves().Single(m => m.UCIString() == "f6g8"));
+        var position = new Position(originalPosition, MoveGenerator.GenerateAllMoves(originalPosition).Single(m => m.UCIString() == "g1f3"));
+        position = new Position(position, MoveGenerator.GenerateAllMoves(position).Single(m => m.UCIString() == "g8f6"));
+        position = new Position(position, MoveGenerator.GenerateAllMoves(position).Single(m => m.UCIString() == "f3g1"));
+        position = new Position(position, MoveGenerator.GenerateAllMoves(position).Single(m => m.UCIString() == "f6g8"));
 
         Assert.AreEqual(originalPosition.UniqueIdentifier, position.UniqueIdentifier);
     }
@@ -56,7 +56,7 @@ public class ZobristHashGenerationTest
 
     private static void TransversePosition(Position originalPosition, Dictionary<string, (string Move, long Hash)> fenDictionary, int maxDepth = 10, int depth = 0)
     {
-        foreach (var move in originalPosition.AllPossibleMoves())
+        foreach (var move in MoveGenerator.GenerateAllMoves(originalPosition))
         {
             var newPosition = new Position(originalPosition, move);
             if (!newPosition.IsValid())


### PR DESCRIPTION
I'm actually glad it failed.
Might apply some of the refactoring though (i.e. removing position bridge methods

```
Score of Lynx 1307 - history depth * depth vs Lynx 1305 - main: 3379 - 3469 - 2190  [0.495] 9038
...      Lynx 1307 - history depth * depth playing White: 2009 - 1394 - 1117  [0.568] 4520
...      Lynx 1307 - history depth * depth playing Black: 1370 - 2075 - 1073  [0.422] 4518
...      White vs Black: 4084 - 2764 - 2190  [0.573] 9038
Elo difference: -3.5 +/- 6.2, LOS: 13.8 %, DrawRatio: 24.2 %
SPRT: llr -2.94 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```