### PR TITLE
🔍 Use spsa tuned search values IV - smaller iter

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -20,27 +20,27 @@
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.74,
-    "LMR_Divisor": 2.94,
+    "LMR_Base": 0.76,
+    "LMR_Divisor": 2.54,
 
     "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 1,
 
-    "AspirationWindow_Delta": 16,
-    "AspirationWindow_MinDepth": 7,
+    "AspirationWindow_Delta": 22,
+    "AspirationWindow_MinDepth": 8,
 
-    "RFP_MaxDepth": 4,
-    "RFP_DepthScalingFactor": 85,
+    "RFP_MaxDepth": 3,
+    "RFP_DepthScalingFactor": 74,
 
-    "Razoring_MaxDepth": 3,
-    "Razoring_Depth1Bonus": 106,
-    "Razoring_NotDepth1Bonus": 156,
+    "Razoring_MaxDepth": 4,
+    "Razoring_Depth1Bonus": 116,
+    "Razoring_NotDepth1Bonus": 177,
 
-    "IIR_MinDepth": 2,
+    "IIR_MinDepth": 3,
 
-    "LMP_MaxDepth": 1,
+    "LMP_MaxDepth": 2,
     "LMP_BaseMovesToTry": 1,
-    "LMP_MovesDepthMultiplier": 11,
+    "LMP_MovesDepthMultiplier": 9,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -122,38 +122,38 @@ public sealed class EngineSettings
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
-    public double LMR_Base { get; set; } = 0.74;
+    public double LMR_Base { get; set; } = 0.76;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
-    public double LMR_Divisor { get; set; } = 2.94;
+    public double LMR_Divisor { get; set; } = 2.54;
 
     public int NMP_MinDepth { get; set; } = 3;
 
     public int NMP_BaseDepthReduction { get; set; } = 1;
 
-    public int AspirationWindow_Delta { get; set; } = 16;
+    public int AspirationWindow_Delta { get; set; } = 22;
 
-    public int AspirationWindow_MinDepth { get; set; } = 7;
+    public int AspirationWindow_MinDepth { get; set; } = 8;
 
-    public int RFP_MaxDepth { get; set; } = 4;
+    public int RFP_MaxDepth { get; set; } = 3;
 
-    public int RFP_DepthScalingFactor { get; set; } = 85;
+    public int RFP_DepthScalingFactor { get; set; } = 74;
 
-    public int Razoring_MaxDepth { get; set; } = 3;
+    public int Razoring_MaxDepth { get; set; } = 4;
 
-    public int Razoring_Depth1Bonus { get; set; } = 106;
+    public int Razoring_Depth1Bonus { get; set; } = 116;
 
-    public int Razoring_NotDepth1Bonus { get; set; } = 156;
+    public int Razoring_NotDepth1Bonus { get; set; } = 177;
 
-    public int IIR_MinDepth { get; set; } = 2;
+    public int IIR_MinDepth { get; set; } = 3;
 
-    public int LMP_MaxDepth { get; set; } = 1;
+    public int LMP_MaxDepth { get; set; } = 2;
 
     public int LMP_BaseMovesToTry { get; set; } = 1;
 
-    public int LMP_MovesDepthMultiplier { get; set; } = 11;
+    public int LMP_MovesDepthMultiplier { get; set; } = 9;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -110,7 +110,7 @@ public sealed partial class Engine
                 }
             }
 
-            if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
+            if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                 if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
@@ -119,7 +119,7 @@ public sealed partial class Engine
                 }
 
                 // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
-                if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
+                if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
                 {
                     var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
 

--- a/tests/Lynx.Test/ConfigurationValuesTest.cs
+++ b/tests/Lynx.Test/ConfigurationValuesTest.cs
@@ -14,8 +14,6 @@ public class ConfigurationValuesTest
     [Test]
     public void RazoringValues()
     {
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
-
         var config = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
             .Build();

--- a/tests/Lynx.Test/ConfigurationValuesTest.cs
+++ b/tests/Lynx.Test/ConfigurationValuesTest.cs
@@ -24,6 +24,6 @@ public class ConfigurationValuesTest
         Assert.IsNotNull(engineSettingsSection);
         engineSettingsSection.Bind(Configuration.EngineSettings);
 
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
+        Assert.Greater(Configuration.EngineSettings.Razoring_MaxDepth, Configuration.EngineSettings.RFP_MaxDepth);
     }
 }


### PR DESCRIPTION
Note 8 games per iter instead of 32 as in #543, #550 and #553 

```
{
    "engine": "Lynx-2123-tuning.exe",
    "book": "books/UHO_XXL_+0.90_+1.19.epd",
    "games": 8,
    "tc": 20,
    "hash": 128,
    "threads": 8
}

iterations: 58056 (10.30s per iter)
LMR_MinDepth = 3(-0.043424) in [1, 8]
LMR_MinFullDepthSearchedMoves = 4(+0.36) in [1, 10]
LMR_Base = 76(-1.157681) in [10, 200]
LMR_Divisor = 254(-12.708997) in [150, 400]
NMP_MinDepth = 3(-0.198398) in [1, 6]
NMP_BaseDepthReduction = 1(+0.21) in [0, 3]
AspirationWindow_Delta = 22(-28.446117) in [0, 300]
AspirationWindow_MinDepth = 8(+1.86) in [1, 10]
RFP_MaxDepth = 3(+0.90) in [1, 12]
RFP_DepthScalingFactor = 74(-0.997638) in [10, 200]
Razoring_MaxDepth = 4(+1.70) in [1, 10]
Razoring_Depth1Bonus = 116(-9.384600) in [50, 300]
Razoring_NotDepth1Bonus = 177(+2.31) in [50, 300]
IIR_MinDepth = 3(-1.391983) in [1, 10]
LMP_MaxDepth = 2(-0.093704) in [1, 10]
LMP_BaseMovesToTry = 1(+0.80) in [0, 12]
LMP_MovesDepthMultiplier = 9(-1.077967) in [0, 50]
```

![image](https://github.com/lynx-chess/Lynx/assets/11148519/56b2e94b-b29b-4919-bc16-f6fc7b98d263)

```
Score of Lynx-spsa-test-small-iter-2-2221-win-x64 vs Lynx-master-preview-2222-win-x64: 1554 - 1566 - 2610  [0.499] 5730
...      Lynx-spsa-test-small-iter-2-2221-win-x64 playing White: 1110 - 395 - 1361  [0.625] 2866
...      Lynx-spsa-test-small-iter-2-2221-win-x64 playing Black: 444 - 1171 - 1249  [0.373] 2864
...      White vs Black: 2281 - 839 - 2610  [0.626] 5730
Elo difference: -0.7 +/- 6.6, LOS: 41.5 %, DrawRatio: 45.5 %
SPRT: llr -1.41 (-48.7%), lbound -2.25, ubound 2.89
```
