### PR TITLE
Regression adba5ffeb421ebbbedea520c2719dcab388cccff

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,13 +1,13 @@
 ﻿namespace Lynx.Model;
 public readonly struct GameState
 {
-    public readonly sbyte CapturedPiece;
+    public readonly long ZobristKey;
 
     public readonly byte Castle;
 
-    public readonly BoardSquare EnPassant;
+    public readonly sbyte CapturedPiece;
 
-    public readonly long ZobristKey;
+    public readonly BoardSquare EnPassant;
 
     public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
     {

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,13 +1,13 @@
 ﻿namespace Lynx.Model;
 public readonly struct GameState
 {
-    public readonly long ZobristKey;
+    public readonly sbyte CapturedPiece;
 
     public readonly byte Castle;
 
-    public readonly sbyte CapturedPiece;
-
     public readonly BoardSquare EnPassant;
+
+    public readonly long ZobristKey;
 
     public GameState(sbyte capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
     {

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -11,11 +11,6 @@ public static class ZobristTable
 {
     private static readonly long[,] _table = Initialize();
 
-    private static readonly long WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];
-    private static readonly long WQ_Hash = _table[(int)BoardSquare.b8, (int)Piece.p];
-    private static readonly long BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
-    private static readonly long BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
@@ -64,32 +59,29 @@ public static class ZobristTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long CastleHash(byte castle)
     {
-        return castle switch
+        long combinedHash = 0;
+
+        if ((castle & (int)CastlingRights.WK) != default)
         {
-            0 => 0,                                // -    | -
+            combinedHash ^= _table[(int)BoardSquare.a8, (int)Piece.p];        // a8
+        }
 
-            (byte)CastlingRights.WK => WK_Hash,    // K    | -
-            (byte)CastlingRights.WQ => WQ_Hash,    // Q    | -
-            (byte)CastlingRights.BK => BK_Hash,    // -    | k
-            (byte)CastlingRights.BQ => BQ_Hash,    // -    | q
+        if ((castle & (int)CastlingRights.WQ) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.b8, (int)Piece.p];        // b8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ => WK_Hash ^ WQ_Hash,    // KQ   | -
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK => WK_Hash ^ BK_Hash,    // K    | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.BQ => WK_Hash ^ BQ_Hash,    // K    | q
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WQ_Hash ^ BK_Hash,    // Q    | k
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WQ_Hash ^ BQ_Hash,    // Q    | q
-            (byte)CastlingRights.BK | (byte)CastlingRights.BQ => BK_Hash ^ BQ_Hash,    // -    | kq
+        if ((castle & (int)CastlingRights.BK) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.c8, (int)Piece.p];        // c8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WK_Hash ^ WQ_Hash ^ BK_Hash,    // KQ   | k
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WK_Hash ^ WQ_Hash ^ BQ_Hash,    // KQ   | q
-            (byte)CastlingRights.WK | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WK_Hash ^ BK_Hash ^ BQ_Hash,    // K    | kq
-            (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WQ_Hash ^ BK_Hash ^ BQ_Hash,    // Q    | kq
+        if ((castle & (int)CastlingRights.BQ) != default)
+        {
+            combinedHash ^= _table[(int)BoardSquare.d8, (int)Piece.p];        // d8
+        }
 
-            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ =>       // KQ   | kq
-                WK_Hash ^ WQ_Hash ^ BK_Hash ^ BQ_Hash,
-
-            _ => throw new($"Unexpected castle encoded number: {castle}")
-        };
+        return combinedHash;
     }
 
     /// <summary>

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -39,7 +39,7 @@ public static class ZobristTable
         }
 #endif
 
-        var file = enPassantSquare & 0x07;  // enPassantSquare % 8
+        var file = enPassantSquare % 8;
 
         return _table[file, (int)Piece.P];
     }

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -11,6 +11,11 @@ public static class ZobristTable
 {
     private static readonly long[,] _table = Initialize();
 
+    private static readonly long WK_Hash = _table[(int)BoardSquare.a8, (int)Piece.p];
+    private static readonly long WQ_Hash = _table[(int)BoardSquare.b8, (int)Piece.p];
+    private static readonly long BK_Hash = _table[(int)BoardSquare.c8, (int)Piece.p];
+    private static readonly long BQ_Hash = _table[(int)BoardSquare.d8, (int)Piece.p];
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
@@ -59,29 +64,32 @@ public static class ZobristTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static long CastleHash(byte castle)
     {
-        long combinedHash = 0;
-
-        if ((castle & (int)CastlingRights.WK) != default)
+        return castle switch
         {
-            combinedHash ^= _table[(int)BoardSquare.a8, (int)Piece.p];        // a8
-        }
+            0 => 0,                                // -    | -
 
-        if ((castle & (int)CastlingRights.WQ) != default)
-        {
-            combinedHash ^= _table[(int)BoardSquare.b8, (int)Piece.p];        // b8
-        }
+            (byte)CastlingRights.WK => WK_Hash,    // K    | -
+            (byte)CastlingRights.WQ => WQ_Hash,    // Q    | -
+            (byte)CastlingRights.BK => BK_Hash,    // -    | k
+            (byte)CastlingRights.BQ => BQ_Hash,    // -    | q
 
-        if ((castle & (int)CastlingRights.BK) != default)
-        {
-            combinedHash ^= _table[(int)BoardSquare.c8, (int)Piece.p];        // c8
-        }
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ => WK_Hash ^ WQ_Hash,    // KQ   | -
+            (byte)CastlingRights.WK | (byte)CastlingRights.BK => WK_Hash ^ BK_Hash,    // K    | k
+            (byte)CastlingRights.WK | (byte)CastlingRights.BQ => WK_Hash ^ BQ_Hash,    // K    | q
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WQ_Hash ^ BK_Hash,    // Q    | k
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WQ_Hash ^ BQ_Hash,    // Q    | q
+            (byte)CastlingRights.BK | (byte)CastlingRights.BQ => BK_Hash ^ BQ_Hash,    // -    | kq
 
-        if ((castle & (int)CastlingRights.BQ) != default)
-        {
-            combinedHash ^= _table[(int)BoardSquare.d8, (int)Piece.p];        // d8
-        }
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK => WK_Hash ^ WQ_Hash ^ BK_Hash,    // KQ   | k
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BQ => WK_Hash ^ WQ_Hash ^ BQ_Hash,    // KQ   | q
+            (byte)CastlingRights.WK | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WK_Hash ^ BK_Hash ^ BQ_Hash,    // K    | kq
+            (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ => WQ_Hash ^ BK_Hash ^ BQ_Hash,    // Q    | kq
 
-        return combinedHash;
+            (byte)CastlingRights.WK | (byte)CastlingRights.WQ | (byte)CastlingRights.BK | (byte)CastlingRights.BQ =>       // KQ   | kq
+                WK_Hash ^ WQ_Hash ^ BK_Hash ^ BQ_Hash,
+
+            _ => throw new($"Unexpected castle encoded number: {castle}")
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
```
Score of Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2333-win-x64 vs Lynx 2327 - main: 10780 - 10792 - 13163  [0.500] 34735
...      Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2333-win-x64 playing White: 7390 - 3378 - 6599  [0.616] 17367
...      Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2333-win-x64 playing Black: 3390 - 7414 - 6564  [0.384] 17368
...      White vs Black: 14804 - 6768 - 13163  [0.616] 34735
Elo difference: -0.1 +/- 2.9, LOS: 46.7 %, DrawRatio: 37.9 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted

Score of Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2332-win-x64 vs Lynx 2327 - main: 11680 - 11690 - 13139  [0.500] 36509
...      Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2332-win-x64 playing White: 7917 - 3681 - 6657  [0.616] 18255
...      Lynx-regression-adba5ffeb421ebbbedea520c2719dcab388cccff-2332-win-x64 playing Black: 3763 - 8009 - 6482  [0.384] 18254
...      White vs Black: 15926 - 7444 - 13139  [0.616] 36509
Elo difference: -0.1 +/- 2.8, LOS: 47.4 %, DrawRatio: 36.0 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

2334 also failed