### PR TITLE
⚡  Don't attempt to generate or validate castling moves if in check

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -163,6 +163,11 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
     {
+        if (position.IsInCheck())
+        {
+            return;
+        }
+
         var piece = (int)Piece.K + offset;
         var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 
@@ -391,6 +396,11 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyCastlingMoveValid(Position position, int offset)
     {
+        if (position.IsInCheck())
+        {
+            return false;
+        }
+
         var piece = (int)Piece.K + offset;
         var oppositeSide = (Side)Utils.OppositeSide(position.Side);
 


### PR DESCRIPTION
Oh, well

```
Score of Lynx 1310 - movegen-check-castling-rights vs Lynx 1305 - main: 948 - 1047 - 605  [0.481] 2600
...      Lynx 1310 - movegen-check-castling-rights playing White: 556 - 466 - 278  [0.535] 1300
...      Lynx 1310 - movegen-check-castling-rights playing Black: 392 - 581 - 327  [0.427] 1300
...      White vs Black: 1137 - 858 - 605  [0.554] 2600
Elo difference: -13.2 +/- 11.7, LOS: 1.3 %, DrawRatio: 23.3 %
SPRT: llr -2.21 (-75.0%), lbound -2.94, ubound 2.94
```