### PR TITLE
⚖ Scale eval with distance to 50 moves draw

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Lynx.Model;
 
@@ -699,10 +700,23 @@ public class Position
 
         var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
+        eval = ScaleEvalWith50MovesDrawDistance(eval, movesWithoutCaptureOrPawnMove);
+
         return Side == Side.White
             ? eval
             : -eval;
     }
+
+    /// <summary>
+    /// Scales <paramref name="eval"/> with <paramref name="movesWithoutCaptureOrPawnMove"/>, so that
+    /// an eval with 100 halfmove counter is half of the value of one with 0 halfmove counter
+    /// </summary>
+    /// <param name="eval"></param>
+    /// <param name="movesWithoutCaptureOrPawnMove"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
+        eval * (200 - movesWithoutCaptureOrPawnMove) / 200;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int TaperedEvaluation(TaperedEvaluationTerm taperedEvaluationTerm, int phase)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -965,7 +965,7 @@ public class PositionTest
 
         var position = new Position(queenVsRookPosition);
 
-        Assert.Greater(position.StaticEvaluation(0), 10);
+        Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
         Assert.AreEqual(0.5 * position.StaticEvaluation(0), position.StaticEvaluation(100));
         Assert.AreEqual(0.75 * position.StaticEvaluation(0), position.StaticEvaluation(50));
     }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -957,4 +957,16 @@ public class PositionTest
             ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount).EndGameScore
             : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount).EndGameScore;
     }
+
+    [Test]
+    public void ScaleEvalWith50MovesDrawDistance()
+    {
+        const string queenVsRookPosition = "8/4k3/4r3/3Q4/3K4/8/8/8 w - - 0 1";
+
+        var position = new Position(queenVsRookPosition);
+
+        Assert.Greater(position.StaticEvaluation(0), 10);
+        Assert.AreEqual(0.5 * position.StaticEvaluation(0), position.StaticEvaluation(100));
+        Assert.AreEqual(0.75 * position.StaticEvaluation(0), position.StaticEvaluation(50));
+    }
 }


### PR DESCRIPTION
8+0.08
```
Score of Lynx 1591 - eval-scale vs Lynx 1590 - main: 1845 - 1954 - 1513  [0.490] 5312
...      Lynx 1591 - eval-scale playing White: 1184 - 718 - 754  [0.588] 2656
...      Lynx 1591 - eval-scale playing Black: 661 - 1236 - 759  [0.392] 2656
...      White vs Black: 2420 - 1379 - 1513  [0.598] 5312
Elo difference: -7.1 +/- 7.9, LOS: 3.8 %, DrawRatio: 28.5 %
SPRT: llr -2.96 (-100.6%), lbound -2.94, ubound 2.94 - H0 was accepted
```