### PR TITLE
Add negative offset to history move scores

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,6 +316,8 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 7_000;
 
+    public const int BaseHistoryMove = int.MinValue / 2;
+
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
     /// </summary>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,6 +316,8 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 131_072;
 
+    public const int MaxHistoryMoveValue = 8_192;
+
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,7 +316,7 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 131_072;
 
-    public const int MaxHistoryMoveValue = 8_192;
+    public const int MaxHistoryMoveValue = 2_048;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -319,7 +319,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int MoveBaseScore = int.MinValue / 2;
+    public const int BaseMoveScore = int.MinValue / 2;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,7 +316,7 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 131_072;
 
-    public const int MaxHistoryMoveValue = 4_096;
+    public const int MaxHistoryMoveValue = 16_384;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,7 +316,10 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 7_000;
 
-    public const int BaseHistoryMove = int.MinValue / 2;
+    /// <summary>
+    /// Negative offset to ensure history move scores don't reach other move ordering values
+    /// </summary>
+    public const int HistoryMoveOffset = int.MinValue / 2;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,7 +316,7 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 131_072;
 
-    public const int MaxHistoryMoveValue = 2_048;
+    public const int MaxHistoryMoveValue = 4_096;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -314,6 +314,8 @@ public static class EvaluationConstants
 
     public const int SecondKillerMoveValue = 262_144;
 
+    public const int PromotionMoveScoreValue = 131_072;
+
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -301,9 +301,9 @@ public static class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
-    public const int PVMoveScoreValue = 4_194_304;
+    public const int PVMoveScoreValue = 200_000;
 
-    public const int TTMoveScoreValue = 2_097_152;
+    public const int TTMoveScoreValue = 190_000;
 
     /// <summary>
     /// For MVVLVA
@@ -319,7 +319,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int BaseMoveScore = int.MinValue / 2;
+    public const int BaseMoveScore = 0;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -301,25 +301,23 @@ public static class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
-    public const int PVMoveScoreValue = 200_000;
+    public const int PVMoveScoreValue = 4_194_304;
 
-    public const int TTMoveScoreValue = 190_000;
+    public const int TTMoveScoreValue = 2_097_152;
 
     /// <summary>
     /// For MVVLVA
     /// </summary>
-    public const int CaptureMoveBaseScoreValue = 100_000;
+    public const int CaptureMoveBaseScoreValue = 1_048_576;
 
-    public const int FirstKillerMoveValue = 9_000;
+    public const int FirstKillerMoveValue = 524_288;
 
-    public const int SecondKillerMoveValue = 8_000;
-
-    public const int PromotionMoveScoreValue = 7_000;
+    public const int SecondKillerMoveValue = 262_144;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int BaseMoveScore = 0;
+    public const int BaseMoveScore = int.MinValue / 2;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -319,7 +319,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int HistoryMoveBaseScore = int.MinValue / 2;
+    public const int MoveBaseScore = int.MinValue / 2;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,7 +316,7 @@ public static class EvaluationConstants
 
     public const int PromotionMoveScoreValue = 131_072;
 
-    public const int MaxHistoryMoveValue = 16_384;
+    public const int MaxHistoryMoveValue = 8_192; // TODO move to Configuration.EngineSettings, since it's tunable
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -308,15 +308,13 @@ public static class EvaluationConstants
     /// <summary>
     /// For MVVLVA
     /// </summary>
-    public const int CaptureMoveBaseScoreValue = 1_048_576;
+    public const int CaptureMoveBaseScoreValue = 100_000;
 
-    public const int FirstKillerMoveValue = 524_288;
+    public const int FirstKillerMoveValue = 9_000;
 
-    public const int SecondKillerMoveValue = 262_144;
+    public const int SecondKillerMoveValue = 8_000;
 
-    public const int PromotionMoveScoreValue = 131_072;
-
-    public const int MaxHistoryMoveValue = 8_192;
+    public const int PromotionMoveScoreValue = 7_000;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -319,7 +319,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int HistoryMoveOffset = int.MinValue / 2;
+    public const int HistoryMoveBaseScore = int.MinValue / 2;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -156,10 +156,10 @@ public sealed partial class Engine
             }
 
             // History move or 0 if not found
-            return EvaluationConstants.MoveBaseScore + _historyMoves[move.Piece(), move.TargetSquare()];
+            return EvaluationConstants.BaseMoveScore + _historyMoves[move.Piece(), move.TargetSquare()];
         }
 
-        return EvaluationConstants.MoveBaseScore;
+        return EvaluationConstants.BaseMoveScore;
     }
 
     /// <summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -172,7 +172,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / EvaluationConstants.MaxHistoryMoveValue);
+        return score + rawHistoryBonus;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -156,10 +156,10 @@ public sealed partial class Engine
             }
 
             // History move or 0 if not found
-            return EvaluationConstants.HistoryMoveBaseScore + _historyMoves[move.Piece(), move.TargetSquare()];
+            return EvaluationConstants.MoveBaseScore + _historyMoves[move.Piece(), move.TargetSquare()];
         }
 
-        return default;
+        return EvaluationConstants.MoveBaseScore;
     }
 
     /// <summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -172,7 +172,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return EvaluationConstants.BaseHistoryMove + score + rawHistoryBonus;
+        return EvaluationConstants.HistoryMoveOffset + score + rawHistoryBonus;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -172,7 +172,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return score + rawHistoryBonus;
+        return EvaluationConstants.BaseHistoryMove + score + rawHistoryBonus;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -172,7 +172,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return score + rawHistoryBonus;
+        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / EvaluationConstants.MaxHistoryMoveValue);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -156,7 +156,7 @@ public sealed partial class Engine
             }
 
             // History move or 0 if not found
-            return _historyMoves[move.Piece(), move.TargetSquare()];
+            return EvaluationConstants.HistoryMoveBaseScore + _historyMoves[move.Piece(), move.TargetSquare()];
         }
 
         return default;
@@ -172,7 +172,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return EvaluationConstants.HistoryMoveOffset + score + rawHistoryBonus;
+        return score + rawHistoryBonus;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -37,7 +37,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {
-            Assert.AreEqual(0, engine.ScoreMove(move, default, default));
+            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default));
         }
     }
 


### PR DESCRIPTION
Change introduced as a fix for the wrong move ordering at high depths, so that it doesn't depend on the history cap search feature

# Proper SPRT of move ordering fix at LTC and history cap

Aggregated changes from #442:
```
Score of Lynx 1663 - cap history vs Lynx 1661 - main: 464 - 314 - 335  [0.567] 1113
...      Lynx 1663 - cap history playing White: 294 - 100 - 163  [0.674] 557
...      Lynx 1663 - cap history playing Black: 170 - 214 - 172  [0.460] 556
...      White vs Black: 508 - 270 - 335  [0.607] 1113
Elo difference: 47.1 +/- 17.1, LOS: 100.0 %, DrawRatio: 30.1 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Move ordering fix dependently vs what used to be main:
120' + 1''
```
Score of Lynx 1696 - mv ordering fix vs Lynx 1694 - base: 514 - 363 - 378  [0.560] 1255
...      Lynx 1696 - mv ordering fix playing White: 330 - 101 - 196  [0.683] 627
...      Lynx 1696 - mv ordering fix playing Black: 184 - 262 - 182  [0.438] 628
...      White vs Black: 592 - 285 - 378  [0.622] 1255
Elo difference: 42.0 +/- 16.1, LOS: 100.0 %, DrawRatio: 30.1 %
SPRT: llr 2.94 (100.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

[8_192 as history limit](https://github.com/lynx-chess/Lynx/pull/448/commits/97a0ca2c48864285353aa42c0c6fd89bd95e5281)
8+0.08
```
Score of Lynx 1698 8k cap vs Lynx 1696 move order fixed: 12840 - 12738 - 9449  [0.501] 35027
...      Lynx 1698 8k cap playing White: 8167 - 4628 - 4717  [0.601] 17512
...      Lynx 1698 8k cap playing Black: 4673 - 8110 - 4732  [0.402] 17515
...      White vs Black: 16277 - 9301 - 9449  [0.600] 35027
Elo difference: 1.0 +/- 3.1, LOS: 73.8 %, DrawRatio: 27.0 %
SPRT: llr -2.96 (-100.4%), lbound -2.94, ubound 2.94 - H0 was accepted
```

Double checking lack of regression
```
Score of Lynx 1698 8k cap vs Lynx 1684 - main: 4831 - 4775 - 3506  [0.502] 13112
...      Lynx 1698 8k cap playing White: 3062 - 1767 - 1727  [0.599] 6556
...      Lynx 1698 8k cap playing Black: 1769 - 3008 - 1779  [0.406] 6556
...      White vs Black: 6070 - 3536 - 3506  [0.597] 13112
Elo difference: 1.5 +/- 5.1, LOS: 71.6 %, DrawRatio: 26.7 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```

4096 vs main
```
Score of Lynx 1700 vs Lynx 1684 - main: 1318 - 1446 - 918  [0.483] 3682
...      Lynx 1700 playing White: 830 - 518 - 492  [0.585] 1840
...      Lynx 1700 playing Black: 488 - 928 - 426  [0.381] 1842
...      White vs Black: 1758 - 1006 - 918  [0.602] 3682
Elo difference: -12.1 +/- 9.7, LOS: 0.7 %, DrawRatio: 24.9 %
SPRT: llr -2.96 (-100.6%), lbound -2.94, ubound 2.94 - H0 was accepted
```

2048 vs main - didn't go great