### PR TITLE
Npm increase reduction with beta delta

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,6 +30,8 @@
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 2,
+    "NMP_StaticEvalBetaDeltaMaxReduction": 3,
+    "NMP_StaticEvalBetaDeltaIncrementDivisor": 20,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -31,7 +31,7 @@
     "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 2,
     "NMP_StaticEvalBetaDeltaMaxReduction": 3,
-    "NMP_StaticEvalBetaDeltaIncrementDivisor": 20,
+    "NMP_StaticEvalBetaDeltaIncrementDivisor": 200,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -247,6 +247,10 @@ public sealed class EngineSettings
 
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
+    public int NMP_StaticEvalBetaDeltaMaxReduction {  get; set; } = 3;
+
+    public int NMP_StaticEvalBetaDeltaIncrementDivisor {  get; set; } = 200;
+
     public int AspirationWindowDelta { get; set; } = 50;
 
     public int AspirationWindowMinDepth { get; set; } = 6;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction + Math.Min((staticEval - beta) / 200, 3);
+                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction + Math.Min((staticEval - beta) / 500, 3);
                 // TODO adaptative reduction
                 //var nmpReduction = Math.Min(
                 //    depth,

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,9 @@ public sealed partial class Engine
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
                 var nmpReduction = ((depth + 1) / 3) + 1   // Clarity
-                    + Math.Min((staticEval - beta) / 200, 3);   // Increase more when staticEval - beta is bigger
+                    + Math.Min(
+                        Configuration.EngineSettings.NMP_StaticEvalBetaDeltaMaxReduction,   // Increase more when staticEval - beta is bigger
+                        (staticEval - beta) / Configuration.EngineSettings.NMP_StaticEvalBetaDeltaIncrementDivisor);
 
                 // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,7 @@ public sealed partial class Engine
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
                 var nmpReduction = ((depth + 1) / 3) + 1   // Clarity
-                    + Math.Min((staticEval - beta) / 200, 3);
+                    + Math.Min((staticEval - beta) / 200, 3);   // Increase more when staticEval - beta is bigger
 
                 // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)
             // && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction;
+                var nmpReduction = Configuration.EngineSettings.NMP_DepthReduction + Math.Min((staticEval - beta) / 200, 3);
                 // TODO adaptative reduction
                 //var nmpReduction = Math.Min(
                 //    depth,


### PR DESCRIPTION
200, 8+0.08, cancelled
```
Score of Lynx-npm-increase-reduction-with-beta-delta-1879-win-x64 vs Lynx 1875 - main: 2605 - 2506 - 2978  [0.506] 8089
...      Lynx-npm-increase-reduction-with-beta-delta-1879-win-x64 playing White: 1754 - 804 - 1487  [0.617] 4045
...      Lynx-npm-increase-reduction-with-beta-delta-1879-win-x64 playing Black: 851 - 1702 - 1491  [0.395] 4044
...      White vs Black: 3456 - 1655 - 2978  [0.611] 8089
Elo difference: 4.3 +/- 6.0, LOS: 91.7 %, DrawRatio: 36.8 %
SPRT: llr 0.929 (32.2%), lbound -2.25, ubound 2.89
```

500, 8+0.08
```
Score of Lynx-npm-increase-reduction-with-beta-delta-1881-win-x64 vs Lynx 1875 - main: 2614 - 2630 - 3526  [0.499] 8770
...      Lynx-npm-increase-reduction-with-beta-delta-1881-win-x64 playing White: 1744 - 873 - 1768  [0.599] 4385
...      Lynx-npm-increase-reduction-with-beta-delta-1881-win-x64 playing Black: 870 - 1757 - 1758  [0.399] 4385
...      White vs Black: 3501 - 1743 - 3526  [0.600] 8770
Elo difference: -0.6 +/- 5.6, LOS: 41.3 %, DrawRatio: 40.2 %
SPRT: llr -1.9 (-65.9%), lbound -2.25, ubound 2.89
```

Again
```
Score of Lynx-npm-increase-reduction-with-beta-delta-1916-win-x64 vs Lynx 1914 - main: 3765 - 3767 - 5152  [0.500] 12684
...      Lynx-npm-increase-reduction-with-beta-delta-1916-win-x64 playing White: 2549 - 1193 - 2600  [0.607] 6342
...      Lynx-npm-increase-reduction-with-beta-delta-1916-win-x64 playing Black: 1216 - 2574 - 2552  [0.393] 6342
...      White vs Black: 5123 - 2409 - 5152  [0.607] 12684
Elo difference: -0.1 +/- 4.7, LOS: 49.1 %, DrawRatio: 40.6 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```