### PR TITLE
In case of ponder hit and researching from depth 1, clear history but keep killers

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -130,8 +130,9 @@ public sealed partial class Engine
             else
             {
                 Array.Clear(_killerMoves);
-                Array.Clear(_historyMoves);
             }
+
+            Array.Clear(_historyMoves);
 
             do
             {


### PR DESCRIPTION
[Always clear history, but keep killers in case of ponder hit](https://github.com/lynx-chess/Lynx/commit/4bdd454ef2d9ad4de805176e236dcb15923cb3d2)
```
Score of Lynx 1819 vs Lynx 1811: 4964 - 4960 - 5098  [0.500] 15022
...      Lynx 1819 playing White: 3249 - 1709 - 2553  [0.603] 7511
...      Lynx 1819 playing Black: 1715 - 3251 - 2545  [0.398] 7511
...      White vs Black: 6500 - 3424 - 5098  [0.602] 15022
Elo difference: 0.1 +/- 4.5, LOS: 51.6 %, DrawRatio: 33.9 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```