### PR TITLE
🐛 Add support for negative `wtime` and `btime`

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -93,7 +93,7 @@ public sealed partial class Engine
             millisecondsIncrement = goCommand.BlackIncrement;
         }
 
-        if (millisecondsLeft > 0)
+        if (millisecondsLeft != 0)  // Cutechess sometimes sends negative wtime/btime
         {
             if (goCommand.MovesToGo == default)
             {

--- a/src/Lynx/UCI/Commands/GUI/GoCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/GoCommand.cs
@@ -49,7 +49,11 @@ public sealed partial class GoCommand : GUIBaseCommand
 {
     public const string Id = "go";
 
-    [GeneratedRegex(@"(?<wtime>(?<=wtime\s+)\d+)|(?<btime>(?<=btime\s+)\d+)|(?<winc>(?<=winc\s+)\d+)|(?<binc>(?<=binc\s+)\d+)|(?<movestogo>(?<=movestogo\s+)\d+)|(?<depth>(?<=depth\s+)\d+)|(?<movetime>(?<=movetime\s+)\d+)|(?<infinite>infinite)|(?<ponder>ponder)")]
+    /// <summary>
+    /// Note that wtime and btime need to support negative numbers because of cutechess
+    /// </summary>
+    /// <returns></returns>
+    [GeneratedRegex(@"(?<wtime>(?<=wtime\s+)-?\d+)|(?<btime>(?<=btime\s+)-?\d+)|(?<winc>(?<=winc\s+)\d+)|(?<binc>(?<=binc\s+)\d+)|(?<movestogo>(?<=movestogo\s+)\d+)|(?<depth>(?<=depth\s+)\d+)|(?<movetime>(?<=movetime\s+)\d+)|(?<infinite>infinite)|(?<ponder>ponder)")]
     private static partial Regex Regex();
 
     public int WhiteTime { get; }


### PR DESCRIPTION
cutechess stuff

Example:
```
2023-12-30 16:09:37.8302|0|8724|DEBUG|Lynx.LynxDriver|[GUI]	go wtime 205 btime -2 winc 80 binc 80 
2023-12-30 16:09:37.8302|0|8724|WARN|Lynx.Engine|Unexpected or unsupported go command 
```