### PR TITLE
Add tempo bonus II

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -69,10 +69,6 @@
       "MG": 15,
       "EG": -5
     },
-    "BishopPairBonus": {
-      "MG": 22,
-      "EG": 65
-    },
     "PassedPawnBonus": {
       "Rank0": {
         "MG": 0,
@@ -106,6 +102,10 @@
         "MG": 200,
         "EG": 200
       }
+    },
+    "TempoBonus": {
+      "MG": 5,
+      "EG": 5
     },
     // End of evaluation
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -281,6 +281,8 @@ public sealed class EngineSettings
         new(53, 191),
         new(200));
 
+    public TaperedEvaluationTerm TempoBonus { get; set; } = new(5, 5);
+
     #endregion
 
     public bool TranspositionTableEnabled { get; set; } = true;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -687,6 +687,9 @@ public class Position
             }
         }
 
+        middleGameScore += Configuration.EngineSettings.TempoBonus.MG;
+        endGameScore += Configuration.EngineSettings.TempoBonus.EG;
+
         const int maxPhase = 24;
 
         if (gamePhase > maxPhase)    // Early promotions
@@ -697,11 +700,11 @@ public class Position
         int endGamePhase = maxPhase - gamePhase;
         //_logger.Trace("Phase: {0}/24", gamePhase);
 
-        var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
+        var score = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
         return Side == Side.White
-            ? eval
-            : -eval;
+            ? score
+            : -score;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/423

8+0.08
```
Score of Lynx 1797 vs Lynx 1795 - main: 89 - 104 - 107  [0.475] 300
...      Lynx 1797 playing White: 59 - 34 - 57  [0.583] 150
...      Lynx 1797 playing Black: 30 - 70 - 50  [0.367] 150
...      White vs Black: 129 - 64 - 107  [0.608] 300
Elo difference: -17.4 +/- 31.6, LOS: 14.0 %, DrawRatio: 35.7 %
SPRT: llr -0.384 (-13.3%), lbound -2.25, ubound 2.89
```