### PR TITLE
⌛ Add basic time management when `MovesToGo` are provided

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -97,13 +97,22 @@ public sealed partial class Engine
 
             if (millisecondsLeft > 0)
             {
-                // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
-                millisecondsLeft -= 50;
+                if (goCommand.MovesToGo == default)
+                {
+                    // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
+                    millisecondsLeft -= 50;
+                    Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
 
-                Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
+                    // 1/30, suggested by Serdra (EP discord)
+                    decisionTime = Convert.ToInt32(Math.Min(0.5 * millisecondsLeft, (millisecondsLeft * 0.03333) + millisecondsIncrement));
+                }
+                else
+                {
+                    millisecondsLeft -= 500;
+                    Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
 
-                // Suggested by Serdra (EP discord)
-                decisionTime = Convert.ToInt32(Math.Min(0.5 * millisecondsLeft, millisecondsLeft * 0.03333 + millisecondsIncrement));
+                    decisionTime = Convert.ToInt32((millisecondsLeft / goCommand.MovesToGo) + millisecondsIncrement);
+                }
 
                 _logger.Info("Time to move: {0}s", 0.001 * decisionTime);
                 _searchCancellationTokenSource.CancelAfter(decisionTime!.Value);


### PR DESCRIPTION
`(timeLeft - 500) / movesToGo` for now