### PR TITLE
🐛 Make `ZobristTable.CastleHash` calculations static

### DIFF
--- a/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
+++ b/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
@@ -6,40 +6,100 @@
  *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  *
+ *  | Method               | Size  | Mean           | Error         | StdDev        | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------------- |------ |---------------:|--------------:|--------------:|------:|--------:|----------:|------------:|
+ *  | Naive                | 1     |      24.720 ns |     0.1152 ns |     0.1021 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1     |      29.323 ns |     0.1852 ns |     0.1732 ns |  1.19 |    0.01 |         - |          NA |
+ *  | Switch               | 1     |      10.945 ns |     0.0424 ns |     0.0396 ns |  0.44 |    0.00 |         - |          NA |
+ *  | Switch_Precalculated | 1     |       8.767 ns |     0.0461 ns |     0.0431 ns |  0.35 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |       |         |           |             |
+ *  | Naive                | 10    |     250.591 ns |     1.5384 ns |     1.4391 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10    |     267.163 ns |     0.4338 ns |     0.3846 ns |  1.07 |    0.01 |         - |          NA |
+ *  | Switch               | 10    |     111.927 ns |     0.3434 ns |     0.2868 ns |  0.45 |    0.00 |         - |          NA |
+ *  | Switch_Precalculated | 10    |      83.823 ns |     0.2308 ns |     0.2159 ns |  0.33 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |       |         |           |             |
+ *  | Naive                | 100   |   2,445.000 ns |     8.1811 ns |     6.8316 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 100   |   2,804.201 ns |     9.7132 ns |     9.0857 ns |  1.15 |    0.01 |         - |          NA |
+ *  | Switch               | 100   |   1,150.124 ns |     0.5981 ns |     0.5594 ns |  0.47 |    0.00 |         - |          NA |
+ *  | Switch_Precalculated | 100   |     844.910 ns |     2.1514 ns |     2.0124 ns |  0.35 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |       |         |           |             |
+ *  | Naive                | 1000  |  24,657.100 ns |   100.4669 ns |    93.9768 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1000  |  26,637.086 ns |    97.0745 ns |    90.8036 ns |  1.08 |    0.01 |         - |          NA |
+ *  | Switch               | 1000  |  11,114.282 ns |   217.0870 ns |   324.9255 ns |  0.45 |    0.02 |         - |          NA |
+ *  | Switch_Precalculated | 1000  |   8,388.205 ns |    38.5408 ns |    36.0511 ns |  0.34 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |       |         |           |             |
+ *  | Naive                | 10000 | 244,306.105 ns | 1,034.7181 ns |   917.2506 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10000 | 278,922.144 ns |   237.0023 ns |   210.0964 ns |  1.14 |    0.00 |         - |          NA |
+ *  | Switch               | 10000 | 111,157.571 ns | 2,066.9065 ns | 1,933.3856 ns |  0.45 |    0.01 |         - |          NA |
+ *  | Switch_Precalculated | 10000 |  83,847.896 ns |   423.4214 ns |   396.0686 ns |  0.34 |    0.00 |         - |          NA |
  *
-BenchmarkDotNet v0.13.11, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
-AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
-.NET SDK 8.0.100
-  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
-  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
-
-
-| Method               | position            | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
-|--------------------- |-------------------- |----------:|----------:|----------:|------:|----------:|------------:|
-| Naive                | Lynx.Model.Position | 3.6647 ns | 0.0090 ns | 0.0070 ns |  1.00 |         - |          NA |
-| Naive                | Lynx.Model.Position | 3.6659 ns | 0.0061 ns | 0.0047 ns |  1.00 |         - |          NA |
-| Naive                | Lynx.Model.Position | 3.6757 ns | 0.0245 ns | 0.0229 ns |  1.00 |         - |          NA |
-| Naive                | Lynx.Model.Position | 0.5081 ns | 0.0159 ns | 0.0148 ns |  0.14 |         - |          NA |
-| Naive                | Lynx.Model.Position | 3.6627 ns | 0.0065 ns | 0.0051 ns |  1.00 |         - |          NA |
-| Naive                | Lynx.Model.Position | 3.6720 ns | 0.0089 ns | 0.0074 ns |  1.00 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.2204 ns | 0.0277 ns | 0.0259 ns |  1.15 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.3162 ns | 0.0289 ns | 0.0241 ns |  1.18 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.2144 ns | 0.0260 ns | 0.0243 ns |  1.15 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.3022 ns | 0.0205 ns | 0.0171 ns |  1.17 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.3205 ns | 0.0279 ns | 0.0261 ns |  1.18 |         - |          NA |
-| Dictionary           | Lynx.Model.Position | 4.3908 ns | 0.0279 ns | 0.0261 ns |  1.20 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.6192 ns | 0.0015 ns | 0.0012 ns |  0.17 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.6174 ns | 0.0025 ns | 0.0021 ns |  0.17 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.6277 ns | 0.0132 ns | 0.0124 ns |  0.17 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.4964 ns | 0.0159 ns | 0.0141 ns |  0.14 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.6192 ns | 0.0025 ns | 0.0020 ns |  0.17 |         - |          NA |
-| Switch               | Lynx.Model.Position | 0.6189 ns | 0.0017 ns | 0.0014 ns |  0.17 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5519 ns | 0.0102 ns | 0.0096 ns |  0.15 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5597 ns | 0.0119 ns | 0.0112 ns |  0.15 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5493 ns | 0.0049 ns | 0.0043 ns |  0.15 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5647 ns | 0.0108 ns | 0.0101 ns |  0.15 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5602 ns | 0.0121 ns | 0.0107 ns |  0.15 |         - |          NA |
-| Switch_Precalculated | Lynx.Model.Position | 0.5573 ns | 0.0055 ns | 0.0049 ns |  0.15 |         - |          NA |
+ *
+ *  BenchmarkDotNet v0.13.11, Windows 10 (10.0.20348.2159) (Hyper-V)
+ *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *  | Method               | Size  | Mean           | Error         | StdDev        | Median         | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------------- |------ |---------------:|--------------:|--------------:|---------------:|------:|--------:|----------:|------------:|
+ *  | Naive                | 1     |      25.039 ns |     0.0581 ns |     0.0454 ns |      25.035 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1     |      29.354 ns |     0.0116 ns |     0.0090 ns |      29.354 ns |  1.17 |    0.00 |         - |          NA |
+ *  | Switch               | 1     |      10.844 ns |     0.2016 ns |     0.1683 ns |      10.911 ns |  0.43 |    0.01 |         - |          NA |
+ *  | Switch_Precalculated | 1     |       8.787 ns |     0.0374 ns |     0.0350 ns |       8.774 ns |  0.35 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |                |       |         |           |             |
+ *  | Naive                | 10    |     253.652 ns |     0.4784 ns |     0.4475 ns |     253.546 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10    |     284.040 ns |     0.4747 ns |     0.4440 ns |     283.972 ns |  1.12 |    0.00 |         - |          NA |
+ *  | Switch               | 10    |     108.695 ns |     2.2012 ns |     4.7382 ns |     111.581 ns |  0.43 |    0.02 |         - |          NA |
+ *  | Switch_Precalculated | 10    |      84.387 ns |     0.5648 ns |     0.5007 ns |      84.393 ns |  0.33 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |                |       |         |           |             |
+ *  | Naive                | 100   |   2,457.589 ns |     7.3332 ns |     6.5006 ns |   2,456.675 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 100   |   2,827.262 ns |     2.1649 ns |     1.8078 ns |   2,826.887 ns |  1.15 |    0.00 |         - |          NA |
+ *  | Switch               | 100   |   1,076.499 ns |    23.1672 ns |    68.3091 ns |   1,117.677 ns |  0.45 |    0.02 |         - |          NA |
+ *  | Switch_Precalculated | 100   |     850.107 ns |     2.2053 ns |     2.0628 ns |     850.173 ns |  0.35 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |                |       |         |           |             |
+ *  | Naive                | 1000  |  24,523.943 ns |    65.6137 ns |    61.3751 ns |  24,522.876 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1000  |  28,223.102 ns |    26.7723 ns |    23.7330 ns |  28,220.316 ns |  1.15 |    0.00 |         - |          NA |
+ *  | Switch               | 1000  |  11,115.422 ns |   219.5332 ns |   517.4655 ns |  11,445.611 ns |  0.46 |    0.02 |         - |          NA |
+ *  | Switch_Precalculated | 1000  |   8,435.975 ns |    54.8240 ns |    51.2824 ns |   8,430.962 ns |  0.34 |    0.00 |         - |          NA |
+ *  |                      |       |                |               |               |                |       |         |           |             |
+ *  | Naive                | 10000 | 246,858.210 ns |   624.2585 ns |   553.3889 ns | 246,893.701 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10000 | 282,037.061 ns |   189.9960 ns |   148.3364 ns | 282,066.748 ns |  1.14 |    0.00 |         - |          NA |
+ *  | Switch               | 10000 | 106,492.667 ns | 2,610.3488 ns | 7,696.6722 ns | 111,328.833 ns |  0.44 |    0.02 |         - |          NA |
+ *  | Switch_Precalculated | 10000 |  84,086.209 ns |   226.2048 ns |   211.5921 ns |  84,040.710 ns |  0.34 |    0.00 |         - |          NA |
+ *
+ *
+ *  BenchmarkDotNet v0.13.11, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
+ *  Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *  | Method               | Size  | Mean           | Error         | StdDev         | Median         | Ratio | RatioSD | Allocated | Alloc Ratio |
+ *  |--------------------- |------ |---------------:|--------------:|---------------:|---------------:|------:|--------:|----------:|------------:|
+ *  | Naive                | 1     |      38.184 ns |     0.6108 ns |      0.5415 ns |      38.303 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1     |      33.928 ns |     0.5382 ns |      0.4771 ns |      34.043 ns |  0.89 |    0.02 |         - |          NA |
+ *  | Switch               | 1     |      40.382 ns |     0.8582 ns |      0.8027 ns |      40.145 ns |  1.06 |    0.03 |         - |          NA |
+ *  | Switch_Precalculated | 1     |       9.232 ns |     0.2198 ns |      0.1836 ns |       9.153 ns |  0.24 |    0.01 |         - |          NA |
+ *  |                      |       |                |               |                |                |       |         |           |             |
+ *  | Naive                | 10    |     361.811 ns |    10.2376 ns |     30.0251 ns |     371.738 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10    |     340.772 ns |    13.2154 ns |     38.7586 ns |     347.311 ns |  0.95 |    0.15 |         - |          NA |
+ *  | Switch               | 10    |     378.646 ns |     7.4876 ns |     14.0635 ns |     379.538 ns |  1.11 |    0.13 |         - |          NA |
+ *  | Switch_Precalculated | 10    |      89.707 ns |     1.3888 ns |      1.8058 ns |      89.878 ns |  0.29 |    0.02 |         - |          NA |
+ *  |                      |       |                |               |                |                |       |         |           |             |
+ *  | Naive                | 100   |   3,507.128 ns |   122.1937 ns |    360.2908 ns |   3,610.560 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 100   |   3,162.251 ns |    63.1922 ns |    148.9515 ns |   3,114.441 ns |  0.94 |    0.10 |         - |          NA |
+ *  | Switch               | 100   |   3,019.342 ns |   113.1666 ns |    315.4631 ns |   2,870.732 ns |  0.88 |    0.10 |         - |          NA |
+ *  | Switch_Precalculated | 100   |     713.917 ns |    14.0836 ns |     20.1983 ns |     710.728 ns |  0.19 |    0.01 |         - |          NA |
+ *  |                      |       |                |               |                |                |       |         |           |             |
+ *  | Naive                | 1000  |  29,303.931 ns |   582.5555 ns |    623.3279 ns |  29,296.593 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 1000  |  25,915.442 ns |   594.2885 ns |  1,752.2730 ns |  25,621.321 ns |  0.86 |    0.06 |         - |          NA |
+ *  | Switch               | 1000  |  29,887.694 ns |   595.4858 ns |  1,493.9574 ns |  29,332.834 ns |  1.05 |    0.04 |         - |          NA |
+ *  | Switch_Precalculated | 1000  |   7,245.023 ns |   144.2683 ns |    187.5895 ns |   7,212.165 ns |  0.25 |    0.01 |         - |          NA |
+ *  |                      |       |                |               |                |                |       |         |           |             |
+ *  | Naive                | 10000 | 287,375.284 ns | 5,580.5670 ns |  4,947.0273 ns | 287,207.969 ns |  1.00 |    0.00 |         - |          NA |
+ *  | Dictionary           | 10000 | 244,038.977 ns | 4,804.6802 ns |  8,663.8294 ns | 242,586.133 ns |  0.85 |    0.04 |         - |          NA |
+ *  | Switch               | 10000 | 312,948.536 ns | 6,227.9810 ns | 11,999.2050 ns | 313,618.784 ns |  1.10 |    0.05 |         - |          NA |
+ *  | Switch_Precalculated | 10000 |  83,442.668 ns | 1,658.0538 ns |  3,639.4683 ns |  82,906.254 ns |  0.29 |    0.02 |         - |          NA |
  *
  */
 

--- a/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
+++ b/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
@@ -114,6 +114,10 @@ public class ZobristHash_Castle_Benchmark : BaseBenchmark
     [ArgumentsSource(nameof(Data))]
     public long Switch(Position position) => SwitchMethod(position.Castle);
 
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public long Switch_Precalculated(Position position) => ZobristTable.EnPassantHash(position.Castle);
+
     private static readonly long[,] _table = Initialize();
 
     private static readonly long WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];

--- a/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
+++ b/src/Lynx.Benchmark/ZobristHash_Castle_Benchmark.cs
@@ -7,82 +7,39 @@
  *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  *
  *
- *  | Method     | position            | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
- *  |----------- |-------------------- |----------:|----------:|----------:|------:|----------:|------------:|
- *  | Naive      | Lynx.Model.Position | 3.6573 ns | 0.0236 ns | 0.0221 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6536 ns | 0.0270 ns | 0.0253 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6658 ns | 0.0390 ns | 0.0345 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 0.5306 ns | 0.0131 ns | 0.0116 ns |  0.15 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6498 ns | 0.0266 ns | 0.0236 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6450 ns | 0.0182 ns | 0.0152 ns |  1.00 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2155 ns | 0.0417 ns | 0.0348 ns |  1.15 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2197 ns | 0.0365 ns | 0.0342 ns |  1.15 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2167 ns | 0.0281 ns | 0.0263 ns |  1.15 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2664 ns | 0.0254 ns | 0.0238 ns |  1.17 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2085 ns | 0.0254 ns | 0.0237 ns |  1.15 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 4.2174 ns | 0.0287 ns | 0.0254 ns |  1.15 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.6271 ns | 0.0158 ns | 0.0147 ns |  0.17 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.6266 ns | 0.0135 ns | 0.0127 ns |  0.17 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.6262 ns | 0.0151 ns | 0.0141 ns |  0.17 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.4921 ns | 0.0133 ns | 0.0124 ns |  0.13 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.6203 ns | 0.0014 ns | 0.0013 ns |  0.17 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.6133 ns | 0.0126 ns | 0.0118 ns |  0.17 |         - |          NA |
- *
- *
- *  BenchmarkDotNet v0.13.11, Windows 10 (10.0.20348.2159) (Hyper-V)
- *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
- *  .NET SDK 8.0.100
- *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *
- *  | Method     | position            | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
- *  |----------- |-------------------- |----------:|----------:|----------:|------:|----------:|------------:|
- *  | Naive      | Lynx.Model.Position | 3.6573 ns | 0.0171 ns | 0.0133 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6489 ns | 0.0170 ns | 0.0150 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6426 ns | 0.0147 ns | 0.0138 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 0.5414 ns | 0.0018 ns | 0.0017 ns |  0.15 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6448 ns | 0.0237 ns | 0.0210 ns |  1.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 3.6530 ns | 0.0153 ns | 0.0127 ns |  1.00 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9936 ns | 0.0076 ns | 0.0068 ns |  1.09 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9949 ns | 0.0064 ns | 0.0053 ns |  1.09 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9996 ns | 0.0084 ns | 0.0079 ns |  1.09 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9819 ns | 0.0039 ns | 0.0036 ns |  1.09 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9955 ns | 0.0061 ns | 0.0051 ns |  1.09 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 3.9970 ns | 0.0041 ns | 0.0036 ns |  1.09 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3095 ns | 0.0015 ns | 0.0012 ns |  0.08 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3101 ns | 0.0021 ns | 0.0018 ns |  0.08 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3082 ns | 0.0010 ns | 0.0009 ns |  0.08 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3116 ns | 0.0027 ns | 0.0025 ns |  0.09 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3088 ns | 0.0016 ns | 0.0014 ns |  0.08 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.3107 ns | 0.0017 ns | 0.0015 ns |  0.08 |         - |          NA |
- *
- *
- *  BenchmarkDotNet v0.13.11, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
- *  Intel Xeon CPU E5-1650 v2 3.50GHz (Max: 3.34GHz), 1 CPU, 3 logical and 3 physical cores
- *  .NET SDK 8.0.100
- *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX
- *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX
- *
- *  | Method     | position            | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Allocated | Alloc Ratio |
- *  |----------- |-------------------- |----------:|----------:|----------:|----------:|------:|--------:|----------:|------------:|
- *  | Naive      | Lynx.Model.Position | 5.4659 ns | 0.1821 ns | 0.4924 ns | 5.2647 ns |  1.00 |    0.00 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 5.1548 ns | 0.1188 ns | 0.1271 ns | 5.1218 ns |  0.94 |    0.10 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 5.0598 ns | 0.0379 ns | 0.0354 ns | 5.0433 ns |  0.92 |    0.09 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 0.6435 ns | 0.0152 ns | 0.0127 ns | 0.6474 ns |  0.12 |    0.01 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 5.0734 ns | 0.0417 ns | 0.0370 ns | 5.0662 ns |  0.93 |    0.09 |         - |          NA |
- *  | Naive      | Lynx.Model.Position | 5.0377 ns | 0.0530 ns | 0.0414 ns | 5.0147 ns |  0.92 |    0.10 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 5.5652 ns | 0.0642 ns | 0.0569 ns | 5.5691 ns |  1.02 |    0.10 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 5.5223 ns | 0.1023 ns | 0.0957 ns | 5.5145 ns |  1.01 |    0.10 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 6.5139 ns | 0.0813 ns | 0.0721 ns | 6.4870 ns |  1.20 |    0.12 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 6.7231 ns | 0.1553 ns | 0.1453 ns | 6.7304 ns |  1.23 |    0.10 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 5.7433 ns | 0.1528 ns | 0.1429 ns | 5.7473 ns |  1.05 |    0.11 |         - |          NA |
- *  | Dictionary | Lynx.Model.Position | 5.5860 ns | 0.0609 ns | 0.0508 ns | 5.5894 ns |  1.02 |    0.10 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 1.2280 ns | 0.0627 ns | 0.0587 ns | 1.2163 ns |  0.22 |    0.02 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 1.1605 ns | 0.0602 ns | 0.0564 ns | 1.1582 ns |  0.21 |    0.02 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 1.1891 ns | 0.0371 ns | 0.0347 ns | 1.1862 ns |  0.22 |    0.02 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 0.8324 ns | 0.0356 ns | 0.0333 ns | 0.8413 ns |  0.15 |    0.02 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 1.1439 ns | 0.0257 ns | 0.0228 ns | 1.1468 ns |  0.21 |    0.02 |         - |          NA |
- *  | Switch     | Lynx.Model.Position | 1.1235 ns | 0.0397 ns | 0.0332 ns | 1.1063 ns |  0.21 |    0.02 |         - |          NA |
+BenchmarkDotNet v0.13.11, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+.NET SDK 8.0.100
+  [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+  DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+
+
+| Method               | position            | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
+|--------------------- |-------------------- |----------:|----------:|----------:|------:|----------:|------------:|
+| Naive                | Lynx.Model.Position | 3.6647 ns | 0.0090 ns | 0.0070 ns |  1.00 |         - |          NA |
+| Naive                | Lynx.Model.Position | 3.6659 ns | 0.0061 ns | 0.0047 ns |  1.00 |         - |          NA |
+| Naive                | Lynx.Model.Position | 3.6757 ns | 0.0245 ns | 0.0229 ns |  1.00 |         - |          NA |
+| Naive                | Lynx.Model.Position | 0.5081 ns | 0.0159 ns | 0.0148 ns |  0.14 |         - |          NA |
+| Naive                | Lynx.Model.Position | 3.6627 ns | 0.0065 ns | 0.0051 ns |  1.00 |         - |          NA |
+| Naive                | Lynx.Model.Position | 3.6720 ns | 0.0089 ns | 0.0074 ns |  1.00 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.2204 ns | 0.0277 ns | 0.0259 ns |  1.15 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.3162 ns | 0.0289 ns | 0.0241 ns |  1.18 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.2144 ns | 0.0260 ns | 0.0243 ns |  1.15 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.3022 ns | 0.0205 ns | 0.0171 ns |  1.17 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.3205 ns | 0.0279 ns | 0.0261 ns |  1.18 |         - |          NA |
+| Dictionary           | Lynx.Model.Position | 4.3908 ns | 0.0279 ns | 0.0261 ns |  1.20 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.6192 ns | 0.0015 ns | 0.0012 ns |  0.17 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.6174 ns | 0.0025 ns | 0.0021 ns |  0.17 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.6277 ns | 0.0132 ns | 0.0124 ns |  0.17 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.4964 ns | 0.0159 ns | 0.0141 ns |  0.14 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.6192 ns | 0.0025 ns | 0.0020 ns |  0.17 |         - |          NA |
+| Switch               | Lynx.Model.Position | 0.6189 ns | 0.0017 ns | 0.0014 ns |  0.17 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5519 ns | 0.0102 ns | 0.0096 ns |  0.15 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5597 ns | 0.0119 ns | 0.0112 ns |  0.15 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5493 ns | 0.0049 ns | 0.0043 ns |  0.15 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5647 ns | 0.0108 ns | 0.0101 ns |  0.15 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5602 ns | 0.0121 ns | 0.0107 ns |  0.15 |         - |          NA |
+| Switch_Precalculated | Lynx.Model.Position | 0.5573 ns | 0.0055 ns | 0.0049 ns |  0.15 |         - |          NA |
  *
  */
 
@@ -93,30 +50,82 @@ using System.Runtime.CompilerServices;
 namespace Lynx.Benchmark;
 public class ZobristHash_Castle_Benchmark : BaseBenchmark
 {
-    public static IEnumerable<Position> Data => new[] {
+    [Params(1, 10, 100, 1_000, 10_000)]
+    public int Size { get; set; }
+
+    private static readonly Position[] _positions =
+    [
         new Position(Constants.InitialPositionFEN),
         new Position(Constants.TrickyTestPositionFEN),
         new Position(Constants.TrickyTestPositionReversedFEN),
         new Position(Constants.CmkTestPositionFEN),
         new Position(Constants.ComplexPositionFEN),
         new Position(Constants.KillerTestPositionFEN),
-    };
+    ];
 
     [Benchmark(Baseline = true)]
-    [ArgumentsSource(nameof(Data))]
-    public long Naive(Position position) => CalculateMethod(position.Castle);
+    public long Naive()
+    {
+        long count = 0;
+
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                count += CalculateMethod(position.Castle);
+            }
+        }
+
+        return count;
+    }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public long Dictionary(Position position) => DictionaryMethod(position.Castle);
+    public long Dictionary()
+    {
+        long count = 0;
+
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                count += DictionaryMethod(position.Castle);
+            }
+        }
+
+        return count;
+    }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public long Switch(Position position) => SwitchMethod(position.Castle);
+    public long Switch()
+    {
+        long count = 0;
+
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                count += SwitchMethod(position.Castle);
+            }
+        }
+
+        return count;
+    }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public long Switch_Precalculated(Position position) => ZobristTable.EnPassantHash(position.Castle);
+    public long Switch_Precalculated()
+    {
+        long count = 0;
+
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in _positions)
+            {
+                count += ZobristTable.EnPassantHash(position.Castle);
+            }
+        }
+
+        return count;
+    }
 
     private static readonly long[,] _table = Initialize();
 

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -16,6 +16,20 @@ public static class ZobristTable
     private static readonly long BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
     private static readonly long BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
 
+    private static readonly long WK_Hash_XOR_WQ_Hash = WK_Hash ^ WQ_Hash;
+    private static readonly long WK_Hash_XOR_BK_Hash = WK_Hash ^ BK_Hash;
+    private static readonly long WK_Hash_XOR_BQ_Hash = WK_Hash ^ BQ_Hash;
+    private static readonly long WQ_Hash_XOR_BK_Hash = WQ_Hash ^ BK_Hash;
+    private static readonly long WQ_Hash_XOR_BQ_Hash = WQ_Hash ^ BQ_Hash;
+    private static readonly long BK_Hash_XOR_BQ_Hash = BK_Hash ^ BQ_Hash;
+
+    private static readonly long WK_Hash_XOR_WQ_Hash_XOR_BK_Hash = WK_Hash ^ WQ_Hash ^ BK_Hash;
+    private static readonly long WK_Hash_XOR_WQ_Hash_XOR_BQ_Hash = WK_Hash ^ WQ_Hash ^ BQ_Hash;
+    private static readonly long WK_Hash_XOR_BK_Hash_XOR_BQ_Hash = WK_Hash ^ BK_Hash ^ BQ_Hash;
+    private static readonly long WQ_Hash_XOR_BK_Hash_XOR_BQ_Hash = WQ_Hash ^ BK_Hash ^ BQ_Hash;
+
+    private static readonly long WK_Hash_XOR_WQ_Hash_XOR_BK_Hash_XOR_BQ_Hash = WK_Hash ^ WQ_Hash ^ BK_Hash ^ BQ_Hash;
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
@@ -66,27 +80,27 @@ public static class ZobristTable
     {
         return castle switch
         {
-            0 => 0,                                // -    | -
+            0 => 0,                                                                                                             // -    | -
 
-            (byte)CastlingRights.WK => WK_Hash,    // K    | -
-            (byte)CastlingRights.WQ => WQ_Hash,    // Q    | -
-            (byte)CastlingRights.BK => BK_Hash,    // -    | k
-            (byte)CastlingRights.BQ => BQ_Hash,    // -    | q
+            (byte)CastlingRights.WK => WK_Hash,                                                                                 // K    | -
+            (byte)CastlingRights.WQ => WQ_Hash,                                                                                 // Q    | -
+            (byte)CastlingRights.BK => BK_Hash,                                                                                 // -    | k
+            (byte)CastlingRights.BQ => BQ_Hash,                                                                                 // -    | q
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ => WK_Hash ^ WQ_Hash,    // KQ   | -
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK => WK_Hash ^ BK_Hash,    // K    | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.BQ => WK_Hash ^ BQ_Hash,    // K    | q
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WQ_Hash ^ BK_Hash,    // Q    | k
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WQ_Hash ^ BQ_Hash,    // Q    | q
-            (byte)CastlingRights.BK | (byte)CastlingRights.BQ => BK_Hash ^ BQ_Hash,    // -    | kq
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ => WK_Hash_XOR_WQ_Hash,                                           // KQ   | -
+            (byte)CastlingRights.WK | (byte)CastlingRights.BK => WK_Hash_XOR_BK_Hash,                                           // K    | k
+            (byte)CastlingRights.WK | (byte)CastlingRights.BQ => WK_Hash_XOR_BQ_Hash,                                           // K    | q
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WQ_Hash_XOR_BK_Hash,                                           // Q    | k
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WQ_Hash_XOR_BQ_Hash,                                           // Q    | q
+            (byte)CastlingRights.BK | (byte)CastlingRights.BQ => BK_Hash_XOR_BQ_Hash,                                           // -    | kq
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WK_Hash ^ WQ_Hash ^ BK_Hash,    // KQ   | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WK_Hash ^ WQ_Hash ^ BQ_Hash,    // KQ   | q
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WK_Hash ^ BK_Hash ^ BQ_Hash,    // K    | kq
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WQ_Hash ^ BK_Hash ^ BQ_Hash,    // Q    | kq
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WK_Hash_XOR_WQ_Hash_XOR_BK_Hash,     // KQ   | k
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WK_Hash_XOR_WQ_Hash_XOR_BQ_Hash,     // KQ   | q
+            (byte)CastlingRights.WK | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WK_Hash_XOR_BK_Hash_XOR_BQ_Hash,     // K    | kq
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WQ_Hash_XOR_BK_Hash_XOR_BQ_Hash,     // Q    | kq
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ =>       // KQ   | kq
-                WK_Hash ^ WQ_Hash ^ BK_Hash ^ BQ_Hash,
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ =>            // KQ   | kq
+                WK_Hash_XOR_WQ_Hash_XOR_BK_Hash_XOR_BQ_Hash,
 
             _ => throw new($"Unexpected castle encoded number: {castle}")
         };


### PR DESCRIPTION
```
Score of Lynx-bugfix-static-castlehash-calculations-2329-win-x64 vs Lynx 2327 - main: 795 - 862 - 1243  [0.488] 2900
...      Lynx-bugfix-static-castlehash-calculations-2329-win-x64 playing White: 587 - 220 - 643  [0.627] 1450
...      Lynx-bugfix-static-castlehash-calculations-2329-win-x64 playing Black: 208 - 642 - 600  [0.350] 1450
...      White vs Black: 1229 - 428 - 1243  [0.638] 2900
Elo difference: -8.0 +/- 9.5, LOS: 5.0 %, DrawRatio: 42.9 %
SPRT: llr -1.16 (-40.2%), lbound -2.25, ubound 2.89
```