### PR TITLE
⚖ Add tempo bonus

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -106,6 +106,10 @@
         "EG": 200
       }
     },
+    "TempoBonus": {
+      "MG": 15,
+      "EG": 15
+    },
     // End of evaluation
 
     "TranspositionTableEnabled": true,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -273,6 +273,8 @@ public sealed class EngineSettings
         new(53, 191),
         new(200));
 
+    public TaperedEvaluationTerm TempoBonus { get; set; } = new(15, 15);
+
     #endregion
 
     public bool TranspositionTableEnabled { get; set; } = true;

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -370,7 +370,7 @@ public sealed class LynxDriver
                     _logger.Debug("Raw fen: {0}, parsed fen: {1}", fen, ourFen);
                 }
 
-                var eval = WDL.NormalizeScore(position.StaticEvaluation(0));
+                var eval = WDL.NormalizeScore(position.StaticEvaluation(0, position.Side));
                 if (position.Side == Side.Black)
                 {
                     eval = -eval;   // White perspective

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -17,6 +17,8 @@ public sealed class Game
     public Position CurrentPosition { get; private set; }
     private readonly Position _gameInitialPosition;
 
+    public Side SideToMove() => _gameInitialPosition.Side;
+
     public Game() : this(Constants.InitialPositionFEN)
     {
     }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -588,7 +588,7 @@ public class Position
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int StaticEvaluation(int movesWithoutCaptureOrPawnMove, CancellationToken cancellationToken = default)
+    public int StaticEvaluation(int movesWithoutCaptureOrPawnMove, Side sideToMove = Side.Both, CancellationToken cancellationToken = default)
     {
         var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
         Debug.Assert(result < EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
@@ -662,6 +662,12 @@ public class Position
 
         middleGameScore += EvaluationConstants.MiddleGameTable[(int)Piece.k, blackKing] - mgKingScore;
         endGameScore += EvaluationConstants.EndGameTable[(int)Piece.k, blackKing] - egKingScore;
+
+        if (Side == sideToMove)
+        {
+            middleGameScore += Configuration.EngineSettings.TempoBonus.MG;
+            endGameScore += Configuration.EngineSettings.TempoBonus.EG;
+        }
 
         // Check if drawn position due to lack of material
         if (endGameScore >= 0)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -28,7 +28,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, Game.SideToMove(), _searchCancellationTokenSource.Token);
         }
 
         _maxDepthReached[ply] = ply;
@@ -109,7 +109,7 @@ public sealed partial class Engine
         if (!pvNode && !isInCheck
             && depth <= Configuration.EngineSettings.RFP_MaxDepth)
         {
-            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, Game.SideToMove());
 
             if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
             {
@@ -299,7 +299,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, Game.SideToMove(), _searchCancellationTokenSource.Token);
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -308,7 +308,7 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, Game.SideToMove(), _searchCancellationTokenSource.Token);
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)


### PR DESCRIPTION
8+0.08
```
Score of Lynx 1593 - tempo vs Lynx 1590 - main: 984 - 1110 - 823  [0.478] 2917
...      Lynx 1593 - tempo playing White: 654 - 404 - 400  [0.586] 1458
...      Lynx 1593 - tempo playing Black: 330 - 706 - 423  [0.371] 1459
...      White vs Black: 1360 - 734 - 823  [0.607] 2917
Elo difference: -15.0 +/- 10.7, LOS: 0.3 %, DrawRatio: 28.2 %
SPRT: llr -2.95 (-100.2%), lbound -2.94, ubound 2.94 - H0 was accepted
```

8+0.08 - reversed sign
```
Score of Lynx 1593 - tempo vs Lynx 1590 - main: 1468 - 1589 - 1100  [0.485] 4157
...      Lynx 1593 - tempo playing White: 871 - 620 - 588  [0.560] 2079
...      Lynx 1593 - tempo playing Black: 597 - 969 - 512  [0.410] 2078
...      White vs Black: 1840 - 1217 - 1100  [0.575] 4157
Elo difference: -10.1 +/- 9.0, LOS: 1.4 %, DrawRatio: 26.5 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```