### PR TITLE
🧬 Implement SEE and order bad captures after killers but before quiet moves

### DIFF
--- a/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
+++ b/src/Lynx.Benchmark/LocalVariableIn_vs_NoIn.cs
@@ -90,7 +90,7 @@ public static class BenchmarkLegacyMoveExtensions
                 }
             }
 
-            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
+            return EvaluationConstants.BadCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }
         else if (killerMoves is not null && plies is not null)
         {

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -326,10 +326,9 @@ public static readonly int[] EndGameKingTable =
 
     public const int TTMoveScoreValue = 2_097_152;
 
-    /// <summary>
-    /// For MVVLVA
-    /// </summary>
-    public const int CaptureMoveBaseScoreValue = 1_048_576;
+    #region Move ordering
+
+    public const int GoodCaptureMoveBaseScoreValue = 1_048_576;
 
     public const int FirstKillerMoveValue = 524_288;
 
@@ -339,12 +338,16 @@ public static readonly int[] EndGameKingTable =
 
     public const int PromotionMoveScoreValue = 65_536;
 
+    public const int BadCaptureMoveBaseScoreValue = 32_768;
+
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
     public const int BaseMoveScore = int.MinValue / 2;
+
+    #endregion
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -338,14 +338,14 @@ public static readonly int[] EndGameKingTable =
 
     public const int PromotionMoveScoreValue = 65_536;
 
-    public const int BadCaptureMoveBaseScoreValue = 32_768;
+    public const int BadCaptureMoveBaseScoreValue = int.MinValue / 4 * 3;
 
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int BaseMoveScore = int.MinValue / 2;
+    public const int BaseMoveScore = int.MinValue / 4;
 
     #endregion
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -338,14 +338,14 @@ public static readonly int[] EndGameKingTable =
 
     public const int PromotionMoveScoreValue = 65_536;
 
-    public const int BadCaptureMoveBaseScoreValue = int.MinValue / 4 * 3;
+    public const int BadCaptureMoveBaseScoreValue = 32_768;
 
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 
     /// <summary>
     /// Negative offset to ensure history move scores don't reach other move ordering values
     /// </summary>
-    public const int BaseMoveScore = int.MinValue / 4;
+    public const int BaseMoveScore = int.MinValue / 2;
 
     #endregion
 

--- a/src/Lynx/Model/BitBoard.cs
+++ b/src/Lynx/Model/BitBoard.cs
@@ -7,7 +7,11 @@ namespace Lynx.Model;
 
 public static class BitBoardExtensions
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool Empty(this BitBoard board) => board == default;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool NotEmpty(this BitBoard board) => board != default;
 
     public static BitBoard Initialize(params BoardSquare[] occupiedSquares)
     {
@@ -101,6 +105,17 @@ public static class BitBoardExtensions
         bitboard ^= (1ul << squareA | 1ul << squareB);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong LSB(this BitBoard board)
+    {
+        if (System.Runtime.Intrinsics.X86.Bmi1.IsSupported)
+        {
+            return System.Runtime.Intrinsics.X86.Bmi1.X64.ExtractLowestSetBit(board);
+        }
+
+        return board & (~board + 1);
+    }
+
     #region Static methods
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -150,6 +165,30 @@ public static class BitBoardExtensions
     public static int CountBits(this BitBoard board)
     {
         return BitOperations.PopCount(board);
+    }
+
+    /// <summary>
+    /// Extracts the bit that represents each square on a bitboard
+    /// </summary>
+    /// <param name="boardSquare"></param>
+    /// <returns></returns>
+    public static ulong SquareBit(int boardSquare)
+    {
+        return 1UL << boardSquare;
+    }
+
+    public static bool Contains(this BitBoard board, int boardSquare)
+    {
+        var bit = SquareBit(boardSquare);
+
+        return (board & bit) != default;
+    }
+
+    public static bool DoesNotContain(this BitBoard board, int boardSquare)
+    {
+        var bit = SquareBit(boardSquare);
+
+        return (board & bit) == default;
     }
 
     #endregion

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -14,6 +14,12 @@ public class Position
     /// </summary>
     public BitBoard[] PieceBitBoards { get; }
 
+    public BitBoard Queens => PieceBitBoards[(int)Piece.Q] | PieceBitBoards[(int)Piece.q];
+    public BitBoard Rooks => PieceBitBoards[(int)Piece.R] | PieceBitBoards[(int)Piece.r];
+    public BitBoard Bishops => PieceBitBoards[(int)Piece.B] | PieceBitBoards[(int)Piece.b];
+    public BitBoard Knights => PieceBitBoards[(int)Piece.N] | PieceBitBoards[(int)Piece.n];
+    public BitBoard Kings => PieceBitBoards[(int)Piece.K] | PieceBitBoards[(int)Piece.k];
+
     /// <summary>
     /// Black, White, Both
     /// </summary>
@@ -582,6 +588,63 @@ public class Position
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int CountPieces() => PieceBitBoards.Sum(b => b.CountBits());
+
+    /// <summary>
+    /// Based on Stormphrax
+    /// </summary>
+    /// <param name="square"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int PieceAt(int square)
+    {
+        var bit = BitBoardExtensions.SquareBit(square);
+
+        Side color;
+
+        if ((OccupancyBitBoards[(int)Side.Black] & bit) != default)
+        {
+            color = Side.Black;
+        }
+        else if ((OccupancyBitBoards[(int)Side.White] & bit) != default)
+        {
+            color = Side.White;
+        }
+        else
+        {
+            return (int)Piece.Unknown;
+        }
+
+        var offset = Utils.PieceOffset(color);
+
+        for (int pieceIndex = offset; pieceIndex < 6 + offset; ++pieceIndex)
+        {
+            if (!(PieceBitBoards[pieceIndex] & bit).Empty())
+            {
+                return pieceIndex;
+            }
+        }
+
+        System.Diagnostics.Debug.Fail($"Bit set in {Side} occupancy bitboard, but not piece found");
+
+        return (int)Piece.Unknown;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong AllAttackersTo(int square, BitBoard occupancy)
+    {
+        System.Diagnostics.Debug.Assert(square != (int)BoardSquare.noSquare);
+
+        var queens = Queens;
+        var rooks = queens | Rooks;
+        var bishops = queens | Bishops;
+
+        return (rooks & Attacks.RookAttacks(square, occupancy))
+            | (bishops & Attacks.BishopAttacks(square, occupancy))
+            | (PieceBitBoards[(int)Piece.p] & Attacks.PawnAttacks[(int)Side.White, square])
+            | (PieceBitBoards[(int)Piece.P] & Attacks.PawnAttacks[(int)Side.Black, square])
+            | (Knights & Attacks.KnightAttacks[square])
+            | (Kings & Attacks.KingAttacks[square]);
+    }
 
     /// <summary>
     /// Evaluates material and position in a NegaMax style.

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -1,0 +1,232 @@
+﻿using Lynx.Model;
+using System.Runtime.CompilerServices;
+
+namespace Lynx;
+
+/// <summary>
+/// Implementation based on Stormprhax, some comments and clarifications from Altair
+/// </summary>
+public static class SEE
+{
+    #pragma warning disable IDE0055 // Discard formatting in this region
+
+    private static readonly int[] _pieceValues =
+    [
+        100, 450, 450, 650, 1250, 0,
+        100, 450, 450, 650, 1250, 0
+    ];
+
+    #pragma warning restore IDE0055
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsGoodCapture(Position position, Move move, short threshold = 0)
+    {
+        var sideToMove = position.Side;
+
+        var score = Gain(position, move) - threshold;
+
+        // If taking the opponent's piece without any risk is still negative
+        if (score < 0)
+        {
+            return false;
+        }
+
+        var next = move.PromotedPiece() != default
+            ? move.PromotedPiece()
+            : move.Piece();
+
+        score -= _pieceValues[next];
+
+        // If risking our piece being fully lost and the exchange value is still >= 0
+        if (score >= 0)
+        {
+            return true;
+        }
+
+        var targetSquare = move.TargetSquare();
+
+        var occupancy = position.OccupancyBitBoards[(int)Side.Both]
+            ^ BitBoardExtensions.SquareBit(move.SourceSquare())
+            ^ BitBoardExtensions.SquareBit(targetSquare);
+
+        var queens = position.Queens;
+        var bishops = queens | position.Bishops;
+        var rooks = queens | position.Rooks;
+
+        var attackers = position.AllAttackersTo(targetSquare, occupancy);
+
+        var us = Utils.OppositeSide(sideToMove);
+
+        while (true)
+        {
+            var ourAttackers = attackers & position.OccupancyBitBoards[us];
+
+            if (ourAttackers.Empty())
+            {
+                break;
+            }
+
+            var nextPiece = PopLeastValuableAttacker(position, ref occupancy, ourAttackers, us);
+
+            // After removing an attacker, there could be a sliding piece attack
+            if (nextPiece == Piece.P || nextPiece == Piece.p
+                || nextPiece == Piece.B || nextPiece == Piece.b
+                || nextPiece == Piece.Q || nextPiece == Piece.q)
+            {
+                attackers |= Attacks.BishopAttacks(targetSquare, occupancy) & bishops;
+            }
+
+            if (nextPiece == Piece.R || nextPiece == Piece.r
+                || nextPiece == Piece.Q || nextPiece == Piece.q)
+            {
+                attackers |= Attacks.RookAttacks(targetSquare, occupancy) & rooks;
+            }
+
+            // Removing used pieces from attackers
+            attackers &= occupancy;
+
+            score = -score - 1 - _pieceValues[(int)nextPiece];
+            us = Utils.OppositeSide(us);
+
+            if (score >= 0)
+            {
+                // Our only attacker is our king, but the opponent still has defenders
+                if ((nextPiece == Piece.K || nextPiece == Piece.k)
+                    && (attackers & position.OccupancyBitBoards[us]).NotEmpty())
+                {
+                    us = Utils.OppositeSide(us);
+                }
+
+                break;
+            }
+        }
+
+        return (int)sideToMove != us;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int SEEScore(Position position, Move move, short threshold = 0)
+    {
+        var sideToMove = position.Side;
+
+        var score = Gain(position, move) - threshold;
+
+        if (score < 0)
+        {
+            return score;
+        }
+
+        var next = move.PromotedPiece() != default
+            ? move.PromotedPiece()
+            : move.Piece();
+
+        score -= _pieceValues[next];
+
+        if (score >= 0)
+        {
+            return score;
+        }
+
+        var targetSquare = move.TargetSquare();
+
+        var occupancy = position.OccupancyBitBoards[(int)Side.Both]
+            ^ BitBoardExtensions.SquareBit(move.SourceSquare())
+            ^ BitBoardExtensions.SquareBit(targetSquare);
+
+        var queens = position.Queens;
+        var bishops = queens | position.Bishops;
+        var rooks = queens | position.Rooks;
+
+        var attackers = position.AllAttackersTo(targetSquare, occupancy);
+
+        var us = Utils.OppositeSide(sideToMove);
+
+        while (true)
+        {
+            var ourAttackers = attackers & position.OccupancyBitBoards[us];
+
+            if (ourAttackers.Empty())
+            {
+                break;
+            }
+
+            var nextPiece = PopLeastValuableAttacker(position, ref occupancy, ourAttackers, us);
+
+            if (nextPiece == Piece.P || nextPiece == Piece.p
+                || nextPiece == Piece.B || nextPiece == Piece.b
+                || nextPiece == Piece.Q || nextPiece == Piece.q)
+            {
+                attackers |= Attacks.BishopAttacks(targetSquare, occupancy) & bishops;
+            }
+
+            if (nextPiece == Piece.R || nextPiece == Piece.r
+                || nextPiece == Piece.Q || nextPiece == Piece.q)
+            {
+                attackers |= Attacks.RookAttacks(targetSquare, occupancy) & rooks;
+            }
+
+            attackers &= occupancy;
+
+            score = -score - 1 - _pieceValues[(int)nextPiece];
+            us = Utils.OppositeSide(us);
+
+            if (score >= 0)
+            {
+                // our only attacker is our king, but the opponent still has defenders
+
+                if ((nextPiece == Piece.K || nextPiece == Piece.k)
+                    && !(attackers & position.OccupancyBitBoards[us]).Empty())
+                {
+                    us = Utils.OppositeSide(us);
+                }
+
+                break;
+            }
+        }
+
+        return (int)sideToMove == us
+            ? -score
+            : score;
+        //return (int)sideToMove != us;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int Gain(Position position, Move move)
+    {
+        if (move.IsCastle())
+        {
+            return 0;
+        }
+        else if (move.IsEnPassant())
+        {
+            return _pieceValues[(int)Piece.P];
+        }
+
+        var promotedPiece = move.PromotedPiece();
+
+        return promotedPiece == default
+            ? _pieceValues[position.PieceAt(move.TargetSquare())]
+            : _pieceValues[promotedPiece] - _pieceValues[(int)Piece.P];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Piece PopLeastValuableAttacker(Position position, ref BitBoard occupancy, BitBoard attackers, int color)
+    {
+        var start = Utils.PieceOffset(color);
+
+        for (int i = start; i < start + 6; ++i)
+        {
+            var piece = (Piece)i;
+            var board = attackers & position.PieceBitBoards[i];
+
+            if (!board.Empty())
+            {
+                occupancy ^= board.LSB();
+
+                return piece;
+            }
+        }
+
+        return Piece.Unknown;
+    }
+}

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -63,11 +63,11 @@ public sealed partial class Engine
     /// </summary>
     /// <param name="move"></param>
     /// <param name="depth"></param>
-    /// <param name="useKillerAndPositionMoves"></param>
+    /// <param name="isNotQSearch"></param>
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int depth, bool useKillerAndPositionMoves, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int depth, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[depth])
         {
@@ -82,11 +82,12 @@ public sealed partial class Engine
         }
 
         var promotedPiece = move.PromotedPiece();
+        var isPromotion = promotedPiece != default;
 
         // Queen promotion
         if ((promotedPiece + 2) % 6 == 0)
         {
-            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.PromotionMoveScoreValue;
+            return EvaluationConstants.BadCaptureMoveBaseScoreValue + EvaluationConstants.PromotionMoveScoreValue;
         }
 
         if (move.IsCapture())
@@ -108,15 +109,19 @@ public sealed partial class Engine
                 }
             }
 
-            return EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
+            var baseCaptureScore = (isPromotion || SEE.IsGoodCapture(Game.CurrentPosition, move))
+                ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
+                : EvaluationConstants.BadCaptureMoveBaseScoreValue;
+
+            return baseCaptureScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }
 
-        if (promotedPiece != default)
+        if (isPromotion)
         {
             return EvaluationConstants.PromotionMoveScoreValue;
         }
 
-        if (useKillerAndPositionMoves)
+        if (isNotQSearch)
         {
             // 1st killer move
             if (_killerMoves[0, depth] == move)
@@ -154,27 +159,32 @@ public sealed partial class Engine
         return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
     }
 
+    /// <summary>
+    /// When asked to copy an incomplete PV one level ahead, clears the rest of the PV Table+
+    /// PV Table at depth 3
+    /// Copying 60 moves
+    /// src: 250, tgt: 190
+    ///  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+    ///  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+    ///  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+    ///  189                      Qxb1   Qxb1   Qxb1   a8     a8
+    ///  250                             a8     Qxb1   a8     a8
+    ///  310                                    a8     a8     a8
+    ///
+    /// PV Table at depth 3
+    ///  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+    ///  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+    ///  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+    ///  189                      Qxb1   a8     a8     a8     a8
+    ///  250                             a8     a8     a8     a8
+    ///  310                                    a8     a8     a8
+    /// </summary>
+    /// <param name="target"></param>
+    /// <param name="source"></param>
+    /// <param name="moveCountToCopy"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
     {
-        // When asked to copy an incomplete PV one level ahead, clears the rest of the PV Table+
-        // PV Table at depth 3
-        // Copying 60 moves
-        // src: 250, tgt: 190
-        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
-        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
-        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
-        //  189                      Qxb1   Qxb1   Qxb1   a8     a8
-        //  250                             a8     Qxb1   a8     a8
-        //  310                                    a8     a8     a8
-        //
-        // PV Table at depth 3
-        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
-        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
-        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
-        //  189                      Qxb1   a8     a8     a8     a8
-        //  250                             a8     a8     a8     a8
-        //  310                                    a8     a8     a8
         if (_pVTable[source] == default)
         {
             Array.Clear(_pVTable, target, _pVTable.Length - target);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -109,7 +109,7 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -164,7 +164,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -177,7 +177,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
             }
         }
 
@@ -434,7 +434,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/tests/Lynx.Test/BitBoardExtensionsTest.cs
+++ b/tests/Lynx.Test/BitBoardExtensionsTest.cs
@@ -1,0 +1,108 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test;
+public class BitBoardExtensionsTest
+{
+    [TestCase(0b10001UL, 1UL)]
+    [TestCase(0b11001UL, 1UL)]
+    [TestCase(0b11101UL, 1UL)]
+    [TestCase(0b11111UL, 1UL)]
+    [TestCase(0b10111UL, 1UL)]
+    [TestCase(0b10101UL, 1UL)]
+    [TestCase(0b01001UL, 1UL)]
+    [TestCase(0b01101UL, 1UL)]
+    [TestCase(0b01111UL, 1UL)]
+    [TestCase(0b00011UL, 1UL)]
+    [TestCase(0b00001UL, 1UL)]
+
+    [TestCase(0b10000UL, 0b10000UL)]
+    [TestCase(0b11000UL, 0b1000UL)]
+    [TestCase(0b11100UL, 0b100UL)]
+    [TestCase(0b11110UL, 0b10UL)]
+    [TestCase(0b10110UL, 0b10UL)]
+    [TestCase(0b10100UL, 0b100UL)]
+    [TestCase(0b01000UL, 0b1000UL)]
+    [TestCase(0b01100UL, 0b100UL)]
+    [TestCase(0b01110UL, 0b10UL)]
+    [TestCase(0b00101UL, 0b1UL)]
+    [TestCase(0b00010UL, 0b10UL)]
+    [TestCase(0b00001UL, 0b1UL)]
+    public void LSB(BitBoard n, ulong lsb)
+    {
+        Assert.AreEqual(lsb, n.LSB());
+
+        Assert.AreEqual(lsb, lsb & (~lsb + 1));
+
+        if (System.Runtime.Intrinsics.X86.Bmi1.IsSupported)
+        {
+            Assert.AreEqual(lsb, System.Runtime.Intrinsics.X86.Bmi1.X64.ExtractLowestSetBit(n));
+        }
+    }
+
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.a2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.b2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.c2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.d2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.e2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.f2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.g2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.h2, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.a7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.b7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.c7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.d7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.e7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.f7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.g7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.P, BoardSquare.h7, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.a7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.b7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.c7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.d7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.e7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.f7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.g7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.h7, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.a2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.b2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.c2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.d2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.e2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.f2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.g2, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.p, BoardSquare.h2, false)]
+
+    [TestCase(Constants.InitialPositionFEN, Piece.R, BoardSquare.a1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.R, BoardSquare.h1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.r, BoardSquare.a8, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.r, BoardSquare.h8, true)]
+
+    [TestCase(Constants.InitialPositionFEN, Piece.N, BoardSquare.b1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.N, BoardSquare.g1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.n, BoardSquare.b8, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.n, BoardSquare.g8, true)]
+
+    [TestCase(Constants.InitialPositionFEN, Piece.B, BoardSquare.c1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.B, BoardSquare.f1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.b, BoardSquare.c8, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.b, BoardSquare.f8, true)]
+
+    [TestCase(Constants.InitialPositionFEN, Piece.Q, BoardSquare.d1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.Q, BoardSquare.e1, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.q, BoardSquare.d8, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.q, BoardSquare.e8, false)]
+
+    [TestCase(Constants.InitialPositionFEN, Piece.K, BoardSquare.e1, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.K, BoardSquare.d1, false)]
+    [TestCase(Constants.InitialPositionFEN, Piece.k, BoardSquare.e8, true)]
+    [TestCase(Constants.InitialPositionFEN, Piece.k, BoardSquare.d8, false)]
+    public void Contains_DoesNotContain(string fen, Piece piece, BoardSquare square, bool shouldContain)
+    {
+        var position = new Position(fen);
+        var bb = position.PieceBitBoards[(int)piece];
+
+        Assert.AreEqual(shouldContain, bb.Contains((int)square));
+        Assert.AreEqual(!shouldContain, bb.DoesNotContain((int)square));
+    }
+}

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -57,7 +57,7 @@ public class EvaluationConstantsTest
                 }
             }
         }
-        Assert.Greater(TTMoveScoreValue, maxMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+        Assert.Greater(TTMoveScoreValue, maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue);
     }
 
     [Test]
@@ -85,7 +85,7 @@ public class EvaluationConstantsTest
         checked
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
-            Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+            Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
@@ -113,7 +113,7 @@ public class EvaluationConstantsTest
         checked
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
-            Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + CaptureMoveBaseScoreValue);
+            Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -70,6 +70,7 @@ public class EvaluationConstantsTest
     public void FirstKillerMoveValueConstant()
     {
         var minMVVLVAMoveValue = int.MaxValue;
+        var maxMVVLVAMoveValue = int.MinValue;
 
         for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
         {
@@ -79,13 +80,20 @@ public class EvaluationConstantsTest
                 {
                     minMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
                 }
+
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
             }
         }
 
         checked
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
-            Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue);
+            Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
+            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, FirstKillerMoveValue);
+            Assert.Less(minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, ThirdKillerMoveValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
@@ -98,6 +106,7 @@ public class EvaluationConstantsTest
     public void SecondKillerMoveValueConstant()
     {
         var minMVVLVAMoveValue = int.MaxValue;
+        var maxMVVLVAMoveValue = int.MinValue;
 
         for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
         {
@@ -107,19 +116,60 @@ public class EvaluationConstantsTest
                 {
                     minMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
                 }
+
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
             }
         }
 
         checked
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
-            Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue);
+            Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
+            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, SecondKillerMoveValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
         Assert.Less(SecondKillerMoveValue, FirstKillerMoveValue);
 
         Assert.Greater(SecondKillerMoveValue, default);
+    }
+
+    [Test]
+    public void ThirdKillerMoveValueConstant()
+    {
+        var minMVVLVAMoveValue = int.MaxValue;
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] < minMVVLVAMoveValue)
+                {
+                    minMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        checked
+        {
+#pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
+            Assert.Less(ThirdKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
+            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, ThirdKillerMoveValue);
+#pragma warning restore S3949 // Calculations should not overflow
+        }
+
+        Assert.Less(ThirdKillerMoveValue, SecondKillerMoveValue);
+
+        Assert.Greater(ThirdKillerMoveValue, default);
     }
 
     /// <summary>

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -172,25 +172,6 @@ public class EvaluationConstantsTest
         Assert.Greater(ThirdKillerMoveValue, default);
     }
 
-    [Test]
-    public void BadCaptureMoveValueConstant()
-    {
-        var maxMVVLVAMoveValue = int.MinValue;
-
-        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
-        {
-            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
-            {
-                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
-                {
-                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
-                }
-            }
-        }
-
-        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, BaseMoveScore);
-    }
-
     /// <summary>
     /// Avoids drawish evals that can lead the GUI to declare a draw
     /// or negative ones that can lead it to resign

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -172,6 +172,25 @@ public class EvaluationConstantsTest
         Assert.Greater(ThirdKillerMoveValue, default);
     }
 
+    [Test]
+    public void BadCaptureMoveValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, BaseMoveScore);
+    }
+
     /// <summary>
     /// Avoids drawish evals that can lead the GUI to declare a draw
     /// or negative ones that can lead it to resign

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -64,6 +64,6 @@ public class MoveScoreTest : BaseTest
         var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(EvaluationConstants.CaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));
+        Assert.AreEqual(EvaluationConstants.BadCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));
     }
 }

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -23,54 +23,17 @@ public class MoveScoreTest : BaseTest
     public void MoveScore(string fen)
     {
         var engine = GetEngine(fen);
-        var movePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition, movePool).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
         Assert.AreEqual("g2h3", allMoves[2].UCIString());     // PxP
-        Assert.AreEqual("f3f6", allMoves[^5].UCIString());     // QxN
-        Assert.AreEqual("e5d7", allMoves[^4].UCIString());     // NxP
-        Assert.AreEqual("e5f7", allMoves[^3].UCIString());     // NxP
-        Assert.AreEqual("e5g6", allMoves[^2].UCIString());     // NxP
-        Assert.AreEqual("f3h3", allMoves[^1].UCIString());     // QxP
-
-        foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
-        {
-            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default));
-        }
-    }
-
-    /// <summary>
-    /// 'Tricky position'
-    /// 8   r . . . k . . r
-    /// 7   p . p p q p b .
-    /// 6   b n . . p n p .
-    /// 5   . . . P N . . .
-    /// 4   . p . . P . . .
-    /// 3   . . N . . Q . p
-    /// 2   P P P B B P P P
-    /// 1   R . . . K . . R
-    ///     a b c d e f g h
-    /// This tests indirectly <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
-    /// </summary>
-    /// <param name="fen"></param>
-    [TestCase(Constants.TrickyTestPositionFEN)]
-    public void CaptureScore(string fen)
-    {
-        var engine = GetEngine(fen);
-        var movePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var allMoves = MoveGenerator.GenerateAllCaptures(engine.Game.CurrentPosition, movePool).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
-
-        Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
-        Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
-        Assert.AreEqual("g2h3", allMoves[2].UCIString());     // PxP
-        // Castling moves in the middle
-        Assert.AreEqual("f3f6", allMoves[5].UCIString());     // QxN
-        Assert.AreEqual("e5d7", allMoves[6].UCIString());     // NxP
-        Assert.AreEqual("e5f7", allMoves[7].UCIString());     // NxP
-        Assert.AreEqual("e5g6", allMoves[8].UCIString());     // NxP
-        Assert.AreEqual("f3h3", allMoves[9].UCIString());     // QxP
+        Assert.AreEqual("f3f6", allMoves[3].UCIString());     // QxN
+        Assert.AreEqual("e5d7", allMoves[4].UCIString());     // NxP
+        Assert.AreEqual("e5f7", allMoves[5].UCIString());     // NxP
+        Assert.AreEqual("e5g6", allMoves[6].UCIString());     // NxP
+        Assert.AreEqual("f3h3", allMoves[7].UCIString());     // QxP
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -27,9 +27,9 @@ public class MoveScoreTest : BaseTest
         var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
-        Assert.AreEqual("f3f6", allMoves[1].UCIString());     // QxN
-        Assert.AreEqual("d5e6", allMoves[2].UCIString());     // PxP
-        Assert.AreEqual("g2h3", allMoves[3].UCIString());     // PxP
+        Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
+        Assert.AreEqual("g2h3", allMoves[2].UCIString());     // PxP
+        Assert.AreEqual("f3f6", allMoves[3].UCIString());     // QxN
         Assert.AreEqual("e5d7", allMoves[4].UCIString());     // NxP
         Assert.AreEqual("e5f7", allMoves[5].UCIString());     // NxP
         Assert.AreEqual("e5g6", allMoves[6].UCIString());     // NxP
@@ -64,6 +64,6 @@ public class MoveScoreTest : BaseTest
         var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(EvaluationConstants.BadCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));
+        Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0, 0], engine.ScoreMove(allMoves[0], default, default));
     }
 }

--- a/tests/Lynx.Test/SEETest.cs
+++ b/tests/Lynx.Test/SEETest.cs
@@ -82,7 +82,7 @@ public class SEETest
         var allMoves = MoveGenerator.GenerateAllMoves(position);
         var move = allMoves.Single(m => m.UCIString() == moveUCIString);
 
-        if (move.IsCapture() && move.PromotedPiece() == default)
+        if (move.IsCapture() && move.PromotedPiece() == default && !move.IsEnPassant())
         {
             if (expectedScore >= 0)
             {

--- a/tests/Lynx.Test/SEETest.cs
+++ b/tests/Lynx.Test/SEETest.cs
@@ -1,0 +1,97 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test;
+public class SEETest
+{
+    [TestCase("6k1/1pp4p/p1pb4/6q1/3P1pRr/2P4P/PP1Br1P1/5RKN w - -", "f1f4", -100)]                 // P - R + B
+    [TestCase("5rk1/1pp2q1p/p1pb4/8/3P1NP1/2P5/1P1BQ1P1/5RK1 b - -", "d6f4", 0)]                    // -N + B
+    [TestCase("4R3/2r3p1/5bk1/1p1r3p/p2PR1P1/P1BK1P2/1P6/8 b - -", "h5g4", 0)]
+    [TestCase("4R3/2r3p1/5bk1/1p1r1p1p/p2PR1P1/P1BK1P2/1P6/8 b - -", "h5g4", 0)]
+    [TestCase("4r1k1/5pp1/nbp4p/1p2p2q/1P2P1b1/1BP2N1P/1B2QPPK/3R4 b - -", "g4f3", 0)]
+    [TestCase("2r1r1k1/pp1bppbp/3p1np1/q3P3/2P2P2/1P2B3/P1N1B1PP/2RQ1RK1 b - -", "d6e5", 100)]      // P
+    [TestCase("7r/5qpk/p1Qp1b1p/3r3n/BB3p2/5p2/P1P2P2/4RK1R w - -", "e1e8", 0)]
+    [TestCase("6rr/6pk/p1Qp1b1p/2n5/1B3p2/5p2/P1P2P2/4RK1R w - -", "e1e8", -500)]                   // -R
+    [TestCase("7r/5qpk/2Qp1b1p/1N1r3n/BB3p2/5p2/P1P2P2/4RK1R w - -", "e1e8", -500)]                 // -R
+    [TestCase("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - -", "f7f8q", 200)]                                  // B - P
+    [TestCase("6RR/4bP2/8/8/5r2/3K4/5p2/4k3 w - -", "f7f8n", 200)]                                  // N - P
+    [TestCase("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - -", "f7f8q", 800)]                                    // Q - P
+    [TestCase("7R/5P2/8/8/6r1/3K4/5p2/4k3 w - -", "f7f8b", 200)]                                    // B - P
+    [TestCase("7R/4bP2/8/8/1q6/3K4/5p2/4k3 w - -", "f7f8r", -100)]                                  // -P
+    [TestCase("8/4kp2/2npp3/1Nn5/1p2PQP1/7q/1PP1B3/4KR1r b - -", "h1f1", 0)]
+    [TestCase("8/4kp2/2npp3/1Nn5/1p2P1P1/7q/1PP1B3/4KR1r b - -", "h1f1", 0)]
+    [TestCase("2r2r1k/6bp/p7/2q2p1Q/3PpP2/1B6/P5PP/2RR3K b - -", "c5c1", 100)]                      // R - Q + R
+    [TestCase("r2qk1nr/pp2ppbp/2b3p1/2p1p3/8/2N2N2/PPPP1PPP/R1BQR1K1 w kq -", "f3e5", 100)]         // P
+    [TestCase("6r1/4kq2/b2p1p2/p1pPb3/p1P2B1Q/2P4P/2B1R1P1/6K1 w - -", "f4e5", 0)]
+    [TestCase("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R4B/PQ3P1P/3R2K1 w - h6", "g5h6", 0)]
+    [TestCase("3q2nk/pb1r1p2/np6/3P2Pp/2p1P3/2R1B2B/PQ3P1P/3R2K1 w - h6", "g5h6", 100)]             // P
+    [TestCase("2r4r/1P4pk/p2p1b1p/7n/BB3p2/2R2p2/P1P2P2/4RK2 w - -", "c3c8", 500)]                  // R
+    [TestCase("2r5/1P4pk/p2p1b1p/5b1n/BB3p2/2R2p2/P1P2P2/4RK2 w - -", "c3c8", 500)]                 // R
+    [TestCase("2r4k/2r4p/p7/2b2p1b/4pP2/1BR5/P1R3PP/2Q4K w - -", "c3c5", 300)]                      // B
+    [TestCase("8/pp6/2pkp3/4bp2/2R3b1/2P5/PP4B1/1K6 w - -", "g2c6", -200)]                          // P - B
+    [TestCase("4q3/1p1pr1k1/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - -", "e6e4", -400)]              // P - R
+    [TestCase("4q3/1p1pr1kb/1B2rp2/6p1/p3PP2/P3R1P1/1P2R1K1/4Q3 b - -", "h7e4", 100)]               // P
+    [TestCase("3r3k/3r4/2n1n3/8/3p4/2PR4/1B1Q4/3R3K w - -", "d3d4", -100)]                          // P - R + N - P + N - B + R - Q + R
+    [TestCase("1k1r4/1ppn3p/p4b2/4n3/8/P2N2P1/1PP1R1BP/2K1Q3 w - -", "d3e5", 100)]                  // N - N + B - R + N
+    [TestCase("1k1r3q/1ppn3p/p4b2/4p3/8/P2N2P1/1PP1R1BP/2K1Q3 w - -", "d3e5", -200)]                // P - N
+    [TestCase("rnb2b1r/ppp2kpp/5n2/4P3/q2P3B/5R2/PPP2PPP/RN1QKB2 w Q -", "h4f6", 100)]              // N - B + P
+    [TestCase("r2q1rk1/2p1bppp/p2p1n2/1p2P3/4P1b1/1nP1BN2/PP3PPP/RN1QR1K1 b - -", "g4f3", 0)]       // N - B
+    [TestCase("r1bqkb1r/2pp1ppp/p1n5/1p2p3/3Pn3/1B3N2/PPP2PPP/RNBQ1RK1 b kq -", "c6d4", 0)]         // P - N + N - P
+    [TestCase("r1bq1r2/pp1ppkbp/4N1p1/n3P1B1/8/2N5/PPP2PPP/R2QK2R w KQ -", "e6g7", 0)]              // B - N
+    [TestCase("r1bq1r2/pp1ppkbp/4N1pB/n3P3/8/2N5/PPP2PPP/R2QK2R w KQ -", "e6g7", 300)]              // B
+    [TestCase("rnq1k2r/1b3ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq -", "d6h2", -200)]      // P - B
+    [TestCase("rn2k2r/1bq2ppp/p2bpn2/1p1p4/3N4/1BN1P3/PPP2PPP/R1BQR1K1 b kq -", "d6h2", 100)]       // P
+    [TestCase("r2qkbn1/ppp1pp1p/3p1rp1/3Pn3/4P1b1/2N2N2/PPP2PPP/R1BQKB1R b KQq -", "g4f3", 100)]    // N - B + P
+    [TestCase("rnbq1rk1/pppp1ppp/4pn2/8/1bPP4/P1N5/1PQ1PPPP/R1B1KBNR b KQ -", "b4c3", 0)]           // N - B
+    [TestCase("r4rk1/3nppbp/bq1p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - -", "b6b2", -800)]          // P - Q
+    [TestCase("r4rk1/1q1nppbp/b2p1np1/2pP4/8/2N2NPP/PP2PPB1/R1BQR1K1 b - -", "f6d5", -200)]         // P - N
+    [TestCase("1r3r2/5p2/4p2p/2k1n1P1/2PN1nP1/1P3P2/8/2KR1B1R b - -", "b8b3", -400)]                // P - R
+    [TestCase("1r3r2/5p2/4p2p/4n1P1/kPPN1nP1/5P2/8/2KR1B1R b - -", "b8b4", 100)]                    // P
+    [TestCase("2r2rk1/5pp1/pp5p/q2p4/P3n3/1Q3NP1/1P2PP1P/2RR2K1 b - -", "c8c1", 0)]                 // R - R
+    //[TestCase("5rk1/5pp1/2r4p/5b2/2R5/6Q1/R1P1qPP1/5NK1 b - -", "f5c2", -100)]                      // P - B + R - Q + R
+    [TestCase("1r3r1k/p4pp1/2p1p2p/qpQP3P/2P5/3R4/PP3PP1/1K1R4 b - -", "a5a2", -800)]               // P - Q
+    [TestCase("1r5k/p4pp1/2p1p2p/qpQP3P/2P2P2/1P1R4/P4rP1/1K1R4 b - -", "a5a2", 100)]               // P
+    [TestCase("r2q1rk1/1b2bppp/p2p1n2/1ppNp3/3nP3/P2P1N1P/BPP2PP1/R1BQR1K1 w - -", "d5e7", 0)]      // B - N
+    [TestCase("rnbqrbn1/pp3ppp/3p4/2p2k2/4p3/3B1K2/PPP2PPP/RNB1Q1NR w - -", "d3e4", 100)]           // P
+    [TestCase("rnb1k2r/p3p1pp/1p3p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq -", "e4d6", -200)]     // -N + P
+    [TestCase("r1b1k2r/p4npp/1pp2p1b/7n/1N2N3/3P1PB1/PPP1P1PP/R2QKB1R w KQkq -", "e4d6", 0)]        // -N + N
+    [TestCase("2r1k2r/pb4pp/5p1b/2KB3n/4N3/2NP1PB1/PPP1P1PP/R2Q3R w k -", "d5c6", -300)]            // -B
+    [TestCase("2r1k2r/pb4pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w k -", "d5c6", 0)]              // -B + B
+    [TestCase("2r1k3/pbr3pp/5p1b/2KB3n/1N2N3/3P1PB1/PPP1P1PP/R2Q3R w - -", "d5c6", -300)]           // -B + B - N
+    [TestCase("5k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ -", "d7d8q", 800)]                  // (Q - P)
+    [TestCase("r4k2/p2P2pp/8/1pb5/1Nn1P1n1/6Q1/PPP4P/R3K1NR w KQ -", "d7d8q", -100)]                // (Q - P) - Q
+    [TestCase("5k2/p2P2pp/1b6/1p6/1Nn1P1n1/8/PPP4P/R2QK1NR w KQ -", "d7d8q", 200)]                  // (Q - P) - Q + B
+    [TestCase("4kbnr/p1P1pppp/b7/4q3/7n/8/PP1PPPPP/RNBQKBNR w KQk -", "c7c8q", -100)]               // (Q - P) - Q
+    [TestCase("4kbnr/p1P1pppp/b7/4q3/7n/8/PPQPPPPP/RNB1KBNR w KQk -", "c7c8q", 200)]                // (Q - P) - Q + B
+    [TestCase("4kbnr/p1P1pppp/b7/4q3/7n/8/PPQPPPPP/RNB1KBNR w KQk -", "c7c8q", 200)]                // (Q - P)
+    [TestCase("4kbnr/p1P4p/b1q5/5pP1/4n3/5Q2/PP1PPP1P/RNB1KBNR w KQk f6", "g5f6", 0)]               // P - P
+    [TestCase("4kbnr/p1P4p/b1q5/5pP1/4n3/5Q2/PP1PPP1P/RNB1KBNR w KQk f6", "g5f6", 0)]               // P - P
+    [TestCase("4kbnr/p1P4p/b1q5/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk f6", "g5f6", 0)]                // P - P
+    [TestCase("1n2kb1r/p1P4p/2qb4/5pP1/4n2Q/8/PP1PPP1P/RNB1KBNR w KQk -", "c7b8q", 200)]            // N + (Q - P) - Q
+    [TestCase("rnbqk2r/pp3ppp/2p1pn2/3p4/3P4/N1P1BN2/PPB1PPPb/R2Q1RK1 w kq -", "g1h2", 300)]        // B
+    [TestCase("3N4/2K5/2n5/1k6/8/8/8/8 b - -", "c6d8", 0)]                                          // N - N
+    [TestCase("3n3r/2P5/8/1k6/8/8/3Q4/4K3 w - -", "c7d8q", 700)]                                    // (N + Q - P) - Q + R
+    [TestCase("r2n3r/2P1P3/4N3/1k6/8/8/8/4K3 w - -", "e6d8", 300)]                                  // N
+    [TestCase("8/8/8/1k6/6b1/4N3/2p3K1/3n4 w - -", "e3d1", 0)]                                      // N - N
+    [TestCase("8/8/1k6/8/8/2N1N3/4p1K1/3n4 w - -", "c3d1", 100)]                                    // N - (N + Q - P) + Q
+    [TestCase("r1bqk1nr/pppp1ppp/2n5/1B2p3/1b2P3/5N2/PPPP1PPP/RNBQK2R w KQkq -", "e1g1", 0)]
+    public void RunSeeTestsBoolean(string fen, string moveUCIString, int expectedScore)
+    {
+        var position = new Position(fen);
+
+        var allMoves = MoveGenerator.GenerateAllMoves(position);
+        var move = allMoves.Single(m => m.UCIString() == moveUCIString);
+
+        if (move.IsCapture() && move.PromotedPiece() == default)
+        {
+            if (expectedScore >= 0)
+            {
+                Assert.True(SEE.SEE(position, move));
+            }
+            else
+            {
+                Assert.False(SEE.IsGoodCapture(position, move));
+            }
+        }
+    }
+}

--- a/tests/Lynx.Test/SEETest.cs
+++ b/tests/Lynx.Test/SEETest.cs
@@ -86,7 +86,7 @@ public class SEETest
         {
             if (expectedScore >= 0)
             {
-                Assert.True(SEE.SEE(position, move));
+                Assert.True(SEE.IsGoodCapture(position, move));
             }
             else
             {


### PR DESCRIPTION
Between killers and quiets
```
Elo   | 28.03 +- 11.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2112 W: 759 L: 589 D: 764
Penta | [74, 214, 360, 284, 124]
https://openbench.lynx-chess.com/test/35/
```

Below quiets:
```
Elo   | -17.85 +- 11.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.33 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2182 W: 631 L: 743 D: 808
Penta | [120, 255, 413, 223, 80]
https://openbench.lynx-chess.com/test/39/
```