### PR TITLE
NMP tweak min depth

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -28,7 +28,7 @@
     "LMR_MinFullDepthSearchedMoves": 4,
     "LMR_Base": 0.77,
     "LMR_Divisor": 2.67,
-    "NMP_MinDepth": 3,
+    "NMP_MinDepth": 2,
     "NMP_BaseDepthReduction": 1,
     "AspirationWindowDelta": 50,
     "AspirationWindowMinDepth": 6,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -243,7 +243,7 @@ public sealed class EngineSettings
     /// </summary>
     public double LMR_Divisor { get; set; } = 2.67;
 
-    public int NMP_MinDepth { get; set; } = 3;
+    public int NMP_MinDepth { get; set; } = 2;
 
     public int NMP_BaseDepthReduction { get; set; } = 1;
 


### PR DESCRIPTION
8+0.08

Reduce to 2
```
Score of Lynx-1928-mod nmp min 2 vs Lynx 1928 - main: 833 - 913 - 995  [0.485] 2741
...      Lynx-1928-mod nmp min 2 playing White: 566 - 321 - 483  [0.589] 1370
...      Lynx-1928-mod nmp min 2 playing Black: 267 - 592 - 512  [0.381] 1371
...      White vs Black: 1158 - 588 - 995  [0.604] 2741
Elo difference: -10.1 +/- 10.4, LOS: 2.8 %, DrawRatio: 36.3 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Increase to 4
```
Score of Lynx-1928-mod vs Lynx 1928 - main: 359 - 444 - 522  [0.468] 1325
...      Lynx-1928-mod playing White: 245 - 151 - 266  [0.571] 662
...      Lynx-1928-mod playing Black: 114 - 293 - 256  [0.365] 663
...      White vs Black: 538 - 265 - 522  [0.603] 1325
Elo difference: -22.3 +/- 14.6, LOS: 0.1 %, DrawRatio: 39.4 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```