### PR TITLE
Add `printsettings` option to print runtime `Configuration.EngineSettings`

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!--TODO remove after RC-2, according to https://github.com/dotnet/core/issues/8439-->
+    <Features>$(Features);InterceptorsPreview</Features>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Optimized.ToLower())'=='true'">

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -78,7 +78,7 @@ finally
     engineChannel.Writer.TryComplete();
     uciChannel.Writer.TryComplete();
     //source.Cancel();
-    NLog.LogManager.Shutdown(); // Flush and close down internal threads and timers
+    LogManager.Shutdown(); // Flush and close down internal threads and timers
 }
 
 Thread.Sleep(2_000);

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -1,4 +1,6 @@
-﻿namespace Lynx;
+﻿using System.Text.Json.Serialization;
+
+namespace Lynx;
 
 public static class Configuration
 {
@@ -210,4 +212,11 @@ public sealed class EngineSettings
     /// Depth for bench command
     /// </summary>
     public int BenchDepth { get; set; } = 5;
+}
+
+[JsonSourceGenerationOptions(
+    GenerationMode = JsonSourceGenerationMode.Serialization, WriteIndented = true)] // https://github.com/dotnet/runtime/issues/78602#issuecomment-1322004254
+[JsonSerializable(typeof(EngineSettings))]
+internal partial class EngineSettingsJsonSerializerContext : JsonSerializerContext
+{
 }

--- a/tests/Lynx.Test/Lynx.Test.csproj
+++ b/tests/Lynx.Test/Lynx.Test.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!--TODO remove after RC-2, according to https://github.com/dotnet/core/issues/8439-->
+    <Features>$(Features);InterceptorsPreview</Features>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Add `printsettin option to print runtime `Configuration.EngineSettings`
- Add `InterceptorsPreview` to csproj `Features` property, since it'll be required to use the generator in upcoming .NET 8 RC1