### PR TITLE
Add SEE bad capture pruning

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -45,6 +45,8 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
+    "SEE_Pruning_MaxDepth": 8,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -5,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -162,6 +162,8 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
+    public int SEE_Pruning_MaxDepth { get; set; } = 8;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-5, -14);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -275,6 +275,24 @@ public sealed partial class Engine
                     reduction = Math.Clamp(reduction, 0, depth - 2);
                 }
 
+                // 🔍 Static Exchange Evaluation (SEE) pruning
+                // Bad captures are pruned up until a certain depth
+                if (!isInCheck
+                    && depth <= Configuration.EngineSettings.SEE_Pruning_MaxDepth
+                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue
+                    && scores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+                {
+                    // After making a move
+                    Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
+                    if (!isThreeFoldRepetition)
+                    {
+                        Game.PositionHashHistory.Remove(position.UniqueIdentifier);
+                    }
+                    position.UnmakeMove(move, gameState);
+
+                    continue;
+                }
+
                 // Search with reduced depth
                 evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
 


### PR DESCRIPTION
8+0.08
```
Elo   | -42.84 +- 17.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 5.00]
Games | N: 970 W: 255 L: 374 D: 341
Penta | [64, 133, 176, 82, 30]
https://openbench.lynx-chess.com/test/50/
```

40+0.4
```
Score of Lynx-see-bad-capture-pruning-2234-win-x64 vs Lynx 2227 - main: 295 - 398 - 453  [0.455] 1146
...      Lynx-see-bad-capture-pruning-2234-win-x64 playing White: 216 - 120 - 237  [0.584] 573
...      Lynx-see-bad-capture-pruning-2234-win-x64 playing Black: 79 - 278 - 216  [0.326] 573
...      White vs Black: 494 - 199 - 453  [0.629] 1146
Elo difference: -31.3 +/- 15.7, LOS: 0.0 %, DrawRatio: 39.5 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```