### PR TITLE
⚖ Add scuffed mobility

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -956,38 +956,38 @@ static void FileAndRankMasks()
 static void EnhancedPawnEvaluation()
 {
     var position = new Position("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1");
-    var eval = position.StaticEvaluation(default);
+    var eval = position.StaticEvaluation();
     position.Print();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp4pp/p7/8/8/P7/PPP3P1/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PPP4P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/7P/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp1P/p7/8/8/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 }
 
@@ -995,17 +995,17 @@ static void RookEvaluation()
 {
     var position = new Position("r3k3/7p/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    var eval = position.StaticEvaluation(default);
+    var eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1p6/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1P6/8/8/8/8/7p/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 }
 

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -370,7 +370,7 @@ public sealed class LynxDriver
                     _logger.Debug("Raw fen: {0}, parsed fen: {1}", fen, ourFen);
                 }
 
-                var eval = WDL.NormalizeScore(position.StaticEvaluation(0));
+                var eval = WDL.NormalizeScore(position.StaticEvaluation());
                 if (position.Side == Side.Black)
                 {
                     eval = -eval;   // White perspective

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -602,7 +602,6 @@ public class Position
 
         var whitePerspectiveEval = TaperedStaticEvaluationFromWhitePerspective();
 
-        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         whitePerspectiveEval += MoveGenerator.LegalMovesCount(this, movePool);
 
         return Side == Side.White

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -6,7 +6,9 @@ namespace Lynx;
 
 public static class MoveGenerator
 {
+#if DEBUG
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+#endif
 
     private const int TRUE = 1;
 
@@ -294,13 +296,6 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int LegalMovesCount(Position position, Move[] movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return false;
-        }
-#endif
-
         int legalMoveCounter = 0;
 
         foreach (var move in GenerateAllMoves(position, movePool))

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -286,6 +286,38 @@ public static class MoveGenerator
             || IsAnyCastlingMoveValid(position, offset);
     }
 
+    /// <summary>
+    /// Counts legal moves from <paramref name="position"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int LegalMovesCount(Position position, Move[] movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return false;
+        }
+#endif
+
+        int legalMoveCounter = 0;
+
+        foreach (var move in GenerateAllMoves(position, movePool))
+        {
+            var gameState = position.MakeMove(move);
+
+            if (position.WasProduceByAValidMove())
+            {
+                ++legalMoveCounter;
+            }
+
+            position.UnmakeMove(move, gameState);
+        }
+
+        return legalMoveCounter;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyPawnMoveValid(Position position, int offset)
     {

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -294,8 +294,10 @@ public static class MoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int LegalMovesCount(Position position, Move[] movePool)
+    public static int LegalMovesCount(Position position, Move[]? movePool = null)
     {
+        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+
         int legalMoveCounter = 0;
 
         foreach (var move in GenerateAllMoves(position, movePool))

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -28,7 +28,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation(Game.MovePool);
         }
 
         _maxDepthReached[ply] = ply;
@@ -107,7 +107,7 @@ public sealed partial class Engine
 
         if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.RFP_MaxDepth)
         {
-            int staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            int staticEval = position.StaticEvaluation(Game.MovePool);
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
             if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
@@ -332,7 +332,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation(Game.MovePool);
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -341,7 +341,7 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+        var staticEvaluation = position.StaticEvaluation(Game.MovePool);
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -11,10 +11,10 @@ public class ForceOrAvoidDrawTest : BaseTest
     [TestCase("8/8/4NQ2/7k/2P4p/1q2P2P/5P2/6K1 b - - 5 52", new[] { "b3b1", "b3d1" },
         Description = "Force stalemate - https://lichess.org/sM5ekwnW/black#103, Having issues with null pruning implemeneted")]
     [TestCase("8/8/4NQ2/7k/2P4p/4P2P/5PK1/3q4 b - - 7 53", new[] { "d1h1", "d1g1", "d1f1" },
-        Description = "Force stalemate - https://lichess.org/sM5ekwnW/black#105")]
+    Description = "Force stalemate - https://lichess.org/sM5ekwnW/black#105")]
     public async Task ForceStaleMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        var result = await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
+        var result = await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 8);
         Assert.AreEqual(0, result.Evaluation, "No drawn position detected");
     }
 

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -154,11 +154,11 @@ public class GameTest : BaseTest
         }
 
         newPosition = new Position(game.CurrentPosition, repeatedMoves[^1]);
-        Assert.False(game.IsThreefoldRepetition(newPosition));                      // Same position, but white not can't castle
+        Assert.False(game.IsThreefoldRepetition(newPosition));                      // Same position, but white can't castle
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[^1]));
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
 
-        var eval = winningPosition.StaticEvaluation(default);
+        var eval = winningPosition.TaperedStaticEvaluationFromWhitePerspective();
         Assert.AreNotEqual(0, eval);
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -176,7 +176,7 @@ public class PositionTest
     {
         var position = new Position(fen);
 
-        Assert.AreEqual(0, position.StaticEvaluation(default));
+        Assert.AreEqual(0, position.TaperedStaticEvaluationFromWhitePerspective());
     }
 
     [TestCase("4k3/8/8/7Q/7q/8/4K3/8 w - - 0 1", "4k3/8/8/7Q/7q/8/8/4K3 w - - 0 1", Description = "King in 7th rank with queens > King in 8th rank with queens")]
@@ -184,7 +184,7 @@ public class PositionTest
     [TestCase("4k3/7p/8/8/4K3/8/7P/8 w - - 0 1", "4k3/7p/8/q7/4K3/Q7/7P/8 w - - 0 1", Description = "King in the center without queens > King in the center with queens")]
     public void StaticEvaluation_KingEndgame(string fen1, string fen2)
     {
-        Assert.Greater(new Position(fen1).StaticEvaluation(default), new Position(fen2).StaticEvaluation(default));
+        Assert.Greater(new Position(fen1).TaperedStaticEvaluationFromWhitePerspective(), new Position(fen2).TaperedStaticEvaluationFromWhitePerspective());
     }
 
     /// <summary>

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1,6 +1,5 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
-using System.Diagnostics.Contracts;
 
 namespace Lynx.Test.Model;
 


### PR DESCRIPTION
Add super-basic scuffed mobility by counting legal moves


Too expensive to compute?
This branch
```
position startpos
go depth 15
info depth 1 seldepth 1 multipv 1 score cp 92 nodes 20 nps 19 time 34 pv g1f3
info depth 2 seldepth 4 multipv 1 score cp 30 nodes 351 nps 335 time 48 pv d2d4 g8f6
info depth 3 seldepth 8 multipv 1 score cp 89 nodes 1185 nps 1084 time 93 pv d2d4 g8f6 g1f3
info depth 4 seldepth 8 multipv 1 score cp 37 nodes 1922 nps 1633 time 177 pv g1f3 g8f6 d2d4 d7d5
info depth 5 seldepth 9 multipv 1 score cp 92 nodes 2030 nps 1580 time 285 pv g1f3 g8f6 d2d4 b8c6 b1c3
info depth 6 seldepth 16 multipv 1 score cp 42 nodes 22401 nps 12201 time 836 pv g1f3 g8f6 e2e3 e7e6 f1d3 f8d6
info depth 7 seldepth 16 multipv 1 score cp 70 nodes 26606 nps 11952 time 1226 pv g1f3 g8f6 b1c3 d7d5 d2d4 b8c6 c1f4
info depth 8 seldepth 26 multipv 1 score cp 50 nodes 289385 nps 69866 time 3142 pv b1c3 g8f6 g1f3 d7d5 e2e3 b8c6 f1d3 c6b4
info depth 9 seldepth 26 multipv 1 score cp 71 nodes 175756 nps 32608 time 4390 pv g1f3 g8f6 b1c3 d7d5 d2d4 b8c6 h2h3 h7h6 c1f4
info depth 10 seldepth 28 multipv 1 score cp 57 nodes 2651130 nps 140711 time 17841 pv d2d4 g8f6 b1c3 d7d5 c1f4 f6h5 f4d2 h5f6 g1f3 b8c6
info depth 11 seldepth 28 multipv 1 score cp 75 nodes 1402866 nps 52221 time 25864 pv d2d4 g8f6 b1c3 d7d5 g1f3 b8c6 c1f4 f6h5 f4d2 h7h6 c3b5
stop
info depth 11 seldepth 30 multipv 1 score cp 75 nodes 5326836 nps 83421 time 62855 hashfull 52 pv d2d4 g8f6 b1c3 d7d5 g1f3 b8c6 c1f4 f6h5 f4d2 h7h6 c3b5
```

main
```
position startpos
go depth 11
info depth 1 seldepth 1 multipv 1 score cp 66 nodes 20 nps 19 time 35 pv g1f3
info depth 2 seldepth 4 multipv 1 score cp 0 nodes 392 nps 374 time 48 pv g1f3 g8f6
info depth 3 seldepth 8 multipv 1 score cp 61 nodes 1181 nps 1105 time 69 pv d2d4 g8f6 g1f3
info depth 4 seldepth 8 multipv 1 score cp 0 nodes 1936 nps 1750 time 106 pv g1f3 g8f6 d2d4 d7d5
info depth 5 seldepth 9 multipv 1 score cp 60 nodes 1891 nps 1653 time 144 pv g1f3 g8f6 d2d4 d7d5 b1c3
info depth 6 seldepth 12 multipv 1 score cp 0 nodes 22190 nps 15178 time 462 pv g1f3 g8f6 d2d4 d7d5 b1c3 b8c6
info depth 7 seldepth 18 multipv 1 score cp 32 nodes 20471 nps 12214 time 676 pv g1f3 g8f6 d2d4 d7d5 b1c3 b8c6 c1f4
info depth 8 seldepth 22 multipv 1 score cp 5 nodes 86219 nps 36956 time 1333 pv g1f3 g8f6 b1c3 d7d5 e2e3 b8c6 f1d3 c6b4
info depth 9 seldepth 23 multipv 1 score cp 26 nodes 172869 nps 61673 time 1803 pv g1f3 g8f6 b1c3 d7d5 d2d4 b8c6 h2h3 c8f5 c1f4
info depth 10 seldepth 26 multipv 1 score cp 10 nodes 943378 nps 184182 time 4122 pv d2d4 g8f6 g1f3 d7d5 b1c3 b8c6 c1f4
info depth 11 seldepth 26 multipv 1 score cp 34 nodes 1237512 nps 157184 time 6873 pv b1c3 g8f6 d2d4 d7d5 g1f3 b8c6 c1f4
info depth 11 seldepth 26 multipv 1 score cp 34 nodes 1237512 nps 157184 time 6873 hashfull 15 pv b1c3 g8f6 d2d4 d7d5 g1f3 b8c6 c1f4
```

```
Score of Lynx 1709 - scuffed mob vs Lynx 1706 - main: 8 - 62 - 10  [0.163] 80
...      Lynx 1709 - scuffed mob playing White: 5 - 29 - 6  [0.200] 40
...      Lynx 1709 - scuffed mob playing Black: 3 - 33 - 4  [0.125] 40
...      White vs Black: 38 - 32 - 10  [0.537] 80
Elo difference: -284.9 +/- 95.9, LOS: 0.0 %, DrawRatio: 12.5 %
SPRT: llr -1.03 (-34.9%), lbound -2.94, ubound 2.94
```