### PR TITLE
Re-Add hashfull in last UCI `info` command using an approx value

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -207,7 +207,7 @@ public static class TranspositionTableExtensions
     }
 
     /// <summary>
-    /// TT occupancy per mill
+    /// Exact TT occupancy per mill
     /// </summary>
     /// <param name="transpositionTable"></param>
     /// <returns></returns>
@@ -215,6 +215,27 @@ public static class TranspositionTableExtensions
     public static int HashfullPermill(this TranspositionTable transpositionTable) => transpositionTable.Length > 0
         ? (int)(1000L * transpositionTable.PopulatedItemsCount() / transpositionTable.LongLength)
         : 0;
+
+    /// <summary>
+    /// Orders of magnitude faster than <see cref="HashfullPermill(TranspositionTableElement[])"/>
+    /// </summary>
+    /// <param name="transpositionTable"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int HashfullPermillApprox(this TranspositionTable transpositionTable)
+    {
+        int items = 0;
+        for (int i = 0; i < 1000; ++i)
+        {
+            if (transpositionTable[i].Key != default)
+            {
+                ++items;
+            }
+        }
+
+        //Console.WriteLine($"Real: {HashfullPermill(transpositionTable)}, estimated: {items}");
+        return items;
+    }
 
     [Conditional("DEBUG")]
     internal static void Stats(this TranspositionTable transpositionTable)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -25,7 +25,7 @@ public class SearchResult
 
     public bool IsCancelled { get; set; }
 
-    public int HashfullPermill { get; set; }
+    public int HashfullPermill { get; set; } = -1;
 
     public SearchResult(Move bestMove, double evaluation, int targetDepth, List<Move> moves, int alpha, int beta, int mate = default)
     {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -170,6 +170,7 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = _stopWatch.ElapsedMilliseconds;
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, _stopWatch.ElapsedMilliseconds);
+        finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
 
         if (isMateDetected && finalSearchResult.Mate + Game.HalfMovesWithoutCaptureOrPawnMove < 96)
         {

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -20,7 +20,8 @@ public sealed partial class Engine
                     DepthReached = 0,
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = stopWatch.ElapsedMilliseconds,
-                    NodesPerSecond = 0
+                    NodesPerSecond = 0,
+                    HashfullPermill = _tt.HashfullPermillApprox()
                 };
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult));

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -86,6 +86,7 @@ public sealed class InfoCommand : EngineBaseCommand
             $" nodes {searchResult.Nodes}" +
             $" nps {searchResult.NodesPerSecond}" +
             $" time {searchResult.Time}" +
+            (searchResult.HashfullPermill != -1 ? $" hashfull {searchResult.HashfullPermill}" : string.Empty) +
             $" pv {string.Join(" ", searchResult.Moves.Select(move => move.UCIString()))}";
 #pragma warning restore RCS1214 // Unnecessary interpolated string.
     }


### PR DESCRIPTION
* Add hashfull in last info command using an approx. value
  Aprox: non-default items in the first 1k TT entries

Context: `hashfull` uci info was removed in https://github.com/lynx-chess/Lynx/pull/342 due to having a serious perf. hit

6+0.06 [WIP]
```
Score of Lynx 1452 - hashfull approx vs Lynx 1447 - main: 4521 - 4571 - 3438  [0.498] 12530
...      Lynx 1452 - hashfull approx playing White: 2755 - 1812 - 1699  [0.575] 6266
...      Lynx 1452 - hashfull approx playing Black: 1766 - 2759 - 1739  [0.421] 6264
...      White vs Black: 5514 - 3578 - 3438  [0.577] 12530
Elo difference: -1.4 +/- 5.2, LOS: 30.0 %, DrawRatio: 27.4 %
SPRT: llr 0.797 (27.1%), lbound -2.94, ubound 2.94
```

end of it, before it got aborted:
```
   # PLAYER                         :  RATING  POINTS  PLAYED   (%)
   1 Lynx 1447 - main               :  2200.8  9582.5   19084    50
   2 Lynx 1452 - hashfull approx    :  2199.2  9501.5   19084    50

White advantage = 57.01
Draw rate (equal opponents) = 50.00 %

C:\dev\sprt>python3 sprt.py --wins 6927 --draws 5149 --losses 7008 --elo0 -5 --elo1 0
ELO: -1.47 +- 4.21 [-5.68, 2.73]
LLR: 0.846 [-5.0, 0.0] (-2.94, 2.94)
Continue Playing
```


8+0.08, results that can only be explained since 1452 is built with rc-1-

```
Finished game 6784 (Lynx 1447 - main vs Lynx 1452 - hashfull approx): * {No result}
Score of Lynx 1452 - hashfull approx vs Lynx 1447 - main: 2487 - 2388 - 1907  [0.507] 6782
...      Lynx 1452 - hashfull approx playing White: 1543 - 908 - 941  [0.594] 3392
...      Lynx 1452 - hashfull approx playing Black: 944 - 1480 - 966  [0.421] 3390
...      White vs Black: 3023 - 1852 - 1907  [0.586] 6782
Elo difference: 5.1 +/- 7.0, LOS: 92.2 %, DrawRatio: 28.1 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
