### PR TITLE
⚡ Improve `Debug`, `Register`, `SetOption` and `Position` UCI command parsing performance

### DIFF
--- a/src/Lynx.Benchmark/DebugCommand.cs
+++ b/src/Lynx.Benchmark/DebugCommand.cs
@@ -1,0 +1,105 @@
+﻿/*
+ *
+ *  BenchmarkDotNet v0.13.8, Windows 10 (10.0.19045.3448/22H2/2022Update)
+ *  Intel Core i7-5500U CPU 2.40GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100-rc.1.23463.5
+ *    [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
+ *
+ *
+ *  | Method      | command   | Mean     | Error    | StdDev   | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+ *  |------------ |---------- |---------:|---------:|---------:|------:|--------:|-------:|----------:|------------:|
+ *  | StringSplit | debug off | 77.09 ns | 1.584 ns | 1.824 ns |  1.00 |    0.00 | 0.0497 |     104 B |        1.00 |
+ *  | SpanSplit   | debug off | 44.06 ns | 0.591 ns | 0.524 ns |  0.57 |    0.01 |      - |         - |        0.00 |
+ *  | SpanSplit2  | debug off | 46.36 ns | 0.739 ns | 0.617 ns |  0.60 |    0.02 |      - |         - |        0.00 |
+ *  |             |           |          |          |          |       |         |        |           |             |
+ *  | StringSplit | debug on  | 73.92 ns | 1.373 ns | 1.217 ns |  1.00 |    0.00 | 0.0497 |     104 B |        1.00 |
+ *  | SpanSplit   | debug on  | 38.15 ns | 0.732 ns | 0.649 ns |  0.52 |    0.01 |      - |         - |        0.00 |
+ *  | SpanSplit2  | debug on  | 37.50 ns | 0.574 ns | 0.537 ns |  0.51 |    0.01 |      - |         - |        0.00 |
+ *  |             |           |          |          |          |       |         |        |           |             |
+ *  | StringSplit | debug onf | 79.91 ns | 1.378 ns | 1.587 ns |  1.00 |    0.00 | 0.0497 |     104 B |        1.00 |
+ *  | SpanSplit   | debug onf | 48.67 ns | 0.638 ns | 0.533 ns |  0.61 |    0.01 |      - |         - |        0.00 |
+ *  | SpanSplit2  | debug onf | 40.53 ns | 0.550 ns | 0.429 ns |  0.51 |    0.01 |      - |         - |        0.0  | // I forgot a !sign, hence the diff here
+ *
+ */
+
+using BenchmarkDotNet.Attributes;
+using Lynx.UCI.Commands;
+
+namespace Lynx.Benchmark;
+public class DebugCommandBenchmark : BaseBenchmark
+{
+    public static IEnumerable<string> Data => new[]
+    {
+        "debug on",
+        "debug off",
+        "debug onf",
+    };
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public bool StringSplit(string command) => DebugCommandBenchmark_DebugCommandStringSplit.Parse(command);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public bool SpanSplit(string command) => DebugCommandBenchmark_DebugCommandSpanSplit.Parse(command);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public bool SpanSplit2(string command) => DebugCommandBenchmark_DebugCommandSpanSplit2.Parse(command);
+
+    public sealed class DebugCommandBenchmark_DebugCommandStringSplit : GUIBaseCommand
+    {
+        public const string Id = "debug";
+
+        public static bool Parse(string command)
+        {
+            const string on = "on";
+            const string off = "off";
+
+            var state = command.Split(' ', StringSplitOptions.RemoveEmptyEntries)[1];
+
+            return state.Equals(on, StringComparison.OrdinalIgnoreCase)
+                || (!state.Equals(off, StringComparison.OrdinalIgnoreCase)
+                    && Configuration.IsDebug);
+        }
+    }
+
+    public sealed class DebugCommandBenchmark_DebugCommandSpanSplit : GUIBaseCommand
+    {
+        public const string Id = "debug";
+
+        public static bool Parse(ReadOnlySpan<char> command)
+        {
+            const string on = "on";
+            const string off = "off";
+
+            Span<Range> items = stackalloc Range[2];
+            command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+            return command[items[1]].Equals(on, StringComparison.OrdinalIgnoreCase)
+                || (!command[items[1]].Equals(off, StringComparison.OrdinalIgnoreCase)
+                    && Configuration.IsDebug);
+        }
+    }
+
+    public sealed class DebugCommandBenchmark_DebugCommandSpanSplit2 : GUIBaseCommand
+    {
+        public const string Id = "debug";
+
+        public static bool Parse(ReadOnlySpan<char> command)
+        {
+            const string on = "on";
+            const string off = "off";
+
+            Span<Range> items = stackalloc Range[2];
+            command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+            var debugValue = command[items[1]];
+
+            return debugValue.Equals(on, StringComparison.OrdinalIgnoreCase)
+                || (!debugValue.Equals(off, StringComparison.OrdinalIgnoreCase)
+                    && Configuration.IsDebug);
+        }
+    }
+}

--- a/src/Lynx.Benchmark/RegisterCommand.cs
+++ b/src/Lynx.Benchmark/RegisterCommand.cs
@@ -1,0 +1,224 @@
+﻿/*
+ *
+ *  BenchmarkDotNet v0.13.8, Windows 10 (10.0.19045.3448/22H2/2022Update)
+ *  Intel Core i7-5500U CPU 2.40GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100-rc.1.23463.5
+ *    [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
+ *
+ *
+ *  | Method          | command              | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
+ *  |---------------- |--------------------- |----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
+ *  | StringSplit     | register late        | 172.04 ns |  3.535 ns |  6.191 ns | 170.74 ns |  1.00 |    0.00 | 0.1683 |     352 B |        1.00 |
+ *  | SpanSplit       | register late        | 106.20 ns |  1.335 ns |  1.115 ns | 105.79 ns |  0.62 |    0.02 | 0.0842 |     176 B |        0.50 |
+ *  | SpanSplitStruct | register late        |  97.06 ns |  1.711 ns |  1.517 ns |  97.47 ns |  0.57 |    0.02 | 0.0650 |     136 B |        0.39 |
+ *  |                 |                      |           |           |           |           |       |         |        |           |             |
+ *  | StringSplit     | regis(...)74324 [98] | 726.40 ns | 27.308 ns | 72.890 ns | 692.78 ns |  1.00 |    0.00 | 0.8717 |    1824 B |        1.00 |
+ *  | SpanSplit       | regis(...)74324 [98] | 338.85 ns |  6.824 ns |  8.123 ns | 339.86 ns |  0.43 |    0.05 | 0.3748 |     784 B |        0.43 |
+ *  | SpanSplitStruct | regis(...)74324 [98] | 311.02 ns |  6.152 ns |  5.453 ns | 310.14 ns |  0.42 |    0.04 | 0.3557 |     744 B |        0.41 |
+ *  |                 |                      |           |           |           |           |       |         |        |           |             |
+ *  | StringSplit     | regis(...)74324 [41] | 336.63 ns |  6.454 ns |  6.038 ns | 338.06 ns |  1.00 |    0.00 | 0.3328 |     696 B |        1.00 |
+ *  | SpanSplit       | regis(...)74324 [41] | 199.10 ns |  4.035 ns |  3.577 ns | 199.03 ns |  0.59 |    0.01 | 0.1147 |     240 B |        0.34 |
+ *  | SpanSplitStruct | regis(...)74324 [41] | 204.13 ns |  4.136 ns |  3.667 ns | 202.78 ns |  0.61 |    0.02 | 0.0956 |     200 B |        0.29 |
+ *  |                 |                      |           |           |           |           |       |         |        |           |             |
+ *  | StringSplit     | regis(...)74324 [39] | 333.95 ns |  6.689 ns |  8.459 ns | 333.40 ns |  1.00 |    0.00 | 0.3290 |     688 B |        1.00 |
+ *  | SpanSplit       | regis(...)74324 [39] | 200.44 ns |  3.881 ns |  4.313 ns | 199.69 ns |  0.60 |    0.02 | 0.1147 |     240 B |        0.35 |
+ *  | SpanSplitStruct | regis(...)74324 [39] | 193.11 ns |  2.168 ns |  2.028 ns | 193.30 ns |  0.58 |    0.02 | 0.0956 |     200 B |        0.29 |
+ *
+ */
+
+using BenchmarkDotNet.Attributes;
+using Lynx.UCI.Commands;
+using System.Text;
+
+namespace Lynx.Benchmark;
+public class RegisterCommandBenchmark : BaseBenchmark
+{
+    public static IEnumerable<string> Data => new[]
+    {
+        "register late",
+        "register name Stefan MK code 4359874324",
+        "register name Lynx 0.16.0 code 4359874324",
+        "register name Lynx 0.16.0 by eduherminio, check https://github.com/lync-chess/lynx code 4359874324",
+    };
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public RegisterCommandBenchmark_RegisterCommandStringSplit StringSplit(string command) => new RegisterCommandBenchmark_RegisterCommandStringSplit(command);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public RegisterCommandBenchmark_RegisterCommandSpanSplit SpanSplit(string command) => new RegisterCommandBenchmark_RegisterCommandSpanSplit(command);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public RegisterCommandBenchmark_RegisterCommandSpanSplitStruct SpanSplitStruct(string command) => new RegisterCommandBenchmark_RegisterCommandSpanSplitStruct(command);
+
+    public sealed class RegisterCommandBenchmark_RegisterCommandStringSplit : GUIBaseCommand
+    {
+        public const string Id = "register";
+
+        public bool Later { get; }
+
+        public string Name { get; } = string.Empty;
+
+        public string Code { get; } = string.Empty;
+
+        public RegisterCommandBenchmark_RegisterCommandStringSplit(string command)
+        {
+            var items = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (string.Equals("later", items[1], StringComparison.OrdinalIgnoreCase))
+            {
+                Later = true;
+                return;
+            }
+
+            var sb = new StringBuilder();
+
+            foreach (var item in items[1..])
+            {
+                if (string.Equals("name", item, StringComparison.OrdinalIgnoreCase))
+                {
+                    Code = sb.ToString().TrimEnd();
+                    sb.Clear();
+                }
+                else if (string.Equals("code", item, StringComparison.OrdinalIgnoreCase))
+                {
+                    Name = sb.ToString().TrimEnd();
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(item);
+                    sb.Append(' ');
+                }
+            }
+
+            if (string.IsNullOrEmpty(Name))
+            {
+                Name = sb.ToString().TrimEnd();
+            }
+            else
+            {
+                Code = sb.ToString().TrimEnd();
+            }
+        }
+    }
+
+    public sealed class RegisterCommandBenchmark_RegisterCommandSpanSplit : GUIBaseCommand
+    {
+        public const string Id = "register";
+
+        public bool Later { get; }
+
+        public string Name { get; } = string.Empty;
+
+        public string Code { get; } = string.Empty;
+
+        public RegisterCommandBenchmark_RegisterCommandSpanSplit(ReadOnlySpan<char> command)
+        {
+            const string later = "later";
+            const string name = "name";
+            const string code = "code";
+
+            Span<Range> items = stackalloc Range[6];
+            var itemsLength = command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (command[items[1]].Equals(later, StringComparison.OrdinalIgnoreCase))
+            {
+                Later = true;
+                return;
+            }
+
+            var sb = new StringBuilder();
+
+            for (int i = 1; i < itemsLength; ++i)
+            {
+                var item = command[items[i]];
+                if (item.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    Code = sb.ToString();
+                    sb.Clear();
+                }
+                else if (item.Equals(code, StringComparison.OrdinalIgnoreCase))
+                {
+                    Name = sb.ToString();
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(item);
+                    sb.Append(' ');
+                }
+            }
+
+            if (string.IsNullOrEmpty(Name))
+            {
+                Name = sb.ToString();
+            }
+            else
+            {
+                Code = sb.ToString();
+            }
+        }
+    }
+
+    public readonly struct RegisterCommandBenchmark_RegisterCommandSpanSplitStruct
+    {
+        public const string Id = "register";
+
+        public bool Later { get; }
+
+        public string Name { get; } = string.Empty;
+
+        public string Code { get; } = string.Empty;
+
+        public RegisterCommandBenchmark_RegisterCommandSpanSplitStruct(ReadOnlySpan<char> command)
+        {
+            const string later = "later";
+            const string name = "name";
+            const string code = "code";
+
+            Span<Range> items = stackalloc Range[6];
+            var itemsLength = command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+            if (command[items[1]].Equals(later, StringComparison.OrdinalIgnoreCase))
+            {
+                Later = true;
+                return;
+            }
+
+            var sb = new StringBuilder();
+
+            for (int i = 1; i < itemsLength; ++i)
+            {
+                var item = command[items[i]];
+                if (item.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    Code = sb.ToString();
+                    sb.Clear();
+                }
+                else if (item.Equals(code, StringComparison.OrdinalIgnoreCase))
+                {
+                    Name = sb.ToString();
+                    sb.Clear();
+                }
+                else
+                {
+                    sb.Append(item);
+                    sb.Append(' ');
+                }
+            }
+
+            if (string.IsNullOrEmpty(Name))
+            {
+                Name = sb.ToString();
+            }
+            else
+            {
+                Code = sb.ToString();
+            }
+        }
+    }
+}

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -56,7 +56,7 @@ public sealed partial class Engine
         InitializeTT();
     }
 
-    public void AdjustPosition(string rawPositionCommand)
+    public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)
     {
         Game = PositionCommand.ParseGame(rawPositionCommand);
         _isNewGameComing = false;

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -13,7 +13,6 @@ public sealed class LynxDriver
     private readonly Channel<string> _engineWriter;
     private readonly Engine _engine;
     private readonly Logger _logger;
-    private static readonly string[] _none = new[] { "none" };
 
     public LynxDriver(ChannelReader<string> uciReader, Channel<string> engineWriter, Engine engine)
     {
@@ -35,6 +34,14 @@ public sealed class LynxDriver
 
     public async Task Run(CancellationToken cancellationToken)
     {
+        static ReadOnlySpan<char> ExtractCommandItems(string rawCommand)
+        {
+            var span = rawCommand.AsSpan();
+            Span<Range> items = stackalloc Range[2];
+            span.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+            return span[items[0]];
+        }
         try
         {
             while (await _uciReader.WaitToReadAsync(cancellationToken) && !cancellationToken.IsCancellationRequested)
@@ -45,8 +52,7 @@ public sealed class LynxDriver
                     {
                         _logger.Debug("[GUI]\t{0}", rawCommand);
 
-                        var commandItems = rawCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                        switch (commandItems[0].ToLowerInvariant())
+                        switch (ExtractCommandItems(rawCommand))
                         {
                             case DebugCommand.Id:
                                 HandleDebug(rawCommand);
@@ -70,7 +76,7 @@ public sealed class LynxDriver
                                 HandleRegister(rawCommand);
                                 break;
                             case SetOptionCommand.Id:
-                                HandleSetOption(rawCommand, commandItems);
+                                HandleSetOption(rawCommand);
                                 break;
                             case StopCommand.Id:
                                 HandleStop();
@@ -118,7 +124,7 @@ public sealed class LynxDriver
 
     #region Command handlers
 
-    private void HandlePosition(string command)
+    private void HandlePosition(ReadOnlySpan<char> command)
     {
 #if DEBUG
         _engine.Game.CurrentPosition.Print();
@@ -165,18 +171,24 @@ public sealed class LynxDriver
         }
     }
 
-    private void HandleSetOption(string command, string[] commandItems)
+    private void HandleSetOption(ReadOnlySpan<char> command)
     {
-        if (commandItems.Length < 3 || !string.Equals(commandItems[1], "name", StringComparison.OrdinalIgnoreCase))
+        Span<Range> commandItems = stackalloc Range[5];
+        var length = command.Split(commandItems, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+        if (commandItems[2].Start.Equals(commandItems[2].End) || !command[commandItems[1]].Equals("name", StringComparison.OrdinalIgnoreCase))
         {
             return;
         }
 
-        switch (commandItems[2].ToLowerInvariant())
+        Span<char> lowerCaseFirstWord = stackalloc char[command[commandItems[2]].Length];
+        command[commandItems[2]].ToLowerInvariant(lowerCaseFirstWord);
+
+        switch (lowerCaseFirstWord)
         {
             case "ponder":
                 {
-                    if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.IsPonder = value;
                     }
@@ -185,7 +197,7 @@ public sealed class LynxDriver
                 }
             case "uci_analysemode":
                 {
-                    if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.UCI_AnalyseMode = value;
                     }
@@ -193,7 +205,7 @@ public sealed class LynxDriver
                 }
             case "depth":
                 {
-                    if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.EngineSettings.DefaultMaxDepth = value;
                     }
@@ -201,7 +213,7 @@ public sealed class LynxDriver
                 }
             case "hash":
                 {
-                    if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.Hash = Math.Clamp(value, 0, 1024);
                     }
@@ -209,23 +221,26 @@ public sealed class LynxDriver
                 }
             case "uci_opponent":
                 {
-                    if (commandItems.Length > 4)
+                    const string none = "none ";
+                    if (length > 4)
                     {
-                        _logger.Info("Game against {0}", string.Join(' ', commandItems.Skip(4).Except(_none)));
+                        var opponent = command[commandItems[4].Start.Value..].ToString();
+
+                        _logger.Info("Game against {0}", opponent.Replace(none, string.Empty));
                     }
                     break;
                 }
             case "uci_engineabout":
                 {
-                    if (commandItems.Length > 4)
+                    if (length > 4)
                     {
-                        _logger.Info("UCI_EngineAbout: {0}", string.Join(' ', commandItems.Skip(4)));
+                        _logger.Info("UCI_EngineAbout: {0}", command[commandItems[4].Start.Value..].ToString());
                     }
                     break;
                 }
             case "onlinetablebaseinrootpositions":
                 {
-                    if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.EngineSettings.UseOnlineTablebaseInRootPositions = value;
                     }
@@ -233,7 +248,7 @@ public sealed class LynxDriver
                 }
             case "onlinetablebaseinsearch":
                 {
-                    if (commandItems.Length > 4 && bool.TryParse(commandItems[4], out var value))
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.EngineSettings.UseOnlineTablebaseInSearch = value;
                     }
@@ -241,7 +256,7 @@ public sealed class LynxDriver
                 }
             case "threads":
                 {
-                    if (commandItems.Length > 4 && int.TryParse(commandItems[4], out var value))
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
                         if (value != 1)
                         {
@@ -251,7 +266,7 @@ public sealed class LynxDriver
                     break;
                 }
             default:
-                _logger.Warn("Unsupported option: {0}", command);
+                _logger.Warn("Unsupported option: {0}", command.ToString());
                 break;
         }
     }
@@ -265,7 +280,7 @@ public sealed class LynxDriver
         _engine.NewGame();
     }
 
-    private static void HandleDebug(string command) => Configuration.IsDebug = DebugCommand.Parse(command);
+    private static void HandleDebug(ReadOnlySpan<char> command) => Configuration.IsDebug = DebugCommand.Parse(command);
 
     private void HandleQuit()
     {
@@ -276,7 +291,7 @@ public sealed class LynxDriver
         _engineWriter.Writer.Complete();
     }
 
-    private void HandleRegister(string rawCommand) => _engine.Registration = new RegisterCommand(rawCommand);
+    private void HandleRegister(ReadOnlySpan<char> rawCommand) => _engine.Registration = new RegisterCommand(rawCommand);
 
     private async Task HandlePerft(string rawCommand)
     {

--- a/src/Lynx/UCI/Commands/GUI/DebugCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/DebugCommand.cs
@@ -12,11 +12,28 @@ public sealed class DebugCommand : GUIBaseCommand
 {
     public const string Id = "debug";
 
-    public static bool Parse(string command)
+    /// <summary>
+    /// Parse debug command
+    /// </summary>
+    /// <param name="command"></param>
+    /// <returns>
+    /// true if debug command sent 'on'
+    /// false if debug command sent 'off'
+    /// <see cref="Configuration.IsDebug"/> if something else was sent
+    ///
+    /// </returns>
+    public static bool Parse(ReadOnlySpan<char> command)
     {
-        return string.Equals(
-            "on",
-            command.Split(' ', System.StringSplitOptions.RemoveEmptyEntries)[1],
-            System.StringComparison.OrdinalIgnoreCase);
+        const string on = "on";
+        const string off= "off";
+
+        Span<Range> items = stackalloc Range[2];
+        command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+        var debugValue = command[items[1]];
+
+        return debugValue.Equals(on, StringComparison.OrdinalIgnoreCase)
+            || (!debugValue.Equals(off, StringComparison.OrdinalIgnoreCase)
+                && Configuration.IsDebug);
     }
 }

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -1,7 +1,6 @@
 ﻿using Lynx.Model;
 using NLog;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 
 namespace Lynx.UCI.Commands.GUI;
 
@@ -22,12 +21,10 @@ public sealed class PositionCommand : GUIBaseCommand
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    public static Game ParseGame(string positionCommand)
+    public static Game ParseGame(ReadOnlySpan<char> positionCommandSpan)
     {
         try
         {
-            var positionCommandSpan = positionCommand.AsSpan();
-
             // We divide the position command in these two sections:
             // "position startpos                       ||"
             // "position startpos                       || moves e2e4 e7e5"
@@ -57,7 +54,7 @@ public sealed class PositionCommand : GUIBaseCommand
         }
         catch (Exception e)
         {
-            _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+            _logger.Error(e, "Error parsing position command '{0}'", positionCommandSpan.ToString());
             return new Game();
         }
     }

--- a/src/Lynx/UCI/Commands/GUI/RegisterCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/RegisterCommand.cs
@@ -28,11 +28,16 @@ public sealed class RegisterCommand : GUIBaseCommand
 
     public string Code { get; } = string.Empty;
 
-    public RegisterCommand(string command)
+    public RegisterCommand(ReadOnlySpan<char> command)
     {
-        var items = command.Split(' ', System.StringSplitOptions.RemoveEmptyEntries);
+        const string later = "later";
+        const string name = "name";
+        const string code = "code";
 
-        if (string.Equals("later", items[1], System.StringComparison.OrdinalIgnoreCase))
+        Span<Range> items = stackalloc Range[6];
+        var itemsLength = command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (command[items[1]].Equals(later, StringComparison.OrdinalIgnoreCase))
         {
             Later = true;
             return;
@@ -40,16 +45,17 @@ public sealed class RegisterCommand : GUIBaseCommand
 
         var sb = new StringBuilder();
 
-        foreach (var item in items[1..])
+        for (int i = 1; i < itemsLength; ++i)
         {
-            if (string.Equals("name", item, System.StringComparison.OrdinalIgnoreCase))
+            var item = command[items[i]];
+            if (item.Equals(name, StringComparison.OrdinalIgnoreCase))
             {
-                Code = sb.ToString().TrimEnd();
+                Code = sb.ToString();
                 sb.Clear();
             }
-            else if (string.Equals("code", item, System.StringComparison.OrdinalIgnoreCase))
+            else if (item.Equals(code, StringComparison.OrdinalIgnoreCase))
             {
-                Name = sb.ToString().TrimEnd();
+                Name = sb.ToString();
                 sb.Clear();
             }
             else
@@ -61,11 +67,11 @@ public sealed class RegisterCommand : GUIBaseCommand
 
         if (string.IsNullOrEmpty(Name))
         {
-            Name = sb.ToString().TrimEnd();
+            Name = sb.ToString();
         }
         else
         {
-            Code = sb.ToString().TrimEnd();
+            Code = sb.ToString();
         }
     }
 }


### PR DESCRIPTION
Minor improvements, and not that `Debug`, `Register` and `SetOption` are hit often, but here they are.

```
Score of Lynx 1536 - parser vs Lynx 1535 - main: 4980 - 5003 - 3487  [0.499] 13470
...      Lynx 1536 - parser playing White: 3123 - 1857 - 1756  [0.594] 6736
...      Lynx 1536 - parser playing Black: 1857 - 3146 - 1731  [0.404] 6734
...      White vs Black: 6269 - 3714 - 3487  [0.595] 13470
Elo difference: -0.6 +/- 5.0, LOS: 40.9 %, DrawRatio: 25.9 %
SPRT: llr 1.44 (48.8%), lbound -2.94, ubound 2.94
```
<details>
<Summary>Position commands improvements (byte savings)</Summary>

Current
```
BenchmarkDotNet v0.13.8, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 2 logical and 2 physical cores
.NET SDK 8.0.100-rc.1.23455.8
  [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2


| Method              | positionCommand      | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------------------- |--------------------- |-----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
| ParseGame_Original  | position startpos    |   3.975 us | 0.0785 us | 0.1101 us |  1.00 |    0.00 | 1.1253 | 0.0992 |  27.62 KB |        1.00 |
| ParseGame_Improved1 | position startpos    |   3.798 us | 0.0594 us | 0.0526 us |  0.95 |    0.03 | 1.1215 | 0.0992 |   27.5 KB |        1.00 |
| ParseGame_Improved2 | position startpos    |   3.904 us | 0.0747 us | 0.0860 us |  0.98 |    0.03 | 1.1215 | 0.0992 |   27.5 KB |        1.00 |
| ParseGame_Improved3 | position startpos    |   3.869 us | 0.0772 us | 0.0889 us |  0.97 |    0.04 | 1.1215 | 0.0992 |  27.62 KB |        1.00 |
| ParseGame_Improved4 | position startpos    |   3.749 us | 0.0421 us | 0.0373 us |  0.93 |    0.03 | 1.1215 | 0.0992 |   27.5 KB |        1.00 |
| ParseGame_Improved5 | position startpos    |   3.597 us | 0.0513 us | 0.0480 us |  0.89 |    0.03 | 1.1215 | 0.0992 |   27.5 KB |        1.00 |
|                     |                      |            |           |           |       |         |        |        |           |             |
| ParseGame_Original  | posi(...)b7b6 [193]  |  25.784 us | 0.2080 us | 0.1844 us |  1.00 |    0.00 | 1.5564 | 0.1526 |  38.37 KB |        1.00 |
| ParseGame_Improved1 | posi(...)b7b6 [193]  |  25.000 us | 0.2459 us | 0.2300 us |  0.97 |    0.01 | 1.4954 | 0.1526 |  36.89 KB |        0.96 |
| ParseGame_Improved2 | posi(...)b7b6 [193]  |  24.916 us | 0.4187 us | 0.3917 us |  0.97 |    0.02 | 1.4038 | 0.1221 |  34.88 KB |        0.91 |
| ParseGame_Improved3 | posi(...)b7b6 [193]  |  25.537 us | 0.1953 us | 0.1827 us |  0.99 |    0.01 | 1.4648 | 0.1221 |  36.36 KB |        0.95 |
| ParseGame_Improved4 | posi(...)b7b6 [193]  |  24.221 us | 0.1648 us | 0.1542 us |  0.94 |    0.01 | 1.4038 | 0.1221 |  34.68 KB |        0.90 |
| ParseGame_Improved5 | posi(...)b7b6 [193]  |  23.195 us | 0.1498 us | 0.1328 us |  0.90 |    0.01 | 1.4038 | 0.1221 |  34.68 KB |        0.90 |
|                     |                      |            |           |           |       |         |        |        |           |             |
| ParseGame_Original  | posi(...)f3g3 [353]  |  45.627 us | 0.2196 us | 0.1946 us |  1.00 |    0.00 | 1.9531 | 0.1831 |  48.19 KB |        1.00 |
| ParseGame_Improved1 | posi(...)f3g3 [353]  |  39.608 us | 0.2803 us | 0.2622 us |  0.87 |    0.01 | 1.8311 | 0.1221 |  45.45 KB |        0.94 |
| ParseGame_Improved2 | posi(...)f3g3 [353]  |  39.863 us | 0.2684 us | 0.2511 us |  0.87 |    0.01 | 1.6479 | 0.1221 |  41.63 KB |        0.86 |
| ParseGame_Improved3 | posi(...)f3g3 [353]  |  41.310 us | 0.1837 us | 0.1534 us |  0.91 |    0.00 | 1.7700 | 0.1221 |  44.36 KB |        0.92 |
| ParseGame_Improved4 | posi(...)f3g3 [353]  |  40.074 us | 0.[3405](https://github.com/lynx-chess/Lynx/actions/runs/6221757381/job/16884332114#step:7:3406) us | 0.3185 us |  0.88 |    0.01 | 1.6479 | 0.1221 |  41.43 KB |        0.86 |
| ParseGame_Improved5 | posi(...)f3g3 [353]  |  39.640 us | 0.2858 us | 0.2674 us |  0.87 |    0.01 | 1.6479 | 0.1221 |  41.43 KB |        0.86 |
|                     |                      |            |           |           |       |         |        |        |           |             |
| ParseGame_Original  | posi(...)h3f1 [2984] | 279.670 us | 0.6095 us | 0.5701 us |  1.00 |    0.00 | 8.3008 | 0.9766 | 209.61 KB |        1.00 |
| ParseGame_Improved1 | posi(...)h3f1 [2984] | 261.998 us | 0.4168 us | 0.3899 us |  0.94 |    0.00 | 7.3242 | 0.9766 | 186.33 KB |        0.89 |
| ParseGame_Improved2 | posi(...)h3f1 [2984] | 256.380 us | 0.6834 us | 0.6058 us |  0.92 |    0.00 | 5.8594 | 0.4883 | 152.71 KB |        0.73 |
| ParseGame_Improved3 | posi(...)h3f1 [2984] | 260.596 us | 0.8465 us | 0.7504 us |  0.93 |    0.00 | 6.8359 | 0.4883 |    176 KB |        0.84 |
| ParseGame_Improved4 | posi(...)h3f1 [2984] | 243.602 us | 0.8633 us | 0.7653 us |  0.87 |    0.00 | 6.1035 | 0.4883 | 152.51 KB |        0.73 |
| ParseGame_Improved5 | posi(...)h3f1 [2984] | 241.888 us | 1.1715 us | 1.0958 us |  0.86 |    0.00 | 6.1035 | 0.4883 | 152.51 KB |        0.73 |
|                     |                      |            |           |           |       |         |        |        |           |             |
| ParseGame_Original  | posi(...)g4g8 [979]  |  99.230 us | 0.7951 us | 0.7048 us |  1.00 |    0.00 | 3.4180 | 0.3662 |  86.63 KB |        1.00 |
| ParseGame_Improved1 | posi(...)g4g8 [979]  |  91.895 us | 0.2812 us | 0.2348 us |  0.93 |    0.01 | 3.1738 | 0.2441 |  79.01 KB |        0.91 |
| ParseGame_Improved2 | posi(...)g4g8 [979]  |  89.652 us | 0.1537 us | 0.1438 us |  0.90 |    0.01 | 2.6855 | 0.2441 |  68.11 KB |        0.79 |
| ParseGame_Improved3 | posi(...)g4g8 [979]  |  94.573 us | 0.4941 us | 0.4126 us |  0.95 |    0.01 | 3.0518 | 0.2441 |  75.73 KB |        0.87 |
| ParseGame_Improved4 | posi(...)g4g8 [979]  |  88.310 us | 0.2532 us | 0.2114 us |  0.89 |    0.00 | 2.6855 | 0.2441 |  67.91 KB |        0.78 |
| ParseGame_Improved5 | posi(...)g4g8 [979]  |  89.010 us | 0.3568 us | 0.3338 us |  0.90 |    0.01 | 2.6855 | 0.2441 |  67.91 KB |        0.78 |
```

Previous:
```
 *
 BenchmarkDotNet v0.13.8, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
 Intel Xeon Platinum 8370C CPU 2.80GHz, 1 CPU, 2 logical and 2 physical cores
 .NET SDK 8.0.100-rc.1.23455.8
   [Host]     : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
   DefaultJob : .NET 8.0.0 (8.0.23.41904), X64 RyuJIT AVX2
 
 
 | Method              | positionCommand      | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
 |-------------------- |--------------------- |-----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
 | ParseGame_Original  | position startpos    |   5.437 us | 0.0792 us | 0.0741 us |  1.00 |    0.00 | 1.2131 | 0.1144 |   29.8 KB |        1.00 |
 | ParseGame_Improved1 | position startpos    |   5.339 us | 0.0611 us | 0.0542 us |  0.98 |    0.02 | 1.2054 | 0.1068 |  29.68 KB |        1.00 |
 | ParseGame_Improved2 | position startpos    |   5.265 us | 0.0925 us | 0.0865 us |  0.97 |    0.01 | 1.2054 | 0.1068 |  29.68 KB |        1.00 |
 | ParseGame_Improved3 | position startpos    |   5.423 us | 0.0604 us | 0.0535 us |  1.00 |    0.01 | 1.2131 | 0.1144 |   29.8 KB |        1.00 |
 | ParseGame_Improved4 | position startpos    |   5.745 us | 0.1125 us | 0.1104 us |  1.06 |    0.02 | 1.2131 | 0.1144 |  29.77 KB |        1.00 |
 | ParseGame_Improved5 | position startpos    |   5.429 us | 0.1045 us | 0.1499 us |  1.01 |    0.03 | 1.2131 | 0.1144 |  29.77 KB |        1.00 |
 |                     |                      |            |           |           |       |         |        |        |           |             |
 | ParseGame_Original  | posi(...)b7b6 [193]  |  26.556 us | 0.1636 us | 0.1450 us |  1.00 |    0.00 | 1.6479 | 0.1526 |  40.55 KB |        1.00 |
 | ParseGame_Improved1 | posi(...)b7b6 [193]  |  26.311 us | 0.2117 us | 0.1980 us |  0.99 |    0.01 | 1.5869 | 0.1526 |  39.07 KB |        0.96 |
 | ParseGame_Improved2 | posi(...)b7b6 [193]  |  25.852 us | 0.2180 us | 0.2039 us |  0.97 |    0.01 | 1.4954 | 0.1221 |  37.06 KB |        0.91 |
 | ParseGame_Improved3 | posi(...)b7b6 [193]  |  27.533 us | 0.2404 us | 0.2249 us |  1.04 |    0.01 | 1.5564 | 0.1526 |  38.54 KB |        0.95 |
 | ParseGame_Improved4 | posi(...)b7b6 [193]  |  26.357 us | 0.2285 us | 0.2138 us |  0.99 |    0.01 | 1.4954 | 0.1221 |  36.94 KB |        0.91 |
 | ParseGame_Improved5 | posi(...)b7b6 [193]  |  25.903 us | 0.1491 us | 0.1395 us |  0.98 |    0.01 | 1.4954 | 0.1221 |  36.94 KB |        0.91 |
 |                     |                      |            |           |           |       |         |        |        |           |             |
 | ParseGame_Original  | posi(...)f3g3 [353]  |  43.593 us | 0.2400 us | 0.2245 us |  1.00 |    0.00 | 2.0142 | 0.1831 |  50.37 KB |        1.00 |
 | ParseGame_Improved1 | posi(...)f3g3 [353]  |  42.431 us | 0.1899 us | 0.1776 us |  0.97 |    0.01 | 1.8921 | 0.1831 |  47.63 KB |        0.95 |
 | ParseGame_Improved2 | posi(...)f3g3 [353]  |  41.193 us | 0.1674 us | 0.1565 us |  0.94 |    0.01 | 1.7700 | 0.1221 |  43.81 KB |        0.87 |
 | ParseGame_Improved3 | posi(...)f3g3 [353]  |  42.969 us | 0.4555 us | 0.4038 us |  0.99 |    0.01 | 1.8921 | 0.1831 |  46.54 KB |        0.92 |
 | ParseGame_Improved4 | posi(...)f3g3 [353]  |  41.829 us | 0.2377 us | 0.2107 us |  0.96 |    0.01 | 1.7700 | 0.1221 |  43.69 KB |        0.87 |
 | ParseGame_Improved5 | posi(...)f3g3 [353]  |  41.780 us | 0.3129 us | 0.2927 us |  0.96 |    0.01 | 1.7700 | 0.1221 |  43.69 KB |        0.87 |
 |                     |                      |            |           |           |       |         |        |        |           |             |
 | ParseGame_Original  | posi(...)g4g8 [979]  |  96.149 us | 0.6131 us | 0.5735 us |  1.00 |    0.00 | 3.5400 | 0.3662 |  88.81 KB |        1.00 |
 | ParseGame_Improved1 | posi(...)g4g8 [979]  |  98.144 us | 0.4949 us | 0.4387 us |  1.02 |    0.01 | 3.2959 | 0.3662 |  81.19 KB |        0.91 |
 | ParseGame_Improved2 | posi(...)g4g8 [979]  |  97.826 us | 0.3846 us | 0.3597 us |  1.02 |    0.01 | 2.8076 | 0.2441 |  70.29 KB |        0.79 |
 | ParseGame_Improved3 | posi(...)g4g8 [979]  |  97.370 us | 0.3111 us | 0.2910 us |  1.01 |    0.01 | 3.1738 | 0.2441 |  77.91 KB |        0.88 |
 | ParseGame_Improved4 | posi(...)g4g8 [979]  |  91.612 us | 0.3654 us | 0.3418 us |  0.95 |    0.01 | 2.8076 | 0.2441 |  70.17 KB |        0.79 |
 | ParseGame_Improved5 | posi(...)g4g8 [979]  |  88.534 us | 0.3452 us | 0.3229 us |  0.92 |    0.01 | 2.8076 | 0.2441 |  70.17 KB |        0.79 |
 |                     |                      |            |           |           |       |         |        |        |           |             |
 | ParseGame_Original  | posi(...)h3f1 [2984] | 276.602 us | 0.8504 us | 0.7538 us |  1.00 |    0.00 | 8.3008 | 0.9766 | 211.79 KB |        1.00 |
 | ParseGame_Improved1 | posi(...)h3f1 [2984] | 262.196 us | 0.8526 us | 0.7975 us |  0.95 |    0.00 | 7.3242 | 0.9766 |  188.5 KB |        0.89 |
 | ParseGame_Improved2 | posi(...)h3f1 [2984] | 246.968 us | 0.9181 us | 0.8588 us |  0.89 |    0.00 | 5.8594 | 0.4883 | 154.89 KB |        0.73 |
 | ParseGame_Improved3 | posi(...)h3f1 [2984] | 260.619 us | 0.9472 us | 0.8860 us |  0.94 |    0.00 | 6.8359 | 0.4883 | 178.17 KB |        0.84 |
 | ParseGame_Improved4 | posi(...)h3f1 [2984] | 251.254 us | 2.8627 us | 2.6778 us |  0.91 |    0.01 | 5.8594 | 0.4883 | 154.77 KB |        0.73 |
 | ParseGame_Improved5 | posi(...)h3f1 [2984] | 250.528 us | 0.9854 us | 0.9217 us |  0.91 |    0.00 | 5.8594 | 0.4883 | 154.77 KB |        0.73 |
```
</details>