### PR TITLE
🐛 Fix `ucinewgame` command when followed by `go` command

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -51,6 +51,7 @@ public sealed partial class Engine
     public void NewGame()
     {
         AverageDepth = 0;
+        Game = new Game();
         _isNewGameComing = true;
         _isNewGameCommandSupported = true;
         InitializeTT();


### PR DESCRIPTION
Fix `ucinewgame` command, so that it actually internally initializes a new game.

Before:
```bash
position startpos
go depth 3
info depth 1 seldepth 1 multipv 1 score cp 66 nodes 20 nps 19 time 48 pv g1f3
info depth 2 seldepth 4 multipv 1 score cp 0 nodes 392 nps 369 time 61 pv g1f3 g8f6
info depth 3 seldepth 6 multipv 1 score cp 3 nodes 118 nps 111 time 63 pv a2a3 g8f6 g1f3
info depth 3 seldepth 6 multipv 1 score cp 3 nodes 118 nps 111 time 63 hashfull 0 pv a2a3 g8f6 g1f3
bestmove a2a3 ponder g8f6

ucinewgame
go depth 3
# Black to move, board wasn't reset
info depth 1 seldepth 1 multipv 1 score cp 62 nodes 20 nps 20 time 3 pv g8f6
info depth 2 seldepth 5 multipv 1 score cp -3 nodes 379 nps 376 time 9 pv g8f6 g1f3
info depth 3 seldepth 6 multipv 1 score cp 0 nodes 109 nps 108 time 13 pv a7a6 g1f3 g8f6
info depth 3 seldepth 6 multipv 1 score cp 0 nodes 109 nps 108 time 13 hashfull 0 pv a7a6 g1f3 g8f6
bestmove a7a6 ponder g1f3
```

After:
```bash
position startpos
go depth 3
info depth 1 seldepth 1 multipv 1 score cp 66 nodes 20 nps 19 time 53 pv g1f3
info depth 2 seldepth 4 multipv 1 score cp 0 nodes 392 nps 368 time 65 pv g1f3 g8f6
info depth 3 seldepth 8 multipv 1 score cp 61 nodes 1181 nps 1086 time 87 pv d2d4 g8f6 g1f3
info depth 3 seldepth 8 multipv 1 score cp 61 nodes 1181 nps 1086 time 87 hashfull 0 pv d2d4 g8f6 g1f3
bestmove d2d4 ponder g8f6

ucinewgame
go depth 3
# Same result as before
info depth 1 seldepth 1 multipv 1 score cp 66 nodes 20 nps 20 time 0 pv g1f3
info depth 2 seldepth 4 multipv 1 score cp 0 nodes 392 nps 389 time 7 pv g1f3 g8f6
info depth 3 seldepth 8 multipv 1 score cp 61 nodes 1181 nps 1144 time 32 pv d2d4 g8f6 g1f3
info depth 3 seldepth 8 multipv 1 score cp 61 nodes 1181 nps 1144 time 32 hashfull 0 pv d2d4 g8f6 g1f3
bestmove d2d4 ponder g8f6
```