### PR TITLE
Implement PEXT bitboards for bishop and rook attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ If you're a Linux user and are new to .NET ecosystem, the conversation in [this 
 
 - Razoring [[1](https://www.chessprogramming.org/Razoring)]
 
+- PEXT Bitboards [[1](https://www.chessprogramming.org/BMI2#PEXTBitboards)]  [[2](https://analog-hors.github.io/site/magic-bitboards/)]
+
 ## Credits
 
 Lynx development wouldn't have been possible without:

--- a/src/Lynx.Benchmark/InitializeBishopAndRookAttacks.cs
+++ b/src/Lynx.Benchmark/InitializeBishopAndRookAttacks.cs
@@ -34,8 +34,8 @@ public class InitializeBishopAndRookAttacks : BaseBenchmark
             _pawnAttacks = AttackGenerator.InitializePawnAttacks();
             _knightAttacks = AttackGenerator.InitializeKnightAttacks();
 
-            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopAttacks();
-            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookAttacks();
+            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopMagicAttacks();
+            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookMagicAttacks();
         }
 
         /// <summary>
@@ -46,8 +46,8 @@ public class InitializeBishopAndRookAttacks : BaseBenchmark
         {
             InitializePawnKnightAndKingAttacks();
 
-            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopAttacks();
-            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookAttacks();
+            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopMagicAttacks();
+            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookMagicAttacks();
         }
 
         /// <summary>

--- a/src/Lynx.Benchmark/MakeUnmakeMove_implementation.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_implementation.cs
@@ -1261,8 +1261,8 @@ public class MakeUnmakeMove_implementation : BaseBenchmark
             PawnAttacks = AttackGenerator.InitializePawnAttacks();
             KnightAttacks = AttackGenerator.InitializeKnightAttacks();
 
-            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopAttacks();
-            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookAttacks();
+            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopMagicAttacks();
+            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookMagicAttacks();
         }
 
         /// <summary>

--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration.cs
@@ -1671,8 +1671,8 @@ public class MakeUnmakeMove_integration : BaseBenchmark
             PawnAttacks = AttackGenerator.InitializePawnAttacks();
             KnightAttacks = AttackGenerator.InitializeKnightAttacks();
 
-            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopAttacks();
-            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookAttacks();
+            (_bishopOccupancyMasks, _bishopAttacks) = AttackGenerator.InitializeBishopMagicAttacks();
+            (_rookOccupancyMasks, _rookAttacks) = AttackGenerator.InitializeRookMagicAttacks();
         }
 
         /// <summary>

--- a/src/Lynx.Benchmark/PEXT.cs
+++ b/src/Lynx.Benchmark/PEXT.cs
@@ -1,4 +1,44 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿/*
+ *
+ * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ * Intel Xeon Platinum 8171M CPU 2.60GHz, 1 CPU, 2 logical and 2 physical cores
+ * .NET SDK 8.0.100-rc.2.23502.2
+ *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *
+ *
+ * | Method       | Mean     | Error   | StdDev  | Ratio | Allocated | Alloc Ratio |
+ * |------------- |---------:|--------:|--------:|------:|----------:|------------:|
+ * | MagicNumbers | 378.1 ns | 6.19 ns | 5.79 ns |  1.00 |         - |          NA |
+ * | PEXT         | 229.7 ns | 2.79 ns | 2.61 ns |  0.61 |         - |          NA |
+ *
+ * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 10 (10.0.20348.2031) (Hyper-V)
+ * Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
+ * .NET SDK 8.0.100-rc.2.23502.2
+ *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *
+ *
+ * | Method       | Mean     | Error   | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
+ * |------------- |---------:|--------:|---------:|------:|--------:|----------:|------------:|
+ * | MagicNumbers | 408.9 ns | 8.14 ns | 13.59 ns |  1.00 |    0.00 |         - |          NA |
+ * | PEXT         | 326.3 ns | 6.46 ns |  7.93 ns |  0.79 |    0.03 |         - |          NA |
+ *
+ * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, macOS Monterey 12.6.9 (21G726) [Darwin 1.6.0]
+ * Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
+ * .NET SDK 8.0.100-rc.2.23502.2
+ *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
+ *
+ *
+ * | Method       | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
+ * |------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
+ * | MagicNumbers | 436.3 ns | 28.75 ns | 84.33 ns |  1.00 |    0.00 |         - |          NA |
+ * | PEXT         | 274.5 ns | 20.23 ns | 58.69 ns |  0.66 |    0.19 |         - |          NA |
+ *
+ */
+
+using BenchmarkDotNet.Attributes;
 using Lynx.Model;
 
 namespace Lynx.Benchmark;

--- a/src/Lynx.Benchmark/PEXT.cs
+++ b/src/Lynx.Benchmark/PEXT.cs
@@ -1,0 +1,44 @@
+﻿using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+
+namespace Lynx.Benchmark;
+public class PEXTBenchmark : BaseBenchmark
+{
+    private readonly Position _position = new Position(Constants.TrickyTestPositionFEN);
+
+    [Benchmark(Baseline = true)]
+    public ulong MagicNumbers()
+    {
+        ulong result = default;
+
+        for (int i = 0; i < 64; ++i)
+        {
+            result |= MagicNumbersRookAttacks(i, _position.OccupancyBitBoards[0]);
+            result |= MagicNumbersBishopAttacks(i, _position.OccupancyBitBoards[0]);
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public ulong PEXT()
+    {
+        ulong result = default;
+
+        for (int i = 0; i < 64; ++i)
+        {
+            result |= PEXTRookAttacks(i, _position.OccupancyBitBoards[0]);
+            result |= PEXTBishopAttacks(i, _position.OccupancyBitBoards[0]);
+        }
+
+        return result;
+    }
+
+    private static BitBoard MagicNumbersRookAttacks(int squareIndex, BitBoard occupancy) => Attacks.MagicNumbersRookAttacks(squareIndex, occupancy);
+
+    private static BitBoard PEXTRookAttacks(int squareIndex, BitBoard occupancy) => Attacks.RookAttacks(squareIndex, occupancy);
+
+    private static BitBoard MagicNumbersBishopAttacks(int squareIndex, BitBoard occupancy) => Attacks.MagicNumbersBishopAttacks(squareIndex, occupancy);
+
+    private static BitBoard PEXTBishopAttacks(int squareIndex, BitBoard occupancy) => Attacks.BishopAttacks(squareIndex, occupancy);
+}

--- a/src/Lynx/AttackGenerator.cs
+++ b/src/Lynx/AttackGenerator.cs
@@ -72,7 +72,7 @@ public static class AttackGenerator
     /// Returns bishop occupancy masks and attacks
     /// </summary>
     /// <returns>(BitBoard[64], BitBoard[64, 512])</returns>
-    public static (BitBoard[] BishopOccupancyMasks, BitBoard[,] BishopAttacks) InitializeBishopAttacks()
+    public static (BitBoard[] BishopOccupancyMasks, BitBoard[,] BishopAttacks) InitializeBishopMagicAttacks()
     {
         BitBoard[] occupancyMasks = new BitBoard[64];
         BitBoard[,] attacks = new BitBoard[64, 512];
@@ -102,7 +102,7 @@ public static class AttackGenerator
     /// Returns rook occupancy masks and attacks
     /// </summary>
     /// <returns>(BitBoard[64], BitBoard[64, 512])</returns>
-    public static (BitBoard[] RookOccupancyMasks, BitBoard[,] RookAttacks) InitializeRookAttacks()
+    public static (BitBoard[] RookOccupancyMasks, BitBoard[,] RookAttacks) InitializeRookMagicAttacks()
     {
         BitBoard[] occupancyMasks = new BitBoard[64];
         BitBoard[,] attacks = new BitBoard[64, 4096];

--- a/tests/Lynx.Test/PregeneratedAttacks/BishopAttacksTest.cs
+++ b/tests/Lynx.Test/PregeneratedAttacks/BishopAttacksTest.cs
@@ -47,7 +47,7 @@ public class BishopAttacksTest
     }
 
     /// <summary>
-    /// Implicitly tests <see cref="AttackGenerator.InitializeBishopAttacks"/> and <see cref="Constants.BishopMagicNumbers"/>
+    /// Implicitly tests <see cref="AttackGenerator.InitializeBishopMagicAttacks"/> and <see cref="Constants.BishopMagicNumbers"/>
     /// </summary>
     /// <param name="bishopSquare"></param>
     /// <param name="occupiedSquares"></param>
@@ -76,6 +76,7 @@ public class BishopAttacksTest
 
         // Act
         var attacks = Attacks.BishopAttacks((int)bishopSquare, occupancy);
+        Assert.AreEqual(Attacks.MagicNumbersBishopAttacks((int)bishopSquare, occupancy), attacks);
 
         // Assert
         foreach (var attackedSquare in attackedSquares)

--- a/tests/Lynx.Test/PregeneratedAttacks/QueenAttacksTest.cs
+++ b/tests/Lynx.Test/PregeneratedAttacks/QueenAttacksTest.cs
@@ -7,7 +7,7 @@ namespace Lynx.Test.PregeneratedAttacks;
 public class QueenAttacksTest
 {
     /// <summary>
-    /// Implicitly tests <see cref="AttackGenerator.InitializeBishopAttacks"/> and <see cref="Constants.BishopMagicNumbers"/>
+    /// Implicitly tests <see cref="AttackGenerator.InitializeBishopMagicAttacks"/> and <see cref="Constants.BishopMagicNumbers"/>
     /// </summary>
     /// <param name="bishopSquare"></param>
     /// <param name="occupiedSquares"></param>

--- a/tests/Lynx.Test/PregeneratedAttacks/RookAttacksTest.cs
+++ b/tests/Lynx.Test/PregeneratedAttacks/RookAttacksTest.cs
@@ -42,7 +42,7 @@ public class RookAttacksTest
     }
 
     /// <summary>
-    /// Implicitly tests <see cref="AttackGenerator.InitializeRookAttacks"/> and <see cref="Constants.RookMagicNumbers"/>
+    /// Implicitly tests <see cref="AttackGenerator.InitializeRookMagicAttacks"/> and <see cref="Constants.RookMagicNumbers"/>
     /// </summary>
     /// <param name="rookSquare"></param>
     /// <param name="occupiedSquares"></param>
@@ -71,6 +71,7 @@ public class RookAttacksTest
 
         // Act
         var attacks = Attacks.RookAttacks((int)rookSquare, occupancy);
+        Assert.AreEqual(Attacks.MagicNumbersRookAttacks((int)rookSquare, occupancy), attacks);
 
         // Assert
         ValidateAttacks(attackedSquares, attacks);


### PR DESCRIPTION
```
Score of Lynx 1712 - pext vs Lynx 1706 - main: 5927 - 5819 - 4034  [0.503] 15780
...      Lynx 1712 - pext playing White: 3740 - 2139 - 2012  [0.601] 7891
...      Lynx 1712 - pext playing Black: 2187 - 3680 - 2022  [0.405] 7889
...      White vs Black: 7420 - 4326 - 4034  [0.598] 15780
Elo difference: 2.4 +/- 4.7, LOS: 84.0 %, DrawRatio: 25.6 %
SPRT: llr -0.107 (-3.6%), lbound -2.94, ubound 2.94
```

```
C:\dev\sprt [main ≡]> python3 .\sprt.py --wins 5930 --losses 5823 --draws 4037 --elo0 -5 --elo1 0
ELO: 2.35 +- 4.67 [-2.31, 7.02]
LLR: 3.85 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```

```
 * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
 * Intel Xeon Platinum 8171M CPU 2.60GHz, 1 CPU, 2 logical and 2 physical cores
 * .NET SDK 8.0.100-rc.2.23502.2
 *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *
 *
 * | Method       | Mean     | Error   | StdDev  | Ratio | Allocated | Alloc Ratio |
 * |------------- |---------:|--------:|--------:|------:|----------:|------------:|
 * | MagicNumbers | 378.1 ns | 6.19 ns | 5.79 ns |  1.00 |         - |          NA |
 * | PEXT         | 229.7 ns | 2.79 ns | 2.61 ns |  0.61 |         - |          NA |
 *
 * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, Windows 10 (10.0.20348.2031) (Hyper-V)
 * Intel Xeon CPU E5-2673 v4 2.30GHz, 1 CPU, 2 logical and 2 physical cores
 * .NET SDK 8.0.100-rc.2.23502.2
 *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *
 *
 * | Method       | Mean     | Error   | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
 * |------------- |---------:|--------:|---------:|------:|--------:|----------:|------------:|
 * | MagicNumbers | 408.9 ns | 8.14 ns | 13.59 ns |  1.00 |    0.00 |         - |          NA |
 * | PEXT         | 326.3 ns | 6.46 ns |  7.93 ns |  0.79 |    0.03 |         - |          NA |
 *
 * BenchmarkDotNet v0.13.9+228a464e8be6c580ad9408e98f18813f6407fb5a, macOS Monterey 12.6.9 (21G726) [Darwin 1.6.0]
 * Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
 * .NET SDK 8.0.100-rc.2.23502.2
 *   [Host]     : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *   DefaultJob : .NET 8.0.0 (8.0.23.47906), X64 RyuJIT AVX2
 *
 *
 * | Method       | Mean     | Error    | StdDev   | Ratio | RatioSD | Allocated | Alloc Ratio |
 * |------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
 * | MagicNumbers | 436.3 ns | 28.75 ns | 84.33 ns |  1.00 |    0.00 |         - |          NA |
 * | PEXT         | 274.5 ns | 20.23 ns | 58.69 ns |  0.66 |    0.19 |         - |          NA |
 *
 */
```