### PR TITLE
Tweak capture move generation

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -53,12 +53,7 @@ public static class MoveGenerator
         var offset = Utils.PieceOffset(position.Side);
 
         GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
-
-		if (!capturesOnly)
-		{
-			GenerateCastlingMoves(ref localIndex, movePool, position, offset);
-		}
-
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -99,7 +99,7 @@ public static class MoveGenerator
             {
                 // Single pawn push
                 var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
+                if (!capturesOnly && (targetRank == 1 || targetRank == 8)  // Promotion
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -94,7 +94,7 @@ public static class MoveGenerator
             {
                 // Single pawn push
                 var targetRank = (singlePushSquare >> 3) + 1;
-                if (!capturesOnly && (targetRank == 1 || targetRank == 8)  // Promotion
+                if (!capturesOnly && (targetRank == 1 || targetRank == 8))  // Promotion
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -53,7 +53,12 @@ public static class MoveGenerator
         var offset = Utils.PieceOffset(position.Side);
 
         GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
-        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+
+		if (!capturesOnly)
+		{
+			GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+		}
+
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
         GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);


### PR DESCRIPTION
Don't generate castling moves as captures:
```
Score of Lynx-move-generation-remove-castling-as-captures-1884-win-x64 vs Lynx 1875 - main: 844 - 913 - 1280  [0.489] 3037
...      Lynx-move-generation-remove-castling-as-captures-1884-win-x64 playing White: 592 - 305 - 622  [0.594] 1519
...      Lynx-move-generation-remove-castling-as-captures-1884-win-x64 playing Black: 252 - 608 - 658  [0.383] 1518
...      White vs Black: 1200 - 557 - 1280  [0.606] 3037
Elo difference: -7.9 +/- 9.4, LOS: 5.0 %, DrawRatio: 42.1 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Don't generate promotions as captures:
```
Score of Lynx-move-generation-remove-castling-as-captures-1887-win-x64 vs Lynx 1875 - main: 429 - 516 - 566  [0.471] 1511
...      Lynx-move-generation-remove-castling-as-captures-1887-win-x64 playing White: 297 - 160 - 299  [0.591] 756
...      Lynx-move-generation-remove-castling-as-captures-1887-win-x64 playing Black: 132 - 356 - 267  [0.352] 755
...      White vs Black: 653 - 292 - 566  [0.619] 1511
Elo difference: -20.0 +/- 13.9, LOS: 0.2 %, DrawRatio: 37.5 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```