### PR TITLE
⚡  Split `MoveGenerator.GenerateAllMoves` and `MoveGenerator.GenerateAllCaptures`

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -669,7 +669,7 @@ static void _54_ScoreMove()
 
     var engine = new Engine(Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
     engine.SetGame(new(position));
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+    foreach (var move in MoveGenerator.GenerateAllCaptures(position))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }
@@ -678,7 +678,7 @@ static void _54_ScoreMove()
     position.Print();
 
     engine.SetGame(new(position));
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+    foreach (var move in MoveGenerator.GenerateAllCaptures(position))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -384,7 +384,7 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, Game.MovePool, capturesOnly: true);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, Game.MovePool);
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358


### PR DESCRIPTION
```
Score of Lynx-perf-movegenerator-split-captures-method-1883-win-x64 vs Lynx 1875 - main: 2002 - 2048 - 2677  [0.497] 6727
...      Lynx-perf-movegenerator-split-captures-method-1883-win-x64 playing White: 1346 - 689 - 1328  [0.598] 3363
...      Lynx-perf-movegenerator-split-captures-method-1883-win-x64 playing Black: 656 - 1359 - 1349  [0.396] 3364
...      White vs Black: 2705 - 1345 - 2677  [0.601] 6727
Elo difference: -2.4 +/- 6.4, LOS: 23.5 %, DrawRatio: 39.8 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```