### PR TITLE
🔍 SEE bad captures fixed reduction

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -45,6 +45,8 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
+    "SEE_BadCaptureReduction": 2,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -5,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -45,7 +45,7 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 2,
+    "SEE_BadCaptureReduction": 1,
 
     // Evaluation
     "DoubledPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -162,7 +162,7 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 1;
 
     #region Evaluation
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -162,6 +162,8 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
+    public int SEE_BadCaptureReduction { get; set; } = 2;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-5, -14);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -275,7 +275,7 @@ public sealed partial class Engine
                     reduction = Math.Clamp(reduction, 0, depth - 2);
                 }
 
-                // 🔍 Static Exchange Evaluation (SEE)
+                // 🔍 Static Exchange Evaluation (SEE) reduction
                 // Bad captures are reduced more
                 if (!isInCheck
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -275,6 +275,15 @@ public sealed partial class Engine
                     reduction = Math.Clamp(reduction, 0, depth - 2);
                 }
 
+                // 🔍 Static Exchange Evaluation (SEE)
+                // Bad captures are reduced more
+                if (!isInCheck
+                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue
+                    && scores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+                {
+                    reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
+                }
+
                 // Search with reduced depth
                 evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
 


### PR DESCRIPTION
2
```
Elo   | -3.20 +- 5.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8024 W: 2406 L: 2480 D: 3138
Penta | [328, 908, 1565, 932, 279]
https://openbench.lynx-chess.com/test/48/
```

1, [0, 5]
```
Score of Lynx-see-bad-capture-reduction-2244-win-x64 vs Lynx 2241 - main: 15161 - 14745 - 19078  [0.504] 48984
...      Lynx-see-bad-capture-reduction-2244-win-x64 playing White: 10482 - 4576 - 9434  [0.621] 24492
...      Lynx-see-bad-capture-reduction-2244-win-x64 playing Black: 4679 - 10169 - 9644  [0.388] 24492
...      White vs Black: 20651 - 9255 - 19078  [0.616] 48984
Elo difference: 3.0 +/- 2.4, LOS: 99.2 %, DrawRatio: 38.9 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```