### PR TITLE
🔍 Add non-promotion condition to history moves heuristic

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -225,7 +225,7 @@ public sealed partial class Engine
                 bestMove = move;
 
                 // 🔍 History moves
-                if (!move.IsCapture())
+                if (!move.IsCapture() && move.PromotedPiece() == default)
                 {
                     _historyMoves[move.Piece(), move.TargetSquare()] += ply << 2;
                 }


### PR DESCRIPTION
```
Score of Lynx 1315 - history-no-promo vs Lynx 1305 - main: 2507 - 2615 - 1591  [0.492] 6713
...      Lynx 1315 - history-no-promo playing White: 1467 - 1098 - 792  [0.555] 3357
...      Lynx 1315 - history-no-promo playing Black: 1040 - 1517 - 799  [0.429] 3356
...      White vs Black: 2984 - 2138 - 1591  [0.563] 6713
Elo difference: -5.6 +/- 7.3, LOS: 6.6 %, DrawRatio: 23.7 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```