### PR TITLE
Move generator/speed up removing branches

### DIFF
--- a/src/Lynx.Benchmark/Lynx.Benchmark.csproj
+++ b/src/Lynx.Benchmark/Lynx.Benchmark.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NoWarn>S125,CA1822,CA1806,RCS1090</NoWarn>
+    <NoWarn>$(NoWarn),S125,CA1822,CA1806,RCS1090,CS0618</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
+++ b/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
@@ -1,4 +1,39 @@
 ﻿/*
+ * Pretty much inconclusive, there seems to be no improvement
+ *
+ *  BenchmarkDotNet v0.13.11, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *
+ *  | Method                            | data   | Mean            | Error         | StdDev        | Ratio | Gen0      | Allocated  | Alloc Ratio |
+ *  |---------------------------------- |------- |----------------:|--------------:|--------------:|------:|----------:|-----------:|------------:|
+ *  | OldMoveGenerator_GenerateAll      | 1      |        790.8 ns |       7.60 ns |       6.35 ns |  1.00 |    0.0105 |      912 B |        1.00 |
+ *  | OldMoveGenerator_GenerateCaptures | 1      |        603.1 ns |       4.38 ns |       3.88 ns |  0.76 |    0.0029 |      256 B |        0.28 |
+ *  | NewMoveGenerator_GenerateAll      | 1      |        868.9 ns |       2.86 ns |       2.68 ns |  1.10 |    0.0105 |      912 B |        1.00 |
+ *  | NewMoveGenerator_GenerateCaptures | 1      |        614.9 ns |       3.98 ns |       3.53 ns |  0.78 |    0.0029 |      256 B |        0.28 |
+ *  |                                   |        |                 |               |               |       |           |            |             |
+ *  | OldMoveGenerator_GenerateAll      | 10     |      7,715.2 ns |      17.51 ns |      14.62 ns |  1.00 |    0.1068 |     9120 B |        1.00 |
+ *  | OldMoveGenerator_GenerateCaptures | 10     |      5,975.2 ns |      24.84 ns |      22.02 ns |  0.77 |    0.0305 |     2560 B |        0.28 |
+ *  | NewMoveGenerator_GenerateAll      | 10     |      7,526.9 ns |      17.00 ns |      15.07 ns |  0.98 |    0.1068 |     9120 B |        1.00 |
+ *  | NewMoveGenerator_GenerateCaptures | 10     |      6,149.6 ns |      16.54 ns |      13.81 ns |  0.80 |    0.0305 |     2560 B |        0.28 |
+ *  |                                   |        |                 |               |               |       |           |            |             |
+ *  | OldMoveGenerator_GenerateAll      | 1000   |    772,329.2 ns |   4,374.03 ns |   3,877.47 ns |  1.00 |   10.7422 |   912001 B |        1.00 |
+ *  | OldMoveGenerator_GenerateCaptures | 1000   |    584,375.5 ns |     798.98 ns |     623.79 ns |  0.76 |    2.9297 |   256001 B |        0.28 |
+ *  | NewMoveGenerator_GenerateAll      | 1000   |    758,327.8 ns |   4,868.83 ns |   4,316.09 ns |  0.98 |   10.7422 |   912001 B |        1.00 |
+ *  | NewMoveGenerator_GenerateCaptures | 1000   |    590,605.7 ns |   1,740.66 ns |   1,453.53 ns |  0.77 |    2.9297 |   256001 B |        0.28 |
+ *  |                                   |        |                 |               |               |       |           |            |             |
+ *  | OldMoveGenerator_GenerateAll      | 10000  |  7,646,512.6 ns |  43,082.84 ns |  38,191.82 ns |  1.00 |  101.5625 |  9120008 B |        1.00 |
+ *  | OldMoveGenerator_GenerateCaptures | 10000  |  5,807,032.4 ns |  31,200.92 ns |  27,658.80 ns |  0.76 |   23.4375 |  2560008 B |        0.28 |
+ *  | NewMoveGenerator_GenerateAll      | 10000  |  7,624,232.2 ns |  28,030.21 ns |  26,219.48 ns |  1.00 |  101.5625 |  9120008 B |        1.00 |
+ *  | NewMoveGenerator_GenerateCaptures | 10000  |  6,101,343.2 ns |  18,170.07 ns |  16,996.29 ns |  0.80 |   23.4375 |  2560008 B |        0.28 |
+ *  |                                   |        |                 |               |               |       |           |            |             |
+ *  | OldMoveGenerator_GenerateAll      | 100000 | 77,027,912.9 ns | 626,302.21 ns | 555,200.60 ns |  1.00 | 1000.0000 | 91200179 B |        1.00 |
+ *  | OldMoveGenerator_GenerateCaptures | 100000 | 60,132,915.4 ns | 508,151.56 ns | 475,325.28 ns |  0.78 |  250.0000 | 25600134 B |        0.28 |
+ *  | NewMoveGenerator_GenerateAll      | 100000 | 76,396,534.0 ns | 166,527.46 ns | 155,769.89 ns |  0.99 | 1000.0000 | 91200179 B |        1.00 |
+ *  | NewMoveGenerator_GenerateCaptures | 100000 | 58,641,448.1 ns | 460,447.43 ns | 384,494.46 ns |  0.76 |  250.0000 | 25600134 B |        0.28 |
  *
 */
 

--- a/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
+++ b/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
@@ -1,0 +1,715 @@
+﻿/*
+ *
+*/
+
+using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+using NLog;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace Lynx.Benchmark;
+
+public class MoveGenerator_CapturesSeparated : BaseBenchmark
+{
+    private static Move[] _movePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+
+    public static IEnumerable<string> Data => new[]
+    {
+            Constants.InitialPositionFEN,
+            Constants.TrickyTestPositionFEN,
+            Constants.TrickyTestPositionReversedFEN,
+            Constants.CmkTestPositionFEN,
+            Constants.KillerTestPositionFEN
+        };
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public Move[] OldMoveGenerator_GenerateAll(string fen)
+    {
+        return OldMoveGenerator.GenerateAllMoves(new Position(fen), _movePool);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public Move[] OldMoveGenerator_GenerateCaptures(string fen)
+    {
+        return OldMoveGenerator.GenerateAllMoves(new Position(fen), _movePool, capturesOnly: true);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public Move[] NewMoveGenerator_GenerateAll(string fen)
+    {
+        return NewMoveGenerator.GenerateAllMoves(new Position(fen), _movePool);
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public Move[] NewMoveGenerator_GenerateCaptures(string fen)
+    {
+        return NewMoveGenerator.GenerateAllCaptures(new Position(fen), _movePool);
+    }
+}
+
+file static class OldMoveGenerator
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    private const int TRUE = 1;
+
+    /// <summary>
+    /// Indexed by <see cref="Piece"/>.
+    /// Checks are not considered
+    /// </summary>
+    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
+    [
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+    ];
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Move[] GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return Array.Empty<Move>();
+        }
+#endif
+
+        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
+        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
+
+        return movePool[..localIndex];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                if (!capturesOnly)
+                {
+                    var doublePushSquare = sourceSquare + (2 * pawnPush);
+                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                    {
+                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                    }
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquareAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquareAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <param name="capturesOnly"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else if (!capturesOnly)
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+}
+
+file static class NewMoveGenerator
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    private const int TRUE = 1;
+
+    /// <summary>
+    /// Indexed by <see cref="Piece"/>.
+    /// Checks are not considered
+    /// </summary>
+    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
+    [
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+    ];
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [Obsolete("Use override that accepts Move[] when possible")]
+    public static Move[] GenerateAllMoves(Position position) =>
+        GenerateAllMoves(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Move[] GenerateAllMoves(Position position, Move[] movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return [];
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return movePool[..localIndex];
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [Obsolete("Use override that accepts Move[] when possible")]
+    public static Move[] GenerateAllCaptures(Position position) =>
+        GenerateAllCaptures(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Move[] GenerateAllCaptures(Position position, Move[] movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return [];
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnCaptures(ref localIndex, movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return movePool[..localIndex];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateAllPawnMoves(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnCaptures(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="offset"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        var piece = (int)Piece.K + offset;
+        var oppositeSide = (Side)Utils.OppositeSide(position.Side);
+
+        int sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex(); // There's for sure only one
+
+        // Castles
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquareAttackedBySide((int)BoardSquare.e1, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f1, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d1, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c1, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.WhiteLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquareAttackedBySide((int)BoardSquare.e8, position, oppositeSide);
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f8, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackShortCastleKingSquare, piece, isShortCastle: TRUE);
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d8, position, oppositeSide)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c8, position, oppositeSide))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, Constants.BlackLongCastleKingSquare, piece, isLongCastle: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="movePool"></param>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateAllPieceMoves(ref int localIndex, Move[] movePool, int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen capture moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceCaptures(ref int localIndex, Move[] movePool, int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+}

--- a/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
+++ b/src/Lynx.Benchmark/MoveGenerator_CapturesSeparated.cs
@@ -5,50 +5,75 @@
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
 using NLog;
-using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 
 namespace Lynx.Benchmark;
 
 public class MoveGenerator_CapturesSeparated : BaseBenchmark
 {
-    private static Move[] _movePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+    private static readonly Move[] _movePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
 
-    public static IEnumerable<string> Data => new[]
-    {
-            Constants.InitialPositionFEN,
-            Constants.TrickyTestPositionFEN,
-            Constants.TrickyTestPositionReversedFEN,
-            Constants.CmkTestPositionFEN,
-            Constants.KillerTestPositionFEN
-        };
+    public static IEnumerable<int> Data => new[] { 1, 10, 1_000, 10_000, 100_000 };
+
+    private static readonly Position[] _positions =
+    [
+        new(Constants.InitialPositionFEN),
+        new(Constants.TrickyTestPositionFEN),
+        new(Constants.TrickyTestPositionReversedFEN),
+        new(Constants.CmkTestPositionFEN),
+        new(Constants.KillerTestPositionFEN)
+    ];
 
     [Benchmark(Baseline = true)]
     [ArgumentsSource(nameof(Data))]
-    public Move[] OldMoveGenerator_GenerateAll(string fen)
+    public void OldMoveGenerator_GenerateAll(int data)
     {
-        return OldMoveGenerator.GenerateAllMoves(new Position(fen), _movePool);
+        for (int i = 0; i < data; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                OldMoveGenerator.GenerateAllMoves(position, _movePool);
+            }
+        }
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(Data))]
-    public Move[] OldMoveGenerator_GenerateCaptures(string fen)
+    public void OldMoveGenerator_GenerateCaptures(int data)
     {
-        return OldMoveGenerator.GenerateAllMoves(new Position(fen), _movePool, capturesOnly: true);
+        for (int i = 0; i < data; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                OldMoveGenerator.GenerateAllMoves(position, _movePool, capturesOnly: true);
+            }
+        }
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(Data))]
-    public Move[] NewMoveGenerator_GenerateAll(string fen)
+    public void NewMoveGenerator_GenerateAll(int data)
     {
-        return NewMoveGenerator.GenerateAllMoves(new Position(fen), _movePool);
+        for (int i = 0; i < data; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                NewMoveGenerator.GenerateAllMoves(position, _movePool);
+            }
+        }
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(Data))]
-    public Move[] NewMoveGenerator_GenerateCaptures(string fen)
+    public void NewMoveGenerator_GenerateCaptures(int data)
     {
-        return NewMoveGenerator.GenerateAllCaptures(new Position(fen), _movePool);
+        for (int i = 0; i < data; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                NewMoveGenerator.GenerateAllCaptures(position, _movePool);
+            }
+        }
     }
 }
 
@@ -340,7 +365,6 @@ file static class NewMoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use override that accepts Move[] when possible")]
     public static Move[] GenerateAllMoves(Position position) =>
         GenerateAllMoves(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
 
@@ -381,7 +405,6 @@ file static class NewMoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    [Obsolete("Use override that accepts Move[] when possible")]
     public static Move[] GenerateAllCaptures(Position position) =>
         GenerateAllCaptures(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
 

--- a/src/Lynx.Dev/Lynx.Dev.csproj
+++ b/src/Lynx.Dev/Lynx.Dev.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <NoWarn>CS8321,S125,S1481</NoWarn>
+    <NoWarn>$(NoWarn),CS8321,S125,S1481,CS0618</NoWarn>
   </PropertyGroup>
 
 </Project>

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -669,19 +669,23 @@ static void _54_ScoreMove()
 
     var engine = new Engine(Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
     engine.SetGame(new(position));
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+#pragma warning disable CS0618 // Type or member is obsolete
+    foreach (var move in MoveGenerator.GenerateAllCaptures(position))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 
     position = new Position(TrickyPosition);
     position.Print();
 
     engine.SetGame(new(position));
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+#pragma warning disable CS0618 // Type or member is obsolete
+    foreach (var move in MoveGenerator.GenerateAllCaptures(position))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }
 
 static void ZobristTable()

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -14,57 +14,107 @@ public static class MoveGenerator
     /// Indexed by <see cref="Piece"/>.
     /// Checks are not considered
     /// </summary>
-    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks = new Func<int, BitBoard, BitBoard>[]
-    {
-            (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White, origin],
-            (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
-            Attacks.BishopAttacks,
-            Attacks.RookAttacks,
-            Attacks.QueenAttacks,
-            (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
+    [
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
 
-            (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black, origin],
-            (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
-            Attacks.BishopAttacks,
-            Attacks.RookAttacks,
-            Attacks.QueenAttacks,
-            (int origin, BitBoard _) => Attacks.KingAttacks[origin],
-    };
+        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black, origin],
+        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+        Attacks.BishopAttacks,
+        Attacks.RookAttacks,
+        Attacks.QueenAttacks,
+        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+    ];
 
     /// <summary>
     /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
     /// </summary>
     /// <param name="position"></param>
-    /// <param name="capturesOnly">Filters out all moves but captures</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Move[] GenerateAllMoves(Position position, Move[]? movePool = null, bool capturesOnly = false)
+    [Obsolete("Use override that accepts Move[] when possible")]
+    public static Move[] GenerateAllMoves(Position position) =>
+        GenerateAllMoves(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool">Filters out all moves but captures</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Move[] GenerateAllMoves(Position position, Move[] movePool)
     {
 #if DEBUG
         if (position.Side == Side.Both)
         {
-            return Array.Empty<Move>();
+            return [];
         }
 #endif
 
-        movePool ??= new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         int localIndex = 0;
 
         var offset = Utils.PieceOffset(position.Side);
 
-        GeneratePawnMoves(ref localIndex, movePool, position, offset, capturesOnly);
+        GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
         GenerateCastlingMoves(ref localIndex, movePool, position, offset);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position, capturesOnly);
-        GeneratePieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position, capturesOnly);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return movePool[..localIndex];
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [Obsolete("Use override that accepts Move[] when possible")]
+    public static Move[] GenerateAllCaptures(Position position) =>
+        GenerateAllCaptures(position, new Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Move[] GenerateAllCaptures(Position position, Move[] movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return [];
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnCaptures(ref localIndex, movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, movePool, position, offset);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
 
         return movePool[..localIndex];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePawnMoves(ref int localIndex, Move[] movePool, Position position, int offset, bool capturesOnly = false)
+    internal static void GenerateAllPawnMoves(ref int localIndex, Move[] movePool, Position position, int offset)
     {
         int sourceSquare, targetSquare;
 
@@ -101,21 +151,90 @@ public static class MoveGenerator
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                 }
-                else if (!capturesOnly)
+                else
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
                 }
 
                 // Double pawn push
                 // Inside of the if because singlePush square cannot be occupied either
-                if (!capturesOnly)
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
                 {
-                    var doublePushSquare = sourceSquare + (2 * pawnPush);
-                    if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-                        && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
-                    {
-                        movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
-                    }
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnCaptures(ref int localIndex, Move[] movePool, Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
                 }
             }
 
@@ -223,12 +342,12 @@ public static class MoveGenerator
     /// <summary>
     /// Generate Knight, Bishop, Rook and Queen moves
     /// </summary>
+    /// <param name="movePool"></param>
     /// <param name="piece"><see cref="Piece"/></param>
     /// <param name="position"></param>
-    /// <param name="capturesOnly"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePieceMoves(ref int localIndex, Move[] movePool, int piece, Position position, bool capturesOnly = false)
+    internal static void GenerateAllPieceMoves(ref int localIndex, Move[] movePool, int piece, Position position)
     {
         var bitboard = position.PieceBitBoards[piece];
         int sourceSquare, targetSquare;
@@ -250,9 +369,42 @@ public static class MoveGenerator
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
-                else if (!capturesOnly)
+                else
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen capture moves
+    /// </summary>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceCaptures(ref int localIndex, Move[] movePool, int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
                 }
             }
         }

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -114,7 +114,9 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     foreach (var move in bestMoveList)
                     {
@@ -172,7 +174,9 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     foreach (var move in bestMoveList)
                     {
@@ -232,7 +236,9 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     foreach (var move in bestMoveList)
                     {
@@ -289,7 +295,9 @@ public static class OnlineTablebaseProber
 
                 if (bestMoveList is not null)
                 {
+#pragma warning disable CS0618 // Type or member is obsolete
                     allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
+#pragma warning restore CS0618 // Type or member is obsolete
                     foreach (var move in bestMoveList)
                     {
                         if (!MoveExtensions.TryParseFromUCIString(move!.Uci, allPossibleMoves, out var moveCandidate))
@@ -329,10 +337,12 @@ public static class OnlineTablebaseProber
         }
 
         Move? parsedMove = 0;
+#pragma warning disable CS0618 // Type or member is obsolete
         if (bestMove?.Uci is not null && !MoveExtensions.TryParseFromUCIString(bestMove.Uci, MoveGenerator.GenerateAllMoves(position), out parsedMove))
         {
             throw new AssertException($"{bestMove.Uci} should be parsable from position {fen}");
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return (mate, parsedMove ?? 0);
     }

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -50,6 +50,7 @@ public static class Perft
     {
         if (depth != 0)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (var move in MoveGenerator.GenerateAllMoves(position))
             {
                 var state = position.MakeMove(move);
@@ -60,6 +61,7 @@ public static class Perft
                 }
                 position.UnmakeMove(move, state);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return nodes;
         }
@@ -71,6 +73,7 @@ public static class Perft
     {
         if (depth != 0)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (var move in MoveGenerator.GenerateAllMoves(position))
             {
                 var state = position.MakeMove(move);
@@ -85,6 +88,7 @@ public static class Perft
 
                 position.UnmakeMove(move, state);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             await write(string.Empty);
 
@@ -98,6 +102,7 @@ public static class Perft
     {
         if (depth != 0)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (var move in MoveGenerator.GenerateAllMoves(position))
             {
                 var state = position.MakeMove(move);
@@ -112,6 +117,7 @@ public static class Perft
 
                 position.UnmakeMove(move, state);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             write(string.Empty);
 
@@ -134,6 +140,7 @@ public static class Perft
     {
         if (depth != 0)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (var move in MoveGenerator.GenerateAllMoves(position))
             {
                 var newPosition = new Position(position, move);
@@ -143,6 +150,7 @@ public static class Perft
                     nodes = ResultsImplUsingPositionConstructor(newPosition, depth - 1, nodes);
                 }
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return nodes;
         }
@@ -154,6 +162,7 @@ public static class Perft
     {
         if (depth != 0)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             foreach (var move in MoveGenerator.GenerateAllMoves(position))
             {
                 var newPosition = new Position(position, move);
@@ -166,6 +175,7 @@ public static class Perft
                     Console.WriteLine($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
                 }
             }
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return nodes;
         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -421,7 +421,7 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, Game.MovePool, capturesOnly: true);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, Game.MovePool);
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358


### PR DESCRIPTION
8 0.08
```
Score of Lynx-move-generator-speed-up-removing-branches-2118-win-x64 vs Lynx 2117 - main: 2116 - 2164 - 2630  [0.497] 6910
...      Lynx-move-generator-speed-up-removing-branches-2118-win-x64 playing White: 1454 - 698 - 1303  [0.609] 3455
...      Lynx-move-generator-speed-up-removing-branches-2118-win-x64 playing Black: 662 - 1466 - 1327  [0.384] 3455
...      White vs Black: 2920 - 1360 - 2630  [0.613] 6910
Elo difference: -2.4 +/- 6.4, LOS: 23.2 %, DrawRatio: 38.1 %
SPRT: llr -2.27 (-78.6%), lbound -2.25, ubound 2.89 - H0 was accepted
```

40 0.4
```
Score of Lynx-move-generator-speed-up-removing-branches-2118-win-x64 vs Lynx 2117 - main: 1413 - 1463 - 2297  [0.495] 5173
...      Lynx-move-generator-speed-up-removing-branches-2118-win-x64 playing White: 1035 - 422 - 1130  [0.618] 2587
...      Lynx-move-generator-speed-up-removing-branches-2118-win-x64 playing Black: 378 - 1041 - 1167  [0.372] 2586
...      White vs Black: 2076 - 800 - 2297  [0.623] 5173
Elo difference: -3.4 +/- 7.1, LOS: 17.6 %, DrawRatio: 44.4 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```