### PR TITLE
⚡ Use temporary variable that host the first array when reading/writing from/to jagged arrays (`[][]`)

### DIFF
--- a/src/Lynx/AttackGenerator.cs
+++ b/src/Lynx/AttackGenerator.cs
@@ -10,15 +10,16 @@ public static class AttackGenerator
     /// </summary>
     public static BitBoard[][] InitializePawnAttacks()
     {
-        BitBoard[][] pawnAttacks = [new BitBoard[64], new BitBoard[64]];
+        var blackPawns = new BitBoard[64];
+        var whitePawns = new BitBoard[64];
 
         for (int square = 0; square < 64; ++square)
         {
-            pawnAttacks[0][square] = MaskPawnAttacks(square, isWhite: false);
-            pawnAttacks[1][square] = MaskPawnAttacks(square, isWhite: true);
+            blackPawns[square] = MaskPawnAttacks(square, isWhite: false);
+            whitePawns[square] = MaskPawnAttacks(square, isWhite: true);
         }
 
-        return pawnAttacks;
+        return [blackPawns, whitePawns];
     }
 
     public static BitBoard[] InitializeKnightAttacks()
@@ -80,7 +81,7 @@ public static class AttackGenerator
 
         for (int square = 0; square < 64; ++square)
         {
-            attacks[square] = new BitBoard[512];
+            var squareAttacks = new BitBoard[512];
 
             occupancyMasks[square] = MaskBishopOccupancy(square);
 
@@ -94,8 +95,10 @@ public static class AttackGenerator
 
                 var magicIndex = (occupancy * Constants.BishopMagicNumbers[square]) >> (64 - relevantBitsCount);
 
-                attacks[square][magicIndex] = GenerateBishopAttacksOnTheFly(square, occupancy);
+                squareAttacks[magicIndex] = GenerateBishopAttacksOnTheFly(square, occupancy);
             }
+
+            attacks[square] = squareAttacks;
         }
 
         return (occupancyMasks, attacks);
@@ -112,7 +115,7 @@ public static class AttackGenerator
 
         for (int square = 0; square < 64; ++square)
         {
-            attacks[square] = new BitBoard[4096];
+            var squareAttacks = new BitBoard[4096];
 
             occupancyMasks[square] = MaskRookOccupancy(square);
 
@@ -126,8 +129,10 @@ public static class AttackGenerator
 
                 var magicIndex = (occupancy * Constants.RookMagicNumbers[square]) >> (64 - relevantBitsCount);
 
-                attacks[square][magicIndex] = GenerateRookAttacksOnTheFly(square, occupancy);
+                squareAttacks[magicIndex] = GenerateRookAttacksOnTheFly(square, occupancy);
             }
+
+            attacks[square] = squareAttacks;
         }
 
         return (occupancyMasks, attacks);

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -274,8 +274,6 @@ public static class Constants
     /// </summary>
     public const int MaxNumberOfPossibleMovesInAPosition = 250;
 
-    public static readonly int SideLimit = Enum.GetValues(typeof(Piece)).Length / 2;
-
     public static readonly int[] Rank =
     [
         7, 7, 7, 7, 7, 7, 7, 7,

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -259,12 +259,15 @@ public static readonly int[] EndGameKingTable =
     {
         for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
         {
+            var mgPositional = MiddleGamePositionalTables[piece];
+            var egPositional = EndGamePositionalTables[piece];
+
             MiddleGameTable[piece] = new int[64];
             EndGameTable[piece] = new int[64];
             for (int sq = 0; sq < 64; ++sq)
             {
-                MiddleGameTable[piece][sq] = MiddleGamePieceValues[piece] + MiddleGamePositionalTables[piece][sq];
-                EndGameTable[piece][sq] = EndGamePieceValues[piece] + EndGamePositionalTables[piece][sq];
+                MiddleGameTable[piece][sq] = MiddleGamePieceValues[piece] + mgPositional[sq];
+                EndGameTable[piece][sq] = EndGamePieceValues[piece] + egPositional[sq];
             }
         }
 

--- a/src/Lynx/LynxDriver.cs
+++ b/src/Lynx/LynxDriver.cs
@@ -34,6 +34,7 @@ public sealed class LynxDriver
         _ = EvaluationConstants.HistoryBonus[1];
         _ = MoveGenerator.Init();
         _ = GoCommand.Init();
+        _ = Constants.PiecesByChar['P'];
     }
 
     public async Task Run(CancellationToken cancellationToken)

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -799,6 +799,9 @@ public class Position
 
         for (int pieceIndex = (int)Piece.P; pieceIndex < (int)Piece.K; ++pieceIndex)
         {
+            var mg = EvaluationConstants.MiddleGameTable[pieceIndex];
+            var eg = EvaluationConstants.EndGameTable[pieceIndex];
+
             // Bitboard copy that we 'empty'
             var bitboard = PieceBitBoards[pieceIndex];
 
@@ -807,8 +810,8 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                middleGameScore += EvaluationConstants.MiddleGameTable[pieceIndex][pieceSquareIndex];
-                endGameScore += EvaluationConstants.EndGameTable[pieceIndex][pieceSquareIndex];
+                middleGameScore += mg[pieceSquareIndex];
+                endGameScore += eg[pieceSquareIndex];
                 gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
 
                 ++pieceCount[pieceIndex];
@@ -822,6 +825,9 @@ public class Position
 
         for (int pieceIndex = (int)Piece.p; pieceIndex < (int)Piece.k; ++pieceIndex)
         {
+            var mg = EvaluationConstants.MiddleGameTable[pieceIndex];
+            var eg = EvaluationConstants.EndGameTable[pieceIndex];
+
             // Bitboard copy that we 'empty'
             var bitboard = PieceBitBoards[pieceIndex];
 
@@ -830,8 +836,8 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                middleGameScore += EvaluationConstants.MiddleGameTable[pieceIndex][pieceSquareIndex];
-                endGameScore += EvaluationConstants.EndGameTable[pieceIndex][pieceSquareIndex];
+                middleGameScore += mg[pieceSquareIndex];
+                endGameScore += eg[pieceSquareIndex];
                 gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
 
                 ++pieceCount[pieceIndex];

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -332,15 +332,17 @@ public sealed partial class Engine
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 Killer moves
-                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
+                    var firstKillerMove = _killerMoves[0];
+                    if (move.PromotedPiece() == default && move != firstKillerMove[ply])
                     {
-                        if (move != _killerMoves[1][ply])
+                        var secondKillerMove = _killerMoves[1];
+                        if (move != secondKillerMove[ply])
                         {
-                            _killerMoves[2][ply] = _killerMoves[1][ply];
+                            _killerMoves[2][ply] = secondKillerMove[ply];
                         }
 
-                        _killerMoves[1][ply] = _killerMoves[0][ply];
-                        _killerMoves[0][ply] = move;
+                        secondKillerMove[ply] = firstKillerMove[ply];
+                        firstKillerMove[ply] = move;
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -332,17 +332,15 @@ public sealed partial class Engine
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 Killer moves
-                    var firstKillerMove = _killerMoves[0];
-                    if (move.PromotedPiece() == default && move != firstKillerMove[ply])
+                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
                     {
-                        var secondKillerMove = _killerMoves[1];
-                        if (move != secondKillerMove[ply])
+                        if (move != _killerMoves[1][ply])
                         {
-                            _killerMoves[2][ply] = secondKillerMove[ply];
+                            _killerMoves[2][ply] = _killerMoves[1][ply];
                         }
 
-                        secondKillerMove[ply] = firstKillerMove[ply];
-                        firstKillerMove[ply] = move;
+                        _killerMoves[1][ply] = _killerMoves[0][ply];
+                        _killerMoves[0][ply] = move;
                     }
                 }
 


### PR DESCRIPTION
[Make sure to initialize Constants](https://github.com/lynx-chess/Lynx/pull/609/commits/38d02fb553291d19b1a7c747cb0b44570d92d910)

```
Score of Lynx-jaggedarrays-temp-variable-2411-win-x64 vs Lynx 2410 - main: 5908 - 5987 - 7276  [0.498] 19171
...      Lynx-jaggedarrays-temp-variable-2411-win-x64 playing White: 4083 - 1891 - 3612  [0.614] 9586
...      Lynx-jaggedarrays-temp-variable-2411-win-x64 playing Black: 1825 - 4096 - 3664  [0.382] 9585
...      White vs Black: 8179 - 3716 - 7276  [0.616] 19171
Elo difference: -1.4 +/- 3.9, LOS: 23.4 %, DrawRatio: 38.0 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Avoid the changes for killers](https://github.com/lynx-chess/Lynx/pull/609/commits/e713e75e87da5b0552e5be8c5f14a610ee12b249):
```
Elo   | -12.25 +- 8.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.69 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3774 W: 1122 L: 1255 D: 1397
Penta | [169, 468, 709, 409, 132]
https://openbench.lynx-chess.com/test/92/
```

Only PSQT
```
Score of Lynx-jaggedarrays-temp-variable-psqt-2427-win-x64 vs Lynx 2423 - main: 4513 - 4609 - 5756  [0.497] 14878
...      Lynx-jaggedarrays-temp-variable-psqt-2427-win-x64 playing White: 3119 - 1476 - 2844  [0.610] 7439
...      Lynx-jaggedarrays-temp-variable-psqt-2427-win-x64 playing Black: 1394 - 3133 - 2912  [0.383] 7439
...      White vs Black: 6252 - 2870 - 5756  [0.614] 14878
Elo difference: -2.2 +/- 4.4, LOS: 15.7 %, DrawRatio: 38.7 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Only killers
https://github.com/lynx-chess/Lynx/pull/612