### PR TITLE
Add support for tapered eval bonus and penalties

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
     <!--TODO remove after RC-2, according to https://github.com/dotnet/core/issues/8439-->
     <Features>$(Features);InterceptorsPreview</Features>
   </PropertyGroup>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -23,13 +23,6 @@ var config = new ConfigurationBuilder()
 config.GetSection(nameof(EngineSettings)).Bind(Configuration.EngineSettings);
 config.GetSection(nameof(GeneralSettings)).Bind(Configuration.GeneralSettings);
 
-// TODO remove when .NET sdk includes https://github.com/dotnet/runtime/issues/89732
-var generalConfig = config.GetSection(nameof(GeneralSettings));
-if (bool.TryParse(generalConfig[nameof(Configuration.GeneralSettings.EnableLogging)], out var enableLogging))
-{
-    Configuration.GeneralSettings.EnableLogging = enableLogging;
-}
-
 if (Configuration.GeneralSettings.EnableLogging)
 {
     LogManager.Configuration = new NLogLoggingConfiguration(config.GetSection("NLog"));

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -71,7 +71,7 @@
       "Rank7": {
         "MG": 200,
         "EG": 200
-      },
+      }
     },
     "SemiOpenFileRookBonus": {
       "MG": 10,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -32,12 +32,12 @@
     "AspirationWindowBeta": 50,
     // Evaluation
     "IsolatedPawnPenalty": {
-      "MG": 0,
-      "EG": 30
+      "MG": 10,
+      "EG": 10
     },
     "DoubledPawnPenalty": {
-      "MG": 5,
-      "EG": 20
+      "MG": 10,
+      "EG": 10
     },
     "PassedPawnBonus": {
       "Rank0": {

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,32 +30,86 @@
     "NMP_DepthReduction": 3,
     "AspirationWindowAlpha": 50,
     "AspirationWindowBeta": 50,
-
-    "IsolatedPawnPenalty": 10,
-    "DoubledPawnPenalty": 10,
-    "PassedPawnBonus": [
-      0,
-      10,
-      30,
-      50,
-      75,
-      100,
-      150,
-      200
-    ],
-    "SemiOpenFileRookBonus": 10,
-    "OpenFileRookBonus": 15,
-    "SemiOpenFileKingPenalty": 10,
-    "OpenFileKingPenalty": 15,
-    "KingShieldBonus": 5,
-    "BishopMobilityBonus": 1,
-    "QueenMobilityBonus": 1,
+    // Evaluation
+    "IsolatedPawnPenalty": {
+      "MG": 0,
+      "EG": 30
+    },
+    "DoubledPawnPenalty": {
+      "MG": 5,
+      "EG": 20
+    },
+    "PassedPawnBonus": {
+      "Rank0": {
+        "MG": 0,
+        "EG": 0
+      },
+      "Rank1": {
+        "MG": 10,
+        "EG": 10
+      },
+      "Rank2": {
+        "MG": 30,
+        "EG": 30
+      },
+      "Rank3": {
+        "MG": 50,
+        "EG": 50
+      },
+      "Rank4": {
+        "MG": 75,
+        "EG": 75
+      },
+      "Rank5": {
+        "MG": 100,
+        "EG": 100
+      },
+      "Rank6": {
+        "MG": 150,
+        "EG": 150
+      },
+      "Rank7": {
+        "MG": 200,
+        "EG": 200
+      },
+    },
+    "SemiOpenFileRookBonus": {
+      "MG": 10,
+      "EG": 10
+    },
+    "OpenFileRookBonus": {
+      "MG": 15,
+      "EG": 15
+    },
+    "SemiOpenFileKingPenalty": {
+      "MG": 10,
+      "EG": 10
+    },
+    "OpenFileKingPenalty": {
+      "MG": 15,
+      "EG": 15
+    },
+    "KingShieldBonus": {
+      "MG": 5,
+      "EG": 5
+    },
+    "BishopMobilityBonus": {
+      "MG": 1,
+      "EG": 1
+    },
+    "QueenMobilityBonus": {
+      "MG": 1,
+      "EG": 1
+    },
+    "BishopPairBonus": {
+      "MG": 0,
+      "EG": 100
+    },
     "TranspositionTableEnabled": true,
     "TranspositionTableSize": "256",
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
-    "BishopPairMaxBonus": 100,
     "RFP_MaxDepth": 6,
     "RFP_DepthScalingFactor": 75
   },

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -243,9 +243,9 @@ public sealed class EngineSettings
 
     #region Evaluation
 
-    public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(-10, -10);
+    public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(10, 10);
 
-    public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-10, -10);
+    public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(10, 10);
 
     public TaperedEvaluationTermByRank PassedPawnBonus { get; set; } = new(new(0), new(10), new(30), new(50), new(75), new(100), new(150), new TaperedEvaluationTerm(200));
 
@@ -253,9 +253,9 @@ public sealed class EngineSettings
 
     public TaperedEvaluationTerm OpenFileRookBonus { get; set; } = new(15, 15);
 
-    public TaperedEvaluationTerm SemiOpenFileKingPenalty { get; set; } = new(-10, -10);
+    public TaperedEvaluationTerm SemiOpenFileKingPenalty { get; set; } = new(10, 10);
 
-    public TaperedEvaluationTerm OpenFileKingPenalty { get; set; } = new(-15, -15);
+    public TaperedEvaluationTerm OpenFileKingPenalty { get; set; } = new(15, 15);
 
     public TaperedEvaluationTerm KingShieldBonus { get; set; } = new(5, 5);
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -95,10 +95,17 @@ public class TaperedEvaluationTerm
         MG = mg;
         EG = eg;
     }
+
+    public override string ToString()
+    {
+        return $"{{\"MG\":{MG},\"EG\":{EG}}}";
+    }
 }
 
 public class TaperedEvaluationTermByRank
 {
+    private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
+
     public TaperedEvaluationTerm Rank0 { get; set; }
     public TaperedEvaluationTerm Rank1 { get; set; }
     public TaperedEvaluationTerm Rank2 { get; set; }
@@ -107,9 +114,6 @@ public class TaperedEvaluationTermByRank
     public TaperedEvaluationTerm Rank5 { get; set; }
     public TaperedEvaluationTerm Rank6 { get; set; }
     public TaperedEvaluationTerm Rank7 { get; set; }
-
-    public List<TaperedEvaluationTerm> EvaluationTermsIndexedByPiece { get; set; }
-    //private List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
 
     public TaperedEvaluationTermByRank(
         TaperedEvaluationTerm rank0, TaperedEvaluationTerm rank1, TaperedEvaluationTerm rank2,
@@ -125,12 +129,26 @@ public class TaperedEvaluationTermByRank
         Rank6 = rank6;
         Rank7 = rank7;
 
-        EvaluationTermsIndexedByPiece = [rank0, rank1, rank2, rank3, rank4, rank5, rank6, rank7];
+        _evaluationTermsIndexedByPiece = [rank0, rank1, rank2, rank3, rank4, rank5, rank6, rank7];
     }
 
     public TaperedEvaluationTerm this[int i]
     {
-        get { return EvaluationTermsIndexedByPiece[i]; }
+        get { return _evaluationTermsIndexedByPiece[i]; }
+    }
+
+    public override string ToString()
+    {
+        return "{" +
+            $"\"{nameof(Rank0)}\":{Rank0}," +
+            $"\"{nameof(Rank1)}\":{Rank1}," +
+            $"\"{nameof(Rank2)}\":{Rank2}," +
+            $"\"{nameof(Rank3)}\":{Rank3}," +
+            $"\"{nameof(Rank4)}\":{Rank4}," +
+            $"\"{nameof(Rank5)}\":{Rank5}," +
+            $"\"{nameof(Rank6)}\":{Rank6}," +
+            $"\"{nameof(Rank7)}\":{Rank7}" +
+            "}";
     }
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -80,6 +80,60 @@ public sealed class GeneralSettings
     public bool EnableLogging { get; set; } = false;
 }
 
+public class TaperedEvaluationTerm
+{
+    public int MG { get; set; }
+
+    public int EG { get; set; }
+
+    internal TaperedEvaluationTerm(int singleValue) : this(singleValue, singleValue)
+    {
+    }
+
+    public TaperedEvaluationTerm(int mg, int eg)
+    {
+        MG = mg;
+        EG = eg;
+    }
+}
+
+public class TaperedEvaluationTermByRank
+{
+    public TaperedEvaluationTerm Rank0 { get; set; }
+    public TaperedEvaluationTerm Rank1 { get; set; }
+    public TaperedEvaluationTerm Rank2 { get; set; }
+    public TaperedEvaluationTerm Rank3 { get; set; }
+    public TaperedEvaluationTerm Rank4 { get; set; }
+    public TaperedEvaluationTerm Rank5 { get; set; }
+    public TaperedEvaluationTerm Rank6 { get; set; }
+    public TaperedEvaluationTerm Rank7 { get; set; }
+
+    public List<TaperedEvaluationTerm> EvaluationTermsIndexedByPiece { get; set; }
+    //private List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
+
+    public TaperedEvaluationTermByRank(
+        TaperedEvaluationTerm rank0, TaperedEvaluationTerm rank1, TaperedEvaluationTerm rank2,
+        TaperedEvaluationTerm rank3, TaperedEvaluationTerm rank4, TaperedEvaluationTerm rank5,
+        TaperedEvaluationTerm rank6, TaperedEvaluationTerm rank7)
+    {
+        Rank0 = rank0;
+        Rank1 = rank1;
+        Rank2 = rank2;
+        Rank3 = rank3;
+        Rank4 = rank4;
+        Rank5 = rank5;
+        Rank6 = rank6;
+        Rank7 = rank7;
+
+        EvaluationTermsIndexedByPiece = [rank0, rank1, rank2, rank3, rank4, rank5, rank6, rank7];
+    }
+
+    public TaperedEvaluationTerm this[int i]
+    {
+        get { return EvaluationTermsIndexedByPiece[i]; }
+    }
+}
+
 public sealed class EngineSettings
 {
     public int DefaultMaxDepth { get; set; } = 5;
@@ -169,25 +223,31 @@ public sealed class EngineSettings
 
     public int AspirationWindowBeta { get; set; } = 50;
 
-    public int IsolatedPawnPenalty { get; set; } = 10;
+    #region Evaluation
 
-    public int DoubledPawnPenalty { get; set; } = 10;
+    public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(10, 10);
 
-    public int[] PassedPawnBonus { get; set; } = new[] { 0, 10, 30, 50, 75, 100, 150, 200 };
+    public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(10, 10);
 
-    public int SemiOpenFileRookBonus { get; set; } = 10;
+    public TaperedEvaluationTermByRank PassedPawnBonus { get; set; } = new(new(0), new(10), new(30), new(50), new(75), new(100), new(150), new TaperedEvaluationTerm(200));
 
-    public int OpenFileRookBonus { get; set; } = 15;
+    public TaperedEvaluationTerm SemiOpenFileRookBonus { get; set; } = new(10, 10);
 
-    public int SemiOpenFileKingPenalty { get; set; } = 10;
+    public TaperedEvaluationTerm OpenFileRookBonus { get; set; } = new(15, 15);
 
-    public int OpenFileKingPenalty { get; set; } = 15;
+    public TaperedEvaluationTerm SemiOpenFileKingPenalty { get; set; } = new(10, 10);
 
-    public int KingShieldBonus { get; set; } = 5;
+    public TaperedEvaluationTerm OpenFileKingPenalty { get; set; } = new(15, 15);
 
-    public int BishopMobilityBonus { get; set; } = 1;
+    public TaperedEvaluationTerm KingShieldBonus { get; set; } = new(5, 5);
 
-    public int QueenMobilityBonus { get; set; } = 1;
+    public TaperedEvaluationTerm BishopMobilityBonus { get; set; } = new(1, 1);
+
+    public TaperedEvaluationTerm QueenMobilityBonus { get; set; } = new(1, 1);
+
+    public TaperedEvaluationTerm BishopPairBonus { get; set; } = new(0, 100);
+
+    #endregion
 
     public bool TranspositionTableEnabled { get; set; } = true;
 
@@ -212,11 +272,6 @@ public sealed class EngineSettings
     /// Depth for bench command
     /// </summary>
     public int BenchDepth { get; set; } = 5;
-
-    /// <summary>
-    /// It'll be scaled with phase
-    /// </summary>
-    public int BishopPairMaxBonus { get; set; } = 100;
 
     public int RFP_MaxDepth { get; set; } = 6;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -82,9 +82,9 @@ public sealed class GeneralSettings
 
 public class TaperedEvaluationTerm
 {
-    public int MG { get; set; }
+    public int MG { get; }
 
-    public int EG { get; set; }
+    public int EG { get; }
 
     internal TaperedEvaluationTerm(int singleValue) : this(singleValue, singleValue)
     {
@@ -106,14 +106,14 @@ public class TaperedEvaluationTermByRank
 {
     private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
 
-    public TaperedEvaluationTerm Rank0 { get; set; }
-    public TaperedEvaluationTerm Rank1 { get; set; }
-    public TaperedEvaluationTerm Rank2 { get; set; }
-    public TaperedEvaluationTerm Rank3 { get; set; }
-    public TaperedEvaluationTerm Rank4 { get; set; }
-    public TaperedEvaluationTerm Rank5 { get; set; }
-    public TaperedEvaluationTerm Rank6 { get; set; }
-    public TaperedEvaluationTerm Rank7 { get; set; }
+    public TaperedEvaluationTerm Rank0 { get; }
+    public TaperedEvaluationTerm Rank1 { get; }
+    public TaperedEvaluationTerm Rank2 { get; }
+    public TaperedEvaluationTerm Rank3 { get; }
+    public TaperedEvaluationTerm Rank4 { get; }
+    public TaperedEvaluationTerm Rank5 { get; }
+    public TaperedEvaluationTerm Rank6 { get; }
+    public TaperedEvaluationTerm Rank7 { get; }
 
     public TaperedEvaluationTermByRank(
         TaperedEvaluationTerm rank0, TaperedEvaluationTerm rank1, TaperedEvaluationTerm rank2,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -82,9 +82,9 @@ public sealed class GeneralSettings
 
 public class TaperedEvaluationTerm
 {
-    public int MG { get; }
+    public int MG { get; set; }
 
-    public int EG { get; }
+    public int EG { get; set; }
 
     internal TaperedEvaluationTerm(int singleValue) : this(singleValue, singleValue)
     {
@@ -106,14 +106,14 @@ public class TaperedEvaluationTermByRank
 {
     private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
 
-    public TaperedEvaluationTerm Rank0 { get; }
-    public TaperedEvaluationTerm Rank1 { get; }
-    public TaperedEvaluationTerm Rank2 { get; }
-    public TaperedEvaluationTerm Rank3 { get; }
-    public TaperedEvaluationTerm Rank4 { get; }
-    public TaperedEvaluationTerm Rank5 { get; }
-    public TaperedEvaluationTerm Rank6 { get; }
-    public TaperedEvaluationTerm Rank7 { get; }
+    public TaperedEvaluationTerm Rank0 { get; set; }
+    public TaperedEvaluationTerm Rank1 { get; set; }
+    public TaperedEvaluationTerm Rank2 { get; set; }
+    public TaperedEvaluationTerm Rank3 { get; set; }
+    public TaperedEvaluationTerm Rank4 { get; set; }
+    public TaperedEvaluationTerm Rank5 { get; set; }
+    public TaperedEvaluationTerm Rank6 { get; set; }
+    public TaperedEvaluationTerm Rank7 { get; set; }
 
     public TaperedEvaluationTermByRank(
         TaperedEvaluationTerm rank0, TaperedEvaluationTerm rank1, TaperedEvaluationTerm rank2,
@@ -243,9 +243,9 @@ public sealed class EngineSettings
 
     #region Evaluation
 
-    public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(10, 10);
+    public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(-10, -10);
 
-    public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(10, 10);
+    public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-10, -10);
 
     public TaperedEvaluationTermByRank PassedPawnBonus { get; set; } = new(new(0), new(10), new(30), new(50), new(75), new(100), new(150), new TaperedEvaluationTerm(200));
 
@@ -253,9 +253,9 @@ public sealed class EngineSettings
 
     public TaperedEvaluationTerm OpenFileRookBonus { get; set; } = new(15, 15);
 
-    public TaperedEvaluationTerm SemiOpenFileKingPenalty { get; set; } = new(10, 10);
+    public TaperedEvaluationTerm SemiOpenFileKingPenalty { get; set; } = new(-10, -10);
 
-    public TaperedEvaluationTerm OpenFileKingPenalty { get; set; } = new(15, 15);
+    public TaperedEvaluationTerm OpenFileKingPenalty { get; set; } = new(-15, -15);
 
     public TaperedEvaluationTerm KingShieldBonus { get; set; } = new(5, 5);
 
@@ -299,6 +299,8 @@ public sealed class EngineSettings
 [JsonSourceGenerationOptions(
     GenerationMode = JsonSourceGenerationMode.Default, WriteIndented = true)] // https://github.com/dotnet/runtime/issues/78602#issuecomment-1322004254
 [JsonSerializable(typeof(EngineSettings))]
+[JsonSerializable(typeof(TaperedEvaluationTerm))]
+[JsonSerializable(typeof(TaperedEvaluationTermByRank))]
 internal partial class EngineSettingsJsonSerializerContext : JsonSerializerContext
 {
 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -621,7 +621,7 @@ public class Position
 
                 ++pieceCount[pieceIndex];
 
-                (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceIndex, pieceIndex, pieceCount);
+                (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex, pieceCount);
 
                 middleGameScore += mgAdditionalScore;
                 endGameScore += egAdditionalScore;
@@ -644,7 +644,7 @@ public class Position
 
                 ++pieceCount[pieceIndex];
 
-                (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceIndex, pieceIndex, pieceCount);
+                (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex, pieceCount);
 
                 middleGameScore -= mgAdditionalScore;
                 endGameScore -= egAdditionalScore;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -619,6 +619,8 @@ public class Position
                 endGameScore += EvaluationConstants.EndGameTable[pieceIndex, pieceSquareIndex];
                 gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
 
+                ++pieceCount[pieceIndex];
+
                 (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceIndex, pieceIndex, pieceCount);
 
                 middleGameScore += mgAdditionalScore;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -621,8 +621,8 @@ public class Position
 
                 (int mgAdditionalScore, int egAdditionalScore) = AdditionalPieceEvaluation(pieceIndex, pieceIndex, pieceCount);
 
-                middleGameScore -= mgAdditionalScore;
-                endGameScore -= egAdditionalScore;
+                middleGameScore += mgAdditionalScore;
+                endGameScore += egAdditionalScore;
             }
         }
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -265,7 +265,7 @@ public class RegressionTest : BaseTest
     public async Task InvalidPV2(string positionCommand)
     {
         var engine = GetEngine();
-        engine.AdjustPosition(positionCommand[..^10]);  // 8/8/1K2k3/2P5/PP6/8/7p/8 b - - 0 46, ready to promote
+        engine.AdjustPosition(positionCommand.AsSpan()[..^10]);  // 8/8/1K2k3/2P5/PP6/8/7p/8 b - - 0 46, ready to promote
 
         var bestMove = await engine.BestMove(new GoCommand($"go depth {7}"));
         Assert.AreEqual("h2h1q", bestMove.BestMove.UCIString());

--- a/tests/Lynx.Test/ConfigurationTest.cs
+++ b/tests/Lynx.Test/ConfigurationTest.cs
@@ -46,8 +46,17 @@ public class ConfigurationTest
                     continue;
                 }
 
-                var sourceSetting = jsonNode![property.Name]!.ToString().ToLowerInvariant();
-                var configSetting = property.GetValue(Configuration.EngineSettings)!.ToString()!.ToLowerInvariant();
+                var sourceSetting = jsonNode![property.Name]!.ToString()
+                    .Replace("\r", "")
+                    .Replace("\n", "")
+                    .Replace(" ", "")
+                    .ToLowerInvariant();
+
+                var configSetting = property.GetValue(Configuration.EngineSettings)!.ToString()!
+                    .Replace("\r", "")
+                    .Replace("\n", "")
+                    .Replace(" ", "")
+                    .ToLowerInvariant();
 
                 Assert.AreEqual(sourceSetting, configSetting, $"Error in {property.Name} ({property.PropertyType}): (Configuration.cs) {sourceSetting} != {configSetting} (appSettings.json)");
             }

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -9,11 +9,11 @@ public class EvaluationConstantsTest
     /// Shy from 14k
     /// </summary>
     private readonly int _sensibleEvaluation =
-        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.B].Max(), EndGamePositionalTables[(int)Piece.B].Max()) + Configuration.EngineSettings.BishopMobilityBonus * 64) +
+        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.B].Max(), EndGamePositionalTables[(int)Piece.B].Max()) + Configuration.EngineSettings.BishopMobilityBonus.MG * 64) +
         2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.N].Max(), EndGamePositionalTables[(int)Piece.N].Max())) +
-        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.R].Max(), EndGamePositionalTables[(int)Piece.R].Max()) + Configuration.EngineSettings.OpenFileRookBonus + Configuration.EngineSettings.SemiOpenFileRookBonus) +
-        9 * (Math.Max(MiddleGamePositionalTables[(int)Piece.Q].Max(), EndGamePositionalTables[(int)Piece.Q].Max()) + Configuration.EngineSettings.QueenMobilityBonus * 64) +
-        1 * (Math.Max(MiddleGamePositionalTables[(int)Piece.K].Max(), EndGamePositionalTables[(int)Piece.K].Max()) + Configuration.EngineSettings.KingShieldBonus * 8) +
+        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.R].Max(), EndGamePositionalTables[(int)Piece.R].Max()) + Configuration.EngineSettings.OpenFileRookBonus.MG + Configuration.EngineSettings.SemiOpenFileRookBonus.MG) +
+        9 * (Math.Max(MiddleGamePositionalTables[(int)Piece.Q].Max(), EndGamePositionalTables[(int)Piece.Q].Max()) + Configuration.EngineSettings.QueenMobilityBonus.MG * 64) +
+        1 * (Math.Max(MiddleGamePositionalTables[(int)Piece.K].Max(), EndGamePositionalTables[(int)Piece.K].Max()) + Configuration.EngineSettings.KingShieldBonus.MG * 8) +
         MiddleGamePositionalTables[(int)Piece.Q].Max(); // just in case
 
     [TestCase(PositiveCheckmateDetectionLimit)]

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -924,11 +924,13 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece];
         int eval = 0;
 
+        var pieceCount = new int[12];
         while (!bitBoard.Empty())
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, 0);
+            pieceCount[(int)piece]++;
+            eval += position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, pieceCount).MiddleGameScore;
         }
 
         return eval;
@@ -952,7 +954,7 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
         return piece == Piece.K
-            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount, 0)
-            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount, 0);
+            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount).EndGameScore
+            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount).EndGameScore;
     }
 }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+using System.Diagnostics.Contracts;
 
 namespace Lynx.Test.Model;
 
@@ -215,7 +216,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-Configuration.EngineSettings.IsolatedPawnPenalty, evaluation);
+        Assert.AreEqual(-Configuration.EngineSettings.IsolatedPawnPenalty.MG, evaluation);
     }
 
     /// <summary>
@@ -247,7 +248,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-4 * Configuration.EngineSettings.DoubledPawnPenalty, evaluation);
+        Assert.AreEqual(-4 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
     }
 
     /// <summary>
@@ -280,7 +281,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-9 * Configuration.EngineSettings.DoubledPawnPenalty, evaluation);
+        Assert.AreEqual(-9 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
     }
 
     /// <summary>
@@ -422,9 +423,9 @@ public class PositionTest
         }
 
         Assert.AreEqual(
-            4 * Configuration.EngineSettings.DoubledPawnPenalty
-            - Configuration.EngineSettings.IsolatedPawnPenalty
-            + Configuration.EngineSettings.PassedPawnBonus[rank],
+            4 * Configuration.EngineSettings.DoubledPawnPenalty.MG
+            - Configuration.EngineSettings.IsolatedPawnPenalty.MG
+            + Configuration.EngineSettings.PassedPawnBonus[rank].MG,
 
             evaluation);
     }
@@ -458,7 +459,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(Configuration.EngineSettings.SemiOpenFileRookBonus, evaluation);
+        Assert.AreEqual(Configuration.EngineSettings.SemiOpenFileRookBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -489,7 +490,7 @@ public class PositionTest
         {
             evaluation = -evaluation;
         }
-        Assert.AreEqual(Configuration.EngineSettings.OpenFileRookBonus, evaluation);
+        Assert.AreEqual(Configuration.EngineSettings.OpenFileRookBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -521,7 +522,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(2 * Configuration.EngineSettings.SemiOpenFileRookBonus, evaluation);
+        Assert.AreEqual(2 * Configuration.EngineSettings.SemiOpenFileRookBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -553,7 +554,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-2 * Configuration.EngineSettings.OpenFileRookBonus, evaluation);
+        Assert.AreEqual(-2 * Configuration.EngineSettings.OpenFileRookBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -585,7 +586,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-Configuration.EngineSettings.SemiOpenFileKingPenalty, evaluation);
+        Assert.AreEqual(-Configuration.EngineSettings.SemiOpenFileKingPenalty.MG, evaluation);
     }
 
     /// <summary>
@@ -617,7 +618,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(-Configuration.EngineSettings.OpenFileKingPenalty, evaluation);
+        Assert.AreEqual(-Configuration.EngineSettings.OpenFileKingPenalty.MG, evaluation);
     }
 
     /// <summary>
@@ -737,7 +738,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(surroundingPieces * Configuration.EngineSettings.KingShieldBonus, evaluation);
+        Assert.AreEqual(surroundingPieces * Configuration.EngineSettings.KingShieldBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -791,7 +792,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(mobilityDifference * Configuration.EngineSettings.BishopMobilityBonus, evaluation);
+        Assert.AreEqual(mobilityDifference * Configuration.EngineSettings.BishopMobilityBonus.MG, evaluation);
     }
 
     /// <summary>
@@ -905,7 +906,17 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(mobilityDifference * Configuration.EngineSettings.QueenMobilityBonus, evaluation);
+        Assert.AreEqual(mobilityDifference * Configuration.EngineSettings.QueenMobilityBonus.MG, evaluation);
+    }
+
+    [TestCase(0, 0)]
+    [TestCase(0, 100)]
+    [TestCase(100, 100)]
+    [TestCase(100, 200)]
+    public void TaperedEvaluation(int mg, int eg)
+    {
+        Assert.AreEqual(mg, Position.TaperedEvaluation(new(mg, eg), 24));
+        Assert.AreEqual(eg, Position.TaperedEvaluation(new(mg, eg), 0));
     }
 
     private static int AdditionalPieceEvaluation(Position position, Piece piece)
@@ -917,7 +928,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece);
+            eval += position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, 0);
         }
 
         return eval;
@@ -941,7 +952,7 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
         return piece == Piece.K
-            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount)
-            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount);
+            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount, 0)
+            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount, 0);
     }
 }


### PR DESCRIPTION
[1555](https://github.com/lynx-chess/Lynx/pull/414/commits/42d9bc95bffc669c5c8643c8b353ac2a13e38e35):

8+0.08 (regression) 👍🏽ish
```
Score of Lynx 1555 - pre-tune vs Lynx 0.17.0: 17873 - 18084 - 13895  [0.498] 49852
...      Lynx 1555 - pre-tune playing White: 11089 - 6865 - 6972  [0.585] 24926
...      Lynx 1555 - pre-tune playing Black: 6784 - 11219 - 6923  [0.411] 24926
...      White vs Black: 22308 - 13649 - 13895  [0.587] 49852
Elo difference: -1.5 +/- 2.6, LOS: 13.3 %, DrawRatio: 27.9 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```

40+0.4 (regression) 👎🏽
```
Score of Lynx 1555 - eval tapered vs Lynx 0.17.0: 2394 - 2585 - 2436  [0.487] 7415
...      Lynx 1555 - eval tapered playing White: 1565 - 934 - 1208  [0.585] 3707
...      Lynx 1555 - eval tapered playing Black: 829 - 1651 - 1228  [0.389] 3708
...      White vs Black: 3216 - 1763 - 2436  [0.598] 7415
Elo difference: -9.0 +/- 6.5, LOS: 0.3 %, DrawRatio: 32.9 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```