### PR TITLE
🧹 Clean `Position.StaticEval()`

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -956,38 +956,38 @@ static void FileAndRankMasks()
 static void EnhancedPawnEvaluation()
 {
     var position = new Position("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1");
-    var eval = position.StaticEvaluation(default);
+    var eval = position.StaticEvaluation();
     position.Print();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp4pp/p7/8/8/P7/PPP3P1/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PPP4P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/7P/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp1P/p7/8/8/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 }
 
@@ -995,17 +995,17 @@ static void RookEvaluation()
 {
     var position = new Position("r3k3/7p/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    var eval = position.StaticEvaluation(default);
+    var eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1p6/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1P6/8/8/8/8/7p/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation(default);
+    eval = position.StaticEvaluation();
     Console.WriteLine(eval);
 }
 

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -390,7 +390,7 @@ public sealed class LynxDriver
                     _logger.Debug("Raw fen: {0}, parsed fen: {1}", fen, ourFen);
                 }
 
-                var eval = WDL.NormalizeScore(position.StaticEvaluation(0));
+                var eval = WDL.NormalizeScore(position.StaticEvaluation());
                 if (position.Side == Side.Black)
                 {
                     eval = -eval;   // White perspective

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -591,7 +591,7 @@ public class Position
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int StaticEvaluation(int movesWithoutCaptureOrPawnMove)
+    public int StaticEvaluation()
     {
         //var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
         //Debug.Assert(result < EvaluationConstants.CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -28,7 +28,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation();
         }
 
         _maxDepthReached[ply] = ply;
@@ -107,7 +107,7 @@ public sealed partial class Engine
 
         if (!pvNode && !isInCheck && depth <= Configuration.EngineSettings.RFP_MaxDepth)
         {
-            int staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            int staticEval = position.StaticEvaluation();
 
             // 🔍 Reverse FutilityPrunning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
             if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
@@ -368,7 +368,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+            return position.StaticEvaluation();
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -386,7 +386,7 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+        var staticEvaluation = position.StaticEvaluation();
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -158,7 +158,7 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[^1]));
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
 
-        var eval = winningPosition.StaticEvaluation(default);
+        var eval = winningPosition.StaticEvaluation();
         Assert.AreNotEqual(0, eval);
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -176,7 +176,7 @@ public class PositionTest
     {
         var position = new Position(fen);
 
-        Assert.AreEqual(0, position.StaticEvaluation(default));
+        Assert.AreEqual(0, position.StaticEvaluation());
     }
 
     [TestCase("4k3/8/8/7Q/7q/8/4K3/8 w - - 0 1", "4k3/8/8/7Q/7q/8/8/4K3 w - - 0 1", Description = "King in 7th rank with queens > King in 8th rank with queens")]
@@ -184,7 +184,7 @@ public class PositionTest
     [TestCase("4k3/7p/8/8/4K3/8/7P/8 w - - 0 1", "4k3/7p/8/q7/4K3/Q7/7P/8 w - - 0 1", Description = "King in the center without queens > King in the center with queens")]
     public void StaticEvaluation_KingEndgame(string fen1, string fen2)
     {
-        Assert.Greater(new Position(fen1).StaticEvaluation(default), new Position(fen2).StaticEvaluation(default));
+        Assert.Greater(new Position(fen1).StaticEvaluation(), new Position(fen2).StaticEvaluation());
     }
 
     /// <summary>


### PR DESCRIPTION
Stop passing unused `movesWithoutCaptureOrPawnMove` to `Position.StaticEval()`