### PR TITLE
Prune quiet moves with bad SEE score

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -250,6 +250,23 @@ public sealed partial class Engine
                     break;
                 }
 
+                // 🔍 Static Exchange Evaluation (SEE) pruning
+                // Non captures with bad SEE are pruned
+                if (!isInCheck
+                    && !move.IsCapture()
+                    && !SEE.HasPositiveScore(Game.CurrentPosition, move))
+                {
+                    // After making a move
+                    Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
+                    if (!isThreeFoldRepetition)
+                    {
+                        Game.PositionHashHistory.Remove(position.UniqueIdentifier);
+                    }
+                    position.UnmakeMove(move, gameState);
+
+                    continue;
+                }
+
                 int reduction = 0;
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth


### PR DESCRIPTION
```
Elo   | -30.10 +- 21.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.19 (-2.25, 2.89) [0.00, 5.00]
Games | N: 648 W: 170 L: 226 D: 252
Penta | [31, 84, 135, 58, 16]
https://openbench.lynx-chess.com/test/54/
```