### PR TITLE
Revert "⚡ Optimize castling and en-passant moves Zobrist hashing (#577)"

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,13 +1,13 @@
 ﻿namespace Lynx.Model;
 public readonly struct GameState
 {
-    public readonly long ZobristKey;
+    public readonly sbyte CapturedPiece;
 
     public readonly byte Castle;
 
-    public readonly sbyte CapturedPiece;
-
     public readonly BoardSquare EnPassant;
+
+    public readonly long ZobristKey;
 
     public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
     {

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -11,11 +11,6 @@ public static class ZobristTable
 {
     private static readonly long[,] _table = Initialize();
 
-    private static readonly long WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];
-    private static readonly long WQ_Hash = _table[(int)BoardSquare.b8, (int)Piece.p];
-    private static readonly long BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
-    private static readonly long BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
@@ -39,7 +34,7 @@ public static class ZobristTable
         }
 #endif
 
-        var file = enPassantSquare & 0x07;  // enPassantSquare % 8
+        var file = enPassantSquare % 8;
 
         return _table[file, (int)Piece.P];
     }
@@ -62,34 +57,31 @@ public static class ZobristTable
     /// <param name="castle"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long CastleHash(byte castle)
+    public static long CastleHash(int castle)
     {
-        return castle switch
+        long combinedHash = 0;
+
+        if ((castle & (int)CastlingRights.WK) != default)
         {
-            0 => 0,                                // -    | -
+            combinedHash ^= _table[(int)BoardSquare.a8, (int)Piece.p];        // a8
+        }
 
-            (byte)CastlingRights.WK => WK_Hash,    // K    | -
-            (byte)CastlingRights.WQ => WQ_Hash,    // Q    | -
-            (byte)CastlingRights.BK => BK_Hash,    // -    | k
-            (byte)CastlingRights.BQ => BQ_Hash,    // -    | q
+        if ((castle & (int)CastlingRights.WQ) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.b8, (int)Piece.p];        // b8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ => WK_Hash ^ WQ_Hash,    // KQ   | -
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK => WK_Hash ^ BK_Hash,    // K    | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.BQ => WK_Hash ^ BQ_Hash,    // K    | q
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WQ_Hash ^ BK_Hash,    // Q    | k
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WQ_Hash ^ BQ_Hash,    // Q    | q
-            (byte)CastlingRights.BK | (byte)CastlingRights.BQ => BK_Hash ^ BQ_Hash,    // -    | kq
+        if ((castle & (int)CastlingRights.BK) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.c8, (int)Piece.p];        // c8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WK_Hash ^ WQ_Hash ^ BK_Hash,    // KQ   | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WK_Hash ^ WQ_Hash ^ BQ_Hash,    // KQ   | q
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WK_Hash ^ BK_Hash ^ BQ_Hash,    // K    | kq
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WQ_Hash ^ BK_Hash ^ BQ_Hash,    // Q    | kq
+        if ((castle & (int)CastlingRights.BQ) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.d8, (int)Piece.p];        // d8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ =>       // KQ   | kq
-                WK_Hash ^ WQ_Hash ^ BK_Hash ^ BQ_Hash,
-
-            _ => throw new($"Unexpected castle encoded number: {castle}")
-        };
+        return combinedHash;
     }
 
     /// <summary>

--- a/tests/Lynx.Test/ZobristTableTest.cs
+++ b/tests/Lynx.Test/ZobristTableTest.cs
@@ -100,8 +100,6 @@ public class ZobristTableTest
 
         var castleHash = ZobristTable.CastleHash(position.Castle);
 
-        Assert.AreEqual(CalculateCastleHash(position.Castle), castleHash);
-
         Assert.AreEqual(positionWithoutCastlingRightsHash, positionHash ^ castleHash);
     }
 
@@ -120,33 +118,6 @@ public class ZobristTableTest
         var currentHash = ZobristTable.PositionHash(position);
 
         Assert.AreEqual(originalHash, currentHash);
-    }
-  
-    private long CalculateCastleHash(byte castle)
-    {
-        long combinedHash = 0;
-
-        if ((castle & (int)CastlingRights.WK) != default)
-        {
-            combinedHash ^= _zobristTable[(int)BoardSquare.a8, (int)Piece.p];        // a8
-        }
-
-        if ((castle & (int)CastlingRights.WQ) != default)
-        {
-            combinedHash ^= _zobristTable[(int)BoardSquare.b8, (int)Piece.p];        // b8
-        }
-
-        if ((castle & (int)CastlingRights.BK) != default)
-        {
-            combinedHash ^= _zobristTable[(int)BoardSquare.c8, (int)Piece.p];        // c8
-        }
-
-        if ((castle & (int)CastlingRights.BQ) != default)
-        {
-            combinedHash ^= _zobristTable[(int)BoardSquare.d8, (int)Piece.p];        // d8
-        }
-
-        return combinedHash;
     }
 
     private static long OriginalPositionHash(Position position)


### PR DESCRIPTION
This reverts commit adba5ffeb421ebbbedea520c2719dcab388cccff

![image](https://github.com/lynx-chess/Lynx/assets/11148519/7ce197ac-5aa2-4ceb-8d39-414cd482855e)
