### PR TITLE
Disable SEE capture ordering in regular search

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -109,7 +109,7 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || isNotQSearch || SEE.IsGoodCapture(Game.CurrentPosition, move))
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 


### PR DESCRIPTION
```
Elo   | -31.42 +- 17.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.65 (-2.25, 2.89) [0.00, 5.00]
Games | N: 898 W: 236 L: 317 D: 345
Penta | [51, 117, 166, 92, 23]
https://openbench.lynx-chess.com/test/53/
```