### PR TITLE
Revisit Aspiration Windows

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,7 +28,7 @@
     "LMR_MaxDepth": 3,
     "LMR_DepthReduction": 1,
     "NMP_DepthReduction": 3,
-    "AspirationWindowDelta": 50,
+    "AspirationWindowDelta": 25,
     "AspirationWindowMinDepth": 6,
 
     // Evaluation

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,7 +28,7 @@
     "LMR_MaxDepth": 3,
     "LMR_DepthReduction": 1,
     "NMP_DepthReduction": 3,
-    "AspirationWindowDelta": 25,
+    "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 
     // Evaluation

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,8 +28,8 @@
     "LMR_MaxDepth": 3,
     "LMR_DepthReduction": 1,
     "NMP_DepthReduction": 3,
-    "AspirationWindowAlpha": 50,
-    "AspirationWindowBeta": 50,
+    "AspirationWindowDelta": 50,
+    "AspirationWindowMinDepth": 6,
 
     // Evaluation
     "DoubledPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,7 +237,7 @@ public sealed class EngineSettings
 
     public int NMP_DepthReduction { get; set; } = 3;
 
-    public int AspirationWindowDelta { get; set; } = 50;
+    public int AspirationWindowDelta { get; set; } = 25;
 
     public int AspirationWindowMinDepth { get; set; } = 6;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,9 +237,9 @@ public sealed class EngineSettings
 
     public int NMP_DepthReduction { get; set; } = 3;
 
-    public int AspirationWindowAlpha { get; set; } = 50;
+    public int AspirationWindowDelta { get; set; } = 50;
 
-    public int AspirationWindowBeta { get; set; } = 50;
+    public int AspirationWindowMinDepth { get; set; } = 6;
 
     #region Evaluation
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,7 +237,7 @@ public sealed class EngineSettings
 
     public int NMP_DepthReduction { get; set; } = 3;
 
-    public int AspirationWindowDelta { get; set; } = 25;
+    public int AspirationWindowDelta { get; set; } = 50;
 
     public int AspirationWindowMinDepth { get; set; } = 6;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -127,8 +127,6 @@ public sealed partial class Engine
                 }
 
                 depth = lastSearchResult.Depth + 1; // Already reduced by 2
-                alpha = lastSearchResult.Alpha;
-                beta = lastSearchResult.Beta;
             }
             else
             {
@@ -155,8 +153,8 @@ public sealed partial class Engine
                     // 🔍 Aspiration Windows
                     var window = Configuration.EngineSettings.AspirationWindowDelta;
 
-                    alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
-                    beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);
+                    alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);   // lastSearchResult.Alpha?
+                    beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);    // lastSearchResult.Beta?
 
                     while (true)
                     {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -153,8 +153,8 @@ public sealed partial class Engine
                     // 🔍 Aspiration Windows
                     var window = Configuration.EngineSettings.AspirationWindowDelta;
 
-                    alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);   // lastSearchResult.Alpha?
-                    beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);    // lastSearchResult.Beta?
+                    alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
+                    beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);
 
                     while (true)
                     {
@@ -170,17 +170,17 @@ public sealed partial class Engine
 
                         window += window / 2;
 
-                        alpha = Math.Max(bestEvaluation - window, MinValue);
-                        beta = Math.Min(bestEvaluation + window, MaxValue);
-
-                        //if (alpha >= bestEvaluation)     // Fail low
-                        //{
-                        //    alpha = bestEvaluation - window;
-                        //}
-                        //if (beta <= bestEvaluation)     // Fail high
-                        //{
-                        //    beta = bestEvaluation + window;
-                        //}
+                        if (alpha >= bestEvaluation)     // Fail low
+                        {
+                            alpha = Math.Max(bestEvaluation - window, MinValue);
+                            beta = (alpha + beta) / 2;
+                            // TODO reset depth if it's reduced in the other case
+                        }
+                        else if (beta <= bestEvaluation)     // Fail high
+                        {
+                            beta = Math.Min(bestEvaluation + window, MaxValue);
+                            // TODO reduce depth
+                        }
                     }
                 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -239,7 +239,7 @@ public sealed partial class Engine
         SearchResult finalSearchResult;
         if (lastSearchResult is null)
         {
-            finalSearchResult = new(default, bestEvaluation, depth, new List<Move>(), alpha, beta)
+            finalSearchResult = new(default, bestEvaluation, depth, new List<Move>(), alpha, beta);
         }
         else
         {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -120,7 +120,7 @@ public sealed partial class Engine
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
-                for (int d = 1; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
+                for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
                 {
                     _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                depth = lastSearchResult.Depth - 1;
+                depth = lastSearchResult.Depth + 1;
                 alpha = lastSearchResult.Alpha;
                 beta = lastSearchResult.Beta;
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -166,8 +166,15 @@ public sealed partial class Engine
                     _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
                     window *= 2;
-                    alpha = bestEvaluation - window;   // We fell outside the window, so try again with a
-                    beta = bestEvaluation + window;    // bigger window (and the same depth).
+
+                    if (alpha >= bestEvaluation)     // Fail low
+                    {
+                        alpha = bestEvaluation - window;
+                    }
+                    if (beta <= bestEvaluation)     // Fail high
+                    {
+                        beta = bestEvaluation + window;
+                    }
                 }
 
                 alpha = bestEvaluation - Configuration.EngineSettings.AspirationWindowAlpha;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -163,9 +163,7 @@ public sealed partial class Engine
                         _isFollowingPV = true;
                         bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
 
-                        isMateDetected = Math.Abs(bestEvaluation) > EvaluationConstants.PositiveCheckmateDetectionLimit;
-
-                        if (isMateDetected || (alpha < bestEvaluation && beta > bestEvaluation))
+                        if (alpha < bestEvaluation && beta > bestEvaluation)
                         {
                             break;
                         }
@@ -174,8 +172,9 @@ public sealed partial class Engine
 
                         window += window / 2;
 
-                        alpha = bestEvaluation - window;
-                        beta = bestEvaluation + window;
+                        alpha = Math.Max(bestEvaluation - window, MinValue);
+                        beta = Math.Min(bestEvaluation + window, MaxValue);
+
                         //if (alpha >= bestEvaluation)     // Fail low
                         //{
                         //    alpha = bestEvaluation - window;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -146,6 +146,8 @@ public sealed partial class Engine
                 }
                 _nodes = 0;
 
+                int bestEvaluationAbs;
+
                 // 🔍 Aspiration Windows
                 var window = Configuration.EngineSettings.AspirationWindowAlpha;
                 while (true)
@@ -153,7 +155,7 @@ public sealed partial class Engine
                     _isFollowingPV = true;
                     bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
 
-                    var bestEvaluationAbs = Math.Abs(bestEvaluation);
+                    bestEvaluationAbs = Math.Abs(bestEvaluation);
                     isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;
 
                     if (isMateDetected || (alpha < bestEvaluation && beta > bestEvaluation))

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                depth = lastSearchResult.Depth + 1;
+                depth = lastSearchResult.Depth + 1; // Already reduced by 2
                 alpha = lastSearchResult.Alpha;
                 beta = lastSearchResult.Beta;
             }
@@ -236,7 +236,15 @@ public sealed partial class Engine
             _stopWatch.Stop();
         }
 
-        SearchResult finalSearchResult = lastSearchResult ??= new(default, bestEvaluation, depth, new List<Move>(), alpha, beta);
+        SearchResult finalSearchResult;
+        if (lastSearchResult is null)
+        {
+            finalSearchResult = new(default, bestEvaluation, depth, new List<Move>(), alpha, beta)
+        }
+        else
+        {
+            finalSearchResult = _previousSearchResult = lastSearchResult;
+        }
 
         finalSearchResult.IsCancelled = isCancelled;
         finalSearchResult.DepthReached = Math.Max(finalSearchResult.DepthReached, _maxDepthReached.LastOrDefault(item => item != default));

--- a/tests/Lynx.Test/BestMove/MatePositions.cs
+++ b/tests/Lynx.Test/BestMove/MatePositions.cs
@@ -47,7 +47,7 @@ public static class MatePositions
         new object[]{ "8/Q5p1/2Bpq3/KPn2pR1/3kpP1p/1P1p3b/3B1b2/7n w - - 0 1            ", new[] { "g5g6" }, ""},
         new object[]{ "2Q3Kn/p7/8/3NkPp1/p7/P1Np1pPr/1P1p4/1b2b2r w - - 0 1             ", new[] { "b2b4" }, ""},
         new object[]{ "4b1N1/2pr2pR/2rp1p2/1Q1B1kp1/2pP4/4P1K1/1n3PN1/R7 w - - 0 1      ", new[] { "a1g1" }, ""},
-        new object[]{ "r1b5/1p1n3p/4p2K/p5Bp/3k4/Q4B2/2P5/5n2 w - - 0 1                 ", new[] { "g5e7" }, ""},
+        //new object[]{ "r1b5/1p1n3p/4p2K/p5Bp/3k4/Q4B2/2P5/5n2 w - - 0 1                 ", new[] { "g5e7" }, ""}, 1:30h after adding some pruning techniques such as asp windows, razoring
         new object[]{ "4N3/1p6/3B2nN/pPpk4/4R1Pp/P1p2P2/K1P1b3/3n4 w - - 0 1            ", new[] { "d6h2" }, ""},
         new object[]{ "3r1n2/2bp2p1/1p1kp1Pp/4N2p/Pp2B2Q/7P/1P3P1B/K7 w - - 0 1         ", new[] { "e4g2", "e4d3", "e4h1", "e4f3", "e4a8" }, ""},
         new object[]{ "3K4/8/6R1/p3k1pp/2bp1R1p/n1b1P3/2p2N2/2B4B w - - 0 1             ", new[] { "g6g5", "c1d2" }, ""},
@@ -63,7 +63,7 @@ public static class MatePositions
         new object[]{ "8/8/1p6/1P1P1B2/k7/1NK5/2N5/8 w - - 0 1                          ", new[] { "c2e3" }, ""},
         new object[]{ "4nKn1/1Q6/2p2P2/1p6/6r1/2P1B3/1N1Np1b1/4k3 w - - 0 1             ", new[] { "b7f7" }, ""},
         new object[]{ "8/np1N1N2/4p3/1p1b4/1b2kp2/p1R5/p3P3/n1Q2K2 w - - 0 1            ", new[] { "c3g3" }, ""},
-        new object[]{ "bK1N2N1/5Qnr/2p4p/2pnk3/8/1p1BPP2/6rp/7q w - - 0 1               ", new[] { "d3c4" }, ""},
+        //new object[]{ "bK1N2N1/5Qnr/2p4p/2pnk3/8/1p1BPP2/6rp/7q w - - 0 1               ", new[] { "d3c4" }, ""},   2.5h after adding some pruning techniques: razoring
         new object[]{ "1QB3n1/BK4P1/4Pp1r/p2kb2p/7P/5Rp1/1PP2Pp1/8 w - - 0 1            ", new[] { "e6e7" }, ""},
         new object[]{ "n7/3rp1NK/b4pP1/1r6/4kb2/p4R2/qNP2R1P/1n5B w - - 0 1             ", new[] { "f3f4" }, ""},
         new object[]{ "8/1pp5/2b5/4N3/2Q2B2/k1p4r/p5rp/K1R5 w - - 0 1                   ", new[] { "f4h6" }, ""},
@@ -92,14 +92,13 @@ public static class MatePositions
     public static readonly object[] Mates_in_6 = new object[]
     {
         new object[]{ "1r4k1/5q2/3bp3/3p4/3P2n1/4P3/P1Q1KP2/1N4R1 b - -                 ", new[] { "f7f2" }, "https://gameknot.com/chess-puzzle.pl?pz=111491" },
-        new object[]{ "1r6/5pkp/1n1Rr1pN/p1p1P1Q1/1b2qB1P/6P1/5P1K/3R4 w - -            ", new[] { "g5f6" }, "https://gameknot.com/chess-puzzle.pl?pz=145711" }
+        //new object[]{ "1r6/5pkp/1n1Rr1pN/p1p1P1Q1/1b2qB1P/6P1/5P1K/3R4 w - -            ", new[] { "g5f6" }, "https://gameknot.com/chess-puzzle.pl?pz=145711" }
     };
 
     public static readonly object[] Mates_in_7 = new object[]
     {
         new object[]{ "4r1k1/1p3p1p/rb1R2p1/pQ6/P1p1q3/2P3RP/1P3PP1/6K1 b - -           ", new[] { "b6f2" }, "https://gameknot.com/chess-puzzle.pl?pz=228984" },    // info depth 14 seldepth 28 multipv 1 score cp 1405 nodes 202487382 nps 511294 time 395029 pv b6f2 g1h2 a6d6 g3g4 e4e1 b5e8 e1e8 g4c4 d6d2 b2b3 e8e5 g2g3
-
-        new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
+        //new object[]{ "1k2r3/ppN3pp/5n2/8/6P1/P1p1pK1P/1PPr4/1R2RN2 b - -               ", new[] { "d2f2" }, "https://gameknot.com/chess-puzzle.pl?pz=117353" }     // info depth 12 seldepth 26 multipv 1 score cp 160 nodes 102915997 nps 439966 time 232918 pv d2f2 f3g3 f6e4 g3h4 f2f6 c7a6 b7a6 b2c3 b8c8 g4g5 f6f4 h4h5 e4c3, not reachable any more after adding RFP
     };
 
     public static readonly object[] Mates_in_11 = new object[]


### PR DESCRIPTION
1634 👎🏽:
```
Score of Lynx-aspiration-windows-remove-incheck-check-1634-win-x64 vs Lynx 1632 - main: 1751 - 1812 - 1156  [0.494] 4719
...      Lynx-aspiration-windows-remove-incheck-check-1634-win-x64 playing White: 1080 - 677 - 603  [0.585] 2360
...      Lynx-aspiration-windows-remove-incheck-check-1634-win-x64 playing Black: 671 - 1135 - 553  [0.402] 2359
...      White vs Black: 2215 - 1348 - 1156  [0.592] 4719
Elo difference: -4.5 +/- 8.6, LOS: 15.3 %, DrawRatio: 24.5 %
SPRT: llr -1.81 (-61.5%), lbound -2.94, ubound 2.94
```

[1635](https://github.com/lynx-chess/Lynx/pull/437/commits/13ac1564b747edf127e2ec6413d8375f351679e5): 👎🏽
```
Score of Lynx-aspiration-windows-increase-window-1635-win-x64 vs Lynx 1632 - main: 1625 - 1649 - 1198  [0.497] 4472
...      Lynx-aspiration-windows-increase-window-1635-win-x64 playing White: 1020 - 594 - 622  [0.595] 2236
...      Lynx-aspiration-windows-increase-window-1635-win-x64 playing Black: 605 - 1055 - 576  [0.399] 2236
...      White vs Black: 2075 - 1199 - 1198  [0.598] 4472
Elo difference: -1.9 +/- 8.7, LOS: 33.7 %, DrawRatio: 26.8 %
SPRT: llr -1.1 (-37.5%), lbound -2.94, ubound 2.94
```

1637: something's off with illegal moves

8 0.08
```
Score of Lynx 1637 - refactor base vs Lynx 1632 - main: 1241 - 1364 - 979  [0.483] 3584
...      Lynx 1637 - refactor base playing White: 795 - 484 - 513  [0.587] 1792
...      Lynx 1637 - refactor base playing Black: 446 - 880 - 466  [0.379] 1792
...      White vs Black: 1675 - 930 - 979  [0.604] 3584
Elo difference: -11.9 +/- 9.7, LOS: 0.8 %, DrawRatio: 27.3 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted

Player: Lynx 1637 - refactor base
   "Draw by 3-fold repetition": 503
   "Draw by adjudication": 196
   "Draw by fifty moves rule": 50
   "Draw by insufficient mating material": 220
   "Draw by stalemate": 10
   "Loss: Black makes an illegal move: a8a8": 31
   "Loss: Black mates": 22
   "Loss: Black wins by adjudication": 431
   "Loss: White makes an illegal move: a8a8": 31
   "Loss: White mates": 27
   "Loss: White wins by adjudication": 822
   "No result": 7
   "Win: Black mates": 6
   "Win: Black wins by adjudication": 440
   "Win: White mates": 16
   "Win: White wins by adjudication": 779
Player: Lynx 1632 - main
   "Draw by 3-fold repetition": 503
   "Draw by adjudication": 196
   "Draw by fifty moves rule": 50
   "Draw by insufficient mating material": 220
   "Draw by stalemate": 10
   "Loss: Black mates": 6
   "Loss: Black wins by adjudication": 440
   "Loss: White mates": 16
   "Loss: White wins by adjudication": 779
   "No result": 7
   "Win: Black makes an illegal move: a8a8": 31
   "Win: Black mates": 22
   "Win: Black wins by adjudication": 431
   "Win: White makes an illegal move: a8a8": 31
   "Win: White mates": 27
   "Win: White wins by adjudication": 822
Finished match
```

40 0.4
```
Score of Lynx 1637 - asp windows refactor base vs Lynx 1632 - main: 2029 - 2082 - 1727  [0.495] 5838
...      Lynx 1637 - asp windows refactor base playing White: 1318 - 726 - 874  [0.601] 2918
...      Lynx 1637 - asp windows refactor base playing Black: 711 - 1356 - 853  [0.390] 2920
...      White vs Black: 2674 - 1437 - 1727  [0.606] 5838
Elo difference: -3.2 +/- 7.5, LOS: 20.4 %, DrawRatio: 29.6 %
SPRT: llr -1.94 (-66.0%), lbound -2.94, ubound 2.94

Player: Lynx 1637 - asp windows refactor base
   "Draw by 3-fold repetition": 876
   "Draw by adjudication": 393
   "Draw by fifty moves rule": 65
   "Draw by insufficient mating material": 373
   "Draw by stalemate": 20
   "Loss: Black makes an illegal move: a8a8": 24
   "Loss: Black mates": 7
   "Loss: Black wins by adjudication": 693
   "Loss: White makes an illegal move: a8a8": 26
   "Loss: White mates": 15
   "Loss: White wins by adjudication": 1317
   "No result": 8
   "Win: Black mates": 8
   "Win: Black wins by adjudication": 703
   "Win: White mates": 7
   "Win: White wins by adjudication": 1311
Player: Lynx 1632 - main
   "Draw by 3-fold repetition": 876
   "Draw by adjudication": 393
   "Draw by fifty moves rule": 65
   "Draw by insufficient mating material": 373
   "Draw by stalemate": 20
   "Loss: Black mates": 8
   "Loss: Black wins by adjudication": 703
   "Loss: White mates": 7
   "Loss: White wins by adjudication": 1311
   "No result": 8
   "Win: Black makes an illegal move: a8a8": 24
   "Win: Black mates": 7
   "Win: Black wins by adjudication": 693
   "Win: White makes an illegal move: a8a8": 26
   "Win: White mates": 15
   "Win: White wins by adjudication": 1317
Finished match
```

During game:
```
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.LynxDriver|[GUI]	position fen r1bq1rk1/ppp3pp/5n2/2bpNP2/B2n4/2N5/PPPP1PPP/R1BQ1RK1 w - - 0 1 moves g2g4 c7c6 f1e1 f8e8 e5d3 e8e1 d3e1 b7b5 a4b3 d4b3 a2b3 d5d4 e1d3 c5d6 c3a2 c8b7 h2h3 f6e4 d1f3 c6c5 f3g2 d8e7 f2f4 e4g5 f5f6 g7f6 g2f1 g5f3 g1f2 c5c4 b3c4 b5c4 d3e1 f3e1 f1e1 e7e1 f2e1 d6f4 d2d3 f4g3 e1f1 c4d3 c2d3 a8c8 b2b3 c8c2 a2b4 c2f2 f1g1 f2h2 b4c6 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.LynxDriver|[GUI]	isready 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	readyok 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.LynxDriver|[GUI]	go wtime 18330 btime 17222 winc 400 binc 400 
2023-10-11 23:55:09.3111|0|10760|INFO|Lynx.Engine|Time to move: 0.972s 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Engine|Ponder hit 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 6 seldepth 17 multipv 1 score cp 1139 nodes 0 nps 0 time 0 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 5 seldepth 9 multipv 1 score cp 1139 nodes 314 nps 314 time 0 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Engine|Eval (939) outside of aspiration window [839, 939] (depth 6, nodes 84) 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 6 seldepth 9 multipv 1 score cp 1139 nodes 400 nps 400 time 0 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Engine|Eval (939) outside of aspiration window [839, 939] (depth 7, nodes 245) 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 7 seldepth 12 multipv 1 score cp 1139 nodes 1618 nps 1615 time 2 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3 
2023-10-11 23:55:09.3111|0|10760|DEBUG|Lynx.Engine|Eval (939) outside of aspiration window [839, 939] (depth 8, nodes 243) 
2023-10-11 23:55:09.3597|0|10760|DEBUG|Lynx.Engine|Eval (1014) outside of aspiration window [864, 1014] (depth 8, nodes 45537) 
2023-10-11 23:55:09.4031|0|10760|DEBUG|Lynx.Engine|Eval (1126) outside of aspiration window [902, 1126] (depth 8, nodes 100153) 
2023-10-11 23:55:09.4333|0|10760|DEBUG|Lynx.Engine|Eval (1294) outside of aspiration window [958, 1294] (depth 8, nodes 131691) 
2023-10-11 23:55:09.4794|0|10760|DEBUG|Lynx.Engine|Eval (1546) outside of aspiration window [1042, 1546] (depth 8, nodes 180731) 
2023-10-11 23:55:09.5351|0|10760|DEBUG|Lynx.Engine|Eval (1924) outside of aspiration window [1168, 1924] (depth 8, nodes 253227) 
2023-10-11 23:55:09.5535|0|10760|DEBUG|Lynx.Engine|Eval (2491) outside of aspiration window [1357, 2491] (depth 8, nodes 280047) 
2023-10-11 23:55:09.5760|0|10760|DEBUG|Lynx.Engine|Eval (3341) outside of aspiration window [1641, 3341] (depth 8, nodes 314393) 
2023-10-11 23:55:09.5760|0|10760|DEBUG|Lynx.Engine|Eval (4616) outside of aspiration window [2066, 4616] (depth 8, nodes 322461) 
2023-10-11 23:55:09.5870|0|10760|DEBUG|Lynx.Engine|Eval (6528) outside of aspiration window [2704, 6528] (depth 8, nodes 330953) 
2023-10-11 23:55:09.5870|0|10760|DEBUG|Lynx.Engine|Eval (9396) outside of aspiration window [3660, 9396] (depth 8, nodes 336916) 
2023-10-11 23:55:09.5870|0|10760|DEBUG|Lynx.Engine|Eval (13698) outside of aspiration window [5094, 13698] (depth 8, nodes 342868) 
2023-10-11 23:55:09.5870|0|10760|DEBUG|Lynx.Engine|Eval (20151) outside of aspiration window [7245, 20151] (depth 8, nodes 348820) 
2023-10-11 23:55:09.6255|0|10760|INFO|Lynx.Engine|Stopping at depth 8: mate detected 
2023-10-11 23:55:09.6255|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 8 seldepth 16 multipv 1 score mate 9 nodes 381684 nps 290696 time 313 pv  
2023-10-11 23:55:09.6255|0|10760|INFO|Lynx.Engine|Engine search found a short enough mate, cancelling online tb probing if still active 
2023-10-11 23:55:09.6255|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 8 seldepth 16 multipv 1 score mate 9 nodes 381684 nps 290696 time 313 hashfull 399 pv  
2023-10-11 23:55:09.6255|0|10760|DEBUG|Lynx.Cli.Writer|[Lynx]	bestmove a8a8 
```

```
position fen r1bq1rk1/ppp3pp/5n2/2bpNP2/B2n4/2N5/PPPP1PPP/R1BQ1RK1 w - - 0 1 moves g2g4 c7c6 f1e1 f8e8 e5d3 e8e1 d3e1 b7b5 a4b3 d4b3 a2b3 d5d4 e1d3 c5d6 c3a2 c8b7 h2h3 f6e4 d1f3 c6c5 f3g2 d8e7 f2f4 e4g5 f5f6 g7f6 g2f1 g5f3 g1f2 c5c4 b3c4 b5c4 d3e1 f3e1 f1e1 e7e1 f2e1 d6f4 d2d3 f4g3 e1f1 c4d3 c2d3 a8c8 b2b3 c8c2 a2b4 c2f2 f1g1 f2h2 b4c6
go wtime 18330 btime 17222 winc 400 binc 400
info depth 1 seldepth 5 multipv 1 score cp 534 nodes 40 nps 39 time 27 pv b7c6 a1a7 h2h3
info depth 2 seldepth 6 multipv 1 score cp 534 nodes 64 nps 62 time 37 pv b7c6 a1a7 h2h3
info depth 3 seldepth 9 multipv 1 score cp 615 nodes 395 nps 379 time 42 pv b7c6 g1f1 c6g2 f1e2 g2h3
info depth 4 seldepth 9 multipv 1 score cp 615 nodes 352 nps 337 time 46 pv b7c6 g1f1 c6g2
info depth 5 seldepth 12 multipv 1 score cp 1139 nodes 3666 nps 3382 time 84 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3
info depth 6 seldepth 12 multipv 1 score cp 1139 nodes 1587 nps 1448 time 96 pv b7c6 g1f1 c6f3 c1e3 d4e3 a1a7 h2h3
info depth 7 seldepth 13 multipv 1 score cp 1139 nodes 5920 nps 5134 time 153 pv b7c6 g1f1 c6f3 c1e3
info depth 8 seldepth 15 multipv 1 score mate 9 nodes 246739 nps 127251 time 939 pv
info depth 8 seldepth 15 multipv 1 score mate 9 nodes 246739 nps 127185 time 940 hashfull 3 pv
bestmove a8a8
```

1639 - illegal moves fixed, window 50

8 0.08
```
Score of Lynx 1639 - refactor base vs Lynx 1632 - main: 1802 - 1916 - 1342  [0.489] 5060
...      Lynx 1639 - refactor base playing White: 1170 - 712 - 649  [0.590] 2531
...      Lynx 1639 - refactor base playing Black: 632 - 1204 - 693  [0.387] 2529
...      White vs Black: 2374 - 1344 - 1342  [0.602] 5060
Elo difference: -7.8 +/- 8.2, LOS: 3.1 %, DrawRatio: 26.5 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```

40 0.4
```
Score of Lynx 1639 - asp windows refactor base vs Lynx 1632 - main: 1846 - 1763 - 1579  [0.508] 5188
...      Lynx 1639 - asp windows refactor base playing White: 1207 - 592 - 795  [0.619] 2594
...      Lynx 1639 - asp windows refactor base playing Black: 639 - 1171 - 784  [0.397] 2594
...      White vs Black: 2378 - 1231 - 1579  [0.611] 5188
Elo difference: 5.6 +/- 7.9, LOS: 91.6 %, DrawRatio: 30.4 %
SPRT: llr 0.945 (32.1%), lbound -2.94, ubound 2.94
```

1646 
8 0.08
```
Score of Lynx 1646 - asp 25 vs Lynx 1632 - main: 721 - 853 - 616  [0.470] 2190
...      Lynx 1646 - asp 25 playing White: 455 - 330 - 310  [0.557] 1095
...      Lynx 1646 - asp 25 playing Black: 266 - 523 - 306  [0.383] 1095
...      White vs Black: 978 - 596 - 616  [0.587] 2190
Elo difference: -21.0 +/- 12.3, LOS: 0.0 %, DrawRatio: 28.1 %
SPRT: llr -2.96 (-100.6%), lbound -2.94, ubound 2.94 - H0 was accepted
```

40 0.4
```
Score of Lynx 1646 - asp 25 vs Lynx 1632 - main: 770 - 901 - 643  [0.472] 2314
...      Lynx 1646 - asp 25 playing White: 505 - 309 - 342  [0.585] 1156
...      Lynx 1646 - asp 25 playing Black: 265 - 592 - 301  [0.359] 1158
...      White vs Black: 1097 - 574 - 643  [0.613] 2314
Elo difference: -19.7 +/- 12.0, LOS: 0.1 %, DrawRatio: 27.8 %
SPRT: llr -2.95 (-100.1%), lbound -2.94, ubound 2.94 - H0 was accepted
```

asp window 40

8 0.08
```
Score of Lynx 1646 - asp 25 vs Lynx 1632 - main: 3858 - 3932 - 2832  [0.497] 10622
...      Lynx 1646 - asp 25 playing White: 2439 - 1470 - 1403  [0.591] 5312
...      Lynx 1646 - asp 25 playing Black: 1419 - 2462 - 1429  [0.402] 5310
...      White vs Black: 4901 - 2889 - 2832  [0.595] 10622
Elo difference: -2.4 +/- 5.7, LOS: 20.1 %, DrawRatio: 26.7 %
SPRT: llr -2.95 (-100.3%), lbound -2.94, ubound 2.94 - H0 was accepted
```

40 0.4
```
Score of Lynx 1646 - asp 25 vs Lynx 1632 - main: 1093 - 1135 - 901  [0.493] 3129
...      Lynx 1646 - asp 25 playing White: 704 - 390 - 470  [0.600] 1564
...      Lynx 1646 - asp 25 playing Black: 389 - 745 - 431  [0.386] 1565
...      White vs Black: 1449 - 779 - 901  [0.607] 3129
Elo difference: -4.7 +/- 10.3, LOS: 18.7 %, DrawRatio: 28.8 %
SPRT: llr -1.3 (-44.3%), lbound -2.94, ubound 2.94
```

40+0.4
```
Score of Lynx 1648 vs Lynx 1647: 3492 - 3339 - 2954  [0.508] 9785
...      Lynx 1648 playing White: 2309 - 1131 - 1453  [0.620] 4893
...      Lynx 1648 playing Black: 1183 - 2208 - 1501  [0.395] 4892
...      White vs Black: 4517 - 2314 - 2954  [0.613] 9785
Elo difference: 5.4 +/- 5.7, LOS: 96.8 %, DrawRatio: 30.2 %
SPRT: llr 1.7 (57.8%), lbound -2.94, ubound 2.94
```