### PR TITLE
Avoid TT cutoffs in pv nodes

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -45,7 +45,7 @@ public sealed partial class Engine
         if (!isRoot)
         {
             (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
-            if (ttEvaluation != EvaluationConstants.NoHashEntry)
+            if (ttEvaluation != EvaluationConstants.NoHashEntry && !pvNode)
             {
                 return ttEvaluation;
             }


### PR DESCRIPTION
```
Score of Lynx-pv-tt-cutoff-2049-win-x64 vs Lynx 2043 - main: 1134 - 1202 - 1503  [0.491] 3839
...      Lynx-pv-tt-cutoff-2049-win-x64 playing White: 784 - 402 - 735  [0.599] 1921
...      Lynx-pv-tt-cutoff-2049-win-x64 playing Black: 350 - 800 - 768  [0.383] 1918
...      White vs Black: 1584 - 752 - 1503  [0.608] 3839
Elo difference: -6.2 +/- 8.6, LOS: 8.0 %, DrawRatio: 39.2 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```