### PR TITLE
🐛 Fix `UCI_EngineAbout` string

### DIFF
--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -123,7 +123,7 @@ public sealed class OptionCommand : EngineBaseCommand
 
     public static readonly ImmutableArray<string> AvailableOptions = ImmutableArray.Create<string>(
         "option name UCI_Opponent type string",
-        $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.Name}, see https://github.com/lynx-chess/Lynx",
+        $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.EngineAuthor}, see https://github.com/lynx-chess/Lynx",
         $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min 0 max 1024",
         "option name OnlineTablebaseInRootPositions type check default false",
         "option name OnlineTablebaseInSearch type check default false",


### PR DESCRIPTION
Old one was triggering a weird cutechess behavior which ended up in a warning
```
>Lynx 0.16.0(0): ucinewgame
>Lynx 0.16.0(0): setoption name UCI_Opponent value none none human Eduardo
>Lynx 0.16.0(0): position startpos
<Lynx 0.16.0(0): 02:08:39 | [WARN] Unsupported option: setoption name Lynx 0.16.0, see https://github.com/lynx-chess/Lynx value Lynx by id 
```