### PR TITLE
🔍 Don't clear TT move if no best move is provided: keep old one

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -172,7 +172,7 @@ public static class TranspositionTableExtensions
         entry.Key = position.UniqueIdentifier;
         entry.Score = score;
         entry.Depth = depth;
-        entry.Move = move ?? entry.Move;
+        entry.Move = move ?? entry.Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
         entry.Type = nodeType;
     }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -172,7 +172,7 @@ public static class TranspositionTableExtensions
         entry.Key = position.UniqueIdentifier;
         entry.Score = score;
         entry.Depth = depth;
-        entry.Move = move ?? 0;
+        entry.Move = move ?? entry.Move;
         entry.Type = nodeType;
     }
 


### PR DESCRIPTION
8+0.08
```
Score of Lynx 1794 vs Lynx 1792 - main: 1347 - 1187 - 1330  [0.521] 3864
...      Lynx 1794 playing White: 886 - 405 - 642  [0.624] 1933
...      Lynx 1794 playing Black: 461 - 782 - 688  [0.417] 1931
...      White vs Black: 1668 - 866 - 1330  [0.604] 3864
Elo difference: 14.4 +/- 8.9, LOS: 99.9 %, DrawRatio: 34.4 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```