### PR TITLE
Remove `[MethodImpl(MethodImplOptions.AggressiveInlining)]` from some big methods.

### DIFF
--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -11,7 +11,6 @@ public static class FENParser
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static ParseResult ParseFEN(ReadOnlySpan<char> fen)
     {
         fen = fen.Trim();

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -212,7 +212,6 @@ public class Position
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move move)
     {
         sbyte capturedPiece = -1;
@@ -340,7 +339,6 @@ public class Position
         //}
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void UnmakeMove(Move move, GameState gameState)
     {
         var oppositeSide = (int)Side;
@@ -484,7 +482,6 @@ public class Position
         return Attacks.IsSquareInCheck(kingSquare, oppositeSide, PieceBitBoards, OccupancyBitBoards);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public string FEN(int halfMovesWithoutCaptureOrPawnMove = 0, int fullMoveClock = 1)
     {
         var sb = new StringBuilder(100);
@@ -587,7 +584,6 @@ public class Position
     /// That is, positive scores always favour playing <see cref="Side"/>.
     /// </summary>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int StaticEvaluation(int movesWithoutCaptureOrPawnMove, CancellationToken cancellationToken = default)
     {
         var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
@@ -742,7 +738,6 @@ public class Position
     /// <param name="pieceIndex"></param>
     /// <param name="pieceCount">Incomplete count</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal (int MiddleGameScore, int EndGameScore) AdditionalPieceEvaluation(int pieceSquareIndex, int pieceIndex, int[] pieceCount)
     {
         return pieceIndex switch

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -1,12 +1,13 @@
 ﻿using Lynx.Model;
-using NLog;
 using System.Runtime.CompilerServices;
 
 namespace Lynx;
 
 public static class MoveGenerator
 {
-    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+#if DEBUG
+    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+#endif
 
     private const int TRUE = 1;
 
@@ -39,7 +40,6 @@ public static class MoveGenerator
     /// <param name="position"></param>
     /// <param name="capturesOnly">Filters out all moves but captures</param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static IEnumerable<Move> GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
     {
 #if DEBUG

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -92,7 +92,6 @@ public sealed partial class Engine
     /// <param name="useKillerAndPositionMoves"></param>
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScoreMove(Move move, int depth, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[depth])


### PR DESCRIPTION
````
Score of Lynx 1603 - inlining vs Lynx 1590 - main: 1560 - 1678 - 1183  [0.487] 4421
...      Lynx 1603 - inlining playing White: 986 - 624 - 600  [0.582] 2210
...      Lynx 1603 - inlining playing Black: 574 - 1054 - 583  [0.391] 2211
...      White vs Black: 2040 - 1198 - 1183  [0.595] 4421
Elo difference: -9.3 +/- 8.8, LOS: 1.9 %, DrawRatio: 26.8 %
SPRT: llr -2.94 (-100.0%), lbound -2.94, ubound 2.94 - H0 was accepted
````