### PR TITLE
Attempt to get rid of `_isFollowingPV` and `_isScoringPV`

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -671,7 +671,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, false, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default, default)}");
     }
 
     position = new Position(TrickyPosition);
@@ -680,7 +680,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, false, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default, default)}");
     }
 }
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -671,7 +671,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, false, default)}");
     }
 
     position = new Position(TrickyPosition);
@@ -680,7 +680,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, false, default)}");
     }
 }
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScoreMove(Move move, int depth, bool isPvNode, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
     {
-        if (isPvNode)
+        if (isPvNode && move == _pVTable[depth])
         {
             return EvaluationConstants.PVMoveScoreValue;
         }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -59,20 +59,19 @@ public sealed partial class Engine
     private const int MaxValue = short.MaxValue;
 
     /// <summary>
-    /// Returns the score evaluation of a move taking into account <see cref="_isScoringPV"/>, <paramref name="bestMoveTTCandidate"/>, <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_historyMoves"/>
+    /// Returns the score evaluation of a move taking into account <paramref name="isPvNode"/>, <paramref name="bestMoveTTCandidate"/>, <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_historyMoves"/>
     /// </summary>
     /// <param name="move"></param>
     /// <param name="depth"></param>
+    /// <param name="isPvNode"></param>
     /// <param name="useKillerAndPositionMoves"></param>
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int depth, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int depth, bool isPvNode, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
     {
-        if (_isScoringPV && move == _pVTable[depth])
+        if (isPvNode)
         {
-            _isScoringPV = false;
-
             return EvaluationConstants.PVMoveScoreValue;
         }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -18,8 +18,6 @@ public sealed partial class Engine
     private int _ttMask;
 
     private int _nodes;
-    private bool _isFollowingPV;
-    private bool _isScoringPV;
 
     private SearchResult? _previousSearchResult;
     private readonly int[,] _previousKillerMoves = new int[2, Configuration.EngineSettings.MaxDepth];
@@ -37,8 +35,6 @@ public sealed partial class Engine
     {
         // Cleanup
         _nodes = 0;
-        _isFollowingPV = false;
-        _isScoringPV = false;
         _stopWatch.Reset();
 
         Array.Clear(_pVTable);
@@ -93,7 +89,6 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        _isFollowingPV = true;
                         bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
                         if (alpha < bestEvaluation && beta > bestEvaluation)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -372,6 +372,8 @@ public sealed partial class Engine
             return staticEvaluation;
         }
 
+        bool pvNode = beta - alpha > 1;
+
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
         bool isThereAnyValidCapture = false;
@@ -379,7 +381,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, pvNode, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -147,26 +147,9 @@ public sealed partial class Engine
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, Game.MovePool);
 
         var scores = new int[pseudoLegalMoves.Length];
-        if (_isFollowingPV)
+        for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            _isFollowingPV = false;
-            for (int i = 0; i < pseudoLegalMoves.Length; ++i)
-            {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, ttBestMove);
-
-                if (pseudoLegalMoves[i] == _pVTable[depth])
-                {
-                    _isFollowingPV = true;
-                    _isScoringPV = true;
-                }
-            }
-        }
-        else
-        {
-            for (int i = 0; i < pseudoLegalMoves.Length; ++i)
-            {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, ttBestMove);
-            }
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, pvNode, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
@@ -358,14 +341,12 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        Move ttBestMove = default;
-
         var ttProbeResult = _tt.ProbeHash(_ttMask, position, 0, ply, alpha, beta);
         if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
         {
             return ttProbeResult.Evaluation;
         }
-        ttBestMove = ttProbeResult.BestMove;
+        Move ttBestMove = ttProbeResult.BestMove;
 
         _maxDepthReached[ply] = ply;
 
@@ -398,7 +379,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, false, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -149,7 +149,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, pvNode, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, pvNode, useKillerAndPositionMoves: true, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
@@ -381,7 +381,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, pvNode, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, pvNode, useKillerAndPositionMoves: false, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -24,7 +24,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("f3f6", allMoves[1].UCIString());     // QxN
@@ -37,7 +37,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {
-            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default));
+            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default, default));
         }
     }
 
@@ -61,9 +61,9 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));
+        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default, default));
     }
 }


### PR DESCRIPTION
First attempt: https://github.com/lynx-chess/Lynx/pull/311/files

```
Score of Lynx-remove-is-following-is-scoring-pv-1891-win-x64 vs Lynx 1875 - main: 555 - 657 - 985  [0.477] 2197
...      Lynx-remove-is-following-is-scoring-pv-1891-win-x64 playing White: 405 - 185 - 508  [0.600] 1098
...      Lynx-remove-is-following-is-scoring-pv-1891-win-x64 playing Black: 150 - 472 - 477  [0.354] 1099
...      White vs Black: 877 - 335 - 985  [0.623] 2197
Elo difference: -16.1 +/- 10.8, LOS: 0.2 %, DrawRatio: 44.8 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```