### PR TITLE
Add depth extension on promotion

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -176,6 +176,12 @@ public sealed partial class Engine
             Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
             var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
 
+            var isPromotion = move.PromotedPiece() != default;
+            if (isPromotion)
+            {
+                ++depth;
+            }
+
             int evaluation;
             if (isThreeFoldRepetition || Game.Is50MovesRepetition())
             {
@@ -283,6 +289,11 @@ public sealed partial class Engine
                 CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                 nodeType = NodeType.Exact;
+            }
+
+            if (isPromotion)
+            {
+                --depth;
             }
 
             ++movesSearched;


### PR DESCRIPTION
8+0.08 👎🏽
```
Score of Lynx-extend-depth-on-promos-1859-win-x64 vs Lynx 1863 - main: 4077 - 4080 - 4984  [0.500] 13141
...      Lynx-extend-depth-on-promos-1859-win-x64 playing White: 2737 - 1352 - 2482  [0.605] 6571
...      Lynx-extend-depth-on-promos-1859-win-x64 playing Black: 1340 - 2728 - 2502  [0.394] 6570
...      White vs Black: 5465 - 2692 - 4984  [0.606] 13141
Elo difference: -0.1 +/- 4.7, LOS: 48.7 %, DrawRatio: 37.9 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```