### PR TITLE
Add static SEE threshold

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -45,6 +45,8 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
+    "SEE_Threshold": -15,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -5,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -162,6 +162,8 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
+    public int SEE_Threshold { get; set; } = -15;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-5, -14);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -109,7 +109,7 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move, threshold: Configuration.EngineSettings.SEE_Threshold))
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 


### PR DESCRIPTION
```
Elo   | -5.22 +- 7.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5720 W: 1708 L: 1794 D: 2218
Penta | [233, 708, 1054, 642, 223]
https://openbench.lynx-chess.com/test/52/
```