### PR TITLE
NativeAOT compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       run: dotnet build -c Release src/Lynx.Cli/Lynx.Cli.csproj /p:DeterministicBuild=true
 
     - name: Publish CLI
-      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true -o artifacts/${{ matrix.runtime-identifier }}
+      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:NativeAOT=true -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
       uses: actions/upload-artifact@v3
@@ -94,6 +94,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Publish library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         (Get-Content $input_path) -Replace $regex, '${{ github.event.inputs.new_engine_version }}' | Out-File $input_path
 
     - name: Publish ${{ matrix.runtime-identifier }} version
-      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true /p:DeterministicBuild=true -o artifacts/${{ matrix.runtime-identifier }}
+      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:NativeAOT=true /p:DeterministicBuild=true -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Lynx-${{ matrix.runtime-identifier }} artifact
       if: github.event.inputs.new_engine_version != ''
@@ -102,6 +102,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
@@ -112,6 +114,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Deterministic build

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 	dotnet test -c Release & dotnet test -c Release --filter "TestCategory=LongRunning" & dotnet test -c Release --filter "TestCategory=Perft"
 
 publish:
-	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:DeterministicBuild=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
+	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:NativeAOT=true /p:DeterministicBuild=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
 
 run:
 	dotnet run --project src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME}

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -19,6 +19,20 @@
     <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(NativeAOT.ToLower())'=='true'">
+    <Configuration>Release</Configuration>
+    <SelfContained>true</SelfContained>
+    <PublishTrimmed>true</PublishTrimmed>
+    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <!--In favour of tiered compilation-->
+    <PublishReadyToRun>false</PublishReadyToRun>
+
+    <PublishAot>true</PublishAot>
+    <OptimizationPreference>Speed</OptimizationPreference>
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0-rc.2.23479.6" />

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>


### PR DESCRIPTION
`NativeAOT` property group is the same as `Optimized` one but with:

```
<PublishAot>true</PublishAot>
<PublishSingleFile>false</PublishSingleFile>
```
and
```
    <OptimizationPreference>Speed</OptimizationPreference>
```

to choose between [performance vs speed optimization preference](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/optimizing#optimize-for-size-or-speed).

----

8+0.08
```
Score of Lynx 1810 - nativeaot vs Lynx 1806 - main: 293 - 350 - 357  [0.471] 1000
...      Lynx 1810 - nativeaot playing White: 201 - 122 - 178  [0.579] 501
...      Lynx 1810 - nativeaot playing Black: 92 - 228 - 179  [0.364] 499
...      White vs Black: 429 - 214 - 357  [0.608] 1000
Elo difference: -19.8 +/- 17.3, LOS: 1.2 %, DrawRatio: 35.7 %
SPRT: llr -1.44 (-49.8%), lbound -2.25, ubound 2.89
```