### PR TITLE
🔍 Increase NMP reduction with depth

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,7 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_DepthReduction": 3,
+    "NMP_DepthReduction": 2,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,7 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_DepthReduction": 2,
+    "NMP_BaseDepthReduction": 2,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_DepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 2;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_DepthReduction { get; set; } = 3;
+    public int NMP_DepthReduction { get; set; } = 2;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction + (depth / 3);
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 3);
                 // TODO adaptative reduction
                 //var nmpReduction = Math.Min(
                 //    depth,

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,15 +75,16 @@ public sealed partial class Engine
         {
             var staticEval = position.StaticEvaluation();
 
-            // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving ouropponent a double move and still remain ahead of beta
+            // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
                 && staticEval >= beta
                 && !parentWasNullMove)
-            // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
+            // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta (From Stormphrax)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = ((depth + 1) / 3) + 1;
-                // TODO adaptative reduction
+                var nmpReduction = ((depth + 1) / 3) + 1;   // Clarity
+
+                // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(
                 //    depth,
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction;
+                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction + (depth / 3);
                 // TODO adaptative reduction
                 //var nmpReduction = Math.Min(
                 //    depth,

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 3);
+                var nmpReduction = ((depth + 1) / 3) + 1;
                 // TODO adaptative reduction
                 //var nmpReduction = Math.Min(
                 //    depth,


### PR DESCRIPTION
```
Score of Lynx-npm-increase-reduction-with-depth-1878-win-x64 vs Lynx 1875 - main: 3657 - 3629 - 4850  [0.501] 12136
...      Lynx-npm-increase-reduction-with-depth-1878-win-x64 playing White: 2551 - 1118 - 2400  [0.618] 6069
...      Lynx-npm-increase-reduction-with-depth-1878-win-x64 playing Black: 1106 - 2511 - 2450  [0.384] 6067
...      White vs Black: 5062 - 2224 - 4850  [0.617] 12136
Elo difference: 0.8 +/- 4.8, LOS: 62.9 %, DrawRatio: 40.0 %
SPRT: llr -1.42 (-49.2%), lbound -2.25, ubound 2.89
```

Clarity:
8+0.08
```
Score of Lynx-npm-increase-reduction-with-depth-1882-win-x64 vs Lynx 1875 - main: 1704 - 1544 - 2157  [0.515] 5405
...      Lynx-npm-increase-reduction-with-depth-1882-win-x64 playing White: 1112 - 494 - 1098  [0.614] 2704
...      Lynx-npm-increase-reduction-with-depth-1882-win-x64 playing Black: 592 - 1050 - 1059  [0.415] 2701
...      White vs Black: 2162 - 1086 - 2157  [0.600] 5405
Elo difference: 10.3 +/- 7.2, LOS: 99.8 %, DrawRatio: 39.9 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx-npm-increase-reduction-with-depth-1882-win-x64 vs Lynx 1875 - main: 5668 - 5411 - 9495  [0.506] 20574
...      Lynx-npm-increase-reduction-with-depth-1882-win-x64 playing White: 4043 - 1508 - 4736  [0.623] 10287
...      Lynx-npm-increase-reduction-with-depth-1882-win-x64 playing Black: 1625 - 3903 - 4759  [0.389] 10287
...      White vs Black: 7946 - 3133 - 9495  [0.617] 20574
Elo difference: 4.3 +/- 3.5, LOS: 99.3 %, DrawRatio: 46.2 %
SPRT: llr 2.91 (100.8%), lbound -2.25, ubound 2.89 - H1 was accepted
```