### PR TITLE
Remove mobility and king shield bonuses, since they're not tuned

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -750,7 +750,7 @@ public class Position
             (int)Piece.P or (int)Piece.p => PawnAdditionalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.R or (int)Piece.r => RookAdditonalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex, pieceCount),
-            (int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex),
+            //(int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex),
             _ => (0, 0)
         };
     }
@@ -829,10 +829,10 @@ public class Position
     {
         int middleGameBonus = 0, endGameBonus = 0;
 
-        var attacksCount = Attacks.BishopAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
+        //var attacksCount = Attacks.BishopAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
 
-        middleGameBonus += attacksCount * Configuration.EngineSettings.BishopMobilityBonus.MG;
-        endGameBonus += attacksCount * Configuration.EngineSettings.BishopMobilityBonus.EG;
+        //middleGameBonus += attacksCount * Configuration.EngineSettings.BishopMobilityBonus.MG;
+        //endGameBonus += attacksCount * Configuration.EngineSettings.BishopMobilityBonus.EG;
 
         if (pieceCount[pieceIndex] == 2)
         {
@@ -883,6 +883,8 @@ public class Position
                 endGameBonus += Configuration.EngineSettings.SemiOpenFileKingPenalty.EG;
             }
         }
+
+        return (middleGameBonus, endGameBonus);
 
         var ownPiecesAroundCount = (Attacks.KingAttacks[squareIndex] & OccupancyBitBoards[(int)kingSide]).CountBits();
 


### PR DESCRIPTION
```
Score of Lynx 1572 - tune vs Lynx 1571 - main: 820 - 953 - 648  [0.473] 2421
...      Lynx 1572 - tune playing White: 517 - 367 - 327  [0.562] 1211
...      Lynx 1572 - tune playing Black: 303 - 586 - 321  [0.383] 1210
...      White vs Black: 1103 - 670 - 648  [0.589] 2421
Elo difference: -19.1 +/- 11.8, LOS: 0.1 %, DrawRatio: 26.8 %
SPRT: llr -2.96 (-100.5%), lbound -2.94, ubound 2.94 - H0 was accepted
```