### PR TITLE
NMP depth tweaking - use NMP base reduction variable

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,7 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_BaseDepthReduction": 2,
+    "NMP_BaseDepthReduction": 1,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 1;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta (From Stormphrax)
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 4);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta (From Stormphrax)
             {
-                var nmpReduction = ((depth + 1) / 3) + 1;   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2)   // Zugzwang risk reduction: pieces other than pawn presents
             // && (!ttHit || !(ttBound & BOUND_UPPER) || ttValue >= beta)   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta (From Stormphrax)
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 4);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Akimbo and Stormphrax are doing
                 //var nmpReduction = Math.Min(


### PR DESCRIPTION
[Increase NMP base reduction to 2](https://github.com/lynx-chess/Lynx/commit/140c691a700c0899348f1638be6a1faec6e2660f)
```
Score of Lynx-nmp-depth-tweaking-1921-win-x64 vs Lynx 1918 - main: 811 - 891 - 981  [0.485] 2683
...      Lynx-nmp-depth-tweaking-1921-win-x64 playing White: 545 - 304 - 492  [0.590] 1341
...      Lynx-nmp-depth-tweaking-1921-win-x64 playing Black: 266 - 587 - 489  [0.380] 1342
...      White vs Black: 1132 - 570 - 981  [0.605] 2683
Elo difference: -10.4 +/- 10.5, LOS: 2.6 %, DrawRatio: 36.6 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Try depth / 4, keeping 2 as min](https://github.com/lynx-chess/Lynx/commit/d3037949446ccf49dcbca62a83c9397684625918):
```
Score of Lynx-nmp-depth-tweaking-1922-win-x64 vs Lynx 1918 - main: 1357 - 1403 - 1610  [0.495] 4370
...      Lynx-nmp-depth-tweaking-1922-win-x64 playing White: 924 - 459 - 803  [0.606] 2186
...      Lynx-nmp-depth-tweaking-1922-win-x64 playing Black: 433 - 944 - 807  [0.383] 2184
...      White vs Black: 1868 - 892 - 1610  [0.612] 4370
Elo difference: -3.7 +/- 8.2, LOS: 19.1 %, DrawRatio: 36.8 %
SPRT: llr -1.76 (-61.1%), lbound -2.25, ubound 2.89
```