### PR TITLE
Consistent fail hard beta cutoffs

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -290,7 +290,7 @@ public sealed partial class Engine
 
                 _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);
 
-                return beta;    // TODO return evaluation?
+                return evaluation;
             }
 
             if (evaluation > alpha)


### PR DESCRIPTION
```
Score of Lynx-non-proper-but-consistent-failoff-1926-win-x64 vs Lynx 1924 - main: 2877 - 2914 - 3191  [0.498] 8982
...      Lynx-non-proper-but-consistent-failoff-1926-win-x64 playing White: 1957 - 981 - 1553  [0.609] 4491
...      Lynx-non-proper-but-consistent-failoff-1926-win-x64 playing Black: 920 - 1933 - 1638  [0.387] 4491
...      White vs Black: 3890 - 1901 - 3191  [0.611] 8982
Elo difference: -1.4 +/- 5.8, LOS: 31.3 %, DrawRatio: 35.5 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```