### PR TITLE
🔍 Rewrite basic NMP

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,6 +28,7 @@
     "LMR_MinFullDepthSearchedMoves": 4,
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
+    "NMP_MinDepth": 3,
     "NMP_DepthReduction": 3,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -243,6 +243,8 @@ public sealed class EngineSettings
     /// </summary>
     public double LMR_Divisor { get; set; } = 2.67;
 
+    public int NMP_MinDepth { get; set; } = 3;
+
     public int NMP_DepthReduction { get; set; } = 3;
 
     public int AspirationWindowDelta { get; set; } = 50;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -81,7 +81,7 @@ public sealed partial class Engine
 
                 if (depth < Configuration.EngineSettings.AspirationWindowMinDepth || lastSearchResult?.Evaluation is null)
                 {
-                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
                 }
                 else
                 {
@@ -94,7 +94,7 @@ public sealed partial class Engine
                     while (true)
                     {
                         _isFollowingPV = true;
-                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, isVerifyingNullMoveCutOff: true);
+                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
                         if (alpha < bestEvaluation && beta > bestEvaluation)
                         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -18,7 +18,7 @@ public sealed partial class Engine
     /// Defaults to the worse possible score for Side to move's opponent, Int.MaxValue
     /// </param>
     /// <returns></returns>
-    private int NegaMax(int depth, int ply, int alpha, int beta, bool ancestorWasNullMove = false)
+    private int NegaMax(int depth, int ply, int alpha, int beta, bool parentWasNullMove = false)
     {
         var position = Game.CurrentPosition;
 
@@ -78,9 +78,9 @@ public sealed partial class Engine
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving ouropponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
                 && staticEval >= beta
-                && !ancestorWasNullMove)
-            //(!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
-            //&& staticEvalResult.Phase > 1)   // Zugzwang risk reduction: pieces other than pawn presents
+                && !parentWasNullMove)
+            // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
+            // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction;
                 // TODO adaptative reduction
@@ -89,7 +89,7 @@ public sealed partial class Engine
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                 var gameState = position.MakeNullMove();
-                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, ancestorWasNullMove: true);
+                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
                 position.UnMakeNullMove(gameState);
 
                 if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -18,7 +18,7 @@ public sealed partial class Engine
     /// Defaults to the worse possible score for Side to move's opponent, Int.MaxValue
     /// </param>
     /// <returns></returns>
-    private int NegaMax(int depth, int ply, int alpha, int beta)
+    private int NegaMax(int depth, int ply, int alpha, int beta, bool ancestorWasNullMove = false)
     {
         var position = Game.CurrentPosition;
 
@@ -75,11 +75,11 @@ public sealed partial class Engine
         {
             var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
 
-            // 🔍 Null Move Pruning (NMP)
+            // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving ouropponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                && staticEval >= beta   // Our position is so good that we can't potentially afford giving our opponent a null move
-                )
-            //&& !ancestorWasNullMove
+                && staticEval >= beta
+                && !ancestorWasNullMove)
+            //(!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             //&& staticEvalResult.Phase > 1)   // Zugzwang risk reduction: pieces other than pawn presents
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction;
@@ -89,7 +89,7 @@ public sealed partial class Engine
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                 var gameState = position.MakeNullMove();
-                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1);
+                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, ancestorWasNullMove: true);
                 position.UnMakeNullMove(gameState);
 
                 if (evaluation >= beta)


### PR DESCRIPTION
After confirming how shitty the current NMP implementation is (results in https://github.com/lynx-chess/Lynx/pull/473), let's rewrite bit by bit.
This a first basic PR, after having failed to add more complex features in https://github.com/lynx-chess/Lynx/pull/474.

8+0.08, no resignation or draw agreements
```
Score of Lynx-nmp-basic-1870-win-x64 vs Lynx 1869 - main: 898 - 754 - 1000  [0.527] 2652
...      Lynx-nmp-basic-1870-win-x64 playing White: 577 - 260 - 490  [0.619] 1327
...      Lynx-nmp-basic-1870-win-x64 playing Black: 321 - 494 - 510  [0.435] 1325
...      White vs Black: 1071 - 581 - 1000  [0.592] 2652
Elo difference: 18.9 +/- 10.4, LOS: 100.0 %, DrawRatio: 37.7 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```