### PR TITLE
In case of ponder-hit, research last depth

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -127,8 +127,7 @@ public sealed partial class Engine
                 }
 
                 // depth Already reduced by 2 in SearchResult constructor
-                depth = lastSearchResult.Depth + 1;
-                depth = Math.Clamp(depth, 1, Configuration.EngineSettings.MaxDepth - 1);
+                depth = Math.Clamp(lastSearchResult.Depth, 1, Configuration.EngineSettings.MaxDepth - 1);
             }
             else
             {


### PR DESCRIPTION
In case of ponder-hit, research at the depth where we already know the line instead of the next one
8+0.08 👍🏽
```
Score of Lynx 1807 ponder vs Lynx 1806 - main: 3484 - 3277 - 3471  [0.510] 10232
...      Lynx 1807 ponder playing White: 2297 - 1068 - 1751  [0.620] 5116
...      Lynx 1807 ponder playing Black: 1187 - 2209 - 1720  [0.400] 5116
...      White vs Black: 4506 - 2255 - 3471  [0.610] 10232
Elo difference: 7.0 +/- 5.5, LOS: 99.4 %, DrawRatio: 33.9 %
SPRT: llr 2.91 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4 👍🏽
```
Score of Lynx 1807 vs Lynx 1806 - main: 3947 - 3734 - 5162  [0.508] 12843
...      Lynx 1807 playing White: 2758 - 1119 - 2546  [0.628] 6423
...      Lynx 1807 playing Black: 1189 - 2615 - 2616  [0.389] 6420
...      White vs Black: 5373 - 2308 - 5162  [0.619] 12843
Elo difference: 5.8 +/- 4.6, LOS: 99.2 %, DrawRatio: 40.2 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```