### PR TITLE
Decay history moves between searches instead of clearing them

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -106,23 +106,6 @@ public sealed partial class Engine
                 return result;
             }
 
-            if (Game.MoveHistory.Count >= 2
-                && _previousSearchResult?.Moves.Count > 2
-                && _previousSearchResult.BestMove != default
-                && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
-                && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
-            {
-                _logger.Debug("Ponder hit");
-
-                lastSearchResult = new SearchResult(_previousSearchResult);
-
-                Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
-
-                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
-
-                depth = lastSearchResult.Depth + 1; // Already reduced by 2
-            }
-
             Array.Clear(_killerMoves);
             Array.Clear(_historyMoves);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -120,26 +120,11 @@ public sealed partial class Engine
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
-                for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
-                {
-                    _killerMoves[0, d] = _previousKillerMoves[0, d + 2];
-                    _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
-                }
-
                 depth = lastSearchResult.Depth + 1; // Already reduced by 2
             }
-            else
-            {
-                Array.Clear(_killerMoves);
 
-                for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
-                {
-                    for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
-                    {
-                        _historyMoves[pieceIndex, squareIndex] /= 10;
-                    }
-                }
-            }
+            Array.Clear(_killerMoves);
+            Array.Clear(_historyMoves);
 
             do
             {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -136,7 +136,7 @@ public sealed partial class Engine
                 {
                     for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
                     {
-                        _historyMoves[pieceIndex, squareIndex] /= 2;
+                        _historyMoves[pieceIndex, squareIndex] /= 10;
                     }
                 }
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -131,7 +131,14 @@ public sealed partial class Engine
             else
             {
                 Array.Clear(_killerMoves);
-                Array.Clear(_historyMoves);
+
+                for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
+                {
+                    for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
+                    {
+                        _historyMoves[pieceIndex, squareIndex] /= 2;
+                    }
+                }
             }
 
             do


### PR DESCRIPTION
Decay history moves to 0.5 between searches instead of clearing them (resetting to 0)

1771: decay 50%

```
Score of Lynx 1771 - hist decay vs Lynx 1768 - main: 375 - 435 - 448  [0.476] 1258
...      Lynx 1771 - hist decay playing White: 243 - 159 - 228  [0.567] 630
...      Lynx 1771 - hist decay playing Black: 132 - 276 - 220  [0.385] 628
...      White vs Black: 519 - 291 - 448  [0.591] 1258
Elo difference: -16.6 +/- 15.4, LOS: 1.8 %, DrawRatio: 35.6 %
SPRT: llr -1.55 (-53.5%), lbound -2.25, ubound 2.89
```

1772: decay 90%
```
Score of Lynx 1772 - hist decay vs Lynx 1768 - main: 1262 - 1335 - 1411  [0.491] 4008
...      Lynx 1772 - hist decay playing White: 855 - 444 - 705  [0.603] 2004
...      Lynx 1772 - hist decay playing Black: 407 - 891 - 706  [0.379] 2004
...      White vs Black: 1746 - 851 - 1411  [0.612] 4008
Elo difference: -6.3 +/- 8.6, LOS: 7.6 %, DrawRatio: 35.2 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

1778: always clear history
```
Score of Lynx 1778 vs Lynx 1770 - main: 719 - 802 - 856  [0.483] 2377
...      Lynx 1778 playing White: 477 - 265 - 447  [0.589] 1189
...      Lynx 1778 playing Black: 242 - 537 - 409  [0.376] 1188
...      White vs Black: 1014 - 507 - 856  [0.607] 2377
Elo difference: -12.1 +/- 11.2, LOS: 1.7 %, DrawRatio: 36.0 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

1779/1788: remove ponder hit
```
Score of Lynx 1788 vs Lynx 1786 - main: 963 - 1048 - 956  [0.486] 2967
...      Lynx 1788 playing White: 614 - 394 - 475  [0.574] 1483
...      Lynx 1788 playing Black: 349 - 654 - 481  [0.397] 1484
...      White vs Black: 1268 - 743 - 956  [0.588] 2967
Elo difference: -10.0 +/- 10.3, LOS: 2.9 %, DrawRatio: 32.2 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```