### PR TITLE
🔍 Prune bad captures in QSearch using SEE

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -336,6 +336,7 @@ public static readonly int[] EndGameKingTable =
 
     public const int ThirdKillerMoveValue = 131_072;
 
+    // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
     public const int PromotionMoveScoreValue = 65_536;
 
     public const int BadCaptureMoveBaseScoreValue = 32_768;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Transactions;
 
 namespace Lynx;
 
@@ -451,6 +452,12 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[i];
+
+            // Prune bad captures
+            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            {
+                continue;
+            }
 
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -172,6 +172,25 @@ public class EvaluationConstantsTest
         Assert.Greater(ThirdKillerMoveValue, default);
     }
 
+    [Test]
+    public void PromotionMoveValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, PromotionMoveScoreValue);
+    }
+
     /// <summary>
     /// Avoids drawish evals that can lead the GUI to declare a draw
     /// or negative ones that can lead it to resign


### PR DESCRIPTION
```
Elo   | 51.98 +- 16.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1138 W: 444 L: 275 D: 419
Penta | [34, 90, 194, 175, 76]
https://openbench.lynx-chess.com/test/43/
```

```
Elo   | 34.56 +- 13.23 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1624 W: 574 L: 413 D: 637
Penta | [45, 159, 276, 254, 78]
https://openbench.lynx-chess.com/test/46/
```