### PR TITLE
🐛 Don't rename executable if no new new is provded

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -37,7 +37,7 @@
     </None>
   </ItemGroup>
 
-  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='$(AssemblyName)'">
+  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and $(ExecutableName)'!='$(AssemblyName)'">
     <Message Text="Attempting to rename executable file from $(PublishDir)/$(AssemblyName) to $(PublishDir)/$(ExecutableName)" Importance="high" />
     <Move SourceFiles="$(PublishDir)/$(AssemblyName)" DestinationFiles="$(PublishDir)/$(ExecutableName)" ContinueOnError="true" />
     <Message Text="Attempting to rename executable file from $(PublishDir)\$(AssemblyName).exe to $(PublishDir)/$(ExecutableName).exe" Importance="high" />

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -37,7 +37,7 @@
     </None>
   </ItemGroup>
 
-  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and $(ExecutableName)'!='$(AssemblyName)'">
+  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and '$(ExecutableName)'!='$(AssemblyName)'">
     <Message Text="Attempting to rename executable file from $(PublishDir)/$(AssemblyName) to $(PublishDir)/$(ExecutableName)" Importance="high" />
     <Move SourceFiles="$(PublishDir)/$(AssemblyName)" DestinationFiles="$(PublishDir)/$(ExecutableName)" ContinueOnError="true" />
     <Message Text="Attempting to rename executable file from $(PublishDir)\$(AssemblyName).exe to $(PublishDir)/$(ExecutableName).exe" Importance="high" />


### PR DESCRIPTION
Windows one was being renamed to `.exe`, Linux and Mac were unaffected.