### PR TITLE
Decrease AspirationWindow_MinDepth to 4

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -27,7 +27,7 @@
     "NMP_BaseDepthReduction": 1,
 
     "AspirationWindow_Delta": 50,
-    "AspirationWindow_MinDepth": 6,
+    "AspirationWindow_MinDepth": 4,
 
     "RFP_MaxDepth": 6,
     "RFP_DepthScalingFactor": 75,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -135,7 +135,7 @@ public sealed class EngineSettings
 
     public int AspirationWindow_Delta { get; set; } = 50;
 
-    public int AspirationWindow_MinDepth { get; set; } = 6;
+    public int AspirationWindow_MinDepth { get; set; } = 4;
 
     public int RFP_MaxDepth { get; set; } = 6;
 


### PR DESCRIPTION
20+0.2- incomplete

```
Score of Lynx-main-1951-win-x64-2 vs Lynx 1951 - main: 762 - 710 - 1007  [0.510] 2479
...      Lynx-main-1951-win-x64-2 playing White: 523 - 208 - 509  [0.627] 1240
...      Lynx-main-1951-win-x64-2 playing Black: 239 - 502 - 498  [0.394] 1239
...      White vs Black: 1025 - 447 - 1007  [0.617] 2479
Elo difference: 7.3 +/- 10.5, LOS: 91.2 %, DrawRatio: 40.6 %
SPRT: llr 0.828 (28.7%), lbound -2.25, ubound 2.89
```

8+0.08 - incomplete
```
Score of Lynx-main-1951-win-x64 - mod vs Lynx 1951 - main: 1311 - 1286 - 1613  [0.503] 4210
...      Lynx-main-1951-win-x64 - mod playing White: 893 - 413 - 798  [0.614] 2104
...      Lynx-main-1951-win-x64 - mod playing Black: 418 - 873 - 815  [0.392] 2106
...      White vs Black: 1766 - 831 - 1613  [0.611] 4210
Elo difference: 2.1 +/- 8.2, LOS: 68.8 %, DrawRatio: 38.3 %
SPRT: llr -0.124 (-4.3%), lbound -2.25, ubound 2.89
```

40+0.4
```
Score of Lynx-aspiration-windows-decrease-mindepth-2005-win-x64 vs Lynx 2004 - main: 2821 - 2770 - 4479  [0.503] 10070
...      Lynx-aspiration-windows-decrease-mindepth-2005-win-x64 playing White: 2018 - 816 - 2201  [0.619] 5035
...      Lynx-aspiration-windows-decrease-mindepth-2005-win-x64 playing Black: 803 - 1954 - 2278  [0.386] 5035
...      White vs Black: 3972 - 1619 - 4479  [0.617] 10070
Elo difference: 1.8 +/- 5.0, LOS: 75.2 %, DrawRatio: 44.5 %
SPRT: llr -0.556 (-19.3%), lbound -2.25, ubound 2.89
```