### PR TITLE
🔍 Add Internal Iterative Reduction (IIR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ If you're a Linux user and are new to .NET ecosystem, the conversation in [this 
 
 - PEXT Bitboards [[1](https://www.chessprogramming.org/BMI2#PEXTBitboards)]  [[2](https://analog-hors.github.io/site/magic-bitboards/)]
 
+- Internal Iterative Deepening [[1](https://www.chessprogramming.org/Internal_Iterative_Deepening)]
+
 ## Credits
 
 Lynx development wouldn't have been possible without:

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -36,7 +36,7 @@
     "Razoring_Depth1Bonus": 125,
     "Razoring_NotDepth1Bonus": 175,
 
-    "IIR_MinDepth": 4,
+    "IIR_MinDepth": 3,
 
     "History_MaxMoveValue": 8192,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -36,7 +36,7 @@
     "Razoring_Depth1Bonus": 125,
     "Razoring_NotDepth1Bonus": 175,
 
-    "IIR_MinDepth": 3,
+    "IIR_MinDepth": 5,
 
     "History_MaxMoveValue": 8192,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -36,6 +36,8 @@
     "Razoring_Depth1Bonus": 125,
     "Razoring_NotDepth1Bonus": 175,
 
+    "IIR_MinDepth": 4,
+
     "History_MaxMoveValue": 8192,
 
     // Evaluation

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -36,7 +36,7 @@
     "Razoring_Depth1Bonus": 125,
     "Razoring_NotDepth1Bonus": 175,
 
-    "IIR_MinDepth": 5,
+    "IIR_MinDepth": 4,
 
     "History_MaxMoveValue": 8192,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -147,7 +147,7 @@ public sealed class EngineSettings
 
     public int Razoring_NotDepth1Bonus { get; set; } = 175;
 
-    public int IIR_MinDepth { get; set; } = 4;
+    public int IIR_MinDepth { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -147,7 +147,7 @@ public sealed class EngineSettings
 
     public int Razoring_NotDepth1Bonus { get; set; } = 175;
 
-    public int IIR_MinDepth { get; set; } = 5;
+    public int IIR_MinDepth { get; set; } = 4;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -147,6 +147,8 @@ public sealed class EngineSettings
 
     public int Razoring_NotDepth1Bonus { get; set; } = 175;
 
+    public int IIR_MinDepth { get; set; } = 4;
+
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     #region Evaluation

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -147,7 +147,7 @@ public sealed class EngineSettings
 
     public int Razoring_NotDepth1Bonus { get; set; } = 175;
 
-    public int IIR_MinDepth { get; set; } = 3;
+    public int IIR_MinDepth { get; set; } = 5;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -42,6 +42,8 @@ public sealed partial class Engine
         NodeType ttElementType = default;
         int ttEvaluation = default;
 
+        bool isInCheck = position.IsInCheck();
+
         if (!isRoot)
         {
             (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
@@ -50,12 +52,14 @@ public sealed partial class Engine
                 return ttEvaluation;
             }
 
-            // Internal iterative reduction (IIR)
+            // Internal Iterative Reduction (IIR)
             // If this position isn't found in TT, it has never been searched before,
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (ttElementType == default
+                && depth >= Configuration.EngineSettings.IIR_MinDepth
+                && !isInCheck)
             {
                 --depth;
             }
@@ -63,8 +67,6 @@ public sealed partial class Engine
 
         // Before any time-consuming operations
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
-
-        bool isInCheck = position.IsInCheck();
 
         if (isInCheck)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -55,7 +55,7 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttBestMove == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -55,7 +55,7 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (ttBestMove == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -42,8 +42,6 @@ public sealed partial class Engine
         NodeType ttElementType = default;
         int ttEvaluation = default;
 
-        bool isInCheck = position.IsInCheck();
-
         if (!isRoot)
         {
             (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
@@ -52,14 +50,12 @@ public sealed partial class Engine
                 return ttEvaluation;
             }
 
-            // Internal Iterative Reduction (IIR)
+            // Internal iterative reduction (IIR)
             // If this position isn't found in TT, it has never been searched before,
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default
-                && depth >= Configuration.EngineSettings.IIR_MinDepth
-                && !isInCheck)
+            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }
@@ -67,6 +63,8 @@ public sealed partial class Engine
 
         // Before any time-consuming operations
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+
+        bool isInCheck = position.IsInCheck();
 
         if (isInCheck)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -55,7 +55,7 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default)
+            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -49,6 +49,16 @@ public sealed partial class Engine
             {
                 return ttEvaluation;
             }
+
+            // Internal iterative reduction (IIR)
+            // If this position isn't found in TT, it has never been searched before,
+            // so the search will be potentially expensive.
+            // Therefore, we search with reduced depth for now, expecting to record a TT move
+            // which we'll be able to use later for the full depth search
+            if (ttElementType == default)
+            {
+                --depth;
+            }
         }
 
         // Before any time-consuming operations


### PR DESCRIPTION
Most basic attempt, without min. depth 👎🏽 (it also makes a bunch of tests fail, but because they assume a certain depth to be reached when searching depth 5)
```
Score of Lynx-iir-basic-1965-win-x64 vs Lynx 1964 - main: 764 - 840 - 1036  [0.486] 2640
...      Lynx-iir-basic-1965-win-x64 playing White: 516 - 297 - 507  [0.583] 1320
...      Lynx-iir-basic-1965-win-x64 playing Black: 248 - 543 - 529  [0.388] 1320
...      White vs Black: 1059 - 545 - 1036  [0.597] 2640
Elo difference: -10.0 +/- 10.3, LOS: 2.9 %, DrawRatio: 39.2 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Using min depth 4, as recommended in EP discord

8+0.08 👍🏽ish (had to cancel)
```
Score of Lynx-iir-basic-1966-win-x64 vs Lynx 1964 - main: 3972 - 3794 - 4844  [0.507] 12610
...      Lynx-iir-basic-1966-win-x64 playing White: 2699 - 1235 - 2372  [0.616] 6306
...      Lynx-iir-basic-1966-win-x64 playing Black: 1273 - 2559 - 2472  [0.398] 6304
...      White vs Black: 5258 - 2508 - 4844  [0.609] 12610
Elo difference: 4.9 +/- 4.8, LOS: 97.8 %, DrawRatio: 38.4 %
SPRT: llr 2.04 (70.6%), lbound -2.25, ubound 2.89
```

40+0.4 👍🏽
```
Score of Lynx-iir-basic-1966-win-x64 vs Lynx 1964 - main: 1628 - 1476 - 2472  [0.514] 5576
...      Lynx-iir-basic-1966-win-x64 playing White: 1170 - 404 - 1214  [0.637] 2788
...      Lynx-iir-basic-1966-win-x64 playing Black: 458 - 1072 - 1258  [0.390] 2788
...      White vs Black: 2242 - 862 - 2472  [0.624] 5576
Elo difference: 9.5 +/- 6.8, LOS: 99.7 %, DrawRatio: 44.3 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```

[Try checking ttBestMove instead of ttHit](https://github.com/lynx-chess/Lynx/pull/507/commits/badab15c9bc7582adbe42ac179c887b3e5d972cb) failed as well

Using min depth 3 vs depth 4
8+0.08 👎🏽ish
```
Finished game 10401 (Lynx-iir-basic-1986-win-x64 vs Lynx-iir-basic-1985-win-x64): * {No result}
Score of Lynx-iir-basic-1986-win-x64 vs Lynx-iir-basic-1985-win-x64: 3154 - 3107 - 4137  [0.502] 10398
...      Lynx-iir-basic-1986-win-x64 playing White: 2146 - 998 - 2055  [0.610] 5199
...      Lynx-iir-basic-1986-win-x64 playing Black: 1008 - 2109 - 2082  [0.394] 5199
...      White vs Black: 4255 - 2006 - 4137  [0.608] 10398
Elo difference: 1.6 +/- 5.2, LOS: 72.4 %, DrawRatio: 39.8 %
```

Using min depth 5 vs depth 4
8+0.08 👎🏽ish
```
Score of Lynx-iir-basic-1987-win-x64 vs Lynx-iir-basic-1985-win-x64: 3194 - 3182 - 4054  [0.501] 10430
...      Lynx-iir-basic-1987-win-x64 playing White: 2166 - 1010 - 2040  [0.611] 5216
...      Lynx-iir-basic-1987-win-x64 playing Black: 1028 - 2172 - 2014  [0.390] 5214
...      White vs Black: 4338 - 2038 - 4054  [0.610] 10430
Elo difference: 0.4 +/- 5.2, LOS: 56.0 %, DrawRatio: 38.9 %
SPRT: llr -1.48 (-51.4%), lbound -2.25, ubound 2.89
```