### PR TITLE
Use standard `depth` concept in `NegaMax` method 

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1051,20 +1051,20 @@ static void TranspositionTable()
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(mask, position, targetDepth: 5, ply: 3, eval: +19, nodeType: NodeType.Alpha, move: 1234);
-    var entry = transpositionTable.ProbeHash(mask, position, targetDepth: 5, ply: 3, alpha: 20, beta: 30);
+    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +19, nodeType: NodeType.Alpha, move: 1234);
+    var entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 20
 
-    transpositionTable.RecordHash(mask, position, targetDepth: 5, ply: 3, eval: +21, nodeType: NodeType.Alpha, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, targetDepth: 5, ply: 3, alpha: 20, beta: 30);
+    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +21, nodeType: NodeType.Alpha, move: 1234);
+    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(mask, position, targetDepth: 5, ply: 3, eval: +29, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, targetDepth: 5, ply: 3, alpha: 20, beta: 30);
+    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +29, nodeType: NodeType.Beta, move: 1234);
+    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(mask, position, targetDepth: 5, ply: 3, eval: +31, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, targetDepth: 5, ply: 3, alpha: 20, beta: 30);
+    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +31, nodeType: NodeType.Beta, move: 1234);
+    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 30
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -145,7 +145,7 @@ public sealed partial class Engine
             Game.MakeMove(resultToReturn.BestMove);
         }
 
-        AverageDepth += (resultToReturn.TargetDepth - AverageDepth) / Math.Ceiling(0.5 * Game.MoveHistory.Count);
+        AverageDepth += (resultToReturn.Depth - AverageDepth) / Math.Ceiling(0.5 * Game.MoveHistory.Count);
 
         return resultToReturn;
     }
@@ -173,7 +173,7 @@ public sealed partial class Engine
         if (searchResult is not null)
         {
             _logger.Info("Search evaluation result - eval: {0}, mate: {1}, depth: {2}, pv: {3}",
-                searchResult.Evaluation, searchResult.Mate, searchResult.TargetDepth, string.Join(", ", searchResult.Moves.Select(m => m.ToMoveString())));
+                searchResult.Evaluation, searchResult.Mate, searchResult.Depth, string.Join(", ", searchResult.Moves.Select(m => m.ToMoveString())));
         }
 
         if (tbResult is not null)
@@ -184,7 +184,7 @@ public sealed partial class Engine
             if (searchResult?.Mate > 0 && searchResult.Mate <= tbResult.Mate && searchResult.Mate + currentHalfMovesWithoutCaptureOrPawnMove < 96)
             {
                 _logger.Info("Relying on search result mate line due to dtm match and low enough dtz");
-                ++searchResult.TargetDepth;
+                ++searchResult.Depth;
                 tbResult = null;
             }
         }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -708,17 +708,17 @@ public class Position
     /// this method determines if a position is a result of either a loss by Checkmate or a draw by stalemate.
     /// NegaMax style
     /// </summary>
-    /// <param name="depth">Modulates the output, favouring positions with lower depth left (i.e. Checkmate in less moves)</param>
+    /// <param name="ply">Modulates the output, favouring positions with lower ply (i.e. Checkmate in less moves)</param>
     /// <param name="isInCheck"></param>
-    /// <returns>At least <see cref="CheckMateEvaluation"/> if Position.Side lost (more extreme values when <paramref name="depth"/> increases)
+    /// <returns>At least <see cref="CheckMateEvaluation"/> if Position.Side lost (more extreme values when <paramref name="ply"/> increases)
     /// or 0 if Position.Side was stalemated</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int EvaluateFinalPosition(int depth, bool isInCheck)
+    public static int EvaluateFinalPosition(int ply, bool isInCheck)
     {
         if (isInCheck)
         {
             // Checkmate evaluation, but not as bad/shallow as it looks like since we're already searching at a certain depth
-            return -EvaluationConstants.CheckMateBaseEvaluation + (EvaluationConstants.CheckmateDepthFactor * depth);
+            return -EvaluationConstants.CheckMateBaseEvaluation + (EvaluationConstants.CheckmateDepthFactor * ply);
         }
         else
         {

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -104,7 +104,7 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Evaluation, Move BestMove) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int targetDepth, int ply, int alpha, int beta)
+    public static (int Evaluation, Move BestMove) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         if (!Configuration.EngineSettings.TranspositionTableEnabled)
         {
@@ -120,7 +120,7 @@ public static class TranspositionTableExtensions
 
         var eval = EvaluationConstants.NoHashEntry;
 
-        if (entry.Depth >= (targetDepth - ply))
+        if (entry.Depth >= depth)
         {
             // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
             // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
@@ -149,7 +149,7 @@ public static class TranspositionTableExtensions
     /// <param name="nodeType"></param>
     /// <param name="move"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void RecordHash(this TranspositionTable tt, int ttMask, Position position, int targetDepth, int ply, int eval, NodeType nodeType, Move? move = 0)
+    public static void RecordHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int eval, NodeType nodeType, Move? move = 0)
     {
         if (!Configuration.EngineSettings.TranspositionTableEnabled)
         {
@@ -169,7 +169,7 @@ public static class TranspositionTableExtensions
 
         entry.Key = position.UniqueIdentifier;
         entry.Score = score;
-        entry.Depth = targetDepth - ply;
+        entry.Depth = depth;
         entry.Move = move ?? 0;
         entry.Type = nodeType;
     }
@@ -180,14 +180,14 @@ public static class TranspositionTableExtensions
     /// Logic for when to pass +depth or -depth for the desired effect in https://www.talkchess.com/forum3/viewtopic.php?f=7&t=74411 and https://talkchess.com/forum3/viewtopic.php?p=861852#p861852
     /// </summary>
     /// <param name="score"></param>
-    /// <param name="depth"></param>
+    /// <param name="ply"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static int RecalculateMateScores(int score, int depth) => score +
+    internal static int RecalculateMateScores(int score, int ply) => score +
             score switch
             {
-                > EvaluationConstants.PositiveCheckmateDetectionLimit => -EvaluationConstants.CheckmateDepthFactor * depth,
-                < EvaluationConstants.NegativeCheckmateDetectionLimit => EvaluationConstants.CheckmateDepthFactor * depth,
+                > EvaluationConstants.PositiveCheckmateDetectionLimit => -EvaluationConstants.CheckmateDepthFactor * ply,
+                < EvaluationConstants.NegativeCheckmateDetectionLimit => EvaluationConstants.CheckmateDepthFactor * ply,
                 _ => 0
             };
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -9,7 +9,7 @@ public class SearchResult
 {
     public Move BestMove { get; init; }
     public double Evaluation { get; init; }
-    public int TargetDepth { get; set; }
+    public int Depth { get; set; }
     public List<Move> Moves { get; init; }
     public int Alpha { get; init; }
     public int Beta { get; init; }
@@ -31,7 +31,7 @@ public class SearchResult
     {
         BestMove = bestMove;
         Evaluation = evaluation;
-        TargetDepth = targetDepth;
+        Depth = targetDepth;
         Moves = moves;
         Alpha = alpha;
         Beta = beta;
@@ -42,7 +42,7 @@ public class SearchResult
     {
         BestMove = previousSearchResult.Moves.ElementAtOrDefault(2);
         Evaluation = previousSearchResult.Evaluation;
-        TargetDepth = previousSearchResult.TargetDepth - 2;
+        Depth = previousSearchResult.Depth - 2;
         DepthReached = previousSearchResult.DepthReached - 2;
         Moves = previousSearchResult.Moves.Skip(2).ToList();
         Alpha = previousSearchResult.Alpha;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
                 _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
             }
 
-            depth = lastSearchResult.TargetDepth - 1;
+            depth = lastSearchResult.Depth - 1;
             alpha = lastSearchResult.Alpha;
             beta = lastSearchResult.Beta;
         }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
                 _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
             }
 
-            depth = lastSearchResult.TargetDepth + 1;
+            depth = lastSearchResult.TargetDepth - 1;
             alpha = lastSearchResult.Alpha;
             beta = lastSearchResult.Beta;
         }
@@ -97,7 +97,7 @@ public sealed partial class Engine
                 AspirationWindows_SearchAgain:
 
                 _isFollowingPV = true;
-                bestEvaluation = NegaMax(minDepth, targetDepth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true); ;
 
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
                 isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,11 +75,11 @@ public sealed partial class Engine
 
         // 🔍 Verified Null-move pruning (NMP) - https://www.researchgate.net/publication/297377298_Verified_Null-Move_Pruning
         bool isFailHigh = false;    // In order to detect zugzwangs
-        if (ply > Configuration.EngineSettings.NullMovePruning_R    // TODO Use depth
+        if (depth > Configuration.EngineSettings.NullMovePruning_R
             && !isInCheck
             && !ancestorWasNullMove
-            && (!isVerifyingNullMoveCutOff || depth > 1))    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
-                                                                         // following pv?
+            /*&& (!isVerifyingNullMoveCutOff || depth > 1)*/)    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
+                                                             // following pv?
         {
             var gameState = position.MakeNullMove();
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -65,7 +65,7 @@ public sealed partial class Engine
         {
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
             {
-                return QuiescenceSearch(ply, alpha, beta);  // realPly + 1?
+                return QuiescenceSearch(ply, alpha, beta);
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
@@ -73,7 +73,7 @@ public sealed partial class Engine
             return finalPositionEvaluation;
         }
 
-        // 🔍 Null-move pruning
+        // 🔍 Verified Null-move pruning (NMP) - https://www.researchgate.net/publication/297377298_Verified_Null-Move_Pruning
         bool isFailHigh = false;    // In order to detect zugzwangs
         if (ply > Configuration.EngineSettings.NullMovePruning_R    // TODO Use depth
             && !isInCheck

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -7,9 +7,8 @@ public sealed partial class Engine
     /// <summary>
     /// NegaMax algorithm implementation using alpha-beta pruning, quiescence search and Iterative Deepeting Depth-First Search (IDDFS)
     /// </summary>
-    /// <param name="minDepth">Minimum number of depth (plies), regardless of time constrains</param>
-    /// <param name="targetDepth"></param>
-    /// <param name="ply">Current depth or number of half moves</param>
+    /// <param name="depth"></param>
+    /// <param name="ply"></param>
     /// <param name="alpha">
     /// Best score the Side to move can achieve, assuming best play by the opponent.
     /// Defaults to the worse possible score for Side to move, Int.MinValue.
@@ -21,11 +20,11 @@ public sealed partial class Engine
     /// <param name="isVerifyingNullMoveCutOff">Indicates if the search is verifying an ancestors null-move that failed high, or the root node</param>
     /// <param name="ancestorWasNullMove">Indicates whether the immediate ancestor node was a null move</param>
     /// <returns></returns>
-    private int NegaMax(int minDepth, int targetDepth, int ply, int alpha, int beta, bool isVerifyingNullMoveCutOff, bool ancestorWasNullMove = false)
+    private int NegaMax(int depth, int ply, int alpha, int beta, bool isVerifyingNullMoveCutOff, bool ancestorWasNullMove = false)
     {
         var position = Game.CurrentPosition;
 
-        // Prevents runtime failure, in case targetDepth is increased due to check extension
+        // Prevents runtime failure in case depth is increased due to check extension, since we're using ply when calculating pvTable index,
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
@@ -39,12 +38,13 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
+        bool isRoot = ply == 0;
         bool pvNode = beta - alpha > 1;
         Move ttBestMove = default;
 
-        if (ply > 0)
+        if (!isRoot)
         {
-            var ttProbeResult = _tt.ProbeHash(_ttMask, position, targetDepth, ply, alpha, beta);
+            var ttProbeResult = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
             if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttProbeResult.Evaluation;
@@ -59,31 +59,31 @@ public sealed partial class Engine
 
         if (isInCheck)
         {
-            ++targetDepth;
+            ++depth;
         }
-        if (ply >= targetDepth)
+        if (depth <= 0)
         {
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
             {
-                return QuiescenceSearch(ply, alpha, beta);
+                return QuiescenceSearch(ply, alpha, beta);  // realPly + 1?
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(_ttMask, position, targetDepth, ply, finalPositionEvaluation, NodeType.Exact);
+            _tt.RecordHash(_ttMask, position, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
 
         // 🔍 Null-move pruning
         bool isFailHigh = false;    // In order to detect zugzwangs
-        if (ply > Configuration.EngineSettings.NullMovePruning_R
+        if (ply > Configuration.EngineSettings.NullMovePruning_R    // TODO Use depth
             && !isInCheck
             && !ancestorWasNullMove
-            && (!isVerifyingNullMoveCutOff || ply < targetDepth - 1))    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
+            && (!isVerifyingNullMoveCutOff || depth > 1))    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
                                                                          // following pv?
         {
             var gameState = position.MakeNullMove();
 
-            var evaluation = -NegaMax(minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.NullMovePruning_R, -beta, -beta + 1, isVerifyingNullMoveCutOff, ancestorWasNullMove: true);
+            var evaluation = -NegaMax(depth - 1 - Configuration.EngineSettings.NullMovePruning_R, ply + 1, -beta, -beta + 1, isVerifyingNullMoveCutOff, ancestorWasNullMove: true);
 
             position.UnMakeNullMove(gameState);
 
@@ -91,7 +91,7 @@ public sealed partial class Engine
             {
                 if (isVerifyingNullMoveCutOff)
                 {
-                    ++ply;
+                    --depth;
                     isVerifyingNullMoveCutOff = false;
                     isFailHigh = true;
                 }
@@ -145,13 +145,13 @@ public sealed partial class Engine
             }
             else if (movesSearched == 0)
             {
-                evaluation = -NegaMax(minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
             }
             else
             {
                 // 🔍 Late Move Reduction (LMR)
                 if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
-                    && ply >= Configuration.EngineSettings.LMR_ReductionLimit
+                    && ply >= Configuration.EngineSettings.LMR_ReductionLimit       // TODO depth? - https://www.chessprogramming.org/Late_Move_Reductions
                     && !pvNode
                     && !isInCheck
                     //&& !newPosition.IsInCheck()
@@ -159,7 +159,7 @@ public sealed partial class Engine
                     && move.PromotedPiece() == default)
                 {
                     // Search with reduced depth
-                    evaluation = -NegaMax(minDepth, targetDepth, ply + 1 + Configuration.EngineSettings.LMR_DepthReduction, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                    evaluation = -NegaMax(depth - 1 - Configuration.EngineSettings.LMR_DepthReduction, ply + 1, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
                 }
                 else
                 {
@@ -177,17 +177,17 @@ public sealed partial class Engine
                         // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                         // Search with full depth but narrowed score bandwidth
-                        evaluation = -NegaMax(minDepth, targetDepth, ply + 1, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
+                        evaluation = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha, isVerifyingNullMoveCutOff);
 
                         if (evaluation > alpha && evaluation < beta)
                         {
                             // Hipothesis invalidated -> search with full depth and full score bandwidth
-                            evaluation = -NegaMax(minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                            evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
                         }
                     }
                     else
                     {
-                        evaluation = -NegaMax(minDepth, targetDepth, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
+                        evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha, isVerifyingNullMoveCutOff);
                     }
                 }
             }
@@ -214,7 +214,7 @@ public sealed partial class Engine
                     _killerMoves[0, ply] = move;
                 }
 
-                _tt.RecordHash(_ttMask, position, targetDepth, ply, beta, NodeType.Beta, bestMove);
+                _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);
 
                 return beta;    // TODO return evaluation?
             }
@@ -242,7 +242,7 @@ public sealed partial class Engine
         // [Null-move pruning] If there is a fail-high report, but no cutoff was found, the position is a zugzwang and has to be re-searched with the original depth
         if (isFailHigh && alpha < beta)
         {
-            --ply;
+            ++depth;
             isFailHigh = false;
             isVerifyingNullMoveCutOff = true;
             goto VerifiedNullMovePruning_SearchAgain;
@@ -252,11 +252,11 @@ public sealed partial class Engine
         {
             var eval = Position.EvaluateFinalPosition(ply, isInCheck);
 
-            _tt.RecordHash(_ttMask, position, targetDepth, ply, eval, NodeType.Exact);
+            _tt.RecordHash(_ttMask, position, depth, ply, eval, NodeType.Exact);
             return eval;
         }
 
-        _tt.RecordHash(_ttMask, position, targetDepth, ply, alpha, nodeType, bestMove);
+        _tt.RecordHash(_ttMask, position, depth, ply, alpha, nodeType, bestMove);
 
         // Node fails low
         return alpha;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -151,7 +151,7 @@ public sealed partial class Engine
             {
                 // 🔍 Late Move Reduction (LMR)
                 if (movesSearched >= Configuration.EngineSettings.LMR_FullDepthMoves
-                    && ply >= Configuration.EngineSettings.LMR_ReductionLimit       // TODO depth? - https://www.chessprogramming.org/Late_Move_Reductions
+                    && depth >= Configuration.EngineSettings.LMR_ReductionLimit
                     && !pvNode
                     && !isInCheck
                     //&& !newPosition.IsInCheck()

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -79,7 +79,7 @@ public sealed class InfoCommand : EngineBaseCommand
     {
 #pragma warning disable RCS1214 // Unnecessary interpolated string.
         return Id +
-            $" depth {searchResult.TargetDepth}" +
+            $" depth {searchResult.Depth}" +
             $" seldepth {searchResult.DepthReached}" +
             $" multipv 1" +
             $" score {(searchResult.Mate == default ? $"cp {searchResult.Evaluation}" : $"mate {searchResult.Mate}")}" +

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -283,7 +283,7 @@ public class RegressionTest : BaseTest
         var engine = GetEngine(fen);
 
         var bestMove = await engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
-        Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.TargetDepth);
+        Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.Depth);
     }
 
     [Explicit]

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -44,7 +44,7 @@ public class WACSilver200 : BaseTest
         if (bestMoveArray.Length == 1)
         {
             var expectedMove = bestMoveArray[0].TrimEnd('+');
-            Assert.AreEqual(expectedMove, bestResult.BestMove.ToEPDString(), $"id {id} depth {bestResult.TargetDepth} seldepth {bestResult.TargetDepth} nodes {bestResult.Nodes}");
+            Assert.AreEqual(expectedMove, bestResult.BestMove.ToEPDString(), $"id {id} depth {bestResult.Depth} seldepth {bestResult.Depth} nodes {bestResult.Nodes}");
         }
         else if (bestMoveArray.Length == 2)
         {
@@ -53,7 +53,7 @@ public class WACSilver200 : BaseTest
                 bestMoveArray[0].TrimEnd('+') == bestResultGot
                 || bestMoveArray[1].TrimEnd('+') == bestResultGot
                 , $"id {id} Expected {bestMove} but got {bestResultGot} " +
-                $"depth {bestResult.TargetDepth} seldepth {bestResult.TargetDepth} nodes {bestResult.Nodes}");
+                $"depth {bestResult.Depth} seldepth {bestResult.Depth} nodes {bestResult.Nodes}");
         }
         else
         {

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -86,9 +86,9 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, targetDepth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
+        transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, targetDepth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor)]
@@ -100,9 +100,9 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, targetDepth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        transpositionTable.RecordHash(mask, position, depth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, targetDepth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor, 5, 4, CheckMateBaseEvaluation - 7 * CheckmateDepthFactor)]
@@ -115,8 +115,8 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, targetDepth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        transpositionTable.RecordHash(mask, position, depth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, targetDepth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
     }
 }


### PR DESCRIPTION
Replace custom-made fixed `targetDepth` and increasing `ply` schema, where `ply == targetDepth` was used to trigger QSearch, with the standard, decreasing `depth` by one + reductions, and increasing `ply` by one no-matter-what.


[0349afb](https://github.com/lynx-chess/Lynx/pull/377/commits/0349afb2f71a9ac45b1f24ab9ea40636676a9836) ([-5, 0] 8+0.08 vs  main, `-draw` and `-resign`) 👍🏽
And no illegal PV move warnings 😊
But might need to revisit stalemates detection
```
Score of Lynx 1348 - refactor depth vs Lynx 1345 - main: 6122 - 6074 - 3440  [0.502] 15636
...      Lynx 1348 - refactor depth playing White: 3742 - 2412 - 1663  [0.585] 7817
...      Lynx 1348 - refactor depth playing Black: 2380 - 3662 - 1777  [0.418] 7819
...      White vs Black: 7404 - 4792 - 3440  [0.584] 15636
Elo difference: 1.1 +/- 4.8, LOS: 66.8 %, DrawRatio: 22.0 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: Lynx 1348 - refactor depth
   "Draw by 3-fold repetition": 1679
   "Draw by adjudication": 686
   "Draw by fifty moves rule": 210
   "Draw by insufficient mating material": 834
   "Draw by stalemate": 31
   "Loss: Black mates": 22
   "Loss: Black wins by adjudication": 2389
   "Loss: White loses on time": 1
   "Loss: White mates": 37
   "Loss: White wins by adjudication": 3625
   "No result": 7
   "Win: Black loses on time": 3
   "Win: Black mates": 21
   "Win: Black wins by adjudication": 2355
   "Win: White loses on time": 4
   "Win: White mates": 36
   "Win: White wins by adjudication": 3703
Player: Lynx 1345 - main
   "Draw by 3-fold repetition": 1679
   "Draw by adjudication": 686
   "Draw by fifty moves rule": 210
   "Draw by insufficient mating material": 834
   "Draw by stalemate": 31
   "Loss: Black loses on time": 3
   "Loss: Black mates": 21
   "Loss: Black wins by adjudication": 2355
   "Loss: White loses on time": 4
   "Loss: White mates": 36
   "Loss: White wins by adjudication": 3703
   "No result": 7
   "Win: Black mates": 22
   "Win: Black wins by adjudication": 2389
   "Win: White loses on time": 1
   "Win: White mates": 37
   "Win: White wins by adjudication": 3625
```

Without `-draw` and `-resign`
```
Score of Lynx 1348 - depth refactor vs Lynx 1345 - main: 8619 - 8627 - 5514  [0.500] 22760
...      Lynx 1348 - depth refactor playing White: 5230 - 3381 - 2770  [0.581] 11381
...      Lynx 1348 - depth refactor playing Black: 3389 - 5246 - 2744  [0.418] 11379
...      White vs Black: 10476 - 6770 - 5514  [0.581] 22760
Elo difference: -0.1 +/- 3.9, LOS: 47.6 %, DrawRatio: 24.2 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: Lynx 1348 - depth refactor
   "Draw by 3-fold repetition": 3294
   "Draw by fifty moves rule": 507
   "Draw by insufficient mating material": 1652
   "Draw by stalemate": 61
   "Loss: Black mates": 3381
   "Loss: White mates": 5246
   "No result": 7
   "Win: Black makes an illegal move: a8a8": 1
   "Win: Black mates": 3389
   "Win: White mates": 5229
Player: Lynx 1345 - main
   "Draw by 3-fold repetition": 3294
   "Draw by fifty moves rule": 507
   "Draw by insufficient mating material": 1652
   "Draw by stalemate": 61
   "Loss: Black makes an illegal move: a8a8": 1
   "Loss: Black mates": 3389
   "Loss: White mates": 5229
   "No result": 7
   "Win: Black mates": 3381
```


[71397c4](https://github.com/lynx-chess/Lynx/pull/377/commits/71397c46a970f11ed16deb341cf0c7347e98f737)  ([0, 5] 8+0.08 vs main, `-draw` and `-resign`) 👍🏽
And no illegal PV move warnings either
```
Score of Lynx 1349 - refactor depth vs Lynx 1345 - main: 2780 - 2573 - 1645  [0.515] 6998
...      Lynx 1349 - refactor depth playing White: 1698 - 994 - 808  [0.601] 3500
...      Lynx 1349 - refactor depth playing Black: 1082 - 1579 - 837  [0.429] 3498
...      White vs Black: 3277 - 2076 - 1645  [0.586] 6998
Elo difference: 10.3 +/- 7.1, LOS: 99.8 %, DrawRatio: 23.5 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Without `-draw` and `-resign`: 👍🏽
```
Score of Lynx 1349 - refactor depth vs Lynx 1345 - main: 1258 - 1082 - 795  [0.528] 3135
...      Lynx 1349 - refactor depth playing White: 742 - 433 - 394  [0.598] 1569
...      Lynx 1349 - refactor depth playing Black: 516 - 649 - 401  [0.458] 1566
...      White vs Black: 1391 - 949 - 795  [0.570] 3135
Elo difference: 19.5 +/- 10.5, LOS: 100.0 %, DrawRatio: 25.4 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted

Player: Lynx 1349 - refactor depth
   "Draw by 3-fold repetition": 472
   "Draw by fifty moves rule": 75
   "Draw by insufficient mating material": 240
   "Draw by stalemate": 8
   "Loss: Black mates": 433
   "Loss: White mates": 649
   "No result": 7
   "Win: Black mates": 516
   "Win: White mates": 742
Player: Lynx 1345 - main
   "Draw by 3-fold repetition": 472
   "Draw by fifty moves rule": 75
   "Draw by insufficient mating material": 240
   "Draw by stalemate": 8
   "Loss: Black mates": 516
   "Loss: White mates": 742
   "No result": 7
   "Win: Black mates": 433
   "Win: White mates": 649
```

Unfinished run, it was also looking good
```
Score of Lynx 1349 - depth refactor vs Lynx 1345 - main: 1188 - 1121 - 725  [0.511] 3034
...      Lynx 1349 - depth refactor playing White: 700 - 448 - 369  [0.583] 1517
...      Lynx 1349 - depth refactor playing Black: 488 - 673 - 356  [0.439] 1517
...      White vs Black: 1373 - 936 - 725  [0.572] 3034
Elo difference: 7.7 +/- 10.8, LOS: 91.8 %, DrawRatio: 23.9 %
SPRT: llr 0.854 (29.0%), lbound -2.94, ubound 2.94

Player: Lynx 1349 - depth refactor
   "Draw by 3-fold repetition": 361
   "Draw by adjudication": 133
   "Draw by fifty moves rule": 42
   "Draw by insufficient mating material": 183
   "Draw by stalemate": 6
   "Loss: Black loses on time": 1
   "Loss: Black mates": 4
   "Loss: Black wins by adjudication": 444
   "Loss: White mates": 2
   "Loss: White wins by adjudication": 670
   "No result": 4
   "Win: Black mates": 3
   "Win: Black wins by adjudication": 485
   "Win: White mates": 4
   "Win: White wins by adjudication": 696
Player: Lynx 1345 - main
   "Draw by 3-fold repetition": 361
   "Draw by adjudication": 133
   "Draw by fifty moves rule": 42
   "Draw by insufficient mating material": 183
   "Draw by stalemate": 6
   "Loss: Black mates": 3
   "Loss: Black wins by adjudication": 485
   "Loss: White mates": 4
   "Loss: White wins by adjudication": 696
   "No result": 4
   "Win: Black loses on time": 1
   "Win: Black mates": 4
   "Win: Black wins by adjudication": 444
   "Win: White mates": 2
   "Win: White wins by adjudication": 670
```

````
```