### PR TITLE
Proper fail hard beta cutoffs

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -377,7 +377,7 @@ public sealed partial class Engine
         if (staticEvaluation >= beta)
         {
             PrintMessage(ply - 1, "Pruning before starting quiescence search");
-            return staticEvaluation;
+            return beta;
         }
 
         // Better move
@@ -467,7 +467,7 @@ public sealed partial class Engine
 
                 _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
 
-                return evaluation; // The refutation doesn't matter, since it'll be pruned
+                return beta; // The refutation doesn't matter, since it'll be pruned
             }
 
             if (evaluation > alpha)


### PR DESCRIPTION
```
Score of Lynx-proper-fail-hard-1925-win-x64 vs Lynx 1924 - main: 1364 - 1432 - 1617  [0.492] 4413
...      Lynx-proper-fail-hard-1925-win-x64 playing White: 909 - 473 - 825  [0.599] 2207
...      Lynx-proper-fail-hard-1925-win-x64 playing Black: 455 - 959 - 792  [0.386] 2206
...      White vs Black: 1868 - 928 - 1617  [0.607] 4413
Elo difference: -5.4 +/- 8.1, LOS: 9.9 %, DrawRatio: 36.6 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```