### PR TITLE
🐛 Checkmate has precedence over 50 moves rule

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -122,8 +122,15 @@ public sealed class Game
     public bool IsThreefoldRepetition(Position position) => PositionHashHistory.Contains(position.UniqueIdentifier);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition() => HalfMovesWithoutCaptureOrPawnMove >= 100
-            && (!CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition));
+    public bool Is50MovesRepetition()
+    {
+        if (HalfMovesWithoutCaptureOrPawnMove < 100)
+        {
+            return false;
+        }
+
+        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition);
+    }
 
     /// <summary>
     /// To be used in online tb proving only, with a copy of <see cref="PositionHashHistory"/>

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -122,7 +122,8 @@ public sealed class Game
     public bool IsThreefoldRepetition(Position position) => PositionHashHistory.Contains(position.UniqueIdentifier);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition() => HalfMovesWithoutCaptureOrPawnMove >= 100;
+    public bool Is50MovesRepetition() => HalfMovesWithoutCaptureOrPawnMove >= 100
+            && (!CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition));
 
     /// <summary>
     /// To be used in online tb proving only, with a copy of <see cref="PositionHashHistory"/>

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -216,4 +216,18 @@ public class ForceOrAvoidDrawTest : BaseTest
         Assert.AreEqual(movesThatAllowsRepetition.UCIString(), bestMoveFound.UCIString(), "No 50 moves rule forced");
         Assert.AreEqual(0, searchResult.Evaluation, "No drawn position detected");
     }
+
+    /// <summary>
+    /// If a checkmate is delivered in move 50 (ply 100), the result of the game is checkmate
+    /// </summary>
+    /// <returns></returns>
+    [Test]
+    public async Task CheckmateHasPrecedenceOver50MovesRule()
+    {
+        // Source: https://github.com/PGG106/Alexandria/issues/213
+        const string mateIn1Fen = "4Q3/8/1p4pk/1PbB1p1p/7P/p3P1PK/P3qP2/8 w - - 99 88";
+
+        var result = await TestBestMove(mateIn1Fen, new[] { "e8h8" }, Array.Empty<string>(), depth: 1);
+        Assert.AreEqual(1, result.Mate);
+    }
 }

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -192,7 +192,8 @@ public class GameTest : BaseTest
 
         Assert.AreEqual(101, game.MoveHistory.Count);
 
-        Assert.True(game.Is50MovesRepetition());
+        // If the checkmate is in the move when it's claimed, checkmate remains
+        Assert.False(game.Is50MovesRepetition());
     }
 
     [Test]


### PR DESCRIPTION
If mate is delivered in move 50 (ply 100) without captures or pawn moves, it's mate


SSS, but enough
```
Score of Lynx 1729 mate move 50 vs Lynx 1717 - main: 253 - 223 - 164  [0.523] 640
...      Lynx 1729 mate move 50 playing White: 152 - 83 - 85  [0.608] 320
...      Lynx 1729 mate move 50 playing Black: 101 - 140 - 79  [0.439] 320
...      White vs Black: 292 - 184 - 164  [0.584] 640
Elo difference: 16.3 +/- 23.2, LOS: 91.5 %, DrawRatio: 25.6 %
SPRT: llr 0.67 (22.8%), lbound -2.94, ubound 2.94
```