### PR TITLE
⚖ Add tapered bishop pair bonus (higher in endgames)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -54,7 +54,8 @@
     "TranspositionTableSize": "256",
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
-    "BenchDepth": 5
+    "BenchDepth": 5,
+    "BishopPairMaxBonus": 100
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -210,4 +210,9 @@ public sealed class EngineSettings
     /// Depth for bench command
     /// </summary>
     public int BenchDepth { get; set; } = 5;
+
+    /// <summary>
+    /// It'll be scaled with phase
+    /// </summary>
+    public int BishopPairMaxBonus { get; set; } = 100;
 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -701,6 +701,15 @@ public class Position
 
         eval += ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / 24;
 
+        if (pieceCount[(int)Piece.B] >= 2)
+        {
+            eval += Configuration.EngineSettings.BishopPairMaxBonus * endGamePhase / 24;
+        }
+        if (pieceCount[(int)Piece.b] >= 2)
+        {
+            eval -= Configuration.EngineSettings.BishopPairMaxBonus * endGamePhase / 24;
+        }
+
         return Side == Side.White
             ? eval
             : -eval;


### PR DESCRIPTION
8+0.08 👍🏽
```
Score of Lynx 1405 - bishop pair 100 vs Lynx 1399 - main: 3470 - 3254 - 2462  [0.512] 9186
...      Lynx 1405 - bishop pair 100 playing White: 2148 - 1240 - 1205  [0.599] 4593
...      Lynx 1405 - bishop pair 100 playing Black: 1322 - 2014 - 1257  [0.425] 4593
...      White vs Black: 4162 - 2562 - 2462  [0.587] 9186
Elo difference: 8.2 +/- 6.1, LOS: 99.6 %, DrawRatio: 26.8 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```

40+0.4 👍🏽
```
Score of Lynx 1405 - bishop pair 100 vs Lynx 1399 - main: 2502 - 2311 - 2206  [0.514] 7019
...      Lynx 1405 - bishop pair 100 playing White: 1569 - 849 - 1092  [0.603] 3510
...      Lynx 1405 - bishop pair 100 playing Black: 933 - 1462 - 1114  [0.425] 3509
...      White vs Black: 3031 - 1782 - 2206  [0.589] 7019
Elo difference: 9.5 +/- 6.7, LOS: 99.7 %, DrawRatio: 31.4 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```