### PR TITLE
Tweak NMP depth reduction

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,7 +30,7 @@
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
     "NMP_BaseReduction": 1,
-    "NMP_DepthReductionDivisor": 2,
+    "NMP_DepthReductionDivisor": 4,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,7 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_BaseReduction": 1,
+    "NMP_BaseReduction": 2,
     "NMP_DepthReductionDivisor": 3,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,7 +30,7 @@
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
     "NMP_BaseReduction": 1,
-    "NMP_DepthReductionDivisor": 3,
+    "NMP_DepthReductionDivisor": 2,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -31,6 +31,8 @@
     "NMP_MinDepth": 3,
     "NMP_BaseReduction": 1,
     "NMP_DepthReductionDivisor": 3,
+    "NMP_StaticEvalBetaDeltaMaxReduction": 3,
+    "NMP_StaticEvalBetaDeltaDivisor": 200,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,8 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_BaseDepthReduction": 1,
+    "NMP_BaseReduction": 1,
+    "NMP_DepthReductionDivisor": 3,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -30,7 +30,7 @@
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
     "NMP_BaseReduction": 1,
-    "NMP_DepthReductionDivisor": 4,
+    "NMP_DepthReductionDivisor": 3,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -29,7 +29,7 @@
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
     "NMP_MinDepth": 3,
-    "NMP_BaseReduction": 2,
+    "NMP_BaseReduction": 1,
     "NMP_DepthReductionDivisor": 3,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -247,7 +247,7 @@ public sealed class EngineSettings
 
     public int NMP_BaseReduction { get; set; } = 1;
 
-    public int NMP_DepthReductionDivisor { get; set; } = 4;
+    public int NMP_DepthReductionDivisor { get; set; } = 3;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -247,7 +247,7 @@ public sealed class EngineSettings
 
     public int NMP_BaseReduction { get; set; } = 1;
 
-    public int NMP_DepthReductionDivisor { get; set; } = 3;
+    public int NMP_DepthReductionDivisor { get; set; } = 2;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -247,7 +247,7 @@ public sealed class EngineSettings
 
     public int NMP_BaseReduction { get; set; } = 1;
 
-    public int NMP_DepthReductionDivisor { get; set; } = 2;
+    public int NMP_DepthReductionDivisor { get; set; } = 4;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -249,6 +249,10 @@ public sealed class EngineSettings
 
     public int NMP_DepthReductionDivisor { get; set; } = 3;
 
+    public int NMP_StaticEvalBetaDeltaMaxReduction { get; set; } = 3;
+
+    public int NMP_StaticEvalBetaDeltaDivisor { get; set; } = 200;
+
     public int AspirationWindowDelta { get; set; } = 50;
 
     public int AspirationWindowMinDepth { get; set; } = 6;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_BaseReduction { get; set; } = 1;
+    public int NMP_BaseReduction { get; set; } = 2;
 
     public int NMP_DepthReductionDivisor { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,9 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_BaseDepthReduction { get; set; } = 1;
+    public int NMP_BaseReduction { get; set; } = 1;
+
+    public int NMP_DepthReductionDivisor { get; set; } = 3;
 
     public int AspirationWindowDelta { get; set; } = 50;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
 
     public int NMP_MinDepth { get; set; } = 3;
 
-    public int NMP_BaseReduction { get; set; } = 2;
+    public int NMP_BaseReduction { get; set; } = 1;
 
     public int NMP_DepthReductionDivisor { get; set; } = 3;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -84,7 +84,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 3);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseReduction + (depth / Configuration.EngineSettings.NMP_DepthReductionDivisor);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -84,7 +84,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseReduction + (depth / Configuration.EngineSettings.NMP_DepthReductionDivisor);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseReduction + ((depth + 1) / Configuration.EngineSettings.NMP_DepthReductionDivisor);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -92,7 +92,7 @@ public sealed partial class Engine
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                 var gameState = position.MakeNullMove();
-                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
+                var evaluation = -NegaMax(depth - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
                 position.UnMakeNullMove(gameState);
 
                 if (evaluation >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -84,7 +84,11 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseReduction + ((depth + 1) / Configuration.EngineSettings.NMP_DepthReductionDivisor);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseReduction
+					+ ((depth + 1) / Configuration.EngineSettings.NMP_DepthReductionDivisor)   // Clarity
+					+ Math.Min(
+                        Configuration.EngineSettings.NMP_StaticEvalBetaDeltaMaxReduction,
+                        (staticEval - beta) / Configuration.EngineSettings.NMP_StaticEvalBetaDeltaDivisor);
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -84,7 +84,7 @@ public sealed partial class Engine
                 && staticEvalResult.Phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / 3);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(


### PR DESCRIPTION
Simplify depth formula: depth / 3 👎🏽

8+0.08
```
Score of Lynx-nmp-depth-tweaking-2-1930-win-x64 vs Lynx 1928 - main: 2285 - 2332 - 2682  [0.497] 7299
...      Lynx-nmp-depth-tweaking-2-1930-win-x64 playing White: 1575 - 767 - 1308  [0.611] 3650
...      Lynx-nmp-depth-tweaking-2-1930-win-x64 playing Black: 710 - 1565 - 1374  [0.383] 3649
...      White vs Black: 3140 - 1477 - 2682  [0.614] 7299
Elo difference: -2.2 +/- 6.3, LOS: 24.5 %, DrawRatio: 36.7 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[NMP_DepthReductionDivisor = 2](https://github.com/lynx-chess/Lynx/pull/497/commits/a2ddbf8c8bab6644bf880cf3edfe744b36d66ec9), 1933 ~~

8+0.08
```
Score of Lynx-nmp-depth-tweaking-2-1933-win-x64 vs Lynx 1928 - main: 10275 - 10050 - 11928  [0.503] 32253
...      Lynx-nmp-depth-tweaking-2-1933-win-x64 playing White: 6884 - 3278 - 5964  [0.612] 16126
...      Lynx-nmp-depth-tweaking-2-1933-win-x64 playing Black: 3391 - 6772 - 5964  [0.395] 16127
...      White vs Black: 13656 - 6669 - 11928  [0.608] 32253
Elo difference: 2.4 +/- 3.0, LOS: 94.3 %, DrawRatio: 37.0 %
SPRT: llr -0.162 (-5.6%), lbound -2.25, ubound 2.89
```

40+0.4
```
Score of Lynx-nmp-depth-tweaking-2-1933-win-x64 vs Lynx 1928 - main: 1539 - 1510 - 2346  [0.503] 5395
...      Lynx-nmp-depth-tweaking-2-1933-win-x64 playing White: 1096 - 394 - 1208  [0.630] 2698
...      Lynx-nmp-depth-tweaking-2-1933-win-x64 playing Black: 443 - 1116 - 1138  [0.375] 2697
...      White vs Black: 2212 - 837 - 2346  [0.627] 5395
Elo difference: 1.9 +/- 7.0, LOS: 70.0 %, DrawRatio: 43.5 %
SPRT: llr -0.25 (-8.7%), lbound -2.25, ubound 2.89
```


NMP_DepthReductionDivisor = 4, 1934 👎🏽

8+0.08
```
Score of Lynx-nmp-depth-tweaking-2-1934-win-x64 vs Lynx 1928 - main: 455 - 543 - 581  [0.472] 1579
...      Lynx-nmp-depth-tweaking-2-1934-win-x64 playing White: 311 - 186 - 293  [0.579] 790
...      Lynx-nmp-depth-tweaking-2-1934-win-x64 playing Black: 144 - 357 - 288  [0.365] 789
...      White vs Black: 668 - 330 - 581  [0.607] 1579
Elo difference: -19.4 +/- 13.6, LOS: 0.3 %, DrawRatio: 36.8 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Try reducing the base to really 1, 1936, need to combine this with the beta static eval delta 👎🏽
8+0.08
```
Score of Lynx-nmp-depth-tweaking-2-1936-win-x64 vs Lynx 1928 - main: 329 - 424 - 390  [0.458] 1143
...      Lynx-nmp-depth-tweaking-2-1936-win-x64 playing White: 215 - 147 - 209  [0.560] 571
...      Lynx-nmp-depth-tweaking-2-1936-win-x64 playing Black: 114 - 277 - 181  [0.358] 572
...      White vs Black: 492 - 261 - 390  [0.601] 1143
Elo difference: -28.9 +/- 16.4, LOS: 0.0 %, DrawRatio: 34.1 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

1937, combine base reduction to 1 with #496 👎🏽
```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 569 - 650 - 711  [0.479] 1930
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 378 - 218 - 369  [0.583] 965
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 191 - 432 - 342  [0.375] 965
...      White vs Black: 810 - 409 - 711  [0.604] 1930
Elo difference: -14.6 +/- 12.3, LOS: 1.0 %, DrawRatio: 36.8 %
SPRT: llr -2.16 (-74.9%), lbound -2.25, ubound 2.89
```

Variant with NMP_StaticEvalBetaDeltaMaxReduction 1 NMP_StaticEvalBetaDeltaDivisor 1000 👎🏽

```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 403 - 486 - 511  [0.470] 1400
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 281 - 160 - 259  [0.586] 700
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 122 - 326 - 252  [0.354] 700
...      White vs Black: 607 - 282 - 511  [0.616] 1400
Elo difference: -20.6 +/- 14.5, LOS: 0.3 %, DrawRatio: 36.5 %
SPRT: llr -2.11 (-73.1%), lbound -2.25, ubound 2.89
```

Variant with 5 200 
8+0.08👎🏽
```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 1064 - 1135 - 1367  [0.490] 3566
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 732 - 346 - 706  [0.608] 1784
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 332 - 789 - 661  [0.372] 1782
...      White vs Black: 1521 - 678 - 1367  [0.618] 3566
Elo difference: -6.9 +/- 8.9, LOS: 6.5 %, DrawRatio: 38.3 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```

40+0.4 ~~

```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 1963 - 1913 - 3024  [0.504] 6900
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 1431 - 497 - 1522  [0.635] 3450
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 532 - 1416 - 1502  [0.372] 3450
...      White vs Black: 2847 - 1029 - 3024  [0.632] 6900
Elo difference: 2.5 +/- 6.1, LOS: 78.9 %, DrawRatio: 43.8 %
SPRT: llr 0.00872 (0.3%), lbound -2.25, ubound 2.89 
```

Variant with 5 1000 ~~
8+0.08
```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 1671 - 1644 - 1990  [0.503] 5305
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 1130 - 540 - 983  [0.611] 2653
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 541 - 1104 - 1007  [0.394] 2652
...      White vs Black: 2234 - 1081 - 1990  [0.609] 5305
Elo difference: 1.8 +/- 7.4, LOS: 68.0 %, DrawRatio: 37.5 %
SPRT: llr -0.258 (-8.9%), lbound -2.25, ubound 2.89
```

40+0.4 👎🏽
```
Score of Lynx-nmp-depth-tweaking-2-1937-win-x64 vs Lynx 1928 - main: 1448 - 1492 - 2090  [0.496] 5030
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing White: 1020 - 421 - 1075  [0.619] 2516
...      Lynx-nmp-depth-tweaking-2-1937-win-x64 playing Black: 428 - 1071 - 1015  [0.372] 2514
...      White vs Black: 2091 - 849 - 2090  [0.623] 5030
Elo difference: -3.0 +/- 7.3, LOS: 20.9 %, DrawRatio: 41.6 %
SPRT: llr -1.97 (-68.3%), lbound -2.25, ubound 2.89
```

----

From #494 

[Increase NMP base reduction to 2](https://github.com/lynx-chess/Lynx/commit/140c691a700c0899348f1638be6a1faec6e2660f) 👎🏽
```
Score of Lynx-nmp-depth-tweaking-1921-win-x64 vs Lynx 1918 - main: 811 - 891 - 981  [0.485] 2683
...      Lynx-nmp-depth-tweaking-1921-win-x64 playing White: 545 - 304 - 492  [0.590] 1341
...      Lynx-nmp-depth-tweaking-1921-win-x64 playing Black: 266 - 587 - 489  [0.380] 1342
...      White vs Black: 1132 - 570 - 981  [0.605] 2683
Elo difference: -10.4 +/- 10.5, LOS: 2.6 %, DrawRatio: 36.6 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Try depth / 4, keeping 2 as min](https://github.com/lynx-chess/Lynx/commit/d3037949446ccf49dcbca62a83c9397684625918): 👎🏽
 
```
Score of Lynx-nmp-depth-tweaking-1922-win-x64 vs Lynx 1918 - main: 2735 - 2774 - 3090  [0.498] 8599
...      Lynx-nmp-depth-tweaking-1922-win-x64 playing White: 1855 - 910 - 1534  [0.610] 4299
...      Lynx-nmp-depth-tweaking-1922-win-x64 playing Black: 880 - 1864 - 1556  [0.386] 4300
...      White vs Black: 3719 - 1790 - 3090  [0.612] 8599
Elo difference: -1.6 +/- 5.9, LOS: 30.0 %, DrawRatio: 35.9 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```