### PR TITLE
EvaluateSEE on the fly during QSearch

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -67,7 +67,7 @@ public sealed partial class Engine
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int depth, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int depth, bool isNotQSearch, ShortMove bestMoveTTCandidate = default, bool shouldNotSEE = false)
     {
         if (_isScoringPV && move == _pVTable[depth])
         {
@@ -109,7 +109,7 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (shouldNotSEE || isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,7 +435,7 @@ public sealed partial class Engine
         var scores = new int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove, shouldNotSEE: true);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
@@ -454,7 +454,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!SEE.IsGoodCapture(Game.CurrentPosition, move))
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -454,7 +454,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (!SEE.IsGoodCapture(Game.CurrentPosition, move))
+            if (move.IsCapture() && move.PromotedPiece() == default && !move.IsEnPassant() && !SEE.IsGoodCapture(Game.CurrentPosition, move))
             {
                 continue;
             }


### PR DESCRIPTION
Suggested by zzzzz and Ciekce back in the day

```
Elo   | -4.39 +- 6.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6572 W: 2013 L: 2096 D: 2463
Penta | [273, 764, 1270, 731, 248]
https://openbench.lynx-chess.com/test/45/
```