### PR TITLE
🐛 Avoid re-searches in IDDFS

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -120,13 +120,13 @@ public sealed partial class Engine
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
-                for (int d = 1; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
+                for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
                 {
                     _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                depth = lastSearchResult.Depth - 1;
+                depth = lastSearchResult.Depth + 1; // Already reduced by 2
                 alpha = lastSearchResult.Alpha;
                 beta = lastSearchResult.Beta;
             }
@@ -215,7 +215,15 @@ public sealed partial class Engine
             _stopWatch.Stop();
         }
 
-        SearchResult finalSearchResult = lastSearchResult ??= new(default, bestEvaluation, depth, new List<Move>(), alpha, beta);
+        SearchResult finalSearchResult;
+        if (lastSearchResult is null)
+        {
+            finalSearchResult = new(default, bestEvaluation, depth, new List<Move>(), alpha, beta);
+        }
+        else
+        {
+            finalSearchResult = _previousSearchResult = lastSearchResult;
+        }
 
         finalSearchResult.IsCancelled = isCancelled;
         finalSearchResult.DepthReached = Math.Max(finalSearchResult.DepthReached, _maxDepthReached.LastOrDefault(item => item != default));


### PR DESCRIPTION
```
Score of Lynx 1647 vs Lynx 1632 - main: 2346 - 2241 - 1686  [0.508] 6273
...      Lynx 1647 playing White: 1482 - 807 - 848  [0.608] 3137
...      Lynx 1647 playing Black: 864 - 1434 - 838  [0.409] 3136
...      White vs Black: 2916 - 1671 - 1686  [0.599] 6273
Elo difference: 5.8 +/- 7.3, LOS: 93.9 %, DrawRatio: 26.9 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```