### PR TITLE
🐛 Ensure no search depth 0 happens after a 'ponder hit'

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -109,7 +109,6 @@ public sealed partial class Engine
             if (Game.MoveHistory.Count >= 2
                 && _previousSearchResult?.Moves.Count > 2
                 && _previousSearchResult.BestMove != default
-                && _previousSearchResult?.Depth > 2 // i.e. depth 1 seldepth 3 that finds a mate would cause a bug here
                 && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
                 && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
             {
@@ -192,7 +191,7 @@ public sealed partial class Engine
                 var pvMoves = _pVTable.TakeWhile(m => m != default).ToList();
                 var maxDepthReached = _maxDepthReached.LastOrDefault(item => item != default);
 
-                int mate = default; f
+                int mate = default;
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
                 isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;
                 if (isMateDetected)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -109,6 +109,7 @@ public sealed partial class Engine
             if (Game.MoveHistory.Count >= 2
                 && _previousSearchResult?.Moves.Count > 2
                 && _previousSearchResult.BestMove != default
+                && _previousSearchResult?.Depth > 2 // i.e. depth 1 seldepth 3 that finds a mate would cause a bug here
                 && Game.MoveHistory[^2] == _previousSearchResult.Moves[0]
                 && Game.MoveHistory[^1] == _previousSearchResult.Moves[1])
             {
@@ -126,7 +127,9 @@ public sealed partial class Engine
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                depth = lastSearchResult.Depth + 1; // Already reduced by 2
+                // depth Already reduced by 2 in SearchResult constructor
+                depth = lastSearchResult.Depth + 1;
+                depth = Math.Clamp(depth, 1, Configuration.EngineSettings.MaxDepth - 1);
             }
             else
             {
@@ -189,7 +192,7 @@ public sealed partial class Engine
                 var pvMoves = _pVTable.TakeWhile(m => m != default).ToList();
                 var maxDepthReached = _maxDepthReached.LastOrDefault(item => item != default);
 
-                int mate = default;
+                int mate = default; f
                 var bestEvaluationAbs = Math.Abs(bestEvaluation);
                 isMateDetected = bestEvaluationAbs > EvaluationConstants.PositiveCheckmateDetectionLimit;
                 if (isMateDetected)


### PR DESCRIPTION
This was the case when a mate sequence discovered at depth 1 seldepth 3 was saved from previous search.

i.e.
```
position fen r1bq1rk1/p3ppbp/1pnp1np1/2p5/4P3/1BPPBN2/PP3PPP/RN1Q1RK1 w - - 0 1 moves h2h3 d6d5 b1d2 c8a6 e4e5 f6h5 d1e2 c6e5 f3e5 g7e5 e3c5 e5c3 c5e7 h5f4 e2f3 d8e7 b2c3 e7g5 f1e1 a6d3 g1h2 d3f5 a1d1 a8e8 e1e3 f5d7 d2f1 d7b5 g2g3 f4e6 b3d5 e8d8 e3e1 b5a4 d1d3 a4c2 d3d2 c2f5 e1d1 g5e7 h3h4 e6c5 f1e3 f5e4 f3f4 d8e8 e3g4 g8g7 f4h6 g7h8 h2g1 f7f5 d5e4 e7e4 d2d7 c5d7 d1d7 f8f7 d7f7 e4e1 g1h2 e1g1 h2g1 e8e1 g1g2 e1g1 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	isready 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	readyok 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	go wtime 17889 btime 14841 winc 400 binc 400 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Time to move: 0.995s 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Stopping at depth 1: mate detected 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 1 seldepth 3 multipv 1 score mate 2 nodes 15 nps 15 time 0 pv g2g1 f5g4 h6h7 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Engine search found a short enough mate, cancelling online tb probing if still active 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 1 seldepth 3 multipv 1 score mate 2 nodes 15 nps 15 time 0 hashfull 533 pv g2g1 f5g4 h6h7 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	bestmove g2g1 ponder f5g4 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	position fen r1bq1rk1/p3ppbp/1pnp1np1/2p5/4P3/1BPPBN2/PP3PPP/RN1Q1RK1 w - - 0 1 moves h2h3 d6d5 b1d2 c8a6 e4e5 f6h5 d1e2 c6e5 f3e5 g7e5 e3c5 e5c3 c5e7 h5f4 e2f3 d8e7 b2c3 e7g5 f1e1 a6d3 g1h2 d3f5 a1d1 a8e8 e1e3 f5d7 d2f1 d7b5 g2g3 f4e6 b3d5 e8d8 e3e1 b5a4 d1d3 a4c2 d3d2 c2f5 e1d1 g5e7 h3h4 e6c5 f1e3 f5e4 f3f4 d8e8 e3g4 g8g7 f4h6 g7h8 h2g1 f7f5 d5e4 e7e4 d2d7 c5d7 d1d7 f8f7 d7f7 e4e1 g1h2 e1g1 h2g1 e8e1 g1g2 e1g1 g2g1 f5g4 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	isready 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	readyok 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	go wtime 18289 btime 15241 winc 400 binc 400 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Time to move: 1.008s 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Engine|Ponder hit 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Stopping at depth 0: mate detected 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth -1 seldepth 1 multipv 1 score mate 1 nodes 0 nps 0 time 0 pv h6h7 
2023-10-25 00:39:33.7068|0|19380|INFO|Lynx.Engine|Engine search found a short enough mate, cancelling online tb probing if still active 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 0 seldepth 0 multipv 1 score mate 1 nodes 0 nps 0 time 0 pv  
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	info depth 0 seldepth 0 multipv 1 score mate 1 nodes 0 nps 0 time 0 hashfull 533 pv  
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	bestmove a8a8 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	isready 
2023-10-25 00:39:33.7068|0|19380|DEBUG|Lynx.Cli.Writer|[Lynx]	readyok 
2023-10-25 00:39:33.7262|0|19380|DEBUG|Lynx.LynxDriver|[GUI]	ucinewgame 
```