### PR TITLE
🔍 Keep existing TT move in TT when no best move is found

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -266,7 +266,7 @@ public sealed partial class Engine
         {
             var eval = Position.EvaluateFinalPosition(ply, isInCheck);
 
-            _tt.RecordHash(_ttMask, position, depth, ply, eval, NodeType.Exact);
+            _tt.RecordHash(_ttMask, position, depth, ply, eval, NodeType.Exact, ttBestMove);
             return eval;
         }
 


### PR DESCRIPTION
8+0.08 - aborted
```
Score of Lynx 1509 vs Lynx 1502 - main: 3937 - 3887 - 2687  [0.502] 10511
...      Lynx 1509 playing White: 2462 - 1456 - 1337  [0.596] 5255
...      Lynx 1509 playing Black: 1475 - 2431 - 1350  [0.409] 5256
...      White vs Black: 4893 - 2931 - 2687  [0.593] 10511
Elo difference: 1.7 +/- 5.7, LOS: 71.4 %, DrawRatio: 25.6 %
SPRT: llr -0.496 (-16.8%), lbound -2.94, ubound 2.94
```