### PR TITLE
⚡  Replace `foreach` pseudoLegalMoves in NegaMax with a `for` loop

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -125,8 +125,10 @@ public sealed partial class Engine
 
         var pseudoLegalMoves = SortMoves(MoveGenerator.GenerateAllMoves(position, Game.MovePool), ply, ttBestMove);
 
-        foreach (var move in pseudoLegalMoves)
+        for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Count; ++moveIndex)
         {
+            var move = pseudoLegalMoves[moveIndex];
+
             var gameState = position.MakeMove(move);
 
             if (!position.WasProduceByAValidMove())


### PR DESCRIPTION
In order to be able to measure changes that require a `for` loop, gotta do this first to rule out that any potential improvements come from this change.

Unfinished 8+0.08 regression
```
Score of Lynx 1455 - for loop vs Lynx 1454 - main: 1224 - 1214 - 965  [0.501] 3403
...      Lynx 1455 - for loop playing White: 769 - 460 - 472  [0.591] 1701
...      Lynx 1455 - for loop playing Black: 455 - 754 - 493  [0.412] 1702
...      White vs Black: 1523 - 915 - 965  [0.589] 3403
Elo difference: 1.0 +/- 9.9, LOS: 58.0 %, DrawRatio: 28.4 %
SPRT: llr 0.693 (23.5%), lbound -2.94, ubound 2.94
```