### PR TITLE
🔍 Add minimum phase for NMP

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -956,38 +956,38 @@ static void FileAndRankMasks()
 static void EnhancedPawnEvaluation()
 {
     var position = new Position("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1");
-    var eval = position.StaticEvaluation();
+    var eval = position.StaticEvaluation().Score;
     position.Print();
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp4pp/p7/8/8/P7/PPP3P1/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PPP4P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp3pp1/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp2/p7/8/7P/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("4k3/pp2pp1P/p7/8/8/P7/PP3P2/4K3 w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 }
 
@@ -995,17 +995,17 @@ static void RookEvaluation()
 {
     var position = new Position("r3k3/7p/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    var eval = position.StaticEvaluation();
+    var eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1p6/8/8/8/8/7P/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 
     position = new Position("r3k3/1P6/8/8/8/8/7p/4K2R w - - 0 1");
     position.Print();
-    eval = position.StaticEvaluation();
+    eval = position.StaticEvaluation().Score;
     Console.WriteLine(eval);
 }
 

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -390,7 +390,7 @@ public sealed class LynxDriver
                     _logger.Debug("Raw fen: {0}, parsed fen: {1}", fen, ourFen);
                 }
 
-                var eval = WDL.NormalizeScore(position.StaticEvaluation());
+                var eval = WDL.NormalizeScore(position.StaticEvaluation().Score);
                 if (position.Side == Side.Black)
                 {
                     eval = -eval;   // White perspective

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -158,7 +158,7 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[^1]));
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
 
-        var eval = winningPosition.StaticEvaluation();
+        var eval = winningPosition.StaticEvaluation().Score;
         Assert.AreNotEqual(0, eval);
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -176,7 +176,7 @@ public class PositionTest
     {
         var position = new Position(fen);
 
-        Assert.AreEqual(0, position.StaticEvaluation());
+        Assert.AreEqual(0, position.StaticEvaluation().Score);
     }
 
     [TestCase("4k3/8/8/7Q/7q/8/4K3/8 w - - 0 1", "4k3/8/8/7Q/7q/8/8/4K3 w - - 0 1", Description = "King in 7th rank with queens > King in 8th rank with queens")]
@@ -184,7 +184,7 @@ public class PositionTest
     [TestCase("4k3/7p/8/8/4K3/8/7P/8 w - - 0 1", "4k3/7p/8/q7/4K3/Q7/7P/8 w - - 0 1", Description = "King in the center without queens > King in the center with queens")]
     public void StaticEvaluation_KingEndgame(string fen1, string fen2)
     {
-        Assert.Greater(new Position(fen1).StaticEvaluation(), new Position(fen2).StaticEvaluation());
+        Assert.Greater(new Position(fen1).StaticEvaluation().Score, new Position(fen2).StaticEvaluation().Score);
     }
 
     /// <summary>


### PR DESCRIPTION
```
Score of Lynx-nmp-minimum-phase-1908-win-x64 vs Lynx 1907 - main: 3379 - 3179 - 4286  [0.509] 10844
...      Lynx-nmp-minimum-phase-1908-win-x64 playing White: 2253 - 1042 - 2128  [0.612] 5423
...      Lynx-nmp-minimum-phase-1908-win-x64 playing Black: 1126 - 2137 - 2158  [0.407] 5421
...      White vs Black: 4390 - 2168 - 4286  [0.602] 10844
Elo difference: 6.4 +/- 5.1, LOS: 99.3 %, DrawRatio: 39.5 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```