### PR TITLE
🔍 Don't attempt NMP if TT hints a not good enough move

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -65,7 +65,7 @@ public struct TranspositionTableElement
 public static class TranspositionTableExtensions
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-    private static int _ttElementSize = Marshal.SizeOf(typeof(TranspositionTableElement));
+    private static readonly int _ttElementSize = Marshal.SizeOf(typeof(TranspositionTableElement));
 
     public static (int Length, int Mask) CalculateLength(int size)
     {
@@ -105,18 +105,18 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Evaluation, Move BestMove) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
+    public static (int Evaluation, Move BestMove, NodeType NodeType) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         if (!Configuration.EngineSettings.TranspositionTableEnabled)
         {
-            return (EvaluationConstants.NoHashEntry, default);
+            return (EvaluationConstants.NoHashEntry, default, default);
         }
 
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         if (position.UniqueIdentifier != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default);
+            return (EvaluationConstants.NoHashEntry, default, default);
         }
 
         var eval = EvaluationConstants.NoHashEntry;
@@ -136,7 +136,7 @@ public static class TranspositionTableExtensions
             };
         }
 
-        return (eval, entry.Move);
+        return (eval, entry.Move, entry.Type);
     }
 
     /// <summary>


### PR DESCRIPTION
```
Score of Lynx-nmp-tt-condition-1920-win-x64 vs Lynx 1918 - main: 6964 - 6681 - 8235  [0.506] 21880
...      Lynx-nmp-tt-condition-1920-win-x64 playing White: 4704 - 2126 - 4110  [0.618] 10940
...      Lynx-nmp-tt-condition-1920-win-x64 playing Black: 2260 - 4555 - 4125  [0.395] 10940
...      White vs Black: 9259 - 4386 - 8235  [0.611] 21880
Elo difference: 4.5 +/- 3.6, LOS: 99.2 %, DrawRatio: 37.6 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```