### PR TITLE
⚖ Soft cap history moves score

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -301,20 +301,22 @@ public static class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
-    public const int PVMoveScoreValue = 200_000;
+    public const int PVMoveScoreValue = 4_194_304;
 
-    public const int TTMoveScoreValue = 190_000;
+    public const int TTMoveScoreValue = 2_097_152;
 
     /// <summary>
     /// For MVVLVA
     /// </summary>
-    public const int CaptureMoveBaseScoreValue = 100_000;
+    public const int CaptureMoveBaseScoreValue = 1_048_576;
 
-    public const int FirstKillerMoveValue = 9_000;
+    public const int FirstKillerMoveValue = 524_288;
 
-    public const int SecondKillerMoveValue = 8_000;
+    public const int SecondKillerMoveValue = 262_144;
 
-    public const int PromotionMoveScoreValue = 7_000;
+    public const int PromotionMoveScoreValue = 131_072;
+
+    public const int MaxHistoryMoveValue = 8_192;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -162,6 +162,19 @@ public sealed partial class Engine
         return default;
     }
 
+    /// <summary>
+    /// Soft caps history score
+    /// Formula taken from EP discord, https://discord.com/channels/1132289356011405342/1132289356447625298/1141102105847922839
+    /// </summary>
+    /// <param name="score"></param>
+    /// <param name="rawHistoryBonus"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ScoreHistoryMove(int score, int rawHistoryBonus)
+    {
+        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / EvaluationConstants.MaxHistoryMoveValue);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
     {
@@ -337,6 +350,21 @@ $" {369,-3}                                           {_pVTable[369].ToEPDString
 $" {427,-3}                                                  {_pVTable[427].ToEPDString(),-6} {_pVTable[428].ToEPDString(),-6} {_pVTable[429].ToEPDString(),-6} {_pVTable[430].ToEPDString(),-6}" + Environment.NewLine +
 $" {484,-3}                                                         {_pVTable[484].ToEPDString(),-6} {_pVTable[485].ToEPDString(),-6} {_pVTable[486].ToEPDString(),-6}" + Environment.NewLine +
 (target == -1 ? "------------------------------------------------------------------------------------" + Environment.NewLine : ""));
+    }
+
+    internal void PrintHistoryMoves()
+    {
+        int max = int.MinValue;
+
+        foreach (var item in _historyMoves)
+        {
+            if (item > max)
+            {
+                max = item;
+            }
+        }
+
+        _logger.Debug($"Max history: {max}");
     }
 
     #endregion

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -149,7 +149,7 @@ public sealed partial class Engine
                 AspirationWindows_SearchAgain:
 
                 _isFollowingPV = true;
-                bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true); ;
+                bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
 
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
                 isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -241,7 +241,10 @@ public sealed partial class Engine
                 // 🔍 History moves
                 if (!move.IsCapture())
                 {
-                    _historyMoves[move.Piece(), move.TargetSquare()] += ply << 2;
+                    var piece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+
+                    _historyMoves[piece, targetSquare] = ScoreHistoryMove(_historyMoves[piece, targetSquare], ply << 2);
                 }
 
                 _pVTable[pvIndex] = move;


### PR DESCRIPTION
2'+1''
```
Score of Lynx 1663 - cap history vs Lynx 1661 - main: 464 - 314 - 335  [0.567] 1113
...      Lynx 1663 - cap history playing White: 294 - 100 - 163  [0.674] 557
...      Lynx 1663 - cap history playing Black: 170 - 214 - 172  [0.460] 556
...      White vs Black: 508 - 270 - 335  [0.607] 1113
Elo difference: 47.1 +/- 17.1, LOS: 100.0 %, DrawRatio: 30.1 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```