### PR TITLE
Prune bad captures in QSearch only when not in check

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -336,6 +336,7 @@ public static readonly int[] EndGameKingTable =
 
     public const int ThirdKillerMoveValue = 131_072;
 
+    // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
     public const int PromotionMoveScoreValue = 65_536;
 
     public const int BadCaptureMoveBaseScoreValue = 32_768;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -428,6 +428,7 @@ public sealed partial class Engine
             return staticEvaluation;
         }
 
+        var isInCheck = position.IsInCheck();
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
         bool isThereAnyValidCapture = false;
@@ -454,7 +455,9 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!isInCheck
+                && scores[i] < EvaluationConstants.PromotionMoveScoreValue
+                && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }
@@ -527,7 +530,7 @@ public sealed partial class Engine
             && !isThereAnyValidCapture
             && !MoveGenerator.CanGenerateAtLeastAValidMove(position))
         {
-            var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
+            var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
             _tt.RecordHash(_ttMask, position, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Transactions;
 
 namespace Lynx;
 
@@ -451,6 +452,12 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[i];
+
+            // Prune bad captures
+            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            {
+                continue;
+            }
 
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -172,6 +172,25 @@ public class EvaluationConstantsTest
         Assert.Greater(ThirdKillerMoveValue, default);
     }
 
+    [Test]
+    public void PromotionMoveValueConstant()
+    {
+        var maxMVVLVAMoveValue = int.MinValue;
+
+        for (int s = (int)Piece.P; s <= (int)Piece.r; ++s)
+        {
+            for (int t = (int)Piece.P; t <= (int)Piece.r; ++t)
+            {
+                if (MostValueableVictimLeastValuableAttacker[s, t] > maxMVVLVAMoveValue)
+                {
+                    maxMVVLVAMoveValue = MostValueableVictimLeastValuableAttacker[s, t];
+                }
+            }
+        }
+
+        Assert.Less(BadCaptureMoveBaseScoreValue + maxMVVLVAMoveValue, PromotionMoveScoreValue);
+    }
+
     /// <summary>
     /// Avoids drawish evals that can lead the GUI to declare a draw
     /// or negative ones that can lead it to resign


### PR DESCRIPTION
Done in other engines, i.e. Leorik

```
Elo   | -11.47 +- 9.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3030 W: 886 L: 986 D: 1158
Penta | [122, 394, 556, 348, 95]
https://openbench.lynx-chess.com/test/47/
```