### PR TITLE
Castle hashing: avoid any static calculation

### DIFF
--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -11,11 +11,6 @@ public static class ZobristTable
 {
     private static readonly long[,] _table = Initialize();
 
-    private static readonly long WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];
-    private static readonly long WQ_Hash = _table[(int)BoardSquare.b8, (int)Piece.p];
-    private static readonly long BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
-    private static readonly long BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
@@ -64,6 +59,11 @@ public static class ZobristTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long CastleHash(byte castle)
     {
+        var WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];
+        var WQ_Hash = _table[(int)BoardSquare.b8, (int)Piece.p];
+        var BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
+        var BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
+
         return castle switch
         {
             0 => 0,                                // -    | -


### PR DESCRIPTION
Since https://github.com/lynx-chess/Lynx/pull/586 fails, who knows
```
Elo   | -4.49 +- 4.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12060 W: 3781 L: 3937 D: 4342
Penta | [521, 1381, 2354, 1281, 493]
https://openbench.lynx-chess.com/test/72/
```