### PR TITLE
🔍 Add basic LMP

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -38,6 +38,8 @@
 
     "IIR_MinDepth": 4,
 
+    "LMP_MaxDepth": 3,
+
     "History_MaxMoveValue": 8192,
 
     // Evaluation

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -38,8 +38,9 @@
 
     "IIR_MinDepth": 4,
 
-    "LMP_MaxDepth": 3,
-    "LMP_BaseMovesToTry": 3,
+    "LMP_MaxDepth": 2,
+    "LMP_BaseMovesToTry": 0,
+    "LMP_MovesDepthMultiplier": 10,
 
     "History_MaxMoveValue": 8192,
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -39,6 +39,7 @@
     "IIR_MinDepth": 4,
 
     "LMP_MaxDepth": 3,
+    "LMP_BaseMovesToTry": 3,
 
     "History_MaxMoveValue": 8192,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -149,9 +149,11 @@ public sealed class EngineSettings
 
     public int IIR_MinDepth { get; set; } = 4;
 
-    public int LMP_MaxDepth { get; set; } = 3;
+    public int LMP_MaxDepth { get; set; } = 2;
 
-    public int LMP_BaseMovesToTry { get; set; } = 3;
+    public int LMP_BaseMovesToTry { get; set; } = 0;
+
+    public int LMP_MovesDepthMultiplier { get; set; } = 10;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -149,6 +149,8 @@ public sealed class EngineSettings
 
     public int IIR_MinDepth { get; set; } = 4;
 
+    public int LMP_MaxDepth { get; set; } = 3;
+
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     #region Evaluation

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -151,6 +151,8 @@ public sealed class EngineSettings
 
     public int LMP_MaxDepth { get; set; } = 3;
 
+    public int LMP_BaseMovesToTry { get; set; } = 3;
+
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     #region Evaluation

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -236,7 +236,6 @@ public sealed partial class Engine
                 if (!pvNode
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
-                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
                     && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                 {
                     // After making a move

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -236,6 +236,7 @@ public sealed partial class Engine
                 if (!pvNode
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
+                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
                     && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                 {
                     // After making a move

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -231,6 +231,26 @@ public sealed partial class Engine
             }
             else
             {
+                // Late Move Pruning (LMP) - all quiet moves can be pruned
+                // after searching the first few given by the move ordering algorithm
+                if (!pvNode
+                    && !isInCheck
+                    && depth <= Configuration.EngineSettings.LMP_MaxDepth
+                    && scores[i] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
+                    && i >= depth * 10) // Suggested by Antares
+                                        //&& i >= base + depth * depth) // SP, base 2 or 3
+                {
+                    // After making a move
+                    Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
+                    if (!isThreeFoldRepetition)
+                    {
+                        Game.PositionHashHistory.Remove(position.UniqueIdentifier);
+                    }
+                    position.UnmakeMove(move, gameState);
+
+                    break;
+                }
+
                 int reduction = 0;
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -237,7 +237,7 @@ public sealed partial class Engine
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + Configuration.EngineSettings.LMP_MovesDepthMultiplier) // Based on SP and Altair
+                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on SP and Altair
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -237,7 +237,7 @@ public sealed partial class Engine
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on SP and Altair
+                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + Configuration.EngineSettings.LMP_MovesDepthMultiplier) // Based on SP and Altair
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -237,7 +237,7 @@ public sealed partial class Engine
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on SP and Altair
+                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -182,20 +182,20 @@ public sealed partial class Engine
             }
         }
 
-        for (int i = 0; i < pseudoLegalMoves.Length; ++i)
+        for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
             // There's no need to sort all the moves since most of them don't get checked anyway
             // So just find the first unsearched one with the best score and try it
-            for (int j = i + 1; j < pseudoLegalMoves.Length; j++)
+            for (int j = moveIndex + 1; j < pseudoLegalMoves.Length; j++)
             {
-                if (scores[j] > scores[i])
+                if (scores[j] > scores[moveIndex])
                 {
-                    (scores[i], scores[j], pseudoLegalMoves[i], pseudoLegalMoves[j]) = (scores[j], scores[i], pseudoLegalMoves[j], pseudoLegalMoves[i]);
+                    (scores[moveIndex], scores[j], pseudoLegalMoves[moveIndex], pseudoLegalMoves[j]) = (scores[j], scores[moveIndex], pseudoLegalMoves[j], pseudoLegalMoves[moveIndex]);
                 }
             }
 
-            var move = pseudoLegalMoves[i];
+            var move = pseudoLegalMoves[moveIndex];
 
             var gameState = position.MakeMove(move);
 
@@ -236,8 +236,8 @@ public sealed partial class Engine
                 if (!pvNode
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
-                    && scores[i] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && i >= Configuration.EngineSettings.LMP_BaseMovesToTry + 10 * depth) // Based on SP and Altair
+                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
+                    && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on SP and Altair
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -237,7 +237,7 @@ public sealed partial class Engine
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
                     && scores[i] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && i >= Configuration.EngineSettings.LMP_BaseMovesToTry + depth * depth) // Based on SP
+                    && i >= Configuration.EngineSettings.LMP_BaseMovesToTry + 10 * depth) // Based on SP and Altair
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -237,8 +237,7 @@ public sealed partial class Engine
                     && !isInCheck
                     && depth <= Configuration.EngineSettings.LMP_MaxDepth
                     && scores[i] < EvaluationConstants.PromotionMoveScoreValue  // Quiet moves
-                    && i >= depth * 10) // Suggested by Antares
-                                        //&& i >= base + depth * depth) // SP, base 2 or 3
+                    && i >= Configuration.EngineSettings.LMP_BaseMovesToTry + depth * depth) // Based on SP
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;


### PR DESCRIPTION
`i >= depth * 10`, max 3 👍🏽
8+0.08
```
Score of Lynx-lmr-basic-1990-win-x64 vs Lynx 1989 - main: 5870 - 5612 - 7393  [0.507] 18875
...      Lynx-lmr-basic-1990-win-x64 playing White: 3976 - 1811 - 3651  [0.615] 9438
...      Lynx-lmr-basic-1990-win-x64 playing Black: 1894 - 3801 - 3742  [0.399] 9437
...      White vs Black: 7777 - 3705 - 7393  [0.608] 18875
Elo difference: 4.7 +/- 3.9, LOS: 99.2 %, DrawRatio: 39.2 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```

`i >= Configuration.EngineSettings.LMP_BaseMovesToTry + depth * depth)`, being LMP_BaseMovesToTry  3 👎🏽
8+0.08
```
Score of Lynx-lmr-basic-1991-win-x64 vs Lynx 1989 - main: 366 - 455 - 482  [0.466] 1303
...      Lynx-lmr-basic-1991-win-x64 playing White: 240 - 165 - 246  [0.558] 651
...      Lynx-lmr-basic-1991-win-x64 playing Black: 126 - 290 - 236  [0.374] 652
...      White vs Black: 530 - 291 - 482  [0.592] 1303
Elo difference: -23.8 +/- 15.0, LOS: 0.1 %, DrawRatio: 37.0 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

`i >= Configuration.EngineSettings.LMP_BaseMovesToTry + depth * 10)`, being LMP_BaseMovesToTry  3
8+0.08
```
```

`quietMovesCount >= depth * 10)` 👎🏽
```
Finished game 4841 (Lynx-lmr-basic-1995-win-x64-base0 vs Lynx-lmr-basic-1990-win-x64): * {No result}
Score of Lynx-lmr-basic-1995-win-x64-base0 vs Lynx-lmr-basic-1990-win-x64: 1444 - 1505 - 1889  [0.494] 4838
...      Lynx-lmr-basic-1995-win-x64-base0 playing White: 988 - 494 - 937  [0.602] 2419
...      Lynx-lmr-basic-1995-win-x64-base0 playing Black: 456 - 1011 - 952  [0.385] 2419
...      White vs Black: 1999 - 950 - 1889  [0.608] 4838
Elo difference: -4.4 +/- 7.6, LOS: 13.1 %, DrawRatio: 39.0 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

`quietMovesCount >= Configuration.EngineSettings.LMP_BaseMovesToTry + depth * 10)`, being LMP_BaseMovesToTry  3
8+0.08, had to cancel
```
Score of Lynx-lmr-basic-1995-win-x64 vs Lynx 1989 - main: 1997 - 1935 - 2338  [0.505] 6270
...      Lynx-lmr-basic-1995-win-x64 playing White: 1330 - 660 - 1145  [0.607] 3135
...      Lynx-lmr-basic-1995-win-x64 playing Black: 667 - 1275 - 1193  [0.403] 3135
...      White vs Black: 2605 - 1327 - 2338  [0.602] 6270
Elo difference: 3.4 +/- 6.8, LOS: 83.9 %, DrawRatio: 37.3 %
```

vs basic 1990 version 👎🏽
```
Score of Lynx-lmr-basic-1995-win-x64 vs Lynx-lmr-basic-1990-win-x64: 1691 - 1747 - 2179  [0.495] 5617
...      Lynx-lmr-basic-1995-win-x64 playing White: 1136 - 567 - 1105  [0.601] 2808
...      Lynx-lmr-basic-1995-win-x64 playing Black: 555 - 1180 - 1074  [0.389] 2809
...      White vs Black: 2316 - 1122 - 2179  [0.606] 5617
Elo difference: -3.5 +/- 7.1, LOS: 17.0 %, DrawRatio: 38.8 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```
`i >= depth * 10`, max 5 👎🏽
8+0.08
```
Score of Lynx-lmr-basic-1990-win-x64-max5 vs Lynx-lmr-basic-1990-win-x64: 3601 - 3610 - 4704  [0.500] 11915
...      Lynx-lmr-basic-1990-win-x64-max5 playing White: 2422 - 1183 - 2353  [0.604] 5958
...      Lynx-lmr-basic-1990-win-x64-max5 playing Black: 1179 - 2427 - 2351  [0.395] 5957
...      White vs Black: 4849 - 2362 - 4704  [0.604] 11915
Elo difference: -0.3 +/- 4.8, LOS: 45.8 %, DrawRatio: 39.5 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

`i >= depth * 10`, max 2 👍🏽
8+0.08
```
Score of Lynx-lmr-basic-1990-win-x64-max2 vs Lynx-lmr-basic-1990-win-x64: 4089 - 3872 - 5126  [0.508] 13087
...      Lynx-lmr-basic-1990-win-x64-max2 playing White: 2759 - 1245 - 2541  [0.616] 6545
...      Lynx-lmr-basic-1990-win-x64-max2 playing Black: 1330 - 2627 - 2585  [0.401] 6542
...      White vs Black: 5386 - 2575 - 5126  [0.607] 13087
Elo difference: 5.8 +/- 4.6, LOS: 99.2 %, DrawRatio: 39.2 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```

`i >= depth * 10`, max 1 👎🏽ish
8+0.08
```
Score of Lynx-lmr-basic-1997-win-x64-mod vs Lynx-lmr-basic-1997-win-x64: 3180 - 3160 - 4060  [0.501] 10400
...      Lynx-lmr-basic-1997-win-x64-mod playing White: 2181 - 1031 - 1988  [0.611] 5200
...      Lynx-lmr-basic-1997-win-x64-mod playing Black: 999 - 2129 - 2072  [0.391] 5200
...      White vs Black: 4310 - 2030 - 4060  [0.610] 10400
Elo difference: 0.7 +/- 5.2, LOS: 59.9 %, DrawRatio: 39.0 %
SPRT: llr -1.29 (-44.8%), lbound -2.25, ubound 2.89
```

`i >= depth * 5`, max 2 👎🏽
8+0.08
```
Score of Lynx-lmr-basic-1996-win-x64 vs Lynx-lmr-basic-1990-win-x64: 1730 - 1782 - 2331  [0.496] 5843
...      Lynx-lmr-basic-1996-win-x64 playing White: 1174 - 598 - 1149  [0.599] 2921
...      Lynx-lmr-basic-1996-win-x64 playing Black: 556 - 1184 - 1182  [0.393] 2922
...      White vs Black: 2358 - 1154 - 2331  [0.603] 5843
Elo difference: -3.1 +/- 6.9, LOS: 19.0 %, DrawRatio: 39.9 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

```
Score of Lynx-lmr-basic-1997-win-x64-mod vs Lynx-lmr-basic-1997-win-x64: 1085 - 1156 - 1375  [0.490] 3616
...      Lynx-lmr-basic-1997-win-x64-mod playing White: 725 - 389 - 695  [0.593] 1809
...      Lynx-lmr-basic-1997-win-x64-mod playing Black: 360 - 767 - 680  [0.387] 1807
...      White vs Black: 1492 - 749 - 1375  [0.603] 3616
Elo difference: -6.8 +/- 8.9, LOS: 6.7 %, DrawRatio: 38.0 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```


`i >= depth * 13`, max 2 👎🏽
8+0.08
```
Score of Lynx-lmr-basic-1997-win-x64-mod vs Lynx-lmr-basic-1997-win-x64: 1688 - 1743 - 2228  [0.495] 5659
...      Lynx-lmr-basic-1997-win-x64-mod playing White: 1162 - 534 - 1134  [0.611] 2830
...      Lynx-lmr-basic-1997-win-x64-mod playing Black: 526 - 1209 - 1094  [0.379] 2829
...      White vs Black: 2371 - 1060 - 2228  [0.616] 5659
Elo difference: -3.4 +/- 7.0, LOS: 17.4 %, DrawRatio: 39.4 %
SPRT: llr -2.27 (-78.6%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Fixed amount of moves 20 👎🏽
```
Score of Lynx-lmr-basic-1998-win-x64 vs Lynx-lmr-basic-1997-win-x64: 920 - 990 - 1323  [0.489] 3233
...      Lynx-lmr-basic-1998-win-x64 playing White: 622 - 331 - 663  [0.590] 1616
...      Lynx-lmr-basic-1998-win-x64 playing Black: 298 - 659 - 660  [0.388] 1617
...      White vs Black: 1281 - 629 - 1323  [0.601] 3233
Elo difference: -7.5 +/- 9.2, LOS: 5.5 %, DrawRatio: 40.9 %
SPRT: llr -2.27 (-78.6%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Remove move score limitation 👎🏽
8+0.08
```
Score of Lynx-lmr-basic-2001-win-x64 vs Lynx-lmr-basic-1999-win-x64: 782 - 804 - 944  [0.496] 2530
...      Lynx-lmr-basic-2001-win-x64 playing White: 516 - 268 - 482  [0.598] 1266
...      Lynx-lmr-basic-2001-win-x64 playing Black: 266 - 536 - 462  [0.393] 1264
...      White vs Black: 1052 - 534 - 944  [0.602] 2530
Elo difference: -3.0 +/- 10.7, LOS: 29.0 %, DrawRatio: 37.3 %
SPRT: llr -0.923 (-31.9%), lbound -2.25, ubound 2.89
```
40+0.4
```
Score of Lynx-lmr-basic-2001-win-x64 vs Lynx-lmr-basic-1999-win-x64: 119 - 129 - 222  [0.489] 470
...      Lynx-lmr-basic-2001-win-x64 playing White: 85 - 37 - 113  [0.602] 235
...      Lynx-lmr-basic-2001-win-x64 playing Black: 34 - 92 - 109  [0.377] 235
...      White vs Black: 177 - 71 - 222  [0.613] 470
Elo difference: -7.4 +/- 22.8, LOS: 26.3 %, DrawRatio: 47.2 %
SPRT: llr -0.365 (-12.6%), lbound -2.25, ubound 2.89
```
----

Progress control
```
Score of Lynx-lmr-basic-1997-win-x64 vs Lynx 1994 - main: 861 - 717 - 934  [0.529] 2512
...      Lynx-lmr-basic-1997-win-x64 playing White: 574 - 233 - 449  [0.636] 1256
...      Lynx-lmr-basic-1997-win-x64 playing Black: 287 - 484 - 485  [0.422] 1256
...      White vs Black: 1058 - 520 - 934  [0.607] 2512
Elo difference: 19.9 +/- 10.8, LOS: 100.0 %, DrawRatio: 37.2 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```