### PR TITLE
Perf/history moves value

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -227,7 +227,7 @@ public sealed partial class Engine
                 // 🔍 History moves
                 if (!move.IsCapture())
                 {
-                    _historyMoves[move.Piece(), move.TargetSquare()] += ply * ply;
+                    _historyMoves[move.Piece(), move.TargetSquare()] += (1 << ply);
                 }
 
                 _pVTable[pvIndex] = move;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -227,7 +227,7 @@ public sealed partial class Engine
                 // 🔍 History moves
                 if (!move.IsCapture())
                 {
-                    _historyMoves[move.Piece(), move.TargetSquare()] += ply << 2;
+                    _historyMoves[move.Piece(), move.TargetSquare()] += ply * ply;
                 }
 
                 _pVTable[pvIndex] = move;


### PR DESCRIPTION
`ply * ply`
```
Score of Lynx 1307 - history depth * depth vs Lynx 1305 - main: 3379 - 3469 - 2190  [0.495] 9038
...      Lynx 1307 - history depth * depth playing White: 2009 - 1394 - 1117  [0.568] 4520
...      Lynx 1307 - history depth * depth playing Black: 1370 - 2075 - 1073  [0.422] 4518
...      White vs Black: 4084 - 2764 - 2190  [0.573] 9038
Elo difference: -3.5 +/- 6.2, LOS: 13.8 %, DrawRatio: 24.2 %
SPRT: llr -2.94 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```

