### PR TITLE
Extend depth on promotion move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -196,6 +196,7 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[moveIndex];
+            int depthExtensions = 0;
 
             var gameState = position.MakeMove(move);
 
@@ -209,6 +210,11 @@ public sealed partial class Engine
             isAnyMoveValid = true;
 
             PrintPreMove(position, ply, move);
+
+            if (move.PromotedPiece() != default)
+            {
+                ++depthExtensions;
+            }
 
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
@@ -227,7 +233,7 @@ public sealed partial class Engine
             }
             else if (pvNode && movesSearched == 0)
             {
-                evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                evaluation = -NegaMax(depth - 1 + depthExtensions, ply + 1, -beta, -alpha);
             }
             else
             {
@@ -276,7 +282,7 @@ public sealed partial class Engine
                 }
 
                 // Search with reduced depth
-                evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
+                evaluation = -NegaMax(depth - 1 - reduction + depthExtensions, ply + 1, -alpha - 1, -alpha);
 
                 // 🔍 Principal Variation Search (PVS)
                 if (evaluation > alpha && reduction > 0)
@@ -286,13 +292,13 @@ public sealed partial class Engine
                     // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                     // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha);
+                    evaluation = -NegaMax(depth - 1 + depthExtensions, ply + 1, -alpha - 1, -alpha);
                 }
 
                 if (evaluation > alpha && evaluation < beta)
                 {
                     // PVS Hipothesis invalidated -> search with full depth and full score bandwidth
-                    evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                    evaluation = -NegaMax(depth - 1 + depthExtensions, ply + 1, -beta, -alpha);
                 }
             }
 


### PR DESCRIPTION
```
Score of Lynx-promotion-extension-2048-win-x64 vs Lynx 2043 - main: 1986 - 2036 - 2522  [0.496] 6544
...      Lynx-promotion-extension-2048-win-x64 playing White: 1345 - 666 - 1261  [0.604] 3272
...      Lynx-promotion-extension-2048-win-x64 playing Black: 641 - 1370 - 1261  [0.389] 3272
...      White vs Black: 2715 - 1307 - 2522  [0.608] 6544
Elo difference: -2.7 +/- 6.6, LOS: 21.5 %, DrawRatio: 38.5 %
SPRT: llr -2.27 (-78.7%), lbound -2.25, ubound 2.89 - H0 was accepted
```