### PR TITLE
⚡ Use `FrozenDictionary`s where possible

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Collections.Frozen;
 
 namespace Lynx;
 
@@ -100,7 +101,7 @@ public static class Constants
     /// <summary>
     /// Covert ASCII character pieces to encoded constants
     /// </summary>
-    public static readonly IReadOnlyDictionary<char, Piece> PiecesByChar = new Dictionary<char, Piece>(12)
+    public static readonly FrozenDictionary<char, Piece> PiecesByChar = new Dictionary<char, Piece>(12)
     {
         ['P'] = Piece.P,
         ['N'] = Piece.N,
@@ -115,7 +116,7 @@ public static class Constants
         ['r'] = Piece.r,
         ['q'] = Piece.q,
         ['k'] = Piece.k,
-    };
+    }.ToFrozenDictionary();
 
     /// <summary>
     /// Relevant bishop occupancy bit count per square
@@ -322,7 +323,7 @@ public static class Constants
     public const string WhiteLongCastle = "e1c1";
     public const string BlackLongCastle = "e8c8";
 
-    public static readonly IReadOnlyDictionary<int, int> EnPassantCaptureSquares = new Dictionary<int, int>(16)
+    public static readonly FrozenDictionary<int, int> EnPassantCaptureSquares = new Dictionary<int, int>(16)
     {
         [(int)BoardSquare.a6] = (int)BoardSquare.a6 + 8,
         [(int)BoardSquare.b6] = (int)BoardSquare.b6 + 8,
@@ -341,7 +342,7 @@ public static class Constants
         [(int)BoardSquare.f3] = (int)BoardSquare.f3 - 8,
         [(int)BoardSquare.g3] = (int)BoardSquare.g3 - 8,
         [(int)BoardSquare.h3] = (int)BoardSquare.h3 - 8,
-    };
+    }.ToFrozenDictionary();
 
     /// <summary>
     /// https://github.com/maksimKorzh/chess_programming/blob/master/src/bbc/make_move_castling_rights/bbc.c#L1474


### PR DESCRIPTION
As explained in https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/#frozen-collections, Frozen collections are specialized in reading:

<html>
<body>
<!--StartFragment-->

Method | Mean | Ratio
-- | -- | --
ImmutableDictionaryGets | 360.55 us | 13.89
DictionaryGets | 39.43 us | 1.52
FrozenDictionaryGets | 25.95 us | 1.00

<!--EndFragment-->
</body>
</html>

[-5, 0]:
```
Score of Lynx 1486 - frozen dict vs Lynx 1484 - main: 4529 - 4470 - 3435  [0.502] 12434
...      Lynx 1486 - frozen dict playing White: 2776 - 1721 - 1720  [0.585] 6217
...      Lynx 1486 - frozen dict playing Black: 1753 - 2749 - 1715  [0.420] 6217
...      White vs Black: 5525 - 3474 - 3435  [0.582] 12434
Elo difference: 1.6 +/- 5.2, LOS: 73.3 %, DrawRatio: 27.6 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepte
```
