### PR TITLE
🧹 Remove `UseOnlineTablebaseInSearch` from UCI

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -588,16 +588,16 @@ public class Position
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int StaticEvaluation(int movesWithoutCaptureOrPawnMove, CancellationToken cancellationToken = default)
+    public int StaticEvaluation(int movesWithoutCaptureOrPawnMove)
     {
-        var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
-        Debug.Assert(result < EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
-        Debug.Assert(result > -EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
+        //var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
+        //Debug.Assert(result < EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
+        //Debug.Assert(result > -EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
 
-        if (result != OnlineTablebaseProber.NoResult)
-        {
-            return result;
-        }
+        //if (result != OnlineTablebaseProber.NoResult)
+        //{
+        //    return result;
+        //}
 
         var pieceCount = new int[PieceBitBoards.Length];
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -28,7 +28,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
         }
 
         _maxDepthReached[ply] = ply;
@@ -299,7 +299,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -308,7 +308,7 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _searchCancellationTokenSource.Token);
+        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -129,7 +129,7 @@ public sealed class OptionCommand : EngineBaseCommand
         $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL}",
         $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min 0 max 1024",
         $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
-        $"option name OnlineTablebaseInSearch type check default {Configuration.EngineSettings.UseOnlineTablebaseInSearch}",
+        //$"option name OnlineTablebaseInSearch type check default {Configuration.EngineSettings.UseOnlineTablebaseInSearch}",
         "option name Threads type spin default 1 min 1 max 1"
     );
 


### PR DESCRIPTION
Since it just doesn't work due to API rate limiting, we're not showing it as on option via UCI any more.
Configuration field remains and it's actually still settable via UCI, but it just won't have any effects