### PR TITLE
Remove current NMP implementation

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -81,7 +81,7 @@ public sealed partial class Engine
 
                 if (depth < Configuration.EngineSettings.AspirationWindowMinDepth || lastSearchResult?.Evaluation is null)
                 {
-                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
                 }
                 else
                 {
@@ -94,7 +94,7 @@ public sealed partial class Engine
                     while (true)
                     {
                         _isFollowingPV = true;
-                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
                         if (alpha < bestEvaluation && beta > bestEvaluation)
                         {


### PR DESCRIPTION
Remove current NMP implementation: verified NMP

8+0.08, unbalanced
```
Score of Lynx 1844 - no nmp vs Lynx 1843 - main: 974 - 1007 - 1019  [0.494] 3000
...      Lynx 1844 - no nmp playing White: 647 - 348 - 504  [0.600] 1499
...      Lynx 1844 - no nmp playing Black: 327 - 659 - 515  [0.389] 1501
...      White vs Black: 1306 - 675 - 1019  [0.605] 3000
Elo difference: -3.8 +/- 10.1, LOS: 22.9 %, DrawRatio: 34.0 %
SPRT: llr -0.249 (-8.6%), lbound -2.25, ubound 2.89
```

8+0.08, balanced
```
Score of Lynx 1844 - no nmp vs Lynx 1843 - main: 1044 - 1145 - 1561  [0.487] 3750
...      Lynx 1844 - no nmp playing White: 557 - 514 - 805  [0.511] 1876
...      Lynx 1844 - no nmp playing Black: 487 - 631 - 756  [0.462] 1874
...      White vs Black: 1188 - 1001 - 1561  [0.525] 3750
Elo difference: -9.4 +/- 8.5, LOS: 1.5 %, DrawRatio: 41.6 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
```