### PR TITLE
🔍 Fix third killer move population logic

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -312,18 +312,15 @@ public sealed partial class Engine
                 PrintMessage($"Pruning: {move} is enough");
 
                 // 🔍 Killer moves
-                if (!move.IsCapture() && move.PromotedPiece() == default)
+                if (!move.IsCapture() && move.PromotedPiece() == default && move != _killerMoves[0, ply])
                 {
                     if (move != _killerMoves[1, ply])
                     {
                         _killerMoves[2, ply] = _killerMoves[1, ply];
                     }
 
-                    if (move != _killerMoves[0, ply])
-                    {
-                        _killerMoves[1, ply] = _killerMoves[0, ply];
-                        _killerMoves[0, ply] = move;
-                    }
+                    _killerMoves[1, ply] = _killerMoves[0, ply];
+                    _killerMoves[0, ply] = move;
                 }
 
                 _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -312,7 +312,8 @@ public sealed partial class Engine
                 PrintMessage($"Pruning: {move} is enough");
 
                 // 🔍 Killer moves
-                if (!move.IsCapture() && move.PromotedPiece() == default && move != _killerMoves[0, ply])
+                if (!move.IsCapture() && move.PromotedPiece() == default
+                    && move != _killerMoves[0, ply] && move != _killerMoves[1, ply])
                 {
                     _killerMoves[2, ply] = _killerMoves[1, ply];
                     _killerMoves[1, ply] = _killerMoves[0, ply];

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -312,12 +312,18 @@ public sealed partial class Engine
                 PrintMessage($"Pruning: {move} is enough");
 
                 // 🔍 Killer moves
-                if (!move.IsCapture() && move.PromotedPiece() == default
-                    && move != _killerMoves[0, ply] && move != _killerMoves[1, ply])
+                if (!move.IsCapture() && move.PromotedPiece() == default)
                 {
-                    _killerMoves[2, ply] = _killerMoves[1, ply];
-                    _killerMoves[1, ply] = _killerMoves[0, ply];
-                    _killerMoves[0, ply] = move;
+                    if (move != _killerMoves[1, ply])
+                    {
+                        _killerMoves[2, ply] = _killerMoves[1, ply];
+                    }
+
+                    if (move != _killerMoves[0, ply])
+                    {
+                        _killerMoves[1, ply] = _killerMoves[0, ply];
+                        _killerMoves[0, ply] = move;
+                    }
                 }
 
                 _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);


### PR DESCRIPTION
![image](https://github.com/lynx-chess/Lynx/assets/11148519/cb6e12d4-0956-46e5-9f92-f4db2c27d10e)
```
Score of Lynx-third-killer-condition-2059-win-x64 vs Lynx 2058 - main: 2178 - 2220 - 2904  [0.497] 7302
...      Lynx-third-killer-condition-2059-win-x64 playing White: 1455 - 769 - 1427  [0.594] 3651
...      Lynx-third-killer-condition-2059-win-x64 playing Black: 723 - 1451 - 1477  [0.400] 3651
...      White vs Black: 2906 - 1492 - 2904  [0.597] 7302
Elo difference: -2.0 +/- 6.2, LOS: 26.3 %, DrawRatio: 39.8 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

2061:
```
Score of Lynx-third-killer-condition-2061-win-x64 vs Lynx 2058 - main: 5260 - 5016 - 6450  [0.507] 16726
...      Lynx-third-killer-condition-2061-win-x64 playing White: 3512 - 1674 - 3178  [0.610] 8364
...      Lynx-third-killer-condition-2061-win-x64 playing Black: 1748 - 3342 - 3272  [0.405] 8362
...      White vs Black: 6854 - 3422 - 6450  [0.603] 16726
Elo difference: 5.1 +/- 4.1, LOS: 99.2 %, DrawRatio: 38.6 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```