### PR TITLE
Use TT score as a better positional eval

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1056,19 +1056,19 @@ static void TranspositionTable()
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
     transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +19, nodeType: NodeType.Alpha, move: 1234);
-    var entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    var entry = transpositionTable.ProbeHash(mask, position, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 20
 
     transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +21, nodeType: NodeType.Alpha, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(mask, position, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
     transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +29, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(mask, position, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
     transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +31, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(mask, position, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 30
 }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -10,8 +10,8 @@ public enum NodeType : byte
 {
     Unknown,    // Making it 0 instead of -1 because of default struct initialization
     Exact,
-    Alpha,
-    Beta
+    Alpha,      // Upper bound
+    Beta        // Lower bound
 }
 
 public struct TranspositionTableElement

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -88,12 +88,11 @@ public sealed partial class Engine
         {
             var (staticEval, phase) = position.StaticEvaluation();
 
-            if (ttElementType != default &&
-                (ttElementType == NodeType.Exact
+            // Use TT score as a better positional eval - cj5716 and Sirius
+            if (ttElementType == NodeType.Exact
                     || (ttElementType == NodeType.Beta && ttEvaluation >= staticEval)
-                    || (ttElementType == NodeType.Alpha && ttEvaluation <= staticEval)))
+                    || (ttElementType == NodeType.Alpha && ttEvaluation <= staticEval))
             {
-                // preferrably in a separate variable
                 staticEval = ttEvaluation;
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -86,6 +86,15 @@ public sealed partial class Engine
         {
             var (staticEval, phase) = position.StaticEvaluation();
 
+            if (ttElementType != default &&
+                (ttElementType == NodeType.Exact
+                    || (ttElementType == NodeType.Beta && ttEvaluation >= staticEval)
+                    || (ttElementType == NodeType.Alpha && ttEvaluation <= staticEval)))
+            {
+                // preferrably in a separate variable
+                staticEval = ttEvaluation;
+            }
+
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
                 && staticEval >= beta

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -86,7 +86,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor)]
@@ -100,7 +100,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor, 5, 4, CheckMateBaseEvaluation - 7 * CheckmateDepthFactor)]
@@ -115,6 +115,6 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
     }
 }


### PR DESCRIPTION
I probably... got it wrong

https://github.com/lynx-chess/Lynx/pull/559/commits/e7a60124f79f03d1f911db7e32c7177488caf6be
```
Score of Lynx-tt-score-better-positional-eval-2218-win-x64 vs Lynx 2210 - main: 5 - 109 - 50  [0.183] 164
...      Lynx-tt-score-better-positional-eval-2218-win-x64 playing White: 4 - 45 - 33  [0.250] 82
...      Lynx-tt-score-better-positional-eval-2218-win-x64 playing Black: 1 - 64 - 17  [0.116] 82
...      White vs Black: 68 - 46 - 50  [0.567] 164
Elo difference: -260.0 +/- 48.8, LOS: 0.0 %, DrawRatio: 30.5 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

https://github.com/lynx-chess/Lynx/pull/559/commits/ae47e3449cc72a0960f87c10027b180abbd7cd5a
```
Score of Lynx-tt-score-better-positional-eval-2220-win-x64 vs Lynx 2210 - main: 24 - 181 - 69  [0.214] 274
...      Lynx-tt-score-better-positional-eval-2220-win-x64 playing White: 14 - 78 - 45  [0.266] 137
...      Lynx-tt-score-better-positional-eval-2220-win-x64 playing Black: 10 - 103 - 24  [0.161] 137
...      White vs Black: 117 - 88 - 69  [0.553] 274
Elo difference: -226.5 +/- 40.0, LOS: 0.0 %, DrawRatio: 25.2 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```