### PR TITLE
⚡ Avoid checking lack of material in static evaluation when the phase is high enough

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -667,24 +667,15 @@ public class Position
         endGameScore += EvaluationConstants.EndGameTable[(int)Piece.k, blackKing] - egKingScore;
 
         // Check if drawn position due to lack of material
-        if (endGameScore >= 0)
+        if (gamePhase <= 4)
         {
-            bool whiteCannotWin = pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.Q] == 0 && pieceCount[(int)Piece.R] == 0
-                && (pieceCount[(int)Piece.B] + pieceCount[(int)Piece.N] == 1                // B or N
-                    || (pieceCount[(int)Piece.B] == 0 && pieceCount[(int)Piece.N] == 2));   // N+N
+            var offset = Utils.PieceOffset(Side == Side.White);
 
-            if (whiteCannotWin)
-            {
-                return 0;
-            }
-        }
-        else
-        {
-            bool blackCannotWin = pieceCount[(int)Piece.p] == 0 && pieceCount[(int)Piece.q] == 0 && pieceCount[(int)Piece.r] == 0
-                && (pieceCount[(int)Piece.b] + pieceCount[(int)Piece.n] == 1                // B or N
-                    || (pieceCount[(int)Piece.b] == 0 && pieceCount[(int)Piece.n] == 2));   // N+N
+            bool sideCannotWin = pieceCount[(int)Piece.P + offset] == 0 && pieceCount[(int)Piece.Q + offset] == 0 && pieceCount[(int)Piece.R + offset] == 0
+                && (pieceCount[(int)Piece.B + offset] + pieceCount[(int)Piece.N + offset] == 1                                                          // B or N
+                    || (pieceCount[(int)Piece.B + offset] == 0 && pieceCount[(int)Piece.N + offset] == 2));    // N+N
 
-            if (blackCannotWin)
+            if (sideCannotWin)
             {
                 return 0;
             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -669,7 +669,7 @@ public class Position
         // Check if drawn position due to lack of material
         if (gamePhase <= 4)
         {
-            var offset = Utils.PieceOffset(Side == Side.White);
+            var offset = Utils.PieceOffset(endGameScore >= 0);
 
             bool sideCannotWin = pieceCount[(int)Piece.P + offset] == 0 && pieceCount[(int)Piece.Q + offset] == 0 && pieceCount[(int)Piece.R + offset] == 0
                 && (pieceCount[(int)Piece.B + offset] + pieceCount[(int)Piece.N + offset] == 1                                                          // B or N


### PR DESCRIPTION
[-5, 0]
```
Score of Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 vs Lynx 1875 - main: 2690 - 2630 - 3423  [0.503] 8743
...      Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 playing White: 1815 - 849 - 1708  [0.610] 4372
...      Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 playing Black: 875 - 1781 - 1715  [0.396] 4371
...      White vs Black: 3596 - 1724 - 3423  [0.607] 8743
Elo difference: 2.4 +/- 5.7, LOS: 79.5 %, DrawRatio: 39.2 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 vs Lynx 1875 - main: 1144 - 1098 - 1998  [0.505] 4240
...      Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 playing White: 828 - 301 - 992  [0.624] 2121
...      Lynx-perf-avoid-material-checks-when-high-phase-1901-win-x64 playing Black: 316 - 797 - 1006  [0.387] 2119
...      White vs Black: 1625 - 617 - 1998  [0.619] 4240
Elo difference: 3.8 +/- 7.6, LOS: 83.4 %, DrawRatio: 47.1 %
SPRT: llr 0.421 (14.6%), lbound -2.25, ubound 2.89
```