### PR TITLE
⚖ Tune aspiration windows

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,7 +28,7 @@
     "LMR_MaxDepth": 3,
     "LMR_DepthReduction": 1,
     "NMP_DepthReduction": 3,
-    "AspirationWindowDelta": 50,
+    "AspirationWindowDelta": 25,
     "AspirationWindowMinDepth": 6,
 
     // Evaluation

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,7 +237,7 @@ public sealed class EngineSettings
 
     public int NMP_DepthReduction { get; set; } = 3;
 
-    public int AspirationWindowDelta { get; set; } = 50;
+    public int AspirationWindowDelta { get; set; } = 25;
 
     public int AspirationWindowMinDepth { get; set; } = 6;
 


### PR DESCRIPTION
40+0.4 tests

Delta 75

```
Score of Lynx 1674* - asp 75 vs Lynx 1674 - main: 719 - 704 - 637  [0.504] 2060
...      Lynx 1674* - asp 75 playing White: 473 - 233 - 325  [0.616] 1031
...      Lynx 1674* - asp 75 playing Black: 246 - 471 - 312  [0.391] 1029
...      White vs Black: 944 - 479 - 637  [0.613] 2060
Elo difference: 2.5 +/- 12.5, LOS: 65.5 %, DrawRatio: 30.9 %
SPRT: llr 0.00347 (0.1%), lbound -2.94, ubound 2.94
```

Delta 25 [-5 0]
```
Score of Lynx 1674* asp windows 25 vs Lynx 1674 - main: 1978 - 1875 - 1690  [0.509] 5543
...      Lynx 1674* asp windows 25 playing White: 1320 - 624 - 828  [0.626] 2772
...      Lynx 1674* asp windows 25 playing Black: 658 - 1251 - 862  [0.393] 2771
...      White vs Black: 2571 - 1282 - 1690  [0.616] 5543
Elo difference: 6.5 +/- 7.6, LOS: 95.1 %, DrawRatio: 30.5 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
I'm afraid the result above wasn't run with real delta 25.
This is another one:
```
Score of Lynx 1706 asp windows 25 vs Lynx 1706 - main: 302 - 333 - 285  [0.483] 920
...      Lynx 1706 asp windows 25 playing White: 187 - 120 - 153  [0.573] 460
...      Lynx 1706 asp windows 25 playing Black: 115 - 213 - 132  [0.393] 460
...      White vs Black: 400 - 235 - 285  [0.590] 920
Elo difference: -11.7 +/- 18.6, LOS: 10.9 %, DrawRatio: 31.0 %
SPRT: llr -0.785 (-26.7%), lbound -2.94, ubound 2.94
```

8+0.08 tests

Delta 25 [-5 0]
```
Score of Lynx 1674* asp windows 25 vs Lynx 1674 - main: 446 - 509 - 365  [0.476] 1320
...      Lynx 1674* asp windows 25 playing White: 279 - 186 - 195  [0.570] 660
...      Lynx 1674* asp windows 25 playing Black: 167 - 323 - 170  [0.382] 660
...      White vs Black: 602 - 353 - 365  [0.594] 1320
Elo difference: -16.6 +/- 15.9, LOS: 2.1 %, DrawRatio: 27.7 %
SPRT: llr -1.07 (-36.2%), lbound -2.94, ubound 2.94
```


Two SPRT