### PR TITLE
Try adding tempo (yes, again)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -113,6 +113,10 @@
       "Rank7": {
         "MG": 0,
         "EG": 0
+      },
+      "TempoBonus": {
+        "MG": 5,
+        "EG": 5
       }
     }
     // End of evaluation

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -183,6 +183,8 @@ public sealed class EngineSettings
         new(53, 191),
         new(0));
 
+    public TaperedEvaluationTerm TempoBonus { get; set; } = new(5, 5);
+
     #endregion
 }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -666,6 +666,17 @@ public class Position
         middleGameScore += EvaluationConstants.MiddleGameTable[(int)Piece.k, blackKing] - mgKingScore;
         endGameScore += EvaluationConstants.EndGameTable[(int)Piece.k, blackKing] - egKingScore;
 
+        if (Side == Side.White)
+        {
+            middleGameScore += Configuration.EngineSettings.TempoBonus.MG;
+            endGameScore += Configuration.EngineSettings.TempoBonus.EG;
+        }
+        else
+        {
+            middleGameScore -= Configuration.EngineSettings.TempoBonus.MG;
+            endGameScore -= Configuration.EngineSettings.TempoBonus.EG;
+        }
+
         const int maxPhase = 24;
 
         if (gamePhase > maxPhase)    // Early promotions


### PR DESCRIPTION
After #423 and #463

5-5
```
Score of Lynx-tempo-bonus-3-2000-win-x64 vs Lynx 1994 - main: 2888 - 2913 - 3873  [0.499] 9674
...      Lynx-tempo-bonus-3-2000-win-x64 playing White: 1981 - 932 - 1925  [0.608] 4838
...      Lynx-tempo-bonus-3-2000-win-x64 playing Black: 907 - 1981 - 1948  [0.389] 4836
...      White vs Black: 3962 - 1839 - 3873  [0.610] 9674
Elo difference: -0.9 +/- 5.4, LOS: 37.1 %, DrawRatio: 40.0 %
SPRT: llr -2.27 (-78.6%), lbound -2.25, ubound 2.89 - H0 was accepted
```

10-10 vs 5-5
```
Score of Lynx-tempo-bonus-3-2000-win-x64-10 vs Lynx-tempo-bonus-3-2000-win-x64: 2309 - 2349 - 3033  [0.497] 7691
...      Lynx-tempo-bonus-3-2000-win-x64-10 playing White: 1589 - 761 - 1496  [0.608] 3846
...      Lynx-tempo-bonus-3-2000-win-x64-10 playing Black: 720 - 1588 - 1537  [0.387] 3845
...      White vs Black: 3177 - 1481 - 3033  [0.610] 7691
Elo difference: -1.8 +/- 6.0, LOS: 27.9 %, DrawRatio: 39.4 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```

20

```
Score of Lynx-tempo-bonus-3-2000-win-x64-10 vs Lynx-tempo-bonus-3-2000-win-x64: 1407 - 1430 - 1913  [0.498] 4750
...      Lynx-tempo-bonus-3-2000-win-x64-10 playing White: 946 - 454 - 975  [0.604] 2375
...      Lynx-tempo-bonus-3-2000-win-x64-10 playing Black: 461 - 976 - 938  [0.392] 2375
...      White vs Black: 1922 - 915 - 1913  [0.606] 4750
Elo difference: -1.7 +/- 7.6, LOS: 33.3 %, DrawRatio: 40.3 %
SPRT: llr -1.38 (-47.7%), lbound -2.25, ubound 2.89
```