### PR TITLE
🐛 Enable `InvariantGlobalization` and fix crash in some Linux scenarios

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
     <LangVersion>preview</LangVersion>
     <Nullable>Enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
   </PropertyGroup>
 


### PR DESCRIPTION
Enable [InvariantGlobalization](https://github.com/dotnet/runtime/blob/main/docs/design/features/globalization-invariant-mode.md) due to https://aka.ms/dotnet-missing-libicu error found in an OB worker.

Closes #574 

[-5, 0]
```
Score of Lynx-bugfix-linux-crash-invalid-icu-package-2262-win-x64 vs Lynx 2261 - main: 1140 - 1046 - 1464  [0.513] 3650
...      Lynx-bugfix-linux-crash-invalid-icu-package-2262-win-x64 playing White: 762 - 330 - 733  [0.618] 1825
...      Lynx-bugfix-linux-crash-invalid-icu-package-2262-win-x64 playing Black: 378 - 716 - 731  [0.407] 1825
...      White vs Black: 1478 - 708 - 1464  [0.605] 3650
Elo difference: 8.9 +/- 8.7, LOS: 97.8 %, DrawRatio: 40.1 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```