### PR TITLE
Reduce SEE calculations: captures with pawns and queen captures are considered good

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -116,9 +116,14 @@ public sealed partial class Engine
                 }
             }
 
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
-                ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
-                : EvaluationConstants.BadCaptureMoveBaseScoreValue;
+            var baseCaptureScore = (
+                isPromotion
+                || move.IsEnPassant()
+                || (sourcePiece - offset) == (int)Piece.P           // All captures with pawns are worth considering
+                || (targetPiece - offset) == (int)Piece.Q           // All queen captures are worth considering
+                || SEE.IsGoodCapture(Game.CurrentPosition, move))
+                    ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
+                    : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 
             return baseCaptureScore + EvaluationConstants.MostValueableVictimLeastValuableAttacker[sourcePiece, targetPiece];
         }


### PR DESCRIPTION
Assume all captures that take a queen or that take with a pawn are good captures

```
Score of Lynx-save-some-see-calculations-2342-win-x64 vs Lynx 2341 - main: 2199 - 2173 - 2638  [0.502] 7010
...      Lynx-save-some-see-calculations-2342-win-x64 playing White: 1516 - 672 - 1317  [0.620] 3505
...      Lynx-save-some-see-calculations-2342-win-x64 playing Black: 683 - 1501 - 1321  [0.383] 3505
...      White vs Black: 3017 - 1355 - 2638  [0.619] 7010
Elo difference: 1.3 +/- 6.4, LOS: 65.3 %, DrawRatio: 37.6 %
SPRT: llr -0.059 (-2.0%), lbound -2.25, ubound 2.89
```