### PR TITLE
Clean IDDFS impl

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -114,11 +114,9 @@ public sealed partial class Engine
             {
                 _logger.Debug("Ponder hit");
 
-                lastSearchResult = new SearchResult(_previousSearchResult);
+                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(new SearchResult(_previousSearchResult)));
 
                 Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
-
-                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
                 for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)
                 {
@@ -126,8 +124,8 @@ public sealed partial class Engine
                     _killerMoves[1, d] = _previousKillerMoves[1, d + 2];
                 }
 
-                // depth Already reduced by 2 in SearchResult constructor
-                depth = Math.Clamp(lastSearchResult.Depth, 1, Configuration.EngineSettings.MaxDepth - 1);
+                // Re-search from depth 1
+                depth = 1;
             }
             else
             {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -257,9 +257,9 @@ public sealed partial class Engine
         {
             _logger.Debug("Ponder hit");
 
-            lastSearchResult = new SearchResult(_previousSearchResult);
+            var lastSearchResult = new SearchResult(_previousSearchResult);
             await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
-            
+
             Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);
 
             for (int d = 0; d < Configuration.EngineSettings.MaxDepth - 2; ++d)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -127,8 +127,7 @@ public sealed partial class Engine
                 }
 
                 // depth Already reduced by 2 in SearchResult constructor
-                depth = lastSearchResult.Depth + 1;
-                depth = Math.Clamp(depth, 1, Configuration.EngineSettings.MaxDepth - 1);
+                depth = Math.Clamp(lastSearchResult.Depth, 1, Configuration.EngineSettings.MaxDepth - 1);
             }
             else
             {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -62,7 +62,7 @@ public sealed partial class Engine
                 return onlyOneLegalMoveSearchResult;
             }
 
-            depth = await CheckPonderHit(depth);
+            depth = await CheckPonderHit(lastSearchResult, depth);
 
             do
             {
@@ -247,7 +247,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private async Task<int> CheckPonderHit(int depth)
+    private async Task<int> CheckPonderHit(SearchResult? lastSearchResult, int depth)
     {
         if (Game.MoveHistory.Count >= 2
             && _previousSearchResult?.Moves.Count > 2
@@ -257,7 +257,7 @@ public sealed partial class Engine
         {
             _logger.Debug("Ponder hit");
 
-            var lastSearchResult = new SearchResult(_previousSearchResult);
+            lastSearchResult = new SearchResult(_previousSearchResult);
             await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
             Array.Copy(_previousSearchResult.Moves.ToArray(), 2, _pVTable, 0, _previousSearchResult.Moves.Count - 2);

--- a/tests/Lynx.Test/BestMove/IncreaseDepthWhenInCheckTest.cs
+++ b/tests/Lynx.Test/BestMove/IncreaseDepthWhenInCheckTest.cs
@@ -3,7 +3,7 @@ using Lynx.UCI.Commands.GUI;
 using NUnit.Framework;
 
 namespace Lynx.Test.BestMove;
-public class IncreaseDepthWhenInCheck : BaseTest
+public class IncreaseDepthWhenInCheckTest : BaseTest
 {
     /// <summary>
     /// 8   . r . . . . . .

--- a/tests/Lynx.Test/BestMove/PonderHitTest.cs
+++ b/tests/Lynx.Test/BestMove/PonderHitTest.cs
@@ -1,0 +1,21 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test.BestMove;
+public class PonderHitTest : BaseTest
+{
+    [Test]
+    public async Task PonderHit()
+    {
+        var engine = GetEngine(Constants.InitialPositionFEN);
+
+        var result = await engine.BestMove(new("go depth 10"));
+
+        engine.AdjustPosition($"position startpos moves {result.Moves[0].UCIString()} {result.Moves[1].UCIString()}".AsSpan());
+
+        result = await engine.BestMove(new("go wtime 1000 btime 1000"));
+
+        Assert.AreNotEqual(0, result.BestMove);
+        Assert.GreaterOrEqual(result.Depth, 8);
+    }
+}


### PR DESCRIPTION
8+0.08, [-5, 0]
```
Score of Lynx 1831 vs Lynx 1824 - main: 4444 - 4412 - 4822  [0.501] 13678
...      Lynx 1831 playing White: 2998 - 1438 - 2404  [0.614] 6840
...      Lynx 1831 playing Black: 1446 - 2974 - 2418  [0.388] 6838
...      White vs Black: 5972 - 2884 - 4822  [0.613] 13678
Elo difference: 0.8 +/- 4.7, LOS: 63.3 %, DrawRatio: 35.3 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```