### PR TITLE
Add HardTimeBound coefficients

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -24,7 +24,7 @@
     //"DepthWhenLessThanMinMoveTime": 5,
     "MinElapsedTimeToConsiderStopSearching": 0,
     "DecisionTimePercentageToStopSearching": 0.4,
-    "HardTimeBoundDivisor": 2,
+    "HardTimeBoundCoefficient": 2.0,
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,
     "LMR_Base": 0.77,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -24,6 +24,7 @@
     //"DepthWhenLessThanMinMoveTime": 5,
     "MinElapsedTimeToConsiderStopSearching": 0,
     "DecisionTimePercentageToStopSearching": 0.4,
+    "HardTimeBoundDivisor": 2,
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,
     "LMR_Base": 0.77,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -229,7 +229,7 @@ public sealed class EngineSettings
 
     public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
 
-    public int HardTimeBoundDivisor { get; set; } = 2;
+    public double HardTimeBoundCoefficient { get; set; } = 2.0;
 
     public int LMR_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -229,6 +229,8 @@ public sealed class EngineSettings
 
     public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
 
+    public int HardTimeBoundDivisor { get; set; } = 2;
+
     public int LMR_MinDepth { get; set; } = 3;
 
     public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -116,7 +116,7 @@ public sealed partial class Engine
                 }
 
                 _logger.Info("Time to move: {0}s", 0.001 * decisionTime);
-                _searchCancellationTokenSource.CancelAfter(decisionTime!.Value);
+                _searchCancellationTokenSource.CancelAfter(decisionTime!.Value / Configuration.EngineSettings.HardTimeBoundDivisor);
             }
             else if (goCommand.MoveTime > 0)
             {

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -116,7 +116,7 @@ public sealed partial class Engine
                 }
 
                 _logger.Info("Time to move: {0}s", 0.001 * decisionTime);
-                _searchCancellationTokenSource.CancelAfter(decisionTime!.Value / Configuration.EngineSettings.HardTimeBoundDivisor);
+                _searchCancellationTokenSource.CancelAfter((int)(decisionTime!.Value * Configuration.EngineSettings.HardTimeBoundCoefficient));
             }
             else if (goCommand.MoveTime > 0)
             {


### PR DESCRIPTION
/2
```
Score of Lynx 1800 - tm vs Lynx 1795 - main: 67 - 115 - 98  [0.414] 280
...      Lynx 1800 - tm playing White: 42 - 41 - 57  [0.504] 140
...      Lynx 1800 - tm playing Black: 25 - 74 - 41  [0.325] 140
...      White vs Black: 116 - 66 - 98  [0.589] 280
Elo difference: -60.2 +/- 33.1, LOS: 0.0 %, DrawRatio: 35.0 %
SPRT: llr -1.13 (-39.0%), lbound -2.25, ubound 2.89
```


x2
```
Score of Lynx 1802 - tm vs Lynx 1795 - main: 911 - 992 - 1022  [0.486] 2925
...      Lynx 1802 - tm playing White: 617 - 347 - 499  [0.592] 1463
...      Lynx 1802 - tm playing Black: 294 - 645 - 523  [0.380] 1462
...      White vs Black: 1262 - 641 - 1022  [0.606] 2925
Elo difference: -9.6 +/- 10.1, LOS: 3.2 %, DrawRatio: 34.9 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```