### PR TITLE
Normalize eval and add `UCI_ShowWDL` option

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -114,7 +114,8 @@
     "UseOnlineTablebaseInSearch": false,
     "BenchDepth": 5,
     "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 75
+    "RFP_DepthScalingFactor": 75,
+    "ShowWDL": false
   },
 
   // Logging settings
@@ -215,7 +216,7 @@
             "condition": "level == LogLevel.Debug"
           },
           {
-            "regex": "checking|ok|error|seldepth|depth|time|nodes|pv|multipv|score|cp|mate|lowerbound|upperbound|currmove|currmovenumber|hashfull|nps|tbhits|cpuload|string|refutation|currline",
+            "regex": "checking|ok|error|seldepth|depth|time|nodes|pv|multipv|score|cp|mate|lowerbound|upperbound|currmove|currmovenumber|hashfull|nps|tbhits|cpuload|string|refutation|currline|wdl",
             "foregroundColor": "DarkMagenta",
             "condition": "level == LogLevel.Debug"
           }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -302,6 +302,8 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 6;
 
     public int RFP_DepthScalingFactor { get; set; } = 75;
+
+    public bool ShowWDL { get; set; } = false;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -8,6 +8,12 @@ namespace Lynx;
 
 public static class EvaluationConstants
 {
+    public const int EvalNormalizationCoefficient = 81;
+
+    public static readonly double[] As = [-32.78983036, 235.37133071, -249.05082702, 128.26358603];
+
+    public static readonly double[] Bs = [-17.47035102, 113.21912714, -143.31733309, 123.25432020];
+
     public static readonly int[] MiddleGamePieceValues =
     [
             +49, +270, +255, +347, +790, 0,

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -346,7 +346,6 @@ public sealed class LynxDriver
     {
         try
         {
-
             var fullPath = Path.GetFullPath(rawCommand[(rawCommand.IndexOf(' ') + 1)..]);
             if (!File.Exists(fullPath))
             {
@@ -371,7 +370,7 @@ public sealed class LynxDriver
                     _logger.Debug("Raw fen: {0}, parsed fen: {1}", fen, ourFen);
                 }
 
-                var eval = position.StaticEvaluation(0);
+                var eval = WDL.NormalizeScore(position.StaticEvaluation(0));
                 if (position.Side == Side.Black)
                 {
                     eval = -eval;   // White perspective

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -269,6 +269,14 @@ public sealed class LynxDriver
                     }
                     break;
                 }
+            case "uci_showwdl":
+                {
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ShowWDL = value;
+                    }
+                }
+                break;
             default:
                 _logger.Warn("Unsupported option: {0}", command.ToString());
                 break;

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -8,7 +8,7 @@ namespace Lynx;
 public class SearchResult
 {
     public Move BestMove { get; init; }
-    public double Evaluation { get; init; }
+    public int Evaluation { get; init; }
     public int Depth { get; set; }
     public List<Move> Moves { get; init; }
     public int Alpha { get; init; }
@@ -29,7 +29,7 @@ public class SearchResult
 
     public (int WDLWin, int WDLDraw, int WDLLoss)? WDL { get; set; } = null;
 
-    public SearchResult(Move bestMove, double evaluation, int targetDepth, List<Move> moves, int alpha, int beta, int mate = default)
+    public SearchResult(Move bestMove, int evaluation, int targetDepth, List<Move> moves, int alpha, int beta, int mate = default)
     {
         BestMove = bestMove;
         Evaluation = evaluation;

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -27,6 +27,8 @@ public class SearchResult
 
     public int HashfullPermill { get; set; } = -1;
 
+    public (int WDLWin, int WDLDraw, int WDLLoss)? WDL { get; set; } = null;
+
     public SearchResult(Move bestMove, double evaluation, int targetDepth, List<Move> moves, int alpha, int beta, int mate = default)
     {
         BestMove = bestMove;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -223,6 +223,10 @@ public sealed partial class Engine
         finalSearchResult.Time = _stopWatch.ElapsedMilliseconds;
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, _stopWatch.ElapsedMilliseconds);
         finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
+        if (Configuration.EngineSettings.ShowWDL)
+        {
+            finalSearchResult.WDL = WDL.WDLModel(bestEvaluation, depth);
+        }
 
         if (isMateDetected && finalSearchResult.Mate + Game.HalfMovesWithoutCaptureOrPawnMove < 96)
         {

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -21,7 +21,12 @@ public sealed partial class Engine
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = stopWatch.ElapsedMilliseconds,
                     NodesPerSecond = 0,
-                    HashfullPermill = _tt.HashfullPermillApprox()
+                    HashfullPermill = _tt.HashfullPermillApprox(),
+                    WDL = WDL.WDLModel(
+                        (int)Math.CopySign(
+                            EvaluationConstants.PositiveCheckmateDetectionLimit + EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore,
+                            tablebaseResult.MateScore),
+                        0)
                 };
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(searchResult));

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -87,6 +87,7 @@ public sealed class InfoCommand : EngineBaseCommand
             $" nps {searchResult.NodesPerSecond}" +
             $" time {searchResult.Time}" +
             (searchResult.HashfullPermill != -1 ? $" hashfull {searchResult.HashfullPermill}" : string.Empty) +
+            (searchResult.WDL is not null ? $" wdl {searchResult.WDL.Value.WDLWin} {searchResult.WDL.Value.WDLDraw} {searchResult.WDL.Value.WDLLoss}" : string.Empty) +
             $" pv {string.Join(" ", searchResult.Moves.Select(move => move.UCIString()))}";
 #pragma warning restore RCS1214 // Unnecessary interpolated string.
     }

--- a/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/InfoCommand.cs
@@ -82,7 +82,7 @@ public sealed class InfoCommand : EngineBaseCommand
             $" depth {searchResult.Depth}" +
             $" seldepth {searchResult.DepthReached}" +
             $" multipv 1" +
-            $" score {(searchResult.Mate == default ? $"cp {searchResult.Evaluation}" : $"mate {searchResult.Mate}")}" +
+            $" score {(searchResult.Mate == default ? $"cp {WDL.NormalizeScore(searchResult.Evaluation)}" : $"mate {searchResult.Mate}")}" +
             $" nodes {searchResult.Nodes}" +
             $" nps {searchResult.NodesPerSecond}" +
             $" time {searchResult.Time}" +

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Immutable;
 
 namespace Lynx.UCI.Commands.Engine;
+
 #pragma warning disable RCS1243 // Duplicate word in a comment.
 /// <summary>
 /// option
@@ -116,17 +117,19 @@ namespace Lynx.UCI.Commands.Engine;
 ///	    "option name NalimovPath type string default c:\\n"
 ///	    "option name Clear Hash type button\n"
 /// </summary>
-public sealed class OptionCommand : EngineBaseCommand
 #pragma warning restore RCS1243 // Duplicate word in a comment.
+
+public sealed class OptionCommand : EngineBaseCommand
 {
     public const string Id = "option";
 
-    public static readonly ImmutableArray<string> AvailableOptions = ImmutableArray.Create<string>(
+    public static readonly ImmutableArray<string> AvailableOptions = ImmutableArray.Create(
         "option name UCI_Opponent type string",
         $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.EngineAuthor}, see https://github.com/lynx-chess/Lynx",
+        $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL}",
         $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min 0 max 1024",
-        "option name OnlineTablebaseInRootPositions type check default false",
-        "option name OnlineTablebaseInSearch type check default false",
+        $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
+        $"option name OnlineTablebaseInSearch type check default {Configuration.EngineSettings.UseOnlineTablebaseInSearch}",
         "option name Threads type spin default 1 min 1 max 1"
     );
 

--- a/src/Lynx/WDL.cs
+++ b/src/Lynx/WDL.cs
@@ -5,6 +5,7 @@ using static EvaluationConstants;
 public static class WDL
 {
     /// <summary>
+    /// Adjust score so that 100cp == 50% win probability
     /// Based on https://github.com/Ciekce/Stormphrax/blob/main/src/wdl.h
     /// </summary>
     /// <returns></returns>

--- a/src/Lynx/WDL.cs
+++ b/src/Lynx/WDL.cs
@@ -1,0 +1,53 @@
+﻿namespace Lynx;
+
+using static EvaluationConstants;
+
+public static class WDL
+{
+    /// <summary>
+    /// Based on https://github.com/Ciekce/Stormphrax/blob/main/src/wdl.h
+    /// </summary>
+    /// <returns></returns>
+    public static int NormalizeScore(int score)
+    {
+        return (score == 0 || score > PositiveCheckmateDetectionLimit || score < NegativeCheckmateDetectionLimit)
+
+            ? score
+            : score * 100 / EvalNormalizationCoefficient;
+    }
+
+    /// <summary>
+    /// Based on https://github.com/Ciekce/Stormphrax/blob/main/src/wdl.h
+    /// </summary>
+    /// <returns></returns>
+    public static int UnNormalizeScore(int normalizedScore)
+    {
+        return (normalizedScore == 0 || normalizedScore > PositiveCheckmateDetectionLimit || normalizedScore < NegativeCheckmateDetectionLimit)
+            ? normalizedScore
+            : normalizedScore * EvalNormalizationCoefficient / 100;
+    }
+
+    /// <summary>
+    /// Based on https://github.com/Ciekce/Stormphrax/blob/main/src/wdl.cpp and https://github.com/official-stockfish/Stockfish/blob/master/src/uci.cpp
+    /// </summary>
+    /// <param name="score"></param>
+    /// <param name="ply"></param>
+    /// <returns></returns>
+    public static (int WDLWin, int WDLDraw, int WDLLoss) WDLModel(int score, int ply)
+    {
+        // The model only captures up to 240 plies, so limit the input and then rescale
+        double m = Math.Min(240, ply) / 64.0;
+
+        double a = (((As[0] * m + As[1]) * m + As[2]) * m) + As[3];
+        double b = (((Bs[0] * m + Bs[1]) * m + Bs[2]) * m) + Bs[3];
+
+        // Transform the eval to centipawns with limited range
+        double x = Math.Clamp(score, -4000.0, 4000.0);
+
+        int wdlWin = (int)Math.Round(1000.0 / (1.0 + Math.Exp((a - x) / b)));
+        int wdlLoss = (int)Math.Round(1000.0 / (1.0 + Math.Exp((a + x) / b)));
+        int wdlDraw = 1000 - wdlWin - wdlLoss;
+
+        return (wdlWin, wdlDraw, wdlLoss);
+    }
+}

--- a/tests/Lynx.Test/BestMove/MatePositions.cs
+++ b/tests/Lynx.Test/BestMove/MatePositions.cs
@@ -101,4 +101,9 @@ public static class MatePositions
 
         new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
     };
+
+    public static readonly object[] Mates_in_11 = new object[]
+    {
+        new object[]{ "6r1/p1pq1p1p/1p1p1Qnk/3PrR2/2n1P1PP/P1P5/4R3/6K1 w - -           ", new[] { "f5h5" }, "https://talkchess.com/forum3/viewtopic.php?f=7&t=82648" },
+    };
 }

--- a/tests/Lynx.Test/WDLTest.cs
+++ b/tests/Lynx.Test/WDLTest.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+
+namespace Lynx.Test;
+
+[Explicit]
+[Category(Categories.Configuration)]
+[NonParallelizable]
+public class WDLTest
+{
+    /// <summary>
+    /// Enforce that NormalizeToPawnValue corresponds to a 50% win rate at ply 64
+    /// </summary>
+    [Test]
+    public void NormalizeCoefficientAndArrayValues()
+    {
+        Assert.AreEqual(EvaluationConstants.EvalNormalizationCoefficient, (int)EvaluationConstants.As.Sum());
+    }
+
+    [TestCase(500, 617)]
+    [TestCase(1000, 1235)]
+    [TestCase(0, 0)]
+    [TestCase(EvaluationConstants.PositiveCheckmateDetectionLimit + 5, EvaluationConstants.PositiveCheckmateDetectionLimit + 5)]
+    [TestCase(EvaluationConstants.NegativeCheckmateDetectionLimit - 5, EvaluationConstants.NegativeCheckmateDetectionLimit - 5)]
+    public void NormalizeScore(int score, int expectecNormalizedEval)
+    {
+        Assert.AreEqual(expectecNormalizedEval, WDL.NormalizeScore(score));
+    }
+
+    [TestCase(1000, 810)]
+    [TestCase(2000, 1620)]
+    [TestCase(0, 0)]
+    [TestCase(EvaluationConstants.PositiveCheckmateDetectionLimit + 5, EvaluationConstants.PositiveCheckmateDetectionLimit + 5)]
+    [TestCase(EvaluationConstants.NegativeCheckmateDetectionLimit - 5, EvaluationConstants.NegativeCheckmateDetectionLimit - 5)]
+    public void UnNormalizeScore(int score, int expectecNormalizedEval)
+    {
+        Assert.AreEqual(expectecNormalizedEval, WDL.UnNormalizeScore(score));
+    }
+}

--- a/tests/Lynx.Test/WDLTest.cs
+++ b/tests/Lynx.Test/WDLTest.cs
@@ -17,7 +17,7 @@ public class WDLTest
     }
 
     [TestCase(500, 617)]
-    [TestCase(1000, 1235)]
+    [TestCase(1000, 1234)]
     [TestCase(0, 0)]
     [TestCase(EvaluationConstants.PositiveCheckmateDetectionLimit + 5, EvaluationConstants.PositiveCheckmateDetectionLimit + 5)]
     [TestCase(EvaluationConstants.NegativeCheckmateDetectionLimit - 5, EvaluationConstants.NegativeCheckmateDetectionLimit - 5)]


### PR DESCRIPTION
- Use [lynx-chess/WDL_model](https://github.com/lynx-chess/WDL_model) to normalize evaluation
- Add UCI option `UCI_ShowWDL` to show WDL cores in the last `info` command after a `go` command.