### PR TITLE
Add 15 * depth as SEE threshold for bad captures

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -45,6 +45,8 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
+    "SEE_ThresholdDepthFactor": 15,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -5,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -162,6 +162,8 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
+    public int SEE_ThresholdDepthFactor { get; set; } = 15;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-5, -14);

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -26,7 +26,7 @@ public static class SEE
     /// <param name="threshold"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsGoodCapture(Position position, Move move, short threshold = 0)
+    public static bool IsGoodCapture(Position position, Move move, int threshold = 0)
     {
         System.Diagnostics.Debug.Assert(move.IsCapture(), $"{nameof(IsGoodCapture)} doesn't handle non-capture moves");
         System.Diagnostics.Debug.Assert(move.PromotedPiece() == default, $"{nameof(IsGoodCapture)} doesn't handle promotion moves");

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -109,7 +109,7 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move, threshold: Configuration.EngineSettings.SEE_ThresholdDepthFactor * depth))
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 


### PR DESCRIPTION
```
Score of Lynx-see-threshold-depth-related-2230-win-x64 vs Lynx 2227 - main: 40 - 140 - 83  [0.310] 263
...      Lynx-see-threshold-depth-related-2230-win-x64 playing White: 28 - 56 - 47  [0.393] 131
...      Lynx-see-threshold-depth-related-2230-win-x64 playing Black: 12 - 84 - 36  [0.227] 132
...      White vs Black: 112 - 68 - 83  [0.584] 263
Elo difference: -139.1 +/- 36.2, LOS: 0.0 %, DrawRatio: 31.6 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```