### PR TITLE
🐛 Avoid storing the same move duplicated in both killer moves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -254,7 +254,7 @@ public sealed partial class Engine
                 PrintMessage($"Pruning: {move} is enough");
 
                 // 🔍 Killer moves
-                if (!move.IsCapture() && move.PromotedPiece() == default)
+                if (!move.IsCapture() && move.PromotedPiece() == default && move != _killerMoves[0, ply])
                 {
                     _killerMoves[1, ply] = _killerMoves[0, ply];
                     _killerMoves[0, ply] = move;


### PR DESCRIPTION
```
Score of Lynx 1787 killer vs Lynx 1786 - main: 1496 - 1420 - 1584  [0.508] 4500
...      Lynx 1787 killer playing White: 990 - 468 - 792  [0.616] 2250
...      Lynx 1787 killer playing Black: 506 - 952 - 792  [0.401] 2250
...      White vs Black: 1942 - 974 - 1584  [0.608] 4500
Elo difference: 5.9 +/- 8.2, LOS: 92.0 %, DrawRatio: 35.2 %
SPRT: llr 0.969 (33.5%), lbound -2.25, ubound 2.89
```