### PR TITLE
⚡ Group two `IsSquaredAttackedBySide` invocations together into `AreSquaresAttackedBySide`

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -101,6 +101,10 @@ public static class Attacks
         IsSquaredAttacked(squaredIndex, sideToMove, position.PieceBitBoards, position.OccupancyBitBoards);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool AreSquaresAttackedBySide(int squaredIndex1, int squaredIndex2, Position position, Side sideToMove) =>
+        AreSquaresAttacked(squaredIndex1, squaredIndex2, sideToMove, position.PieceBitBoards, position.OccupancyBitBoards);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsSquaredAttacked(int squareIndex, Side sideToMove, BitBoard[] piecePosition, BitBoard[] occupancy)
     {
         Utils.Assert(sideToMove != Side.Both);
@@ -115,6 +119,32 @@ public static class Attacks
             || IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
             || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
             || IsSquareAttackedByKing(squareIndex, offset, piecePosition);
+    }
+
+    /// <summary>
+    /// (A & B) || (C & B) -> (A | C) & B
+    /// </summary>
+    /// <param name="squareIndex1"></param>
+    /// <param name="squareIndex2"></param>
+    /// <param name="sideToMove"></param>
+    /// <param name="piecePosition"></param>
+    /// <param name="occupancy"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool AreSquaresAttacked(int squareIndex1, int squareIndex2, Side sideToMove, BitBoard[] piecePosition, BitBoard[] occupancy)
+    {
+        Utils.Assert(sideToMove != Side.Both);
+
+        var offset = Utils.PieceOffset(sideToMove);
+
+        // I tried to order them from most to least likely
+        return
+            AreSquaresAttackedByPawns(squareIndex1, squareIndex2, sideToMove, offset, piecePosition)
+            || AreSquaresAttackedByKnights(squareIndex1, squareIndex2, offset, piecePosition)
+            || AreSquaresAttackedByBishops(squareIndex1, squareIndex2, offset, piecePosition, occupancy, out var bishopAttacks1, out var bishopAttacks2)
+            || AreSquaresAttackedByRooks(squareIndex1, squareIndex2, offset, piecePosition, occupancy, out var rookAttacks1, out var rookAttacks2)
+            || AreSquaresAttackedByQueens(offset, bishopAttacks1, rookAttacks1, bishopAttacks2, rookAttacks2, piecePosition)
+            || AreSquaresAttackedByKing(squareIndex1, squareIndex2, offset, piecePosition);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -142,15 +172,35 @@ public static class Attacks
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByPawns(int squareIndex1, int squareIndex2, Side sideToMove, int offset, BitBoard[] pieces)
+    {
+        var oppositeColorIndex = ((int)sideToMove + 1) % 2;
+
+        return ((PawnAttacks[oppositeColorIndex, squareIndex1] | PawnAttacks[oppositeColorIndex, squareIndex2]) & pieces[offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByKnights(int squareIndex, int offset, BitBoard[] piecePosition)
     {
         return (KnightAttacks[squareIndex] & piecePosition[(int)Piece.N + offset]) != default;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByKnights(int squareIndex1, int squareIndex2, int offset, BitBoard[] piecePosition)
+    {
+        return ((KnightAttacks[squareIndex1] | KnightAttacks[squareIndex2]) & piecePosition[(int)Piece.N + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByKing(int squareIndex, int offset, BitBoard[] piecePosition)
     {
         return (KingAttacks[squareIndex] & piecePosition[(int)Piece.K + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByKing(int squareIndex1, int squareIndex2, int offset, BitBoard[] piecePosition)
+    {
+        return ((KingAttacks[squareIndex1] | KingAttacks[squareIndex2]) & piecePosition[(int)Piece.K + offset]) != default;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -161,6 +211,14 @@ public static class Attacks
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByBishops(int squareIndex1, int squareIndex2, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard bishopAttacks1, out BitBoard bishopAttacks2)
+    {
+        bishopAttacks1 = BishopAttacks(squareIndex1, occupancy[(int)Side.Both]);
+        bishopAttacks2 = BishopAttacks(squareIndex2, occupancy[(int)Side.Both]);
+        return ((bishopAttacks1 | bishopAttacks2) & piecePosition[(int)Piece.B + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByRooks(int squareIndex, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard rookAttacks)
     {
         rookAttacks = RookAttacks(squareIndex, occupancy[(int)Side.Both]);
@@ -168,9 +226,25 @@ public static class Attacks
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByRooks(int squareIndex1, int squareIndex2, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard rookAttacks1, out BitBoard rookAttacks2)
+    {
+        rookAttacks1 = RookAttacks(squareIndex1, occupancy[(int)Side.Both]);
+        rookAttacks2 = RookAttacks(squareIndex2, occupancy[(int)Side.Both]);
+        return ((rookAttacks1 | rookAttacks2) & piecePosition[(int)Piece.R + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByQueens(int offset, BitBoard bishopAttacks, BitBoard rookAttacks, BitBoard[] piecePosition)
     {
         var queenAttacks = QueenAttacks(rookAttacks, bishopAttacks);
         return (queenAttacks & piecePosition[(int)Piece.Q + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreSquaresAttackedByQueens(int offset, BitBoard bishopAttacks1, BitBoard rookAttacks1, BitBoard bishopAttacks2, BitBoard rookAttacks2, BitBoard[] piecePosition)
+    {
+        var queenAttacks1 = QueenAttacks(rookAttacks1, bishopAttacks1);
+        var queenAttacks2 = QueenAttacks(rookAttacks2, bishopAttacks2);
+        return ((queenAttacks1 | queenAttacks2) & piecePosition[(int)Piece.Q + offset]) != default;
     }
 }

--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -159,7 +159,7 @@ public static class Attacks
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsSquareAttackedByPawns(int squareIndex, Side sideToMove, int offset, BitBoard[] pieces)
     {
-        var oppositeColorIndex = ((int)sideToMove + 1) % 2;
+        var oppositeColorIndex = (int)sideToMove ^ 1;
 
         return (PawnAttacks[oppositeColorIndex, squareIndex] & pieces[offset]) != default;
     }
@@ -167,7 +167,7 @@ public static class Attacks
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool AreAnySquaresAttackedByPawns(int squareIndex1, int squareIndex2, Side sideToMove, int offset, BitBoard[] pieces)
     {
-        var oppositeColorIndex = ((int)sideToMove + 1) % 2;
+        var oppositeColorIndex = (int)sideToMove ^ 1;
 
         return ((PawnAttacks[oppositeColorIndex, squareIndex1] & pieces[offset]) != default)
             || ((PawnAttacks[oppositeColorIndex, squareIndex2] & pieces[offset]) != default);

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -178,8 +178,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
                     && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
@@ -189,8 +188,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
                     && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
@@ -202,8 +200,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
                     && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
@@ -213,8 +210,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
                     && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
@@ -406,8 +402,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
                     && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g1, position, oppositeSide)
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
                 {
                     return true;
@@ -418,8 +413,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
                     && !ise1Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c1, position, oppositeSide)
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
                 {
                     return true;
@@ -432,8 +426,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
                     && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.g8, position, oppositeSide)
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
                 {
                     return true;
@@ -444,8 +437,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
                     && !ise8Attacked
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
-                    && !Attacks.IsSquaredAttackedBySide((int)BoardSquare.c8, position, oppositeSide)
+                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
                 {
                     return true;

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -163,14 +163,13 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
     {
-        var piece = (int)Piece.K + offset;
-        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
-
-        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
-
-        // Castles
         if (position.Castle != default)
         {
+            var piece = (int)Piece.K + offset;
+            var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+            int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
             if (position.Side == Side.White)
             {
                 bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
@@ -178,7 +177,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
                     && !ise1Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide))
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
@@ -188,7 +187,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
                     && !ise1Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide))
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
@@ -200,7 +199,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
                     && !ise8Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide))
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
                 }
@@ -210,7 +209,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
                     && !ise8Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide))
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide))
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
                 }
@@ -387,14 +386,13 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyCastlingMoveValid(Position position, int offset)
     {
-        var piece = (int)Piece.K + offset;
-        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
-
-        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
-
-        // Castles
         if (position.Castle != default)
         {
+            var piece = (int)Piece.K + offset;
+            var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+            int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
             if (position.Side == Side.White)
             {
                 bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
@@ -402,7 +400,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
                     && !ise1Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide)
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.f1, (int)BoardSquare.g1, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE)))
                 {
                     return true;
@@ -413,7 +411,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
                     && !ise1Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide)
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.d1, (int)BoardSquare.c1, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE)))
                 {
                     return true;
@@ -426,7 +424,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
                     && !ise8Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide)
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.f8, (int)BoardSquare.g8, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE)))
                 {
                     return true;
@@ -437,7 +435,7 @@ public static class MoveGenerator
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
                     && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
                     && !ise8Attacked
-                    && !Attacks.AreSquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide)
+                    && !Attacks.AreAnySquaresAttackedBySide((int)BoardSquare.d8, (int)BoardSquare.c8, position, oppositeSide)
                     && IsValidMove(position, MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE)))
                 {
                     return true;


### PR DESCRIPTION
Group two `Attacks.IsSquaredAttackedBySide` invocations together into one `Attacks.AreSquaresAttackedBySide`.
`(A & B) || (C & B) -> (A | C) & B`

https://github.com/lynx-chess/Lynx/pull/366/commits/35b7edccafc8b8dea46e39e35e39ba69e1992842 👎🏽
```
Score of Lynx 1311 - ares-squares-attacked vs Lynx 1305 - main: 959 - 956 - 692  [0.501] 2607
...      Lynx 1311 - ares-squares-attacked playing White: 557 - 397 - 350  [0.561] 1304
...      Lynx 1311 - ares-squares-attacked playing Black: 402 - 559 - 342  [0.440] 1303
...      White vs Black: 1116 - 799 - 692  [0.561] 2607
Elo difference: 0.4 +/- 11.4, LOS: 52.7 %, DrawRatio: 26.5 %
SPRT: llr -0.309 (-10.5%), lbound -2.94, ubound 2.94
```

https://github.com/lynx-chess/Lynx/pull/366/commits/258ce985f288e78da3362c2b63c52fd63bb1293d 👎🏼 
```
Score of Lynx 1316 - ares-squares-attacked vs Lynx 1305 - main: 2777 - 2878 - 1795  [0.493] 7450
...      Lynx 1316 - ares-squares-attacked playing White: 1642 - 1165 - 917  [0.564] 3724
...      Lynx 1316 - ares-squares-attacked playing Black: 1135 - 1713 - 878  [0.422] 3726
...      White vs Black: 3355 - 2300 - 1795  [0.571] 7450
Elo difference: -4.7 +/- 6.9, LOS: 9.0 %, DrawRatio: 24.1 %
SPRT: llr -2.93 (-99.6%), lbound -2.94, ubound 2.94
```