### PR TITLE
🐛 Fix engine crash due to a negative calculated time to move

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -99,7 +99,7 @@ public sealed partial class Engine
             {
                 // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
                 millisecondsLeft -= 50;
-                Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
+                millisecondsLeft = Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
 
                 // 1/30, suggested by Serdra (EP discord)
                 decisionTime = Convert.ToInt32(Math.Min(0.5 * millisecondsLeft, (millisecondsLeft * 0.03333) + millisecondsIncrement));
@@ -107,7 +107,7 @@ public sealed partial class Engine
             else
             {
                 millisecondsLeft -= 500;
-                Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
+                millisecondsLeft = Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
 
                 decisionTime = Convert.ToInt32((millisecondsLeft / goCommand.MovesToGo) + millisecondsIncrement);
             }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -154,27 +154,36 @@ public sealed partial class Engine
         return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
     }
 
+#pragma warning disable RCS1226 // Add paragraph to documentation comment
+#pragma warning disable RCS1243 // Duplicate word in a comment
+    /// <summary>
+    /// When asked to copy an incomplete PV one level ahead, clears the rest of the PV Table+
+    /// PV Table at depth 3
+    /// Copying 60 moves
+    /// src: 250, tgt: 190
+    ///  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+    ///  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+    ///  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+    ///  189                      Qxb1   Qxb1   Qxb1   a8     a8
+    ///  250                             a8     Qxb1   a8     a8
+    ///  310                                    a8     a8     a8
+    ///
+    /// PV Table at depth 3
+    ///  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
+    ///  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
+    ///  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
+    ///  189                      Qxb1   a8     a8     a8     a8
+    ///  250                             a8     a8     a8     a8
+    ///  310                                    a8     a8     a8
+    /// </summary>
+    /// <param name="target"></param>
+    /// <param name="source"></param>
+    /// <param name="moveCountToCopy"></param>
+#pragma warning restore RCS1243 // Duplicate word in a comment
+#pragma warning restore RCS1226 // Add paragraph to documentation comment
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CopyPVTableMoves(int target, int source, int moveCountToCopy)
     {
-        // When asked to copy an incomplete PV one level ahead, clears the rest of the PV Table+
-        // PV Table at depth 3
-        // Copying 60 moves
-        // src: 250, tgt: 190
-        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
-        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
-        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
-        //  189                      Qxb1   Qxb1   Qxb1   a8     a8
-        //  250                             a8     Qxb1   a8     a8
-        //  310                                    a8     a8     a8
-        //
-        // PV Table at depth 3
-        //  0   Qxb2   Qxb2   h4     a8     a8     a8     a8     a8
-        //  64         b1=Q   exf6   Kxf6   a8     a8     a8     a8
-        //  127               a8     b1=Q   Qxb1   Qxb1   a8     a8
-        //  189                      Qxb1   a8     a8     a8     a8
-        //  250                             a8     a8     a8     a8
-        //  310                                    a8     a8     a8
         if (_pVTable[source] == default)
         {
             Array.Clear(_pVTable, target, _pVTable.Length - target);


### PR DESCRIPTION
Fix `Math.Clamp` usage when millisecondsLeft < 50, which caused engine crashes

i.e.
```
2023-12-30 16:08:52.6634|0|11420|DEBUG|Lynx.LynxDriver|[GUI]	position startpos moves e2e4 e7e5 f1c4 f8c5 c2c3 d7d6 d2d4 e5d4 c3d4 c5b6 g1f3 c8e6 c4d3 h7h6 e1g1 g8f6 b1c3 e8g8 d4d5 e6d7 a2a4 b8a6 a4a5 b6c5 d3b1 f8e8 h2h3 a6b4 f3d4 c7c6 a5a6 b7a6 d5c6 b4c6 d4b3 c5b4 a1a6 a8b8 c1e3 d8c8 a6a4 a7a5 a4a1 c8c7 c3d5 f6d5 e4d5 c6e5 d1d4 d7h3 f1c1 c7d8 d4e4 e5g6 e4f3 h3d7 f3g3 d8h4 g3h4 g6h4 b3a5 b4a5 a1a5 b8b2 b1c2 h4f5 c2f5 d7f5 c1c6 b2b1 g1h2 e8d8 e3f4 b1b2 h2g3 f5e4 f2f3 e4d3 c6d6 d8d6 f4d6 d3f1 d6e5 b2g2 g3f4 f7f6 e5d4 g2d2 f4e4 f1e2 d5d6 g8f7 d6d7 e2f3 e4e3 d2d4 e3d4 f7e7 a5a7 f3g4 d7d8q e7d8 a7g7 h6h5 g7h7 d8e8 d4e4 e8d8 e4e3 d8e8 e3f4 e8f8 f4g3 g4e2 g3h4 e2g4 h7a7 g4f3 h4g3 f3d5 a7d7 d5f7 g3h4 f8g7 d7c7 g7g6 c7c5 g6g7 c5f5 f7e8 f5a5 g7h6 a5c5 h6g7 c5d5 e8g6 d5b5 g6f7 b5a5 g7f8 a5a7 f8g7 a7a1 g7f8 h4g3 f8g7 a1a5 g7f8 g3h4 f8g7 a5a7 g7g6 h4g3 f6f5 g3f4 g6f6 a7a6 f7e6 a6b6 h5h4 b6b8 f6g7 f4e5 e6c4 b8b4 c4d3 b4h4 d3e4 h4h3 g7g6 h3b3 g6f7 b3b2 f7g6 b2b8 g6g7 b8c8 g7f7 c8c7 f7g6 c7a7 e4f3 e5f4 f3e4 a7a6 g6f7 f4e5 f7g7 a6f6 g7h7 f6b6 
2023-12-30 16:08:52.6634|0|11420|DEBUG|Lynx.LynxDriver|[GUI]	isready 
2023-12-30 16:08:52.6634|0|11420|DEBUG|Lynx.Cli.Writer|[Lynx]	readyok 
2023-12-30 16:08:52.6634|0|11420|DEBUG|Lynx.LynxDriver|[GUI]	go wtime 255 btime 47 winc 80 binc 80 
2023-12-30 16:08:52.6634|0|11420|INFO|Lynx.Engine|Time to move: -0.002s 
2023-12-30 16:08:52.6634|0|11420|FATAL|Lynx.Engine|Error in StartSearching while calculating BestMove System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'millisecondsDelay')
   at Lynx.Engine.BestMove(GoCommand)
   at Lynx.Engine.<>c__DisplayClass39_0.<<StartSearching>b__0>d.MoveNext()
2023-12-30 16:08:53.1531|0|11420|DEBUG|Lynx.LynxDriver|[GUI]	stop 

```