### PR TITLE
🐛 Clamp static evaluation within +- checkmate limits

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -312,6 +312,10 @@ public static class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
+    public const int MinEval = NegativeCheckmateDetectionLimit + 1;
+
+    public const int MaxEval = PositiveCheckmateDetectionLimit - 1;
+
     public const int PVMoveScoreValue = 4_194_304;
 
     public const int TTMoveScoreValue = 2_097_152;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -693,7 +693,7 @@ public class Position
 
         var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
-        eval = Math.Clamp(eval, EvaluationConstants.NegativeCheckmateDetectionLimit, EvaluationConstants.PositiveCheckmateDetectionLimit);
+        eval = Math.Clamp(eval, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
 
         var sideEval = Side == Side.White
             ? eval

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -693,6 +693,8 @@ public class Position
 
         var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
+        eval = Math.Clamp(eval, EvaluationConstants.NegativeCheckmateDetectionLimit, EvaluationConstants.PositiveCheckmateDetectionLimit);
+
         var sideEval = Side == Side.White
             ? eval
             : -eval;


### PR DESCRIPTION
This avoids engine crashes for positions such as:
`QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1`
and engine crashes such as
https://lichess.org/49dBqSDK

```
position fen QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1 moves h1g1
go depth 50
info depth 1 seldepth 1 multipv 1 score mate 138 nodes 1 nps 1 time 20 pv
info depth 1 seldepth 1 multipv 1 score mate 138 nodes 1 nps 1 time 27 hashfull 0 pv
bestmove a8a8
```

Non-regression tests:

8+0.08 👍🏽
```
Score of Lynx-bugfix-staticeval-out-of-range-1977-win-x64 vs Lynx 1.0.0: 2105 - 2033 - 2741  [0.505] 6879
...      Lynx-bugfix-staticeval-out-of-range-1977-win-x64 playing White: 1415 - 666 - 1359  [0.609] 3440
...      Lynx-bugfix-staticeval-out-of-range-1977-win-x64 playing Black: 690 - 1367 - 1382  [0.402] 3439
...      White vs Black: 2782 - 1356 - 2741  [0.604] 6879
Elo difference: 3.6 +/- 6.4, LOS: 86.8 %, DrawRatio: 39.8 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4, had to cancel
```
Score of Lynx-bugfix-staticeval-out-of-range-1977-win-x64 vs Lynx 1.0.0: 2105 - 2033 - 2741  [0.505] 6879
...      Lynx-bugfix-staticeval-out-of-range-1977-win-x64 playing White: 1415 - 666 - 1359  [0.609] 3440
...      Lynx-bugfix-staticeval-out-of-range-1977-win-x64 playing Black: 690 - 1367 - 1382  [0.402] 3439
...      White vs Black: 2782 - 1356 - 2741  [0.604] 6879
Elo difference: 3.6 +/- 6.4, LOS: 86.8 %, DrawRatio: 39.8 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```