### PR TITLE
Fix/improve ponder hit

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -106,31 +106,33 @@ public sealed partial class Engine
                 return result;
             }
 
-            if (Game.MoveHistory.Count >= 2
-                && _previousSearchResult?.Moves.Count > 2
-                && _previousSearchResult.BestMove != default
-                && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
-                && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
-            {
-                _logger.Debug("Ponder hit");
+            //if (Game.MoveHistory.Count >= 2
+            //    && _previousSearchResult?.Moves.Count > 2
+            //    && _previousSearchResult.BestMove != default
+            //    && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
+            //    && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
+            //{
+            //    _logger.Debug("Ponder hit");
 
-                lastSearchResult = new SearchResult(_previousSearchResult);
+            //    lastSearchResult = new SearchResult(_previousSearchResult);
 
-                Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
+            //    Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
 
-                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
+            //    await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
-                for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
-                {
-                    _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
-                    _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
-                }
+            //    for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
+            //    {
+            //        _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
+            //        _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
+            //    }
+            //    //Array.Clear(_killerMoves);
+            //    //Array.Clear(_historyMoves);
 
-                depth = lastSearchResult.Depth + 1;
-                alpha = lastSearchResult.Alpha;
-                beta = lastSearchResult.Beta;
-            }
-            else
+            //    depth = lastSearchResult.Depth + 1;
+            //    alpha = lastSearchResult.Alpha;
+            //    beta = lastSearchResult.Beta;
+            //}
+            //else
             {
                 Array.Clear(_killerMoves);
                 Array.Clear(_historyMoves);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -120,7 +120,7 @@ public sealed partial class Engine
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
-                for (int d = 1; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
+                for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
                 {
                     _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                depth = lastSearchResult.Depth - 1;
+                depth = lastSearchResult.Depth + 1;
                 alpha = lastSearchResult.Alpha;
                 beta = lastSearchResult.Beta;
             }


### PR DESCRIPTION
[Avoid re-search depths that we've already searched](https://github.com/lynx-chess/Lynx/pull/438/commits/8507de0be4d78b96227970c558589f200c007621) (1641):

8 0.08 [-5 0]
```
Score of Lynx 1641 vs Lynx 1632 - main: 2914 - 2927 - 1999  [0.499] 7840
...      Lynx 1641 playing White: 1839 - 1071 - 1010  [0.598] 3920
...      Lynx 1641 playing Black: 1075 - 1856 - 989  [0.400] 3920
...      White vs Black: 3695 - 2146 - 1999  [0.599] 7840
Elo difference: -0.6 +/- 6.6, LOS: 43.2 %, DrawRatio: 25.5 %
SPRT: llr 0.839 (28.5%), lbound -2.94, ubound 2.94
```

[Copy killer moves over from ply 0](https://github.com/lynx-chess/Lynx/pull/438/commits/d9db05fe0e81e021dbde851a04cdb955508e5d71) (1642)

```
Score of Lynx 1642 vs Lynx 1641: 2999 - 3004 - 1995  [0.500] 7998
...      Lynx 1642 playing White: 1889 - 1082 - 1029  [0.601] 4000
...      Lynx 1642 playing Black: 1110 - 1922 - 966  [0.398] 3998
...      White vs Black: 3811 - 2192 - 1995  [0.601] 7998
Elo difference: -0.2 +/- 6.6, LOS: 47.4 %, DrawRatio: 24.9 %
SPRT: llr -1.2 (-40.7%), lbound -2.94, ubound 2.94
```

[Remove ponder hit section completely](https://github.com/lynx-chess/Lynx/pull/438/commits/8669d50bc380832175f4fa7ceae404bd4fbc5ba3) (1643)

```
Score of Lynx 1643- remove ponderhit vs Lynx 1632 - main: 2290 - 2395 - 1690  [0.492] 6375
...      Lynx 1643- remove ponderhit playing White: 1475 - 869 - 843  [0.595] 3187
...      Lynx 1643- remove ponderhit playing Black: 815 - 1526 - 847  [0.388] 3188
...      White vs Black: 3001 - 1684 - 1690  [0.603] 6375
Elo difference: -5.7 +/- 7.3, LOS: 6.3 %, DrawRatio: 26.5 %
SPRT: llr -2.95 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```