### PR TITLE
Add OpenBench support (I)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -41,5 +41,5 @@ jobs:
       run: dotnet build -c Release
 
     - name: Run perft ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
-      run: dotnet run -c Release --no-build "bench" "quit"'
+      run: dotnet run -c Release --no-build "bench"'
       working-directory: ./src/Lynx.Cli

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,45 @@
+name: Bench
+
+on:
+  workflow_dispatch:
+
+jobs:
+
+  bench:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+      fail-fast: false
+
+    env:
+      DOTNET_VERSION: 8.0.x
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_TieredPGO: 1
+      DOTNET_ReadyToRun: 0
+      DOTNET_TC_QuickJitForLoops: 1
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Nuget cache
+      uses: actions/cache@v3
+      with:
+        path:
+          ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Run perft ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
+      run: dotnet run -c Release --no-build "bench" "quit"'
+      working-directory: ./src/Lynx.Cli

--- a/.github/workflows/perft.yml
+++ b/.github/workflows/perft.yml
@@ -48,7 +48,7 @@ jobs:
       run: dotnet build -c Release
 
     - name: Run perft ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
-      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "perft ${{ github.event.inputs.depth }}"'
+      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "perft ${{ github.event.inputs.depth }}" "quit"'
       working-directory: ./src/Lynx.Cli
 
   divide:
@@ -83,5 +83,5 @@ jobs:
       run: dotnet build -c Release
 
     - name: Run divide ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
-      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "divide ${{ github.event.inputs.depth }}"'
+      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "divide ${{ github.event.inputs.depth }}" "quit"'
       working-directory: ./src/Lynx.Cli

--- a/.github/workflows/perft.yml
+++ b/.github/workflows/perft.yml
@@ -1,0 +1,87 @@
+name: Perft
+
+on:
+  workflow_dispatch:
+    inputs:
+      fen:
+        description: 'fen'
+        required: true
+        default: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+      depth:
+        description: 'depth'
+        required: true
+      divide:
+        description: 'Run also divide'
+        required: false
+        type: boolean
+
+jobs:
+
+  perft:
+    runs-on: ubuntu-latest
+
+    env:
+      DOTNET_VERSION: 8.0.x
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_TieredPGO: 1
+      DOTNET_ReadyToRun: 0
+      DOTNET_TC_QuickJitForLoops: 1
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Nuget cache
+      uses: actions/cache@v3
+      with:
+        path:
+          ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Run perft ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
+      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "perft ${{ github.event.inputs.depth }}"'
+      working-directory: ./src/Lynx.Cli
+
+  divide:
+    runs-on: ubuntu-latest
+    if: github.event.inputs.divide
+
+    env:
+      DOTNET_VERSION: 8.0.x
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_TieredPGO: 1
+      DOTNET_ReadyToRun: 0
+      DOTNET_TC_QuickJitForLoops: 1
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Nuget cache
+      uses: actions/cache@v3
+      with:
+        path:
+          ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Run divide ${{ github.event.inputs.depth }} on ${{ github.event.inputs.fen }}
+      run: dotnet run -c Release --no-build "position fen ${{ github.event.inputs.fen }}" "divide ${{ github.event.inputs.depth }}"'
+      working-directory: ./src/Lynx.Cli

--- a/Lynx.sln
+++ b/Lynx.sln
@@ -6,6 +6,7 @@ MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A70D03B5-17BC-4017-9053-15715998735E}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.github\workflows\bench.yml = .github\workflows\bench.yml
 		.github\workflows\benchmarks.yml = .github\workflows\benchmarks.yml
 		.github\workflows\ci.yml = .github\workflows\ci.yml
 		Directory.Build.props = Directory.Build.props

--- a/Lynx.sln
+++ b/Lynx.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		Makefile = Makefile
 		.github\workflows\on_release.yml = .github\workflows\on_release.yml
+		.github\workflows\perft.yml = .github\workflows\perft.yml
 		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 .DEFAULT_GOAL := publish
 
-EXE = Lynx.Cli
-CC = dotnet
+EXE=
 
 RUNTIME=
-OUTPUT_DIR:=artifacts/Lynx/
+OUTPUT_DIR=artifacts/Lynx/
 
 ifeq ($(OS),Windows_NT)
     ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
@@ -35,6 +34,10 @@ ifndef RUNTIME
 $(error RUNTIME is not set for $(OS) $(UNAME_S) $(UNAME_P), please fill an issue in https://github.com/lynx-chess/Lynx/issues/new/choose)
 endif
 
+ifdef EXE
+OUTPUT_DIR=./
+endif
+
 build:
 	dotnet build -c Release
 
@@ -42,7 +45,7 @@ test:
 	dotnet test -c Release & dotnet test -c Release --filter "TestCategory=LongRunning" & dotnet test -c Release --filter "TestCategory=Perft"
 
 publish:
-	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:DeterministicBuild=true -o ${OUTPUT_DIR}
+	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:DeterministicBuild=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
 
 run:
 	dotnet run --project src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME}

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -36,5 +36,12 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='$(AssemblyName)'">
+    <Message Text="Attempting to rename executable file from $(PublishDir)/$(AssemblyName) to $(PublishDir)/$(ExecutableName)" Importance="high" />
+    <Move SourceFiles="$(PublishDir)/$(AssemblyName)" DestinationFiles="$(PublishDir)/$(ExecutableName)" ContinueOnError="true" />
+    <Message Text="Attempting to rename executable file from $(PublishDir)\$(AssemblyName).exe to $(PublishDir)/$(ExecutableName).exe" Importance="high" />
+    <Move SourceFiles="$(PublishDir)/$(AssemblyName).exe" DestinationFiles="$(PublishDir)/$(ExecutableName).exe" ContinueOnError="true" />
+  </Target>
 
 </Project>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -45,7 +45,7 @@ var tasks = new List<Task>
 {
     Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
     Task.Run(() => new LynxDriver(uciChannel, engineChannel, new Engine(engineChannel)).Run(cancellationToken)),
-    Task.Run(() => new Listener(uciChannel).Run(cancellationToken)),
+    Task.Run(() => new Listener(uciChannel).Run(cancellationToken, args)),
     uciChannel.Reader.Completion,
     engineChannel.Reader.Completion
 };

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -43,9 +43,9 @@ CancellationToken cancellationToken = source.Token;
 
 var tasks = new List<Task>
 {
-    new Writer(engineChannel).Run(cancellationToken),
-    new LynxDriver(uciChannel, engineChannel, new Engine(engineChannel)).Run(cancellationToken),
-    new Listener(uciChannel).Run(cancellationToken, args),
+    Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
+    Task.Run(() => new LynxDriver(uciChannel, engineChannel, new Engine(engineChannel)).Run(cancellationToken)),
+    Task.Run(() => new Listener(uciChannel).Run(cancellationToken)),
     uciChannel.Reader.Completion,
     engineChannel.Reader.Completion
 };

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -88,6 +88,7 @@ public sealed class LynxDriver
                                 break;
                             case "bench":
                                 await HandleBench();
+                                HandleQuit();
                                 break;
                             default:
                                 _logger.Warn("Unknown command received: {0}", rawCommand);
@@ -298,7 +299,7 @@ public sealed class LynxDriver
     private async ValueTask HandleBench()
     {
         var results = await OpenBench.Bench(_engineWriter);
-        OpenBench.PrintBenchResults(results, Console.WriteLine);
+        await OpenBench.PrintBenchResults(results, str => _engineWriter.Writer.WriteAsync(str));
     }
 
     #endregion

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -298,7 +298,7 @@ public sealed class LynxDriver
     private async ValueTask HandleBench()
     {
         var results = await OpenBench.Bench(_engineWriter);
-        await OpenBench.PrintBenchResults(results, str => _engineWriter.Writer.WriteAsync(str));
+        OpenBench.PrintBenchResults(results, Console.WriteLine);
     }
 
     #endregion

--- a/src/Lynx/UCI/Commands/Engine/IdCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/IdCommand.cs
@@ -17,7 +17,7 @@ public sealed class IdCommand : EngineBaseCommand
 
     public const string EngineName = "Lynx";
 
-    public const string EngineAuthor = "Eduardo Cáceres";
+    public const string EngineAuthor = "Eduardo Caceres";
 
     public static string GetVersion()
     {


### PR DESCRIPTION
* [Revert 'Get rid of Task.Run() for Writer, LynxDriver and `Listener](https://github.com/lynx-chess/Lynx/commit/9ca207f942d3f46b27844c882ffe8a081b34b84e) 


  It fucked up quit command
* Quit automatically after bench command
* Add option to change executable name, and use that option from makefile when invoked by OB. Set also a different publish path if that's the case (`./`)
* Add `perft` and `bench` GH actions
* Remove `á` from `Cáceres` since it messes with bench output parsing

It's finally playing games :_)