### PR TITLE
Add reduction based in static eval - beta delta

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,6 +30,8 @@
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 1,
+    "NMP_StaticEvalBetaDeltaMaxReduction": 2,
+    "NMP_StaticEvalBetaDeltaDivisor": 1000,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -247,6 +247,10 @@ public sealed class EngineSettings
 
     public int NMP_BaseDepthReduction { get; set; } = 1;
 
+    public int NMP_StaticEvalBetaDeltaMaxReduction { get; set; } = 2;
+
+    public int NMP_StaticEvalBetaDeltaDivisor { get; set; } = 1000;
+
     public int AspirationWindowDelta { get; set; } = 50;
 
     public int AspirationWindowMinDepth { get; set; } = 6;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -81,15 +81,14 @@ public sealed partial class Engine
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
                 && staticEval >= beta
                 && !parentWasNullMove
-                && staticEvalResult.Phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
+                && staticEvalResult.Phase > 2                                   // Zugzwang risk reduction: only try NMP if there are a number pieces other than pawn on the board
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
-
-                // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
-                //var nmpReduction = Math.Min(
-                //    depth,
-                //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
+                    + ((depth + 1) / 3)                             // Depth formula used by Clarity
+                    + Math.Min(
+                        Configuration.EngineSettings.NMP_StaticEvalBetaDeltaMaxReduction,
+                        (staticEval - beta) / Configuration.EngineSettings.NMP_StaticEvalBetaDeltaDivisor);      // Idea taken from Stormphrax and Ethereal
 
                 var gameState = position.MakeNullMove();
                 var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);


### PR DESCRIPTION
Second attempt after https://github.com/lynx-chess/Lynx/pull/484

delta / 1000, max. 2
```
Score of Lynx-nmp-beta-delta-2-1929-win-x64 vs Lynx 1928 - main: 3090 - 3116 - 3776  [0.499] 9982
...      Lynx-nmp-beta-delta-2-1929-win-x64 playing White: 2057 - 1013 - 1921  [0.605] 4991
...      Lynx-nmp-beta-delta-2-1929-win-x64 playing Black: 1033 - 2103 - 1855  [0.393] 4991
...      White vs Black: 4160 - 2046 - 3776  [0.606] 9982
Elo difference: -0.9 +/- 5.4, LOS: 37.1 %, DrawRatio: 37.8 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```


delta / 500, max. 3
```
Score of Lynx-nmp-beta-delta-2-1929-win-x64-2 vs Lynx 1928 - main: 1290 - 1357 - 1621  [0.492] 4268
...      Lynx-nmp-beta-delta-2-1929-win-x64-2 playing White: 874 - 424 - 836  [0.605] 2134
...      Lynx-nmp-beta-delta-2-1929-win-x64-2 playing Black: 416 - 933 - 785  [0.379] 2134
...      White vs Black: 1807 - 840 - 1621  [0.613] 4268
Elo difference: -5.5 +/- 8.2, LOS: 9.6 %, DrawRatio: 38.0 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```


No luck when reducing