### PR TITLE
Move ordering - TT move priority over PV move

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<configuration>
+  <packageSources>
+    <!--<add key="local" value="c:\dev\local-nuget" />-->
+    <!--<add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />-->
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Lynx.TeamsApi/appsettings.Development.json
+++ b/src/Lynx.TeamsApi/appsettings.Development.json
@@ -1,0 +1,14 @@
+﻿{
+  //"MicrosoftAppType": "UserAssignedMSI",
+  //"MicrosoftAppId": "b123382a-3480-482e-9391-a6d999c65955",
+  //"MicrosoftAppPassword": "",
+  //"MicrosoftAppTenantId": "83f6f062-3036-434d-a3ba-386fef34a9ea",
+
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -316,9 +316,9 @@ public static readonly int[] EndGameKingTable =
 
     public const int MaxEval = PositiveCheckmateDetectionLimit - 1;
 
-    public const int PVMoveScoreValue = 4_194_304;
+    public const int PVMoveScoreValue = 2_097_152;
 
-    public const int TTMoveScoreValue = 2_097_152;
+    public const int TTMoveScoreValue = 4_194_304;
 
     /// <summary>
     /// For MVVLVA

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -69,16 +69,16 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScoreMove(Move move, int depth, bool useKillerAndPositionMoves, Move bestMoveTTCandidate = default)
     {
+        if (move == bestMoveTTCandidate)
+        {
+            return EvaluationConstants.TTMoveScoreValue;
+        }
+
         if (_isScoringPV && move == _pVTable[depth])
         {
             _isScoringPV = false;
 
             return EvaluationConstants.PVMoveScoreValue;
-        }
-
-        if (move == bestMoveTTCandidate)
-        {
-            return EvaluationConstants.TTMoveScoreValue;
         }
 
         var promotedPiece = move.PromotedPiece();

--- a/tests/Lynx.Test/Lynx.Test.RunSettings
+++ b/tests/Lynx.Test/Lynx.Test.RunSettings
@@ -1,0 +1,5 @@
+<RunSettings>
+   <NUnit>
+       <DebugExecution>True</DebugExecution>
+   </NUnit>
+</RunSettings>


### PR DESCRIPTION
```
Score of Lynx-move-ordering-invert-pv-and-tt-2046-win-x64 vs Lynx 2043 - main: 1387 - 1447 - 1890  [0.494] 4724
...      Lynx-move-ordering-invert-pv-and-tt-2046-win-x64 playing White: 889 - 494 - 979  [0.584] 2362
...      Lynx-move-ordering-invert-pv-and-tt-2046-win-x64 playing Black: 498 - 953 - 911  [0.404] 2362
...      White vs Black: 1842 - 992 - 1890  [0.590] 4724
Elo difference: -4.4 +/- 7.7, LOS: 13.0 %, DrawRatio: 40.0 %
SPRT: llr -2.26 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```