### PR TITLE
[Experimental] Use inline arrays for move generation

### DIFF
--- a/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
+++ b/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
@@ -1,0 +1,52 @@
+﻿/*
+ *
+ *
+ */
+
+using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+
+namespace Lynx.Benchmark;
+public class InlineArrays_Benchmark : BaseBenchmark
+{
+    private readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+
+    public static IEnumerable<string> Data => new[] {
+        Constants.InitialPositionFEN,
+        Constants.TrickyTestPositionFEN,
+        Constants.TrickyTestPositionReversedFEN,
+        Constants.CmkTestPositionFEN,
+        Constants.ComplexPositionFEN,
+        Constants.KillerTestPositionFEN,
+        Constants.TTPositionFEN
+    };
+
+    [Benchmark(Baseline = true)]
+    [ArgumentsSource(nameof(Data))]
+    public int Span(string fen)
+    {
+        Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), moveSpan);
+
+        return allMoves.Length;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public int Array(string fen)
+    {
+        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), _arrayMovePool);
+
+        return allMoves.Length;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public int InlineArray(string fen)
+    {
+        var moveArray = new MoveArray();
+        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), ref moveArray);
+
+        return allMoves.Length;
+    }
+}

--- a/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
+++ b/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
@@ -1,90 +1,105 @@
 ﻿/*
  *
- *      BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
- *      AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
- *      .NET SDK 8.0.100
- *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *  BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  *
- *      | Method      | Size  | Mean            | Error        | StdDev       | Median          | Ratio | RatioSD | Gen0     | Allocated  | Alloc Ratio       |
- *      |------------ |------     | ----------------:|-------------:|-------------:|----------------:|------:|--------:|---------:|-----------:|-------------:|
- *      | Span        | 1     |        865.0 ns |      2.46 ns |      2.18 ns |        864.3 ns |  1.00 |    0.00 |        - |          - |           N A  |
- *      | Array       | 1     |      1,252.5 ns |      7.91 ns |      7.40 ns |      1,251.9 ns |  1.45 |    0.01 |   0.0134 |     1184 B |           N A  |
- *      | InlineArray | 1     |      1,097.7 ns |      1.58 ns |      1.40 ns |      1,097.9 ns |  1.27 |    0.00 |        - |          - |           N A  |
- *      |             |       |                 |              |              |                 |       |         |          |            |                   |
- *      | Span        | 10    |      8,760.9 ns |     34.07 ns |     28.45 ns |      8,748.4 ns |  1.00 |    0.00 |        - |          - |           N A  |
- *      | Array       | 10    |     11,986.2 ns |     59.23 ns |     55.40 ns |     11,998.5 ns |  1.37 |    0.01 |   0.1373 |    11840 B |           N A  |
- *      | InlineArray | 10    |     10,710.6 ns |      9.52 ns |      7.95 ns |     10,710.0 ns |  1.22 |    0.00 |        - |          - |           N A  |
- *      |             |       |                 |              |              |                 |       |         |          |            |                   |
- *      | Span        | 100   |     88,190.3 ns |    547.56 ns |    512.19 ns |     88,108.9 ns |  1.00 |    0.00 |        - |          - |           N A  |
- *      | Array       | 100   |    119,838.8 ns |    599.71 ns |    560.96 ns |    119,762.5 ns |  1.36 |    0.01 |   1.3428 |   118400 B |           N A  |
- *      | InlineArray | 100   |    107,655.0 ns |    428.70 ns |    380.03 ns |    107,767.0 ns |  1.22 |    0.01 |        - |          - |           N A  |
- *      |             |       |                 |              |              |                 |       |         |          |            |                   |
- *      | Span        | 1000  |    879,708.9 ns |  6,501.91 ns |  5,429.39 ns |    876,643.0 ns |  1.00 |    0.00 |        - |        1 B |         1   .00  |
- *      | Array       | 1000  |  1,230,240.4 ns |  6,643.96 ns |  5,889.69 ns |  1,227,653.0 ns |  1.40 |    0.01 |  13.6719 |  1184002 B | 1   ,184,002.00  |
- *      | InlineArray | 1000  |  1,099,007.6 ns | 21,964.93 ns | 48,213.56 ns |  1,139,939.6 ns |  1.22 |    0.05 |        - |        2 B |         2   .00  |
- *      |             |       |                 |              |              |                 |       |         |          |            |                   |
- *      | Span        | 10000 |  8,794,110.2 ns | 65,234.36 ns | 61,020.26 ns |  8,796,836.6 ns |  1.00 |    0.00 |        - |       17 B |         1   .00  |
- *      | Array       | 10000 | 12,268,578.7 ns | 53,126.63 ns | 41,477.78 ns | 12,282,356.0 ns |  1.40 |    0.01 | 140.6250 | 11840017 B |   6 96,471.59  |
- *      | InlineArray | 10000 | 10,863,634.7 ns | 57,803.32 ns | 54,069.27 ns | 10,865,568.9 ns |  1.24 |    0.01 |        - |       17 B |         1   .00  |
- *
- *
- *      BenchmarkDotNet v0.13.12, Windows 10 (10.0.20348.2159) (Hyper-V)
- *      AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
- *      .NET SDK 8.0.100
- *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *
- *      | Method      | Size  | Mean            | Error         | StdDev        | Ratio | Gen0     | Allocated  | Alloc Ratio  |
- *      |------------ |------ |----------------:|--------------:|--------------:|------:|---------:|-----------:|-------------:|
- *      | Span        | 1     |        885.8 ns |       6.96 ns |       5.43 ns |  1.00 |        - |          - |           NA |
- *      | Array       | 1     |      1,144.1 ns |       6.15 ns |       5.75 ns |  1.29 |   0.0706 |     1184 B |           NA |
- *      | InlineArray | 1     |      1,029.4 ns |       1.23 ns |       1.03 ns |  1.16 |        - |          - |           NA |
- *      |             |       |                 |               |               |       |          |            |              |
- *      | Span        | 10    |      8,517.7 ns |      12.26 ns |      10.86 ns |  1.00 |        - |          - |           NA |
- *      | Array       | 10    |     11,135.2 ns |      37.68 ns |      33.40 ns |  1.31 |   0.7019 |    11840 B |           NA |
- *      | InlineArray | 10    |     10,289.7 ns |      12.62 ns |      11.19 ns |  1.21 |        - |          - |           NA |
- *      |             |       |                 |               |               |       |          |            |              |
- *      | Span        | 100   |     87,016.3 ns |     167.74 ns |     140.07 ns |  1.00 |        - |          - |           NA |
- *      | Array       | 100   |    109,855.2 ns |     405.28 ns |     359.27 ns |  1.26 |   6.9580 |   118400 B |           NA |
- *      | InlineArray | 100   |    100,458.3 ns |     127.24 ns |     112.80 ns |  1.15 |        - |          - |           NA |
- *      |             |       |                 |               |               |       |          |            |              |
- *      | Span        | 1000  |    848,901.3 ns |   3,623.56 ns |   3,212.19 ns |  1.00 |        - |        1 B |         1.00 |
- *      | Array       | 1000  |  1,100,846.0 ns |   7,050.30 ns |   6,249.90 ns |  1.30 |  70.3125 |  1184001 B | 1,184,001.00 |
- *      | InlineArray | 1000  |  1,011,266.8 ns |   1,444.43 ns |   1,127.72 ns |  1.19 |        - |        1 B |         1.00 |
- *      |             |       |                 |               |               |       |          |            |              |
- *      | Span        | 10000 |  8,754,527.3 ns |  25,603.41 ns |  23,949.44 ns |  1.00 |        - |       12 B |         1.00 |
- *      | Array       | 10000 | 11,037,788.5 ns | 128,035.75 ns | 113,500.36 ns |  1.26 | 703.1250 | 11840006 B |   986,667.17 |
- *      | InlineArray | 10000 | 10,138,412.1 ns |  54,830.85 ns |  51,288.81 ns |  1.16 |        - |       12 B |         1.00 |
+ *  | Method             | Size  | Mean            | Error        | StdDev       | Ratio | Gen0     | Allocated  | Alloc Ratio  |
+ *  |------------------- |------ |----------------:|-------------:|-------------:|------:|---------:|-----------:|-------------:|
+ *  | Span               | 1     |        883.1 ns |      4.33 ns |      3.84 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 1     |      1,082.4 ns |      3.12 ns |      2.61 ns |  1.23 |   0.0134 |     1184 B |           NA |
+ *  | InlineArray        | 1     |        919.1 ns |      1.36 ns |      1.14 ns |  1.04 |        - |          - |           NA |
+ *  | InlineArray_Reused | 1     |        875.4 ns |      4.57 ns |      4.06 ns |  0.99 |        - |          - |           NA |
+ *  |                    |       |                 |              |              |       |          |            |              |
+ *  | Span               | 10    |      8,789.4 ns |     22.18 ns |     17.32 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 10    |     10,349.9 ns |     56.43 ns |     50.02 ns |  1.18 |   0.1373 |    11840 B |           NA |
+ *  | InlineArray        | 10    |      8,938.9 ns |     54.96 ns |     51.41 ns |  1.02 |        - |          - |           NA |
+ *  | InlineArray_Reused | 10    |      8,618.9 ns |     50.39 ns |     47.14 ns |  0.98 |        - |          - |           NA |
+ *  |                    |       |                 |              |              |       |          |            |              |
+ *  | Span               | 100   |     87,232.9 ns |    146.96 ns |    122.72 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 100   |    103,752.8 ns |    485.79 ns |    454.41 ns |  1.19 |   1.3428 |   118400 B |           NA |
+ *  | InlineArray        | 100   |     89,623.4 ns |    335.00 ns |    313.36 ns |  1.03 |        - |          - |           NA |
+ *  | InlineArray_Reused | 100   |     85,666.4 ns |    208.26 ns |    184.62 ns |  0.98 |        - |          - |           NA |
+ *  |                    |       |                 |              |              |       |          |            |              |
+ *  | Span               | 1000  |    872,890.6 ns |  6,438.10 ns |  6,022.20 ns |  1.00 |        - |        1 B |         1.00 |
+ *  | Array              | 1000  |  1,031,827.4 ns |  9,332.64 ns |  8,273.14 ns |  1.18 |  13.6719 |  1184002 B | 1,184,002.00 |
+ *  | InlineArray        | 1000  |    909,521.5 ns |  5,940.70 ns |  5,266.28 ns |  1.04 |        - |        1 B |         1.00 |
+ *  | InlineArray_Reused | 1000  |    846,181.2 ns |    744.44 ns |    659.93 ns |  0.97 |        - |        1 B |         1.00 |
+ *  |                    |       |                 |              |              |       |          |            |              |
+ *  | Span               | 10000 |  8,752,783.4 ns | 47,153.07 ns | 41,799.97 ns |  1.00 |        - |       17 B |         1.00 |
+ *  | Array              | 10000 | 10,461,701.1 ns | 34,890.65 ns | 29,135.27 ns |  1.19 | 140.6250 | 11840017 B |   696,471.59 |
+ *  | InlineArray        | 10000 |  8,942,111.9 ns | 41,962.68 ns | 35,040.74 ns |  1.02 |        - |       17 B |         1.00 |
+ *  | InlineArray_Reused | 10000 |  8,533,991.9 ns | 53,289.38 ns | 49,846.92 ns |  0.98 |        - |       17 B |         1.00 |
  *
  *
- *      BenchmarkDotNet v0.13.12, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
- *      Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
- *      .NET SDK 8.0.100
- *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *  BenchmarkDotNet v0.13.12, Windows 10 (10.0.20348.2159) (Hyper-V)
+ *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
  *
- *      | Method      | Size  | Mean          | Error       | StdDev        | Median        | Ratio | RatioSD | Gen0      | Allocated  | Alloc Ratio |
- *      |------------ |------ |--------------:|------------:|--------------:|--------------:|------:|--------:|----------:|-----------:|------------:|
- *      | Span        | 1     |      1.701 us |   0.0335 us |     0.0595 us |      1.721 us |  1.00 |    0.00 |         - |          - |          NA |
- *      | Array       | 1     |      1.899 us |   0.0376 us |     0.0502 us |      1.909 us |  1.11 |    0.04 |    0.1869 |     1184 B |          NA |
- *      | InlineArray | 1     |      2.004 us |   0.0392 us |     0.0550 us |      2.027 us |  1.17 |    0.05 |         - |          - |          NA |
- *      |             |       |               |             |               |               |       |         |           |            |             |
- *      | Span        | 10    |     17.044 us |   0.3350 us |     0.3585 us |     17.018 us |  1.00 |    0.00 |         - |          - |          NA |
- *      | Array       | 10    |     19.391 us |   0.2286 us |     0.2138 us |     19.385 us |  1.14 |    0.03 |    1.8616 |    11840 B |          NA |
- *      | InlineArray | 10    |     20.511 us |   0.3951 us |     0.4057 us |     20.403 us |  1.21 |    0.03 |         - |          - |          NA |
- *      |             |       |               |             |               |               |       |         |           |            |             |
- *      | Span        | 100   |    171.641 us |   2.4507 us |     2.2924 us |    171.424 us |  1.00 |    0.00 |         - |          - |          NA |
- *      | Array       | 100   |    186.504 us |   3.1989 us |     2.9922 us |    186.839 us |  1.09 |    0.02 |   18.7988 |   118400 B |          NA |
- *      | InlineArray | 100   |    203.386 us |   4.0060 us |     7.0161 us |    201.587 us |  1.22 |    0.03 |         - |          - |          NA |
- *      |             |       |               |             |               |               |       |         |           |            |             |
- *      | Span        | 1000  |  1,382.093 us |  28.3285 us |    78.9686 us |  1,358.361 us |  1.00 |    0.00 |         - |        2 B |        1.00 |
- *      | Array       | 1000  |  1,483.328 us |  29.3896 us |    71.5384 us |  1,465.778 us |  1.07 |    0.07 |  187.5000 |  1184002 B |  592,001.00 |
- *      | InlineArray | 1000  |  1,537.432 us |  24.4554 us |    20.4213 us |  1,533.203 us |  1.05 |    0.05 |         - |        2 B |        1.00 |
- *      |             |       |               |             |               |               |       |         |           |            |             |
- *      | Span        | 10000 | 13,118.931 us | 241.1647 us |   236.8560 us | 13,088.418 us |  1.00 |    0.00 |         - |       17 B |        1.00 |
- *      | Array       | 10000 | 14,841.933 us | 296.6092 us |   721.9879 us | 14,674.459 us |  1.12 |    0.06 | 1875.0000 | 11840017 B |  696,471.59 |
- *      | InlineArray | 10000 | 19,648.227 us | 757.0622 us | 2,122.8835 us | 19,642.494 us |  1.42 |    0.13 |         - |       34 B |        2.00 |
+ *  | Method             | Size  | Mean           | Error        | StdDev       | Ratio | Gen0     | Allocated  | Alloc Ratio  |
+ *  |------------------- |------ |---------------:|-------------:|-------------:|------:|---------:|-----------:|-------------:|
+ *  | Span               | 1     |       860.8 ns |      2.32 ns |      1.81 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 1     |       899.8 ns |      3.94 ns |      3.50 ns |  1.05 |   0.0706 |     1184 B |           NA |
+ *  | InlineArray        | 1     |       853.9 ns |      1.29 ns |      1.14 ns |  0.99 |        - |          - |           NA |
+ *  | InlineArray_Reused | 1     |       794.5 ns |      1.14 ns |      1.01 ns |  0.92 |        - |          - |           NA |
+ *  |                    |       |                |              |              |       |          |            |              |
+ *  | Span               | 10    |     8,818.1 ns |     15.26 ns |     13.53 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 10    |     9,062.9 ns |     33.85 ns |     28.27 ns |  1.03 |   0.7019 |    11840 B |           NA |
+ *  | InlineArray        | 10    |     8,182.4 ns |      8.03 ns |      7.12 ns |  0.93 |        - |          - |           NA |
+ *  | InlineArray_Reused | 10    |     8,052.2 ns |     24.72 ns |     23.12 ns |  0.91 |        - |          - |           NA |
+ *  |                    |       |                |              |              |       |          |            |              |
+ *  | Span               | 100   |    88,095.0 ns |    231.17 ns |    204.92 ns |  1.00 |        - |          - |           NA |
+ *  | Array              | 100   |    89,988.3 ns |    403.75 ns |    377.67 ns |  1.02 |   6.9580 |   118400 B |           NA |
+ *  | InlineArray        | 100   |    81,689.1 ns |    138.49 ns |    129.54 ns |  0.93 |        - |          - |           NA |
+ *  | InlineArray_Reused | 100   |    78,813.6 ns |    230.98 ns |    192.88 ns |  0.89 |        - |          - |           NA |
+ *  |                    |       |                |              |              |       |          |            |              |
+ *  | Span               | 1000  |   849,082.5 ns |  1,195.96 ns |  1,060.19 ns |  1.00 |        - |        1 B |         1.00 |
+ *  | Array              | 1000  |   907,569.7 ns |  4,929.51 ns |  4,611.07 ns |  1.07 |  70.3125 |  1184001 B | 1,184,001.00 |
+ *  | InlineArray        | 1000  |   811,824.9 ns |    811.69 ns |    677.80 ns |  0.96 |        - |        1 B |         1.00 |
+ *  | InlineArray_Reused | 1000  |   777,328.7 ns |    929.95 ns |    824.38 ns |  0.92 |        - |        1 B |         1.00 |
+ *  |                    |       |                |              |              |       |          |            |              |
+ *  | Span               | 10000 | 8,701,565.3 ns | 20,803.81 ns | 17,372.12 ns |  1.00 |        - |       12 B |         1.00 |
+ *  | Array              | 10000 | 9,091,302.7 ns | 42,180.68 ns | 37,392.07 ns |  1.04 | 703.1250 | 11840012 B |   986,667.67 |
+ *  | InlineArray        | 10000 | 8,145,242.6 ns | 22,198.85 ns | 19,678.70 ns |  0.94 |        - |       12 B |         1.00 |
+ *  | InlineArray_Reused | 10000 | 7,793,048.5 ns | 14,878.03 ns | 13,916.92 ns |  0.90 |        - |        6 B |         0.50 |
+ *
+ *
+ *  BenchmarkDotNet v0.13.12, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
+ *  Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
+ *  .NET SDK 8.0.100
+ *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *  | Method             | Size  | Mean          | Error       | StdDev      | Ratio | RatioSD | Gen0      | Allocated  | Alloc Ratio |
+ *  |------------------- |------ |--------------:|------------:|------------:|------:|--------:|----------:|-----------:|------------:|
+ *  | Span               | 1     |      2.011 us |   0.1176 us |   0.3317 us |  1.00 |    0.00 |         - |          - |          NA |
+ *  | Array              | 1     |      2.318 us |   0.1594 us |   0.4495 us |  1.18 |    0.28 |    0.1869 |     1184 B |          NA |
+ *  | InlineArray        | 1     |      2.070 us |   0.1032 us |   0.3010 us |  1.06 |    0.24 |         - |          - |          NA |
+ *  | InlineArray_Reused | 1     |      1.850 us |   0.0615 us |   0.1774 us |  0.95 |    0.19 |         - |          - |          NA |
+ *  |                    |       |               |             |             |       |         |           |            |             |
+ *  | Span               | 10    |     19.822 us |   0.4571 us |   1.3116 us |  1.00 |    0.00 |         - |          - |          NA |
+ *  | Array              | 10    |     16.880 us |   0.7633 us |   2.2022 us |  0.85 |    0.13 |    1.8616 |    11840 B |          NA |
+ *  | InlineArray        | 10    |     14.244 us |   0.2703 us |   0.2396 us |  0.72 |    0.04 |         - |          - |          NA |
+ *  | InlineArray_Reused | 10    |     11.675 us |   0.2289 us |   0.3355 us |  0.59 |    0.04 |         - |          - |          NA |
+ *  |                    |       |               |             |             |       |         |           |            |             |
+ *  | Span               | 100   |    137.491 us |   1.2058 us |   1.3403 us |  1.00 |    0.00 |         - |          - |          NA |
+ *  | Array              | 100   |    151.970 us |   2.8787 us |   6.8972 us |  1.09 |    0.04 |   18.7988 |   118400 B |          NA |
+ *  | InlineArray        | 100   |    133.268 us |   1.5003 us |   1.2528 us |  0.97 |    0.02 |         - |          - |          NA |
+ *  | InlineArray_Reused | 100   |    117.669 us |   2.1540 us |   2.0148 us |  0.85 |    0.01 |         - |          - |          NA |
+ *  |                    |       |               |             |             |       |         |           |            |             |
+ *  | Span               | 1000  |  1,373.589 us |  25.5374 us |  22.6382 us |  1.00 |    0.00 |         - |        2 B |        1.00 |
+ *  | Array              | 1000  |  1,406.298 us |   6.4660 us |   6.0483 us |  1.02 |    0.02 |  187.5000 |  1184004 B |  592,002.00 |
+ *  | InlineArray        | 1000  |  1,301.676 us |  19.3396 us |  18.0903 us |  0.95 |    0.02 |         - |        2 B |        1.00 |
+ *  | InlineArray_Reused | 1000  |  1,183.944 us |   9.0701 us |   8.4842 us |  0.86 |    0.02 |         - |        2 B |        1.00 |
+ *  |                    |       |               |             |             |       |         |           |            |             |
+ *  | Span               | 10000 | 13,362.301 us |  95.9558 us |  80.1274 us |  1.00 |    0.00 |         - |       17 B |        1.00 |
+ *  | Array              | 10000 | 14,564.486 us | 273.5531 us | 325.6455 us |  1.09 |    0.02 | 1875.0000 | 11840017 B |  696,471.59 |
+ *  | InlineArray        | 10000 | 13,082.905 us |  82.3161 us |  64.2670 us |  0.98 |    0.01 |         - |       17 B |        1.00 |
+ *  | InlineArray_Reused | 10000 | 11,576.168 us | 169.3217 us | 150.0993 us |  0.87 |    0.01 |         - |       17 B |        1.00 |
  *
  */
 
@@ -94,10 +109,10 @@ using Lynx.Model;
 namespace Lynx.Benchmark;
 public class InlineArrays_Benchmark : BaseBenchmark
 {
-    private static readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-
     [Params(1, 10, 100, 1_000, 10_000)]
     public int Size { get; set; }
+
+    private static readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
 
     private static readonly Position[] Positions =
     [
@@ -150,13 +165,6 @@ public class InlineArrays_Benchmark : BaseBenchmark
         }
 
         return result;
-
-        int Array(Position position)
-        {
-            var allMoves = MoveGenerator.GenerateAllMoves(position, _arrayMovePool);
-
-            return allMoves.Length;
-        }
     }
 
     [Benchmark]
@@ -176,14 +184,6 @@ public class InlineArrays_Benchmark : BaseBenchmark
         }
 
         return result;
-
-        static int InlineArray(Position position)
-        {
-            var moveArray = new MoveArray();
-            var allMoves = MoveGenerator.GenerateAllMoves(position, ref moveArray);
-
-            return allMoves.Length;
-        }
     }
 
     [Benchmark]

--- a/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
+++ b/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
@@ -11,42 +11,88 @@ public class InlineArrays_Benchmark : BaseBenchmark
 {
     private readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
 
-    public static IEnumerable<string> Data => new[] {
-        Constants.InitialPositionFEN,
-        Constants.TrickyTestPositionFEN,
-        Constants.TrickyTestPositionReversedFEN,
-        Constants.CmkTestPositionFEN,
-        Constants.ComplexPositionFEN,
-        Constants.KillerTestPositionFEN,
-        Constants.TTPositionFEN
-    };
+    [Params(1, 10, 100, 1_000, 10_000)]
+    public int Size { get; set; }
+
+    private static readonly Position[] Positions =
+    [
+        new Position(Constants.InitialPositionFEN),
+        new Position(Constants.TrickyTestPositionFEN),
+        new Position(Constants.TrickyTestPositionReversedFEN),
+        new Position(Constants.CmkTestPositionFEN),
+        new Position(Constants.ComplexPositionFEN),
+        new Position(Constants.KillerTestPositionFEN),
+        new Position(Constants.TTPositionFEN)
+    ];
 
     [Benchmark(Baseline = true)]
-    [ArgumentsSource(nameof(Data))]
-    public int Span(string fen)
+    public long Span()
     {
-        Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), moveSpan);
+        long result = 0;
 
-        return allMoves.Length;
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in Positions)
+            {
+                result += Span(position);
+            }
+        }
+
+        return result;
+
+        static int Span(Position position)
+        {
+            Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            var allMoves = MoveGenerator.GenerateAllMoves(position, moveSpan);
+
+            return allMoves.Length;
+        }
     }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public int Array(string fen)
+    public long Array()
     {
-        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), _arrayMovePool);
+        long result = 0;
 
-        return allMoves.Length;
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in Positions)
+            {
+                result += Array(position);
+            }
+        }
+
+        return result;
+
+        int Array(Position position)
+        {
+            var allMoves = MoveGenerator.GenerateAllMoves(position, _arrayMovePool);
+
+            return allMoves.Length;
+        }
     }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public int InlineArray(string fen)
+    public long InlineArray()
     {
-        var moveArray = new MoveArray();
-        var allMoves = MoveGenerator.GenerateAllMoves(new Position(fen), ref moveArray);
+        long result = 0;
 
-        return allMoves.Length;
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in Positions)
+            {
+                result += InlineArray(position);
+            }
+        }
+
+        return result;
+
+        static int InlineArray(Position position)
+        {
+            var moveArray = new MoveArray();
+            var allMoves = MoveGenerator.GenerateAllMoves(position, ref moveArray);
+
+            return allMoves.Length;
+        }
     }
 }

--- a/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
+++ b/src/Lynx.Benchmark/InlineArrays_Benchmark.cs
@@ -1,5 +1,90 @@
 ﻿/*
  *
+ *      BenchmarkDotNet v0.13.12, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ *      AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *      .NET SDK 8.0.100
+ *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *      | Method      | Size  | Mean            | Error        | StdDev       | Median          | Ratio | RatioSD | Gen0     | Allocated  | Alloc Ratio       |
+ *      |------------ |------     | ----------------:|-------------:|-------------:|----------------:|------:|--------:|---------:|-----------:|-------------:|
+ *      | Span        | 1     |        865.0 ns |      2.46 ns |      2.18 ns |        864.3 ns |  1.00 |    0.00 |        - |          - |           N A  |
+ *      | Array       | 1     |      1,252.5 ns |      7.91 ns |      7.40 ns |      1,251.9 ns |  1.45 |    0.01 |   0.0134 |     1184 B |           N A  |
+ *      | InlineArray | 1     |      1,097.7 ns |      1.58 ns |      1.40 ns |      1,097.9 ns |  1.27 |    0.00 |        - |          - |           N A  |
+ *      |             |       |                 |              |              |                 |       |         |          |            |                   |
+ *      | Span        | 10    |      8,760.9 ns |     34.07 ns |     28.45 ns |      8,748.4 ns |  1.00 |    0.00 |        - |          - |           N A  |
+ *      | Array       | 10    |     11,986.2 ns |     59.23 ns |     55.40 ns |     11,998.5 ns |  1.37 |    0.01 |   0.1373 |    11840 B |           N A  |
+ *      | InlineArray | 10    |     10,710.6 ns |      9.52 ns |      7.95 ns |     10,710.0 ns |  1.22 |    0.00 |        - |          - |           N A  |
+ *      |             |       |                 |              |              |                 |       |         |          |            |                   |
+ *      | Span        | 100   |     88,190.3 ns |    547.56 ns |    512.19 ns |     88,108.9 ns |  1.00 |    0.00 |        - |          - |           N A  |
+ *      | Array       | 100   |    119,838.8 ns |    599.71 ns |    560.96 ns |    119,762.5 ns |  1.36 |    0.01 |   1.3428 |   118400 B |           N A  |
+ *      | InlineArray | 100   |    107,655.0 ns |    428.70 ns |    380.03 ns |    107,767.0 ns |  1.22 |    0.01 |        - |          - |           N A  |
+ *      |             |       |                 |              |              |                 |       |         |          |            |                   |
+ *      | Span        | 1000  |    879,708.9 ns |  6,501.91 ns |  5,429.39 ns |    876,643.0 ns |  1.00 |    0.00 |        - |        1 B |         1   .00  |
+ *      | Array       | 1000  |  1,230,240.4 ns |  6,643.96 ns |  5,889.69 ns |  1,227,653.0 ns |  1.40 |    0.01 |  13.6719 |  1184002 B | 1   ,184,002.00  |
+ *      | InlineArray | 1000  |  1,099,007.6 ns | 21,964.93 ns | 48,213.56 ns |  1,139,939.6 ns |  1.22 |    0.05 |        - |        2 B |         2   .00  |
+ *      |             |       |                 |              |              |                 |       |         |          |            |                   |
+ *      | Span        | 10000 |  8,794,110.2 ns | 65,234.36 ns | 61,020.26 ns |  8,796,836.6 ns |  1.00 |    0.00 |        - |       17 B |         1   .00  |
+ *      | Array       | 10000 | 12,268,578.7 ns | 53,126.63 ns | 41,477.78 ns | 12,282,356.0 ns |  1.40 |    0.01 | 140.6250 | 11840017 B |   6 96,471.59  |
+ *      | InlineArray | 10000 | 10,863,634.7 ns | 57,803.32 ns | 54,069.27 ns | 10,865,568.9 ns |  1.24 |    0.01 |        - |       17 B |         1   .00  |
+ *
+ *
+ *      BenchmarkDotNet v0.13.12, Windows 10 (10.0.20348.2159) (Hyper-V)
+ *      AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
+ *      .NET SDK 8.0.100
+ *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *      | Method      | Size  | Mean            | Error         | StdDev        | Ratio | Gen0     | Allocated  | Alloc Ratio  |
+ *      |------------ |------ |----------------:|--------------:|--------------:|------:|---------:|-----------:|-------------:|
+ *      | Span        | 1     |        885.8 ns |       6.96 ns |       5.43 ns |  1.00 |        - |          - |           NA |
+ *      | Array       | 1     |      1,144.1 ns |       6.15 ns |       5.75 ns |  1.29 |   0.0706 |     1184 B |           NA |
+ *      | InlineArray | 1     |      1,029.4 ns |       1.23 ns |       1.03 ns |  1.16 |        - |          - |           NA |
+ *      |             |       |                 |               |               |       |          |            |              |
+ *      | Span        | 10    |      8,517.7 ns |      12.26 ns |      10.86 ns |  1.00 |        - |          - |           NA |
+ *      | Array       | 10    |     11,135.2 ns |      37.68 ns |      33.40 ns |  1.31 |   0.7019 |    11840 B |           NA |
+ *      | InlineArray | 10    |     10,289.7 ns |      12.62 ns |      11.19 ns |  1.21 |        - |          - |           NA |
+ *      |             |       |                 |               |               |       |          |            |              |
+ *      | Span        | 100   |     87,016.3 ns |     167.74 ns |     140.07 ns |  1.00 |        - |          - |           NA |
+ *      | Array       | 100   |    109,855.2 ns |     405.28 ns |     359.27 ns |  1.26 |   6.9580 |   118400 B |           NA |
+ *      | InlineArray | 100   |    100,458.3 ns |     127.24 ns |     112.80 ns |  1.15 |        - |          - |           NA |
+ *      |             |       |                 |               |               |       |          |            |              |
+ *      | Span        | 1000  |    848,901.3 ns |   3,623.56 ns |   3,212.19 ns |  1.00 |        - |        1 B |         1.00 |
+ *      | Array       | 1000  |  1,100,846.0 ns |   7,050.30 ns |   6,249.90 ns |  1.30 |  70.3125 |  1184001 B | 1,184,001.00 |
+ *      | InlineArray | 1000  |  1,011,266.8 ns |   1,444.43 ns |   1,127.72 ns |  1.19 |        - |        1 B |         1.00 |
+ *      |             |       |                 |               |               |       |          |            |              |
+ *      | Span        | 10000 |  8,754,527.3 ns |  25,603.41 ns |  23,949.44 ns |  1.00 |        - |       12 B |         1.00 |
+ *      | Array       | 10000 | 11,037,788.5 ns | 128,035.75 ns | 113,500.36 ns |  1.26 | 703.1250 | 11840006 B |   986,667.17 |
+ *      | InlineArray | 10000 | 10,138,412.1 ns |  54,830.85 ns |  51,288.81 ns |  1.16 |        - |       12 B |         1.00 |
+ *
+ *
+ *      BenchmarkDotNet v0.13.12, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
+ *      Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
+ *      .NET SDK 8.0.100
+ *        [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *        DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *
+ *      | Method      | Size  | Mean          | Error       | StdDev        | Median        | Ratio | RatioSD | Gen0      | Allocated  | Alloc Ratio |
+ *      |------------ |------ |--------------:|------------:|--------------:|--------------:|------:|--------:|----------:|-----------:|------------:|
+ *      | Span        | 1     |      1.701 us |   0.0335 us |     0.0595 us |      1.721 us |  1.00 |    0.00 |         - |          - |          NA |
+ *      | Array       | 1     |      1.899 us |   0.0376 us |     0.0502 us |      1.909 us |  1.11 |    0.04 |    0.1869 |     1184 B |          NA |
+ *      | InlineArray | 1     |      2.004 us |   0.0392 us |     0.0550 us |      2.027 us |  1.17 |    0.05 |         - |          - |          NA |
+ *      |             |       |               |             |               |               |       |         |           |            |             |
+ *      | Span        | 10    |     17.044 us |   0.3350 us |     0.3585 us |     17.018 us |  1.00 |    0.00 |         - |          - |          NA |
+ *      | Array       | 10    |     19.391 us |   0.2286 us |     0.2138 us |     19.385 us |  1.14 |    0.03 |    1.8616 |    11840 B |          NA |
+ *      | InlineArray | 10    |     20.511 us |   0.3951 us |     0.4057 us |     20.403 us |  1.21 |    0.03 |         - |          - |          NA |
+ *      |             |       |               |             |               |               |       |         |           |            |             |
+ *      | Span        | 100   |    171.641 us |   2.4507 us |     2.2924 us |    171.424 us |  1.00 |    0.00 |         - |          - |          NA |
+ *      | Array       | 100   |    186.504 us |   3.1989 us |     2.9922 us |    186.839 us |  1.09 |    0.02 |   18.7988 |   118400 B |          NA |
+ *      | InlineArray | 100   |    203.386 us |   4.0060 us |     7.0161 us |    201.587 us |  1.22 |    0.03 |         - |          - |          NA |
+ *      |             |       |               |             |               |               |       |         |           |            |             |
+ *      | Span        | 1000  |  1,382.093 us |  28.3285 us |    78.9686 us |  1,358.361 us |  1.00 |    0.00 |         - |        2 B |        1.00 |
+ *      | Array       | 1000  |  1,483.328 us |  29.3896 us |    71.5384 us |  1,465.778 us |  1.07 |    0.07 |  187.5000 |  1184002 B |  592,001.00 |
+ *      | InlineArray | 1000  |  1,537.432 us |  24.4554 us |    20.4213 us |  1,533.203 us |  1.05 |    0.05 |         - |        2 B |        1.00 |
+ *      |             |       |               |             |               |               |       |         |           |            |             |
+ *      | Span        | 10000 | 13,118.931 us | 241.1647 us |   236.8560 us | 13,088.418 us |  1.00 |    0.00 |         - |       17 B |        1.00 |
+ *      | Array       | 10000 | 14,841.933 us | 296.6092 us |   721.9879 us | 14,674.459 us |  1.12 |    0.06 | 1875.0000 | 11840017 B |  696,471.59 |
+ *      | InlineArray | 10000 | 19,648.227 us | 757.0622 us | 2,122.8835 us | 19,642.494 us |  1.42 |    0.13 |         - |       34 B |        2.00 |
  *
  */
 
@@ -9,7 +94,7 @@ using Lynx.Model;
 namespace Lynx.Benchmark;
 public class InlineArrays_Benchmark : BaseBenchmark
 {
-    private readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+    private static readonly Move[] _arrayMovePool = new Move[Constants.MaxNumberOfPossibleMovesInAPosition];
 
     [Params(1, 10, 100, 1_000, 10_000)]
     public int Size { get; set; }
@@ -58,7 +143,9 @@ public class InlineArrays_Benchmark : BaseBenchmark
         {
             foreach (var position in Positions)
             {
-                result += Array(position);
+                var allMoves = MoveGenerator.GenerateAllMoves(position, _arrayMovePool);
+
+                result += allMoves.Length;
             }
         }
 
@@ -81,7 +168,10 @@ public class InlineArrays_Benchmark : BaseBenchmark
         {
             foreach (var position in Positions)
             {
-                result += InlineArray(position);
+                var moveArray = new MoveArray();
+                var allMoves = MoveGenerator.GenerateAllMoves(position, ref moveArray);
+
+                result += allMoves.Length;
             }
         }
 
@@ -94,5 +184,23 @@ public class InlineArrays_Benchmark : BaseBenchmark
 
             return allMoves.Length;
         }
+    }
+
+    [Benchmark]
+    public long InlineArray_Reused()
+    {
+        long result = 0;
+
+        var moveArray = new MoveArray();
+        for (int i = 0; i < Size; ++i)
+        {
+            foreach (var position in Positions)
+            {
+                var allMoves = MoveGenerator.GenerateAllMoves(position, ref moveArray);
+                result += allMoves.Length;
+            }
+        }
+
+        return result;
     }
 }

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -5,6 +5,22 @@ using System.Text;
 
 namespace Lynx.Model;
 
+#pragma warning disable S1144 // Unused private types or members should be removed
+#pragma warning disable RCS1169 // Make field read-only
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable RCS1213 // Remove unused member declaration
+[InlineArray(Constants.MaxNumberOfPossibleMovesInAPosition)]
+public struct MoveArray
+{
+    private Move _move;
+}
+#pragma warning restore RCS1213 // Remove unused member declaration
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning restore RCS1169 // Make field read-only
+#pragma warning restore S1144 // Unused private types or members should be removed
+
 /// <summary>
 ///     Binary move bits                  Hexadecimal
 /// 0000 0000 0000 0000 0000 0000 1111      0xF         Promoted piece (~11 bits)

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -129,7 +129,7 @@ public static class MoveGenerator
     /// <param name="movePool"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Span<Move> GenerateAllMoves(Position position, MoveArray movePool)
+    public static Span<Move> GenerateAllMoves(Position position, ref MoveArray movePool)
     {
 #if DEBUG
         if (position.Side == Side.Both)
@@ -142,13 +142,13 @@ public static class MoveGenerator
 
         var offset = Utils.PieceOffset(position.Side);
 
-        GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
-        GenerateCastlingMoves(ref localIndex, movePool, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        GenerateAllPawnMoves(ref localIndex, ref movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, ref movePool, position);
+        GenerateAllPieceMoves(ref localIndex, ref movePool, (int)Piece.K + offset, position);
+        GenerateAllPieceMoves(ref localIndex, ref movePool, (int)Piece.N + offset, position);
+        GenerateAllPieceMoves(ref localIndex, ref movePool, (int)Piece.B + offset, position);
+        GenerateAllPieceMoves(ref localIndex, ref movePool, (int)Piece.R + offset, position);
+        GenerateAllPieceMoves(ref localIndex, ref movePool, (int)Piece.Q + offset, position);
 
         return MemoryMarshal.CreateSpan(ref Unsafe.As<MoveArray, Move>(ref movePool), localIndex);
     }
@@ -222,7 +222,7 @@ public static class MoveGenerator
     /// <param name="movePool"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Span<Move> GenerateAllCaptures(Position position, MoveArray movePool)
+    public static Span<Move> GenerateAllCaptures(Position position, ref MoveArray movePool)
     {
 #if DEBUG
         if (position.Side == Side.Both)
@@ -235,13 +235,13 @@ public static class MoveGenerator
 
         var offset = Utils.PieceOffset(position.Side);
 
-        GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
-        GenerateCastlingMoves(ref localIndex, movePool, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        GeneratePawnCapturesAndPromotions(ref localIndex, ref movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, ref movePool, position);
+        GeneratePieceCaptures(ref localIndex, ref movePool, (int)Piece.K + offset, position);
+        GeneratePieceCaptures(ref localIndex, ref movePool, (int)Piece.N + offset, position);
+        GeneratePieceCaptures(ref localIndex, ref movePool, (int)Piece.B + offset, position);
+        GeneratePieceCaptures(ref localIndex, ref movePool, (int)Piece.R + offset, position);
+        GeneratePieceCaptures(ref localIndex, ref movePool, (int)Piece.Q + offset, position);
 
         return MemoryMarshal.CreateSpan(ref Unsafe.As<MoveArray, Move>(ref movePool), localIndex);
     }
@@ -332,7 +332,7 @@ public static class MoveGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateAllPawnMoves(ref int localIndex, MoveArray movePool, Position position, int offset)
+    internal static void GenerateAllPawnMoves(ref int localIndex, ref MoveArray movePool, Position position, int offset)
     {
         int sourceSquare, targetSquare;
 
@@ -488,9 +488,8 @@ public static class MoveGenerator
         }
     }
 
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePawnCapturesAndPromotions(ref int localIndex, MoveArray movePool, Position position, int offset)
+    internal static void GeneratePawnCapturesAndPromotions(ref int localIndex, ref MoveArray movePool, Position position, int offset)
     {
         int sourceSquare, targetSquare;
 
@@ -646,7 +645,7 @@ public static class MoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateCastlingMoves(ref int localIndex, MoveArray movePool, Position position)
+    internal static void GenerateCastlingMoves(ref int localIndex, ref MoveArray movePool, Position position)
     {
         if (position.Castle != default)
         {
@@ -761,7 +760,7 @@ public static class MoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateAllPieceMoves(ref int localIndex, MoveArray movePool, int piece, Position position)
+    internal static void GenerateAllPieceMoves(ref int localIndex, ref MoveArray movePool, int piece, Position position)
     {
         var bitboard = position.PieceBitBoards[piece];
         int sourceSquare, targetSquare;
@@ -833,7 +832,7 @@ public static class MoveGenerator
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePieceCaptures(ref int localIndex, MoveArray movePool, int piece, Position position)
+    internal static void GeneratePieceCaptures(ref int localIndex, ref MoveArray movePool, int piece, Position position)
     {
         var bitboard = position.PieceBitBoards[piece];
         int sourceSquare, targetSquare;

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -1,6 +1,10 @@
 ﻿using Lynx.Model;
+using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Xml.Linq;
 
 namespace Lynx;
 
@@ -119,6 +123,37 @@ public static class MoveGenerator
     }
 
     /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<Move> GenerateAllMoves(Position position, MoveArray movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return [];
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, movePool, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return MemoryMarshal.CreateSpan(ref Unsafe.As<MoveArray, Move>(ref movePool), localIndex);
+    }
+
+    /// <summary>
     /// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
     /// </summary>
     /// <param name="position"></param>
@@ -180,8 +215,124 @@ public static class MoveGenerator
         return movePool[..localIndex];
     }
 
+    /// <summary>
+    /// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="movePool"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<Move> GenerateAllCaptures(Position position, MoveArray movePool)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            return [];
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
+        GenerateCastlingMoves(ref localIndex, movePool, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return MemoryMarshal.CreateSpan(ref Unsafe.As<MoveArray, Move>(ref movePool), localIndex);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateAllPawnMoves(ref int localIndex, Span<Move> movePool, Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, doublePushSquare, piece, isDoublePawnPush: TRUE);
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateAllPawnMoves(ref int localIndex, MoveArray movePool, Position position, int offset)
     {
         int sourceSquare, targetSquare;
 
@@ -337,6 +488,79 @@ public static class MoveGenerator
         }
     }
 
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePawnCapturesAndPromotions(ref int localIndex, MoveArray movePool, Position position, int offset)
+    {
+        int sourceSquare, targetSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                var targetRank = (singlePushSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                }
+            }
+
+            var attacks = Attacks.PawnAttacks[(int)position.Side, sourceSquare];
+
+            // En passant
+            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+            {
+                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, (int)position.EnPassant, piece, isCapture: TRUE, isEnPassant: TRUE);
+            }
+
+            // Captures
+            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+            while (attackedSquares != default)
+            {
+                targetSquare = attackedSquares.GetLS1BIndex();
+                attackedSquares.ResetLS1B();
+
+                var targetRank = (targetSquare >> 3) + 1;
+                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, isCapture: TRUE);
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
     /// <summary>
     /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
     /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
@@ -346,6 +570,83 @@ public static class MoveGenerator
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateCastlingMoves(ref int localIndex, Span<Move> movePool, Position position)
+    {
+        if (position.Castle != default)
+        {
+            if (position.Side == Side.White)
+            {
+                bool ise1Attacked = Attacks.IsSquareAttackedBySide(Constants.WhiteKingSourceSquare, position, Side.Black);
+
+                if (((position.Castle & (int)CastlingRights.WK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f1, position, Side.Black)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g1, position, Side.Black))
+                {
+                    movePool[localIndex++] = WhiteShortCastle;
+
+                    Debug.Assert(movePool[localIndex - 1] == MoveExtensions.Encode(Constants.WhiteKingSourceSquare, Constants.WhiteShortCastleKingSquare, (int)Piece.K + Utils.PieceOffset(position.Side), isShortCastle: TRUE),
+                        "Wrong hardcoded white short castle move");
+                }
+
+                if (((position.Castle & (int)CastlingRights.WQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c1)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b1)
+                    && !ise1Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d1, position, Side.Black)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c1, position, Side.Black))
+                {
+                    movePool[localIndex++] = WhiteLongCastle;
+
+                    Debug.Assert(movePool[localIndex - 1] == MoveExtensions.Encode(Constants.WhiteKingSourceSquare, Constants.WhiteLongCastleKingSquare, (int)Piece.K + Utils.PieceOffset(position.Side), isLongCastle: TRUE),
+                        "Wrong hardcoded white long castle move");
+                }
+            }
+            else
+            {
+                bool ise8Attacked = Attacks.IsSquareAttackedBySide(Constants.BlackKingSourceSquare, position, Side.White);
+
+                if (((position.Castle & (int)CastlingRights.BK) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.f8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.g8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.f8, position, Side.White)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.g8, position, Side.White))
+                {
+                    movePool[localIndex++] = BlackShortCastle;
+
+                    Debug.Assert(movePool[localIndex - 1] == MoveExtensions.Encode(Constants.BlackKingSourceSquare, Constants.BlackShortCastleKingSquare, (int)Piece.K + Utils.PieceOffset(position.Side), isShortCastle: TRUE),
+                        "Wrong hardcoded black short castle move");
+                }
+
+                if (((position.Castle & (int)CastlingRights.BQ) != default)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.d8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.c8)
+                    && !position.OccupancyBitBoards[(int)Side.Both].GetBit(BoardSquare.b8)
+                    && !ise8Attacked
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.d8, position, Side.White)
+                    && !Attacks.IsSquareAttackedBySide((int)BoardSquare.c8, position, Side.White))
+                {
+                    movePool[localIndex++] = BlackLongCastle;
+
+                    Debug.Assert(movePool[localIndex - 1] == MoveExtensions.Encode(Constants.BlackKingSourceSquare, Constants.BlackLongCastleKingSquare, (int)Piece.K + Utils.PieceOffset(position.Side), isLongCastle: TRUE),
+                        "Wrong hardcoded black long castle move");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+    /// </summary>
+    /// <param name="movePool"></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateCastlingMoves(ref int localIndex, MoveArray movePool, Position position)
     {
         if (position.Castle != default)
         {
@@ -453,6 +754,44 @@ public static class MoveGenerator
     }
 
     /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen moves
+    /// </summary>
+    /// <param name="movePool"></param>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GenerateAllPieceMoves(ref int localIndex, MoveArray movePool, int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+                else
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece);
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Generate Knight, Bishop, Rook and Queen capture moves
     /// </summary>
     /// <param name="movePool"></param>
@@ -461,6 +800,40 @@ public static class MoveGenerator
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GeneratePieceCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & ~position.OccupancyBitBoards[(int)position.Side];
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
+                {
+                    movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, isCapture: TRUE);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Generate Knight, Bishop, Rook and Queen capture moves
+    /// </summary>
+    /// <param name="movePool"></param>
+    /// <param name="piece"><see cref="Piece"/></param>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void GeneratePieceCaptures(ref int localIndex, MoveArray movePool, int piece, Position position)
     {
         var bitboard = position.PieceBitBoards[piece];
         int sourceSquare, targetSquare;

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -40,7 +40,7 @@ public static class Perft
     {
         if (depth != 0)
         {
-            Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            var moves = new MoveArray();
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
                 var state = position.MakeMove(move);
@@ -62,7 +62,7 @@ public static class Perft
     {
         if (depth != 0)
         {
-            Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            var moves = new MoveArray();
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
                 var state = position.MakeMove(move);

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -63,7 +63,7 @@ public static class Perft
         if (depth != 0)
         {
             var moves = new MoveArray();
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
+            foreach (var move in MoveGenerator.GenerateAllMoves(position, ref moves))
             {
                 var state = position.MakeMove(move);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -195,7 +195,7 @@ public sealed partial class Engine
         Move firstLegalMove = default;
 
         var moves = new MoveArray();
-        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
+        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, ref moves))
         {
             var gameState = Game.CurrentPosition.MakeMove(move);
             bool isPositionValid = Game.CurrentPosition.IsValid();

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -194,7 +194,7 @@ public sealed partial class Engine
         bool onlyOneLegalMove = false;
         Move firstLegalMove = default;
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        var moves = new MoveArray();
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
         {
             var gameState = Game.CurrentPosition.MakeMove(move);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -157,7 +157,7 @@ public sealed partial class Engine
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        var moves = new MoveArray();
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);
 
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
@@ -431,7 +431,7 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        var moves = new MoveArray();
         var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, moves);
         if (pseudoLegalMoves.Length == 0)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -158,7 +158,7 @@ public sealed partial class Engine
         bool isAnyMoveValid = false;
 
         var moves = new MoveArray();
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref moves);
 
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         if (_isFollowingPV)
@@ -432,7 +432,7 @@ public sealed partial class Engine
         }
 
         var moves = new MoveArray();
-        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, moves);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, ref moves);
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using System.Transactions;
 
 namespace Lynx;
 


### PR DESCRIPTION
8+0.08
```
Score of Lynx-experimental-inline-arrays-2347-win-x64 vs Lynx 2341 - main: 1662 - 1809 - 1864  [0.486] 5335
...      Lynx-experimental-inline-arrays-2347-win-x64 playing White: 1174 - 551 - 942  [0.617] 2667
...      Lynx-experimental-inline-arrays-2347-win-x64 playing Black: 488 - 1258 - 922  [0.356] 2668
...      White vs Black: 2432 - 1039 - 1864  [0.631] 5335
Elo difference: -9.6 +/- 7.5, LOS: 0.6 %, DrawRatio: 34.9 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```