### PR TITLE
🔍 Take history into consideration for LMR

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -275,6 +275,9 @@ public sealed partial class Engine
                         --reduction;
                     }
 
+                    // -= history/(maxHistory/2)
+                    reduction -= 2 * _historyMoves[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
+
                     // Don't allow LMR to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want
                     reduction = Math.Clamp(reduction, 0, depth - 2);


### PR DESCRIPTION
Take history into consideration for LMR: reduce less if history value is high

```
Elo   | 11.40 +- 7.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5336 W: 1725 L: 1550 D: 2061
Penta | [165, 591, 1054, 620, 238]
https://openbench.lynx-chess.com/test/100/
```