### PR TITLE
Place SEE bad captures over killers

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -336,6 +336,7 @@ public static readonly int[] EndGameKingTable =
 
     public const int ThirdKillerMoveValue = 131_072;
 
+    // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
     public const int PromotionMoveScoreValue = 65_536;
 
     public const int BadCaptureMoveBaseScoreValue = 32_768;

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -330,16 +330,17 @@ public static readonly int[] EndGameKingTable =
 
     public const int GoodCaptureMoveBaseScoreValue = 1_048_576;
 
-    public const int FirstKillerMoveValue = 524_288;
+    public const int BadCaptureMoveBaseScoreValue = 524_288;
 
-    public const int SecondKillerMoveValue = 262_144;
+    public const int FirstKillerMoveValue = 262_144;
 
-    public const int ThirdKillerMoveValue = 131_072;
+    public const int SecondKillerMoveValue = 131_072;
+
+    public const int ThirdKillerMoveValue = 65_536;
 
     // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
-    public const int PromotionMoveScoreValue = 65_536;
+    public const int PromotionMoveScoreValue = 32_768;
 
-    public const int BadCaptureMoveBaseScoreValue = 32_768;
 
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -454,7 +454,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (scores[i] < EvaluationConstants.GoodCaptureMoveBaseScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Transactions;
 
 namespace Lynx;
 
@@ -451,6 +452,12 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[i];
+
+            // Prune bad captures
+            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            {
+                continue;
+            }
 
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -172,6 +172,25 @@ public class EvaluationConstantsTest
         Assert.Greater(ThirdKillerMoveValue, default);
     }
 
+    [Test]
+    public void PromotionMoveValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, PromotionMoveScoreValue);
+    }
+
     /// <summary>
     /// Avoids drawish evals that can lead the GUI to declare a draw
     /// or negative ones that can lead it to resign

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -92,8 +92,6 @@ public class EvaluationConstantsTest
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
             Assert.Less(FirstKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
-            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, FirstKillerMoveValue);
-            Assert.Less(minMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, ThirdKillerMoveValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
@@ -128,7 +126,6 @@ public class EvaluationConstantsTest
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
             Assert.Less(SecondKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
-            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, SecondKillerMoveValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
@@ -163,7 +160,6 @@ public class EvaluationConstantsTest
         {
 #pragma warning disable S3949 // Calculations should not overflow - well, we're adding checked just in case
             Assert.Less(ThirdKillerMoveValue, minMVVLVAMoveValue + GoodCaptureMoveBaseScoreValue);
-            Assert.Less(maxMVVLVAMoveValue + BadCaptureMoveBaseScoreValue, ThirdKillerMoveValue);
 #pragma warning restore S3949 // Calculations should not overflow
         }
 
@@ -188,7 +184,26 @@ public class EvaluationConstantsTest
             }
         }
 
-        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, PromotionMoveScoreValue);
+        Assert.Less(PromotionMoveScoreValue, ThirdKillerMoveValue);
+    }
+
+    [Test]
+    public void BadCaptureMoveValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, GoodCaptureMoveBaseScoreValue);
     }
 
     /// <summary>


### PR DESCRIPTION
```
Score of Lynx-see-bad-captures-over-killers-2228-win-x64 vs Lynx 2227 - main: 271 - 374 - 411  [0.451] 1056
...      Lynx-see-bad-captures-over-killers-2228-win-x64 playing White: 191 - 122 - 215  [0.565] 528
...      Lynx-see-bad-captures-over-killers-2228-win-x64 playing Black: 80 - 252 - 196  [0.337] 528
...      White vs Black: 443 - 202 - 411  [0.614] 1056
Elo difference: -34.0 +/- 16.4, LOS: 0.0 %, DrawRatio: 38.9 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```