### PR TITLE
Increase History_MaxMoveValue to 16384

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -42,7 +42,7 @@
     "LMP_BaseMovesToTry": 0,
     "LMP_MovesDepthMultiplier": 10,
 
-    "History_MaxMoveValue": 8192,
+    "History_MaxMoveValue": 16384,
 
     // Evaluation
     "DoubledPawnPenalty": {


### PR DESCRIPTION
```
Score of Lynx-main-2043-win-x64-mod vs Lynx 2043 - main: 2734 - 2767 - 3431  [0.498] 8932
...      Lynx-main-2043-win-x64-mod playing White: 1838 - 926 - 1701  [0.602] 4465
...      Lynx-main-2043-win-x64-mod playing Black: 896 - 1841 - 1730  [0.394] 4467
...      White vs Black: 3679 - 1822 - 3431  [0.604] 8932
Elo difference: -1.3 +/- 5.6, LOS: 32.8 %, DrawRatio: 38.4 %
SPRT: llr -2.27 (-78.6%), lbound -2.25, ubound 2.89 - H0 was accepted
```