### PR TITLE
🔍 Add basic (quiet) history malus/penalty

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -325,25 +325,7 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough");
 
-                if (move.IsCapture())
-                {
-                    // 🔍 History penalty/malus
-                    // Penalize previous captures that didn't failed high
-                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
-                    {
-                        var visitedMove = visitedMoves[i];
-                        if (visitedMove.IsCapture())
-                        {
-                            var visitedMovePiece = visitedMove.Piece();
-                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
-
-                            _historyMoves[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
-                                _historyMoves[visitedMovePiece][visitedMoveTargetSquare],
-                                -EvaluationConstants.HistoryBonus[depth]);
-                        }
-                    }
-                }
-                else
+                if (!move.IsCapture())
                 {
                     // 🔍 Quiet history moves
                     // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
@@ -359,7 +341,7 @@ public sealed partial class Engine
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -182,6 +182,9 @@ public sealed partial class Engine
             }
         }
 
+        Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
+        int visitedMovesCounter = 0;
+
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
@@ -204,6 +207,8 @@ public sealed partial class Engine
                 position.UnmakeMove(move, gameState);
                 continue;
             }
+
+            visitedMoves[visitedMovesCounter++] = move;
 
             ++_nodes;
             isAnyMoveValid = true;
@@ -333,9 +338,9 @@ public sealed partial class Engine
 
                     // 🔍 History penalty/malus
                     // When a quiet move fails high, penalize previous visited ones
-                    for (int i = 0; i < moveIndex; ++i)
+                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
-                        var visitedMove = pseudoLegalMoves[i];
+                        var visitedMove = visitedMoves[i];
                         //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -322,7 +322,7 @@ public sealed partial class Engine
 
                 if (!move.IsCapture())
                 {
-                    // 🔍 History moves
+                    // 🔍 Quiet history moves
                     // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
                     var piece = move.Piece();
                     var targetSquare = move.TargetSquare();
@@ -341,6 +341,22 @@ public sealed partial class Engine
 
                         _killerMoves[1][ply] = _killerMoves[0][ply];
                         _killerMoves[0][ply] = move;
+                    }
+                }
+
+                // 🔍 History penalty/malus
+                // When a move fails high, penalize previous visited ones
+                for (int i = 0; i < moveIndex; ++i)
+                {
+                    var visitedMove = pseudoLegalMoves[moveIndex];
+                    // if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                    {
+                        var visitedMovePiece = visitedMove.Piece();
+                        var visitedMoveTargetSquare = visitedMove.TargetSquare();
+
+                        _historyMoves[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
+                            _historyMoves[visitedMovePiece][visitedMoveTargetSquare],
+                            -EvaluationConstants.HistoryBonus[depth]);
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -349,7 +349,7 @@ public sealed partial class Engine
                 for (int i = 0; i < moveIndex; ++i)
                 {
                     var visitedMove = pseudoLegalMoves[moveIndex];
-                    // if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                    if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                     {
                         var visitedMovePiece = visitedMove.Piece();
                         var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -341,7 +341,7 @@ public sealed partial class Engine
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -359,7 +359,7 @@ public sealed partial class Engine
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -335,7 +335,7 @@ public sealed partial class Engine
                     // When a quiet move fails high, penalize previous visited ones
                     for (int i = 0; i < moveIndex; ++i)
                     {
-                        var visitedMove = pseudoLegalMoves[moveIndex];
+                        var visitedMove = pseudoLegalMoves[i];
                         //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -336,7 +336,7 @@ public sealed partial class Engine
                     for (int i = 0; i < moveIndex; ++i)
                     {
                         var visitedMove = pseudoLegalMoves[moveIndex];
-                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -325,7 +325,25 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough");
 
-                if (!move.IsCapture())
+                if (move.IsCapture())
+                {
+                    // 🔍 History penalty/malus
+                    // Penalize previous captures that didn't failed high
+                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
+                    {
+                        var visitedMove = visitedMoves[i];
+                        if (visitedMove.IsCapture())
+                        {
+                            var visitedMovePiece = visitedMove.Piece();
+                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
+
+                            _historyMoves[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
+                                _historyMoves[visitedMovePiece][visitedMoveTargetSquare],
+                                -EvaluationConstants.HistoryBonus[depth]);
+                        }
+                    }
+                }
+                else
                 {
                     // 🔍 Quiet history moves
                     // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
@@ -341,7 +359,7 @@ public sealed partial class Engine
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -337,11 +337,11 @@ public sealed partial class Engine
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 History penalty/malus
-                    // When a quiet move fails high, penalize previous visited ones
+                    // When a quiet move fails high, penalize previous visited quiet moves
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        if (!visitedMove.IsCapture())
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -359,7 +359,7 @@ public sealed partial class Engine
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
-                        //if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
                         {
                             var visitedMovePiece = visitedMove.Piece();
                             var visitedMoveTargetSquare = visitedMove.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -331,6 +331,22 @@ public sealed partial class Engine
                         _historyMoves[piece][targetSquare],
                         EvaluationConstants.HistoryBonus[depth]);
 
+                    // 🔍 History penalty/malus
+                    // When a quiet move fails high, penalize previous visited ones
+                    for (int i = 0; i < moveIndex; ++i)
+                    {
+                        var visitedMove = pseudoLegalMoves[moveIndex];
+                        if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
+                        {
+                            var visitedMovePiece = visitedMove.Piece();
+                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
+
+                            _historyMoves[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
+                                _historyMoves[visitedMovePiece][visitedMoveTargetSquare],
+                                -EvaluationConstants.HistoryBonus[depth]);
+                        }
+                    }
+
                     // 🔍 Killer moves
                     if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
                     {
@@ -341,22 +357,6 @@ public sealed partial class Engine
 
                         _killerMoves[1][ply] = _killerMoves[0][ply];
                         _killerMoves[0][ply] = move;
-                    }
-                }
-
-                // 🔍 History penalty/malus
-                // When a move fails high, penalize previous visited ones
-                for (int i = 0; i < moveIndex; ++i)
-                {
-                    var visitedMove = pseudoLegalMoves[moveIndex];
-                    if (!visitedMove.IsCapture())                           // TODO: Penalize only quiets?
-                    {
-                        var visitedMovePiece = visitedMove.Piece();
-                        var visitedMoveTargetSquare = visitedMove.TargetSquare();
-
-                        _historyMoves[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
-                            _historyMoves[visitedMovePiece][visitedMoveTargetSquare],
-                            -EvaluationConstants.HistoryBonus[depth]);
                     }
                 }
 


### PR DESCRIPTION
Base: [Bugfix: move index](https://github.com/lynx-chess/Lynx/pull/610/commits/41a258d88544e215b0a9b49ba60b635f0319e8c5) vs main:

```
Score of Lynx-history-malus-2417-win-x64 vs Lynx 2410 - main: 970 - 749 - 1025  [0.540] 2744
...      Lynx-history-malus-2417-win-x64 playing White: 658 - 229 - 485  [0.656] 1372
...      Lynx-history-malus-2417-win-x64 playing Black: 312 - 520 - 540  [0.424] 1372
...      White vs Black: 1178 - 541 - 1025  [0.616] 2744
Elo difference: 28.0 +/- 10.3, LOS: 100.0 %, DrawRatio: 37.4 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

[Use span of visited moves to avoid incrementing history of illegal moves](https://github.com/lynx-chess/Lynx/pull/610/commits/03aabdbf69f49bdd32f4c778ba1ce58eb7265d11) vs previous one:

```
Elo   | 0.91 +- 3.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 18998 W: 6039 L: 5989 D: 6970
Penta | [786, 2167, 3546, 2211, 789]
https://openbench.lynx-chess.com/test/98/
```

[Penalize only quiet moves](https://github.com/lynx-chess/Lynx/pull/610/commits/5856b79b6b48ea0d860257dbe163370d716b7ba0) vs previous one:

```
Score of Lynx-history-malus-2419-win-x64 vs Lynx-history-malus-2418-win-x64: 4818 - 4584 - 5673  [0.508] 15075
...      Lynx-history-malus-2419-win-x64 playing White: 3301 - 1393 - 2844  [0.627] 7538
...      Lynx-history-malus-2419-win-x64 playing Black: 1517 - 3191 - 2829  [0.389] 7537
...      White vs Black: 6492 - 2910 - 5673  [0.619] 15075
Elo difference: 5.4 +/- 4.4, LOS: 99.2 %, DrawRatio: 37.6 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

[Penalize captures that didn't produce a cutoff](https://github.com/lynx-chess/Lynx/pull/610/commits/3135900c5a2e8d0dda42515a8f43ca49a5c605ba)

[WIP]
```
Elo   | 1.19 +- 2.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.07 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36046 W: 11377 L: 11254 D: 13415
Penta | [1458, 4161, 6717, 4174, 1513]
https://openbench.lynx-chess.com/test/97/
```

[Combine previous captures penalty when the move that fails hard is a capture and previous quiet moves penalty when the move that fails hard is a quiet move](https://github.com/lynx-chess/Lynx/pull/610/commits/1c0c0a907fcfdfb43bcebbfee44c3f81e76753af) 

[WIP], but not improving just quiet moves
```
Score of Lynx-history-malus-2421-win-x64 vs Lynx-history-malus-2418-win-x64: 8989 - 8817 - 10834  [0.503] 28640
...      Lynx-history-malus-2421-win-x64 playing White: 6200 - 2717 - 5404  [0.622] 14321
...      Lynx-history-malus-2421-win-x64 playing Black: 2789 - 6100 - 5430  [0.384] 14319
...      White vs Black: 12300 - 5506 - 10834  [0.619] 28640
Elo difference: 2.1 +/- 3.2, LOS: 90.1 %, DrawRatio: 37.8 %
SPRT: llr 0.671 (23.2%), lbound -2.25, ubound 2.89
```

