### PR TITLE
Extend depth by 2 in case of checks

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,7 +59,7 @@ public sealed partial class Engine
 
         if (isInCheck)
         {
-            ++depth;
+            depth += 2;
         }
         if (depth <= 0)
         {


### PR DESCRIPTION
Lots of test failing, WAC failing 50%, 
```
Score of Lynx-extend-depth-further-on-checks-1860-win-x64 vs Lynx 1863 - main: 1 - 32 - 11  [0.148] 44
...      Lynx-extend-depth-further-on-checks-1860-win-x64 playing White: 1 - 14 - 7  [0.205] 22
...      Lynx-extend-depth-further-on-checks-1860-win-x64 playing Black: 0 - 18 - 4  [0.091] 22
...      White vs Black: 19 - 14 - 11  [0.557] 44
Elo difference: -304.4 +/- 111.3, LOS: 0.0 %, DrawRatio: 25.0 %
SPRT: llr -0.996 (-34.4%), lbound -2.25, ubound 2.89
```