### PR TITLE
👷🏽‍♂️ Stop generating NuGet package artifact in CI from all 3 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,11 @@ jobs:
         if-no-files-found: error
 
     - name: Publish library
+      if: matrix.os == 'ubuntu-latest'
       run: dotnet pack -c Release --no-build src/Lynx/Lynx.csproj --include-symbols -o artifacts/nuget
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }} NuGet package
+      if: matrix.os == 'ubuntu-latest'
       uses: actions/upload-artifact@v3
       with:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}


### PR DESCRIPTION
Avoid publishing NuGet package and uploading it as an artifact from other jobs than the executed in the Ubuntu one runner.