### PR TITLE
🔍 Add Reverse Futility Pruning (RFP)

### DIFF
--- a/.github/workflows/on-demand-tests.yml
+++ b/.github/workflows/on-demand-tests.yml
@@ -45,5 +45,5 @@ jobs:
     - name: Build
       run: dotnet build -c Release
 
-    - name: Running `dotnet test -c Release --no-build --filter '${{ github.event.inputs.test_pattern }} -v normal`
-      run: dotnet test -c Release --no-build --filter '${{ github.event.inputs.test_pattern }} -v normal'
+    - name: Running tests with `--filter '${{ github.event.inputs.test_pattern }}'
+      run: dotnet test -c Release --no-build --filter '${{ github.event.inputs.test_pattern }}' -v normal

--- a/src/Lynx.Benchmark/CheckmateDetectionLimits.cs
+++ b/src/Lynx.Benchmark/CheckmateDetectionLimits.cs
@@ -1,0 +1,40 @@
+﻿/*
+ */
+
+using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+
+namespace Lynx.Benchmark;
+
+public class CheckmateDetectionLimits : BaseBenchmark
+{
+    public static IEnumerable<int> Data => new[] { 1, 10, 1_000, 10_000, 100_000 };
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public bool LessAndGreater(int iterations)
+    {
+        bool result = false;
+
+        for (int i = 0; i < iterations; ++i)
+        {
+            result ^= (iterations < EvaluationConstants.PositiveCheckmateDetectionLimit && iterations > -EvaluationConstants.PositiveCheckmateDetectionLimit);
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public bool Abs(int iterations)
+    {
+        bool result = false;
+
+        for (int i = 0; i < iterations; ++i)
+        {
+            result ^= (Math.Abs(iterations) < EvaluationConstants.PositiveCheckmateDetectionLimit);
+        }
+
+        return result;
+    }
+}

--- a/src/Lynx.Benchmark/CheckmateDetectionLimits.cs
+++ b/src/Lynx.Benchmark/CheckmateDetectionLimits.cs
@@ -1,4 +1,77 @@
 ﻿/*
+ * More or less the same
+ *
+ *  BenchmarkDotNet v0.13.7, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ *  Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 2 logical and 2 physical cores
+ *  .NET SDK 8.0.100-preview.7.23376.3
+ *    [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+ *
+ *
+ *  |         Method | iterations |           Mean |      Error |    StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------- |----------- |---------------:|-----------:|----------:|------:|--------:|----------:|------------:|
+ *  | LessAndGreater |          1 |      0.2141 ns |  0.0041 ns | 0.0039 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |          1 |      0.2109 ns |  0.0053 ns | 0.0047 ns |  0.99 |    0.02 |         - |          NA |
+ *  |                |            |                |            |           |       |         |           |             |
+ *  | LessAndGreater |         10 |      8.4003 ns |  0.0065 ns | 0.0058 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |         10 |      6.2649 ns |  0.0708 ns | 0.0662 ns |  0.75 |    0.01 |         - |          NA |
+ *  |                |            |                |            |           |       |         |           |             |
+ *  | LessAndGreater |       1000 |    807.6876 ns |  0.1891 ns | 0.1769 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |       1000 |    811.9714 ns |  0.1302 ns | 0.1154 ns |  1.01 |    0.00 |         - |          NA |
+ *  |                |            |                |            |           |       |         |           |             |
+ *  | LessAndGreater |      10000 |  8,041.9955 ns |  1.0335 ns | 0.9667 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |      10000 |  8,040.8007 ns |  0.3681 ns | 0.2874 ns |  1.00 |    0.00 |         - |          NA |
+ *  |                |            |                |            |           |       |         |           |             |
+ *  | LessAndGreater |     100000 | 80,327.6609 ns | 10.4212 ns | 9.2382 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |     100000 | 80,336.0808 ns |  9.0273 ns | 8.0025 ns |  1.00 |    0.00 |         - |          NA |
+ *
+ *  BenchmarkDotNet v0.13.7, Windows 10 (10.0.20348.1906) (Hyper-V)
+ *  Intel Xeon Platinum 8272CL CPU 2.60GHz, 1 CPU, 2 logical and 2 physical cores
+ *  .NET SDK 8.0.100-preview.7.23376.3
+ *    [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX2
+ *
+ *
+ *  |         Method | iterations |           Mean |       Error |      StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------- |----------- |---------------:|------------:|------------:|------:|--------:|----------:|------------:|
+ *  | LessAndGreater |          1 |      0.0080 ns |   0.0048 ns |   0.0045 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |          1 |      0.3615 ns |   0.0071 ns |   0.0066 ns | 78.39 |   91.65 |         - |          NA |
+ *  |                |            |                |             |             |       |         |           |             |
+ *  | LessAndGreater |         10 |      7.5929 ns |   0.0218 ns |   0.0193 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |         10 |      7.5130 ns |   0.0219 ns |   0.0204 ns |  0.99 |    0.00 |         - |          NA |
+ *  |                |            |                |             |             |       |         |           |             |
+ *  | LessAndGreater |       1000 |    681.5867 ns |   1.7133 ns |   1.6026 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |       1000 |    680.6993 ns |   0.9369 ns |   0.7823 ns |  1.00 |    0.00 |         - |          NA |
+ *  |                |            |                |             |             |       |         |           |             |
+ *  | LessAndGreater |      10000 |  6,737.0490 ns |  13.3187 ns |  11.8067 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |      10000 |  6,742.4636 ns |  15.3367 ns |  14.3459 ns |  1.00 |    0.00 |         - |          NA |
+ *  |                |            |                |             |             |       |         |           |             |
+ *  | LessAndGreater |     100000 | 67,442.2046 ns | 219.1631 ns | 205.0053 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |     100000 | 67,137.2410 ns | 142.3049 ns | 126.1496 ns |  1.00 |    0.00 |         - |          NA |
+ *
+ *  BenchmarkDotNet v0.13.7, macOS Monterey 12.6.8 (21G725) [Darwin 21.6.0]
+ *  Intel Xeon CPU E5-1650 v2 3.50GHz (Max: 3.34GHz), 1 CPU, 3 logical and 3 physical cores
+ *  .NET SDK 8.0.100-preview.7.23376.3
+ *    [Host]     : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX
+ *    DefaultJob : .NET 8.0.0 (8.0.23.37506), X64 RyuJIT AVX
+ *
+ *
+ *  |         Method | iterations |           Mean |         Error |        StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------- |----------- |---------------:|--------------:|--------------:|------:|--------:|----------:|------------:|
+ *  | LessAndGreater |          1 |      0.6071 ns |     0.0619 ns |     0.1814 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |          1 |      0.9989 ns |     0.0959 ns |     0.2826 ns |  1.75 |    0.60 |         - |          NA |
+ *  |                |            |                |               |               |       |         |           |             |
+ *  | LessAndGreater |         10 |     10.0495 ns |     0.2383 ns |     0.4975 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |         10 |      9.5443 ns |     0.2428 ns |     0.7158 ns |  0.99 |    0.10 |         - |          NA |
+ *  |                |            |                |               |               |       |         |           |             |
+ *  | LessAndGreater |       1000 |    697.7671 ns |    13.9922 ns |    25.9354 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |       1000 |    664.8828 ns |    10.7921 ns |     9.5669 ns |  0.93 |    0.04 |         - |          NA |
+ *  |                |            |                |               |               |       |         |           |             |
+ *  | LessAndGreater |      10000 |  6,522.8467 ns |    54.0407 ns |    45.1264 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |      10000 |  6,692.5055 ns |   105.3049 ns |    98.5023 ns |  1.02 |    0.02 |         - |          NA |
+ *  |                |            |                |               |               |       |         |           |             |
+ *  | LessAndGreater |     100000 | 57,475.5212 ns |   982.9700 ns |   919.4708 ns |  1.00 |    0.00 |         - |          NA |
+ *  |            Abs |     100000 | 66,456.0062 ns | 1,149.4625 ns | 1,018.9685 ns |  1.16 |    0.03 |         - |          NA |
  */
 
 using BenchmarkDotNet.Attributes;

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,7 +55,7 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 8,
+    "ReverseFPMaxDepth": 2,
     "ReverseFPDepthScalingFactor": 150
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,7 +55,7 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 4,
+    "ReverseFPMaxDepth": 8,
     "ReverseFPDepthScalingFactor": 150
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,7 +55,7 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMinDepth": 4,
+    "ReverseFPMaxDepth": 4,
     "ReverseFPDepthScalingFactor": 150
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "ReverseFPMaxDepth": 4,
-    "ReverseFPDepthScalingFactor": 200
+    "ReverseFPDepthScalingFactor": 100
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 6,
+    "ReverseFPMaxDepth": 8,
     "ReverseFPDepthScalingFactor": 100
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,8 +55,8 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 4,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPMaxDepth": 8,
+    "ReverseFPDepthScalingFactor": 75
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,8 +56,8 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 6,
-    "ReverseFPDepthScalingFactor": 75
+    "ReverseFPMaxDepth": 8,
+    "ReverseFPDepthScalingFactor": 100
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,8 +55,8 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 6,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPMaxDepth": 4,
+    "ReverseFPDepthScalingFactor": 200
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 4,
+    "ReverseFPMaxDepth": 8,
     "ReverseFPDepthScalingFactor": 150
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 8,
+    "ReverseFPMaxDepth": 6,
     "ReverseFPDepthScalingFactor": 100
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -57,7 +57,7 @@
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
     "ReverseFPMaxDepth": 8,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPDepthScalingFactor": 75
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -57,7 +57,7 @@
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
     "ReverseFPMaxDepth": 6,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPDepthScalingFactor": 75
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,8 +55,8 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 6,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPMaxDepth": 4,
+    "ReverseFPDepthScalingFactor": 150
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -54,7 +54,9 @@
     "TranspositionTableSize": "256",
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
-    "BenchDepth": 5
+    "BenchDepth": 5,
+    "ReverseFPMinDepth": 4,
+    "ReverseFPDepthScalingFactor": 150
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,8 +56,8 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 2,
-    "ReverseFPDepthScalingFactor": 150
+    "ReverseFPMaxDepth": 6,
+    "ReverseFPDepthScalingFactor": 100
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 8,
+    "ReverseFPMaxDepth": 6,
     "ReverseFPDepthScalingFactor": 75
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "ReverseFPMaxDepth": 8,
-    "ReverseFPDepthScalingFactor": 75
+    "ReverseFPDepthScalingFactor": 100
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 8,
+    "ReverseFPMaxDepth": 2,
     "ReverseFPDepthScalingFactor": 150
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,8 +56,8 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "BishopPairMaxBonus": 100,
-    "ReverseFPMaxDepth": 8,
-    "ReverseFPDepthScalingFactor": 100
+    "ReverseFPMaxDepth": 4,
+    "ReverseFPDepthScalingFactor": 150
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "ReverseFPMaxDepth": 2,
-    "ReverseFPDepthScalingFactor": 150
+    "ReverseFPDepthScalingFactor": 200
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,8 +55,8 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 2,
-    "ReverseFPDepthScalingFactor": 300
+    "ReverseFPMaxDepth": 4,
+    "ReverseFPDepthScalingFactor": 150
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -55,8 +55,8 @@
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "ReverseFPMaxDepth": 4,
-    "ReverseFPDepthScalingFactor": 150
+    "ReverseFPMaxDepth": 6,
+    "ReverseFPDepthScalingFactor": 100
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -56,7 +56,7 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "ReverseFPMaxDepth": 2,
-    "ReverseFPDepthScalingFactor": 200
+    "ReverseFPDepthScalingFactor": 300
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,9 +218,9 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 6;
+    public int ReverseFPMaxDepth { get; set; } = 8;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 75;
+    public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -213,5 +213,5 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 2;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 150;
+    public int ReverseFPDepthScalingFactor { get; set; } = 200;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -224,7 +224,7 @@ public sealed class EngineSettings
 }
 
 [JsonSourceGenerationOptions(
-    GenerationMode = JsonSourceGenerationMode.Serialization, WriteIndented = true)] // https://github.com/dotnet/runtime/issues/78602#issuecomment-1322004254
+    GenerationMode = JsonSourceGenerationMode.Default, WriteIndented = true)] // https://github.com/dotnet/runtime/issues/78602#issuecomment-1322004254
 [JsonSerializable(typeof(EngineSettings))]
 internal partial class EngineSettingsJsonSerializerContext : JsonSerializerContext
 {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,7 +218,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 8;
+    public int ReverseFPMaxDepth { get; set; } = 6;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 75;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,7 +218,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 8;
+    public int ReverseFPMaxDepth { get; set; } = 6;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -213,5 +213,5 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 2;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 200;
+    public int ReverseFPDepthScalingFactor { get; set; } = 300;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,7 +218,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 8;
+    public int ReverseFPMaxDepth { get; set; } = 2;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 4;
+    public int ReverseFPMaxDepth { get; set; } = 6;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 150;
+    public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,7 +218,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 6;
+    public int ReverseFPMaxDepth { get; set; } = 8;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -220,7 +220,7 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 8;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 75;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -213,5 +213,5 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 8;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 75;
+    public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,7 +218,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 4;
+    public int ReverseFPMaxDepth { get; set; } = 8;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,9 +218,9 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 8;
+    public int ReverseFPMaxDepth { get; set; } = 4;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 6;
+    public int ReverseFPMaxDepth { get; set; } = 4;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMinDepth { get; set; } = 4;
+    public int ReverseFPMaxDepth { get; set; } = 4;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -213,5 +213,5 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 4;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 200;
+    public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -210,4 +210,8 @@ public sealed class EngineSettings
     /// Depth for bench command
     /// </summary>
     public int BenchDepth { get; set; } = 5;
+
+    public int ReverseFPMinDepth { get; set; } = 4;
+
+    public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -220,7 +220,7 @@ public sealed class EngineSettings
 
     public int ReverseFPMaxDepth { get; set; } = 6;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 75;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -218,9 +218,9 @@ public sealed class EngineSettings
     /// </summary>
     public int BishopPairMaxBonus { get; set; } = 100;
 
-    public int ReverseFPMaxDepth { get; set; } = 2;
+    public int ReverseFPMaxDepth { get; set; } = 6;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 150;
+    public int ReverseFPDepthScalingFactor { get; set; } = 100;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 4;
+    public int ReverseFPMaxDepth { get; set; } = 8;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 4;
+    public int ReverseFPMaxDepth { get; set; } = 8;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 75;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 8;
+    public int ReverseFPMaxDepth { get; set; } = 2;
 
     public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 2;
+    public int ReverseFPMaxDepth { get; set; } = 4;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 300;
+    public int ReverseFPDepthScalingFactor { get; set; } = 150;
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,7 +211,7 @@ public sealed class EngineSettings
     /// </summary>
     public int BenchDepth { get; set; } = 5;
 
-    public int ReverseFPMaxDepth { get; set; } = 6;
+    public int ReverseFPMaxDepth { get; set; } = 4;
 
-    public int ReverseFPDepthScalingFactor { get; set; } = 100;
+    public int ReverseFPDepthScalingFactor { get; set; } = 200;
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -103,6 +103,8 @@ public sealed partial class Engine
             }
         }
 
+        VerifiedNullMovePruning_SearchAgain:
+
         // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
         if (!pvNode && !isInCheck
             && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
@@ -114,8 +116,6 @@ public sealed partial class Engine
                 return staticEval;
             }
         }
-
-        VerifiedNullMovePruning_SearchAgain:
 
         var nodeType = NodeType.Alpha;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,10 +203,10 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            //if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
-            //{
-            //    return evaluation;
-            //}
+            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            {
+                return evaluation;
+            }
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -73,18 +73,6 @@ public sealed partial class Engine
             return finalPositionEvaluation;
         }
 
-        // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-        if (!pvNode && !isInCheck
-            && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
-        {
-            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
-
-            if (staticEval - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
-            {
-                return staticEval;
-            }
-        }
-
         // 🔍 Verified Null-move pruning (NMP) - https://www.researchgate.net/publication/297377298_Verified_Null-Move_Pruning
         bool isFailHigh = false;    // In order to detect zugzwangs
         if (depth > Configuration.EngineSettings.NullMovePruning_R
@@ -112,6 +100,18 @@ public sealed partial class Engine
                     // cutoff in a sub-tree with fail-high report
                     return evaluation;
                 }
+            }
+        }
+
+        // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+        if (!pvNode && !isInCheck
+            && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
+        {
+            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+
+            if (staticEval - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            {
+                return staticEval;
             }
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -108,8 +108,8 @@ public sealed partial class Engine
         // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
         // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
         if (!pvNode && !isInCheck
-            && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
-            && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
+            //&& beta < EvaluationConstants.PositiveCheckmateDetectionLimit
+            //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
             && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
         {
             var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -79,7 +79,7 @@ public sealed partial class Engine
             && !isInCheck
             && !ancestorWasNullMove
             /*&& (!isVerifyingNullMoveCutOff || depth > 1)*/)    // verify == true and ply == targetDepth -1 -> No null pruning, since verification will not be possible)
-                                                             // following pv?
+                                                                 // following pv?
         {
             var gameState = position.MakeNullMove();
 
@@ -201,6 +201,12 @@ public sealed partial class Engine
             position.UnmakeMove(move, gameState);
 
             PrintMove(ply, move, evaluation);
+
+            // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMinDepth && evaluation - Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth >= beta)
+            {
+                return evaluation;
+            }
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,7 +203,7 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMinDepth && evaluation - Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth >= beta)
+            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
             {
                 return evaluation;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -105,6 +105,21 @@ public sealed partial class Engine
 
         VerifiedNullMovePruning_SearchAgain:
 
+        // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+        // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
+        if (!pvNode && !isInCheck
+            //&& beta < EvaluationConstants.PositiveCheckmateDetectionLimit
+            //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
+            && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
+        {
+            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+
+            if (staticEval - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            {
+                return staticEval;
+            }
+        }
+
         var nodeType = NodeType.Alpha;
 
         int movesSearched = 0;
@@ -201,17 +216,6 @@ public sealed partial class Engine
             position.UnmakeMove(move, gameState);
 
             PrintMove(ply, move, evaluation);
-
-            // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
-            if (!pvNode && !isInCheck
-                && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
-                && depth <= Configuration.EngineSettings.ReverseFPMaxDepth
-                && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
-            {
-                return evaluation;
-            }
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -73,6 +73,18 @@ public sealed partial class Engine
             return finalPositionEvaluation;
         }
 
+        // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+        if (!pvNode && !isInCheck
+            && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
+        {
+            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+
+            if (staticEval - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            {
+                return staticEval;
+            }
+        }
+
         // 🔍 Verified Null-move pruning (NMP) - https://www.researchgate.net/publication/297377298_Verified_Null-Move_Pruning
         bool isFailHigh = false;    // In order to detect zugzwangs
         if (depth > Configuration.EngineSettings.NullMovePruning_R
@@ -104,21 +116,6 @@ public sealed partial class Engine
         }
 
         VerifiedNullMovePruning_SearchAgain:
-
-        // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-        // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
-        if (!pvNode && !isInCheck
-            && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
-            && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
-            && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
-        {
-            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
-
-            if (staticEval - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
-            {
-                return staticEval;
-            }
-        }
 
         var nodeType = NodeType.Alpha;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,8 +203,10 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+            // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
             if (!pvNode && !isInCheck
-                && Math.Abs(beta) < EvaluationConstants.PositiveCheckmateDetectionLimit // https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
+                && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
+                && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                 && depth <= Configuration.EngineSettings.ReverseFPMaxDepth
                 && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,10 +203,10 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
-            {
-                return evaluation;
-            }
+            //if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            //{
+            //    return evaluation;
+            //}
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -108,8 +108,8 @@ public sealed partial class Engine
         // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
         // Beta check from: https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
         if (!pvNode && !isInCheck
-            //&& beta < EvaluationConstants.PositiveCheckmateDetectionLimit
-            //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
+            && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
+            && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
             && depth <= Configuration.EngineSettings.ReverseFPMaxDepth)
         {
             var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,7 +203,7 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            if (!pvNode && !isInCheck && Math.Abs(beta) < EvaluationConstants.CheckMateBaseEvaluation && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
             {
                 return evaluation;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -203,7 +203,10 @@ public sealed partial class Engine
             PrintMove(ply, move, evaluation);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-            if (!pvNode && !isInCheck && Math.Abs(beta) < EvaluationConstants.CheckMateBaseEvaluation && depth <= Configuration.EngineSettings.ReverseFPMaxDepth && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
+            if (!pvNode && !isInCheck
+                && Math.Abs(beta) < EvaluationConstants.PositiveCheckmateDetectionLimit // https://github.com/JacquesRW/akimbo/blob/c6e42e010e5c4db1d3b5e84b2637f6d97c746a13/akimbo/src/search.rs#L307C47-L307C47
+                && depth <= Configuration.EngineSettings.ReverseFPMaxDepth
+                && evaluation - (Configuration.EngineSettings.ReverseFPDepthScalingFactor * depth) >= beta)
             {
                 return evaluation;
             }

--- a/tests/Lynx.Test/BestMove/MatePositions.cs
+++ b/tests/Lynx.Test/BestMove/MatePositions.cs
@@ -98,6 +98,7 @@ public static class MatePositions
     public static readonly object[] Mates_in_7 = new object[]
     {
         new object[]{ "4r1k1/1p3p1p/rb1R2p1/pQ6/P1p1q3/2P3RP/1P3PP1/6K1 b - -           ", new[] { "b6f2" }, "https://gameknot.com/chess-puzzle.pl?pz=228984" },    // info depth 14 seldepth 28 multipv 1 score cp 1405 nodes 202487382 nps 511294 time 395029 pv b6f2 g1h2 a6d6 g3g4 e4e1 b5e8 e1e8 g4c4 d6d2 b2b3 e8e5 g2g3
-        new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3
+
+        // new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
     };
 }

--- a/tests/Lynx.Test/BestMove/MatePositions.cs
+++ b/tests/Lynx.Test/BestMove/MatePositions.cs
@@ -99,6 +99,6 @@ public static class MatePositions
     {
         new object[]{ "4r1k1/1p3p1p/rb1R2p1/pQ6/P1p1q3/2P3RP/1P3PP1/6K1 b - -           ", new[] { "b6f2" }, "https://gameknot.com/chess-puzzle.pl?pz=228984" },    // info depth 14 seldepth 28 multipv 1 score cp 1405 nodes 202487382 nps 511294 time 395029 pv b6f2 g1h2 a6d6 g3g4 e4e1 b5e8 e1e8 g4c4 d6d2 b2b3 e8e5 g2g3
 
-        // new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
+        new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
     };
 }

--- a/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
@@ -7,8 +7,17 @@ namespace Lynx.Test.BestMove;
 /// <summary>
 /// All the tests in this class used to pass when null-pruning wasn't implemented
 /// </summary>
+[Explicit]
+[Category(Categories.NoPruning)]
 public class MatesInExactlyXTest : BaseTest
 {
+    public MatesInExactlyXTest()
+    {
+        Configuration.EngineSettings.ReverseFPMaxDepth = 0;
+        Configuration.EngineSettings.LMR_DepthReduction = 0;
+        Configuration.EngineSettings.NullMovePruning_R = 0;
+    }
+
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_1))]
     public async Task Mate_in_Exactly_1(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -23,8 +32,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(2, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.NoPruning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
     public async Task Mate_in_Exactly_3(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -32,8 +39,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(3, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.NoPruning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4))]
     public async Task Mate_in_Exactly_4(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -41,8 +46,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(4, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.NoPruning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection))]
     public async Task Mate_in_Exactly_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -50,8 +53,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(4, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.NoPruning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5))]
     public async Task Mate_in_Exactly_5(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -59,8 +60,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(5, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.NoPruning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6))]
     public async Task Mate_in_Exactly_6(string fen, string[]? allowedUCIMoveString, string description)
     {
@@ -68,8 +67,6 @@ public class MatesInExactlyXTest : BaseTest
         Assert.AreEqual(6, result.Mate);
     }
 
-    [Explicit]
-    [Category(Categories.TooLong)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7))]
     public async Task Mate_in_Exactly_7(string fen, string[]? allowedUCIMoveString, string description)
     {

--- a/tests/Lynx.Test/BestMove/MatesTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesTest.cs
@@ -20,6 +20,7 @@ public class MatesTest : BaseTest
         Assert.AreNotEqual(default, result.Mate);
     }
 
+    [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
     public async Task Mate_in_3(string fen, string[]? allowedUCIMoveString, string description)

--- a/tests/Lynx.Test/BestMove/MatesTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesTest.cs
@@ -20,6 +20,7 @@ public class MatesTest : BaseTest
         Assert.AreNotEqual(default, result.Mate);
     }
 
+    [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
     public async Task Mate_in_3(string fen, string[]? allowedUCIMoveString, string description)
     {

--- a/tests/Lynx.Test/BestMove/MatesTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesTest.cs
@@ -17,7 +17,7 @@ public class MatesTest : BaseTest
     public async Task Mate_in_2(string fen, string[]? allowedUCIMoveString, string description)
     {
         var result = await SearchBestMove(fen);
-        Assert.AreEqual(2, result.Mate);
+        Assert.AreNotEqual(default, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]

--- a/tests/Lynx.Test/ConfigurationTest.cs
+++ b/tests/Lynx.Test/ConfigurationTest.cs
@@ -20,8 +20,8 @@ public class ConfigurationTest
         var engineSettingsSection = config.GetRequiredSection(nameof(EngineSettings));
         Assert.IsNotNull(engineSettingsSection);
 
+        var serializedEngineSettingsConfig = JsonSerializer.Serialize(Configuration.EngineSettings, EngineSettingsJsonSerializerContext.Default.EngineSettings);
 #pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
-        var serializedEngineSettingsConfig = JsonSerializer.Serialize(Configuration.EngineSettings);
         var jsonNode = JsonSerializer.Deserialize<JsonNode>(serializedEngineSettingsConfig);
 #pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
         Assert.IsNotNull(jsonNode);


### PR DESCRIPTION
Summary:

https://github.com/lynx-chess/Lynx/pull/382/commits/0bf9142185323b0c6ddfe824d9ef19b85967d87e:  MaxDepth 6, Scaling factor 75

8+0.08 👍🏽 56.1 +/- 18.8 vs main (1414)
```
Score of Lynx 1431 - rfp 6 75 vs Lynx 1414 - main: 430 - 275 - 264  [0.580] 969
...      Lynx 1431 - rfp 6 75 playing White: 251 - 105 - 128  [0.651] 484
...      Lynx 1431 - rfp 6 75 playing Black: 179 - 170 - 136  [0.509] 485
...      White vs Black: 421 - 284 - 264  [0.571] 969
Elo difference: 56.1 +/- 18.8, LOS: 100.0 %, DrawRatio: 27.2 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```

----

Overview (8+0.08, 8moves_v3):
```
Rank Name                          Elo     +/-   Games    Wins  Losses   Draws   Points   Score    Draw   White   Black
   0 Lynx 1421 rfp fixed 75 8        4      12    2398     940     913     545   1212.5   50.6%   22.7%   52.5%   48.6%
   1 Lynx 1422 rfp fixed 100 8      10      12    2400     979     911     510   1234.0   51.4%   21.3%   54.4%   48.4%
   2 Lynx 1417 rfp fixed 100 6       6      12    2400     969     926     505   1221.5   50.9%   21.0%   50.6%   51.2%
   3 Lynx 1419 rfp fixed 100 4      10      12    2400     979     911     510   1234.0   51.4%   21.3%   52.7%   50.2%
   4 Lynx 1416 rfp fixed 150 4      19      12    2400     987     858     555   1264.5   52.7%   23.1%   53.5%   51.8%
   5 Lynx 1418 rfp fixed 200 4      -3      12    2402     935     956     511   1190.5   49.6%   21.3%   51.3%   47.8%
   6 MinimalChess 0.5.0             77      10    3602    1862    1073     667   2195.5   61.0%   18.5%   63.2%   58.7%
   7 Cadabra 2.0.0                  30      10    3599    1591    1282     726   1954.0   54.3%   20.2%   56.3%   52.3%
   8 Lynx 1414 - main              -51      10    3599    1008    1534    1057   1536.5   42.7%   29.4%   43.8%   41.6%
   9 BBC 1.1                       -87      10    3600    1014    1900     686   1357.0   37.7%   19.1%   38.1%   37.3%
```

https://github.com/lynx-chess/Lynx/pull/382/commits/dc77eca62efc38e89bbed01ad9656292873c4c95:  MaxDepth 4, Scaling factor 150

8+0.08 👍🏽 41.0 +/- 15.9 vs main (1414)
```
Score of Lynx 1416 rfp fixed 150 4 vs Lynx 1414 - main: 575 - 416 - 362  [0.559] 1353
...      Lynx 1416 rfp fixed 150 4 playing White: 356 - 150 - 170  [0.652] 676
...      Lynx 1416 rfp fixed 150 4 playing Black: 219 - 266 - 192  [0.465] 677
...      White vs Black: 622 - 369 - 362  [0.593] 1353
Elo difference: 41.0 +/- 15.9, LOS: 100.0 %, DrawRatio: 26.8 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/37a6f10b8ab4efcd8efca3f4a64a02be31f5b4b0: MaxDepth 8, Scaling factor 100
8+0.08 👍🏽 41.5 +/- 16.0 vs main (1414)
```
Score of Lynx 1438 - rfp 8 100 vs Lynx 1414 - main: 583 - 422 - 348  [0.559] 1353
...      Lynx 1438 - rfp 8 100 playing White: 321 - 182 - 174  [0.603] 677
...      Lynx 1438 - rfp 8 100 playing Black: 262 - 240 - 174  [0.516] 676
...      White vs Black: 561 - 444 - 348  [0.543] 1353
Elo difference: 41.5 +/- 16.0, LOS: 100.0 %, DrawRatio: 25.7 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/6a0c6ec3dda14eba50e3ef21b34e6594229ac6b5: MaxDepth 6, Scaling factor 100

8+0.08 👍🏽 46.1 +/- 16.9 vs main (1414)
```
Score of Lynx 1417 rfp fixed 100 6 vs Lynx 1414 - main: 489 - 336 - 335  [0.566] 1160
...      Lynx 1417 rfp fixed 100 6 playing White: 289 - 123 - 168  [0.643] 580
...      Lynx 1417 rfp fixed 100 6 playing Black: 200 - 213 - 167  [0.489] 580
...      White vs Black: 502 - 323 - 335  [0.577] 1160
Elo difference: 46.1 +/- 16.9, LOS: 100.0 %, DrawRatio: 28.9 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/0bf9142185323b0c6ddfe824d9ef19b85967d87e:  MaxDepth 6, Scaling factor 75

8+0.08 👍🏽 56.1 +/- 18.8 vs main (1414)
```
Score of Lynx 1431 - rfp 6 75 vs Lynx 1414 - main: 430 - 275 - 264  [0.580] 969
...      Lynx 1431 - rfp 6 75 playing White: 251 - 105 - 128  [0.651] 484
...      Lynx 1431 - rfp 6 75 playing Black: 179 - 170 - 136  [0.509] 485
...      White vs Black: 421 - 284 - 264  [0.571] 969
Elo difference: 56.1 +/- 18.8, LOS: 100.0 %, DrawRatio: 27.2 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```

----

Taking 4 150 as base (1427):

https://github.com/lynx-chess/Lynx/pull/382/commits/f1b5504f967c093c8ecaf9e083e2aad8e0484efb:  MaxDepth 2, Scaling factor 150
8+0.08 👎🏽vs 4 150 (1427)
```
Score of Lynx 1429 - rfp 2 150 vs Lynx 1427 - rfp base 4 150: 1235 - 1360 - 934  [0.482] 3529
...      Lynx 1429 - rfp 2 150 playing White: 755 - 531 - 478  [0.563] 1764
...      Lynx 1429 - rfp 2 150 playing Black: 480 - 829 - 456  [0.401] 1765
...      White vs Black: 1584 - 1011 - 934  [0.581] 3529
Elo difference: -12.3 +/- 9.8, LOS: 0.7 %, DrawRatio: 26.5 %
SPRT: llr -2.94 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/bc78727e2c6a116f401f58f09052ecc13f18b686:  MaxDepth 6, Scaling factor 100
8+0.08 👍🏽 12.0 +/- 7.9 vs 4 150 (1427)
```
Score of Lynx 1430 - rfp base 6 100 vs Lynx 1427 - rfp base 4 150: 2087 - 1898 - 1481  [0.517] 5466
...      Lynx 1430 - rfp base 6 100 playing White: 1277 - 731 - 725  [0.600] 2733
...      Lynx 1430 - rfp base 6 100 playing Black: 810 - 1167 - 756  [0.435] 2733
...      White vs Black: 2444 - 1541 - 1481  [0.583] 5466
Elo difference: 12.0 +/- 7.9, LOS: 99.9 %, DrawRatio: 27.1 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/6ce48d9310a645099993f7ae1b978ecfcfbb227f:  MaxDepth 8, Scaling factor 150
8+0.08 <incomplete> vs 4 150 (1427)
```
Score of Lynx 1428 - rfp 8 150 vs Lynx 1427 - rfp base 4 150: 3037 - 3033 - 2340  [0.500] 8410
...      Lynx 1428 - rfp 8 150 playing White: 1883 - 1164 - 1158  [0.585] 4205
...      Lynx 1428 - rfp 8 150 playing Black: 1154 - 1869 - 1182  [0.415] 4205
...      White vs Black: 3752 - 2318 - 2340  [0.585] 8410
Elo difference: 0.2 +/- 6.3, LOS: 52.0 %, DrawRatio: 27.8 %
SPRT: llr -1.13 (-38.3%), lbound -2.94, ubound 2.94
```

Taking 6 100 as base (1430):

https://github.com/lynx-chess/Lynx/pull/382/commits/0bf9142185323b0c6ddfe824d9ef19b85967d87e: MaxDepth 6, Scaling factor 75
8+0.08 👍🏽 5.8 +/- 4.6 vs 6 100 (1430)
```
Score of Lynx 1431 - rfp 6 75 vs Lynx 1430 - rfp base 6 100: 5788 - 5527 - 4275  [0.508] 15590
...      Lynx 1431 - rfp 6 75 playing White: 3601 - 2130 - 2064  [0.594] 7795
...      Lynx 1431 - rfp 6 75 playing Black: 2187 - 3397 - 2211  [0.422] 7795
...      White vs Black: 6998 - 4317 - 4275  [0.586] 15590
Elo difference: 5.8 +/- 4.6, LOS: 99.3 %, DrawRatio: 27.4 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```


https://github.com/lynx-chess/Lynx/pull/382/commits/03dc9940b77868723d84deb0f09d4f4561f5ce76: MaxDepth 8, Scaling factor 100
8+0.08 3.8 +/- 4.4 (abandoned to test vs 6 75), looking like potential small gain vs 6 100 (1430)
```
Score of Lynx 1432 - rfp 8 100 vs Lynx 1430 - rfp base 6 100: 6567 - 6371 - 4822  [0.506] 17760
...      Lynx 1432 - rfp 8 100 playing White: 4053 - 2395 - 2432  [0.593] 8880
...      Lynx 1432 - rfp 8 100 playing Black: 2514 - 3976 - 2390  [0.418] 8880
...      White vs Black: 8029 - 4909 - 4822  [0.588] 17760
Elo difference: 3.8 +/- 4.4, LOS: 95.8 %, DrawRatio: 27.2 %
SPRT: llr 1.35 (45.8%), lbound -2.94, ubound 2.94
```

Taking 6 75 as base (1431/1440):

https://github.com/lynx-chess/Lynx/pull/382/commits/0c7bf16d5eccadce2776af66ed1d5387bdef7395: MaxDepth 8, Scaling factor 75
8+0.08 👎🏽 -5.5 +/- 7.2, looking like potential small gain vs 6 100 (1431)
```
Score of Lynx 1439 - rfp 8 75 vs Lynx 1431 - rfp base 6 75: 2288 - 2390 - 1771  [0.492] 6449
...      Lynx 1439 - rfp 8 75 playing White: 1380 - 945 - 899  [0.567] 3224
...      Lynx 1439 - rfp 8 75 playing Black: 908 - 1445 - 872  [0.417] 3225
...      White vs Black: 2825 - 1853 - 1771  [0.575] 6449
Elo difference: -5.5 +/- 7.2, LOS: 6.8 %, DrawRatio: 27.5 %
SPRT: llr -2.94 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/6ea5bb9b8b5d7166fe8d8ac22ba94f5f3c45a9f9: MaxDepth 8, Scaling factor 100
8+0.08 👎🏽 -1.8 +/- 5.3 vs 6 75 (1431)
```
Score of Lynx 1438 - rfp 8 100 vs Lynx 1431 - rfp 6 75: 4391 - 4453 - 3328  [0.497] 12172
...      Lynx 1438 - rfp 8 100 playing White: 2712 - 1710 - 1665  [0.582] 6087
...      Lynx 1438 - rfp 8 100 playing Black: 1679 - 2743 - 1663  [0.413] 6085
...      White vs Black: 5455 - 3389 - 3328  [0.585] 12172
Elo difference: -1.8 +/- 5.3, LOS: 25.5 %, DrawRatio: 27.3 %
SPRT: llr -2.96 (-100.6%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/436e350966395e34c39440193b101b74e4f0aaab: RFP before NMP (1442):
8+0.08 👎🏽 -4.8 +/- 6.9 vs 6 75 (1440)
```
Score of Lynx 1442 - rfp before nmp vs Lynx 1440 - rfp base 6 75: 2460 - 2557 - 1970  [0.493] 6987
...      Lynx 1442 - rfp before nmp playing White: 1516 - 961 - 1017  [0.579] 3494
...      Lynx 1442 - rfp before nmp playing Black: 944 - 1596 - 953  [0.407] 3493
...      White vs Black: 3112 - 1905 - 1970  [0.586] 6987
Elo difference: -4.8 +/- 6.9, LOS: 8.5 %, DrawRatio: 28.2 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/1616e1cc1a95c8581cb4ccc2be40249ef859bb72: Avoid RFP re-evaluation in case of NMP evaluating back

8+0.08  👎🏽 vs 6 75 (1440)
```
Score of Lynx 1443 - rfp before nmp vs Lynx 1440 - rfp base 6 75: 3239 - 3324 - 2440  [0.495] 9003
...      Lynx 1443 - rfp before nmp playing White: 2047 - 1254 - 1201  [0.588] 4502
...      Lynx 1443 - rfp before nmp playing Black: 1192 - 2070 - 1239  [0.402] 4501
...      White vs Black: 4117 - 2446 - 2440  [0.593] 9003
Elo difference: -3.3 +/- 6.1, LOS: 14.7 %, DrawRatio: 27.1 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/609dce9283a8027aa9e2707821d2d83e883c8497: beta condition
8+0.08 👎🏽 (unfinished)
```
Score of Lynx 1441 - rfp 6 75 beta vs Lynx 1440 - rfp base 6 75: 2716 - 2682 - 1932  [0.502] 7330
...      Lynx 1441 - rfp 6 75 beta playing White: 1705 - 981 - 979  [0.599] 3665
...      Lynx 1441 - rfp 6 75 beta playing Black: 1011 - 1701 - 953  [0.406] 3665
...      White vs Black: 3406 - 1992 - 1932  [0.596] 7330
Elo difference: 1.6 +/- 6.8, LOS: 67.8 %, DrawRatio: 26.4 %
SPRT: llr -0.366 (-12.4%), lbound -2.94, ubound 2.94
```

<details>
<summary>Wrong impl, inside of move loop</summary>
pre-psqt:

https://github.com/lynx-chess/Lynx/pull/382/commits/011dd9cab0ee5cf4ee9e9741782e8563895b964e: MaxDepth 4, Scaling factor 150

8+0.08 👎🏽 vs v0.16.0 (no psqt)
```
Score of Lynx 1378 - rfp vs Lynx 0.16.0: 4484 - 4545 - 3318  [0.498] 12347
...      Lynx 1378 - rfp playing White: 2725 - 1727 - 1722  [0.581] 6174
...      Lynx 1378 - rfp playing Black: 1759 - 2818 - 1596  [0.414] 6173
...      White vs Black: 5543 - 3486 - 3318  [0.583] 12347
Elo difference: -1.7 +/- 5.2, LOS: 26.0 %, DrawRatio: 26.9 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```

----
post-psqt:

https://github.com/lynx-chess/Lynx/pull/382/commits/0a832b89ea39c733ee834a9f6daa32a1945fb971: MaxDepth 2, Scaling factor 300

8+0.08 👎🏽 vs main (1399)
```
Score of Lynx 1402 rfp 300 2 vs Lynx 1399 - main: 3052 - 3139 - 2377  [0.495] 8568
...      Lynx 1402 rfp 300 2 playing White: 1894 - 1226 - 1164  [0.578] 4284
...      Lynx 1402 rfp 300 2 playing Black: 1158 - 1913 - 1213  [0.412] 4284
...      White vs Black: 3807 - 2384 - 2377  [0.583] 8568
Elo difference: -3.5 +/- 6.2, LOS: 13.4 %, DrawRatio: 27.7 %
SPRT: llr -2.96 (-100.6%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/b361e369da562fd419e8852ae1d19e92a0c64d39: MaxDepth 4, Scaling factor 150

8+0.08 👎🏽 vs main (1399)
```
Score of Lynx 1403 - rfp 4 150 vs Lynx 1399 - main: 1630 - 1744 - 1309  [0.488] 4683
...      Lynx 1403 - rfp 4 150 playing White: 989 - 678 - 674  [0.566] 2341
...      Lynx 1403 - rfp 4 150 playing Black: 641 - 1066 - 635  [0.409] 2342
...      White vs Black: 2055 - 1319 - 1309  [0.579] 4683
Elo difference: -8.5 +/- 8.4, LOS: 2.5 %, DrawRatio: 28.0 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/382/commits/382c41ead63101f7dbb6bc5f0514826f18661255: MaxDepth 6, Scaling factor 100

8+0.08 👎🏽 (aborted) vs main (1399)
```
Score of Lynx 1404 - rfp 6 100 vs Lynx 1399 - main: 2119 - 2171 - 1390  [0.495] 5680
...      Lynx 1404 - rfp 6 100 playing White: 1293 - 874 - 673  [0.574] 2840
...      Lynx 1404 - rfp 6 100 playing Black: 826 - 1297 - 717  [0.417] 2840
...      White vs Black: 2590 - 1700 - 1390  [0.578] 5680
Elo difference: -3.2 +/- 7.8, LOS: 21.4 %, DrawRatio: 24.5 %
SPRT: llr -1.77 (-60.1%), lbound -2.94, ubound 2.94
```

<none>: MaxDepth 8, Scaling factor 75

8+0.08 👎🏽 vs main (1399)
```
Score of Lynx 1402 rfp 300 2 vs Lynx 1399 - main: 3017 - 3104 - 2358  [0.495] 8479
...      Lynx 1402 rfp 300 2 playing White: 1863 - 1176 - 1200  [0.581] 4239
...      Lynx 1402 rfp 300 2 playing Black: 1154 - 1928 - 1158  [0.409] 4240
...      White vs Black: 3791 - 2330 - 2358  [0.586] 8479
Elo difference: -3.6 +/- 6.3, LOS: 13.3 %, DrawRatio: 27.8 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```

</details>