### PR TITLE
⚡ Check sliding pieces attacks last in `IsSquaredAttacked`

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -105,14 +105,15 @@ public static class Attacks
     {
         Utils.Assert(sideToMove != Side.Both);
 
-        var offset = Utils.PieceOffset(sideToMove);
+        var sideToMoveInt = (int)sideToMove;
+        var offset = Utils.PieceOffset(sideToMoveInt);
 
         // I tried to order them from most to least likely
         return
-            IsSquareAttackedByPawns(squareIndex, sideToMove, offset, piecePosition)
+            IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition)
             || IsSquareAttackedByKing(squareIndex, offset, piecePosition)
             || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks) 
+            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
             || IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
             || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition);
     }
@@ -122,7 +123,8 @@ public static class Attacks
     {
         Utils.Assert(sideToMove != Side.Both);
 
-        var offset = Utils.PieceOffset(sideToMove);
+        var sideToMoveInt = (int)sideToMove;
+        var offset = Utils.PieceOffset(sideToMoveInt);
 
         // I tried to order them from most to least likely
         return
@@ -130,13 +132,13 @@ public static class Attacks
             || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
             || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
             || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByPawns(squareIndex, sideToMove, offset, piecePosition);
+            || IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByPawns(int squareIndex, Side sideToMove, int offset, BitBoard[] pieces)
+    private static bool IsSquareAttackedByPawns(int squareIndex, int sideToMove, int offset, BitBoard[] pieces)
     {
-        var oppositeColorIndex = ((int)sideToMove + 1) % 2;
+        var oppositeColorIndex = sideToMove ^ 1;
 
         return (PawnAttacks[oppositeColorIndex, squareIndex] & pieces[offset]) != default;
     }

--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -110,11 +110,11 @@ public static class Attacks
         // I tried to order them from most to least likely
         return
             IsSquareAttackedByPawns(squareIndex, sideToMove, offset, piecePosition)
+            || IsSquareAttackedByKing(squareIndex, offset, piecePosition)
             || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
+            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks) 
             || IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
-            || IsSquareAttackedByKing(squareIndex, offset, piecePosition);
+            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -391,14 +391,13 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyCastlingMoveValid(Position position, int offset)
     {
-        var piece = (int)Piece.K + offset;
-        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
-
-        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
-
-        // Castles
         if (position.Castle != default)
         {
+            var piece = (int)Piece.K + offset;
+            var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+            int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
             if (position.Side == Side.White)
             {
                 bool ise1Attacked = Attacks.IsSquaredAttackedBySide((int)BoardSquare.e1, position, oppositeSide);


### PR DESCRIPTION
```
Score of Lynx 1318 - movegen perf vs Lynx 1305 - main: 8475 - 8470 - 5384  [0.500] 22329
...      Lynx 1318 - movegen perf playing White: 5095 - 3419 - 2651  [0.575] 11165
...      Lynx 1318 - movegen perf playing Black: 3380 - 5051 - 2733  [0.425] 11164
...      White vs Black: 10146 - 6799 - 5384  [0.575] 22329
Elo difference: 0.1 +/- 4.0, LOS: 51.5 %, DrawRatio: 24.1 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```