### PR TITLE
Add basic knight outpost bonus only when the knight is centered

### DIFF
--- a/src/Lynx.Benchmark/IsDarkSquare_IsLightSquare_Benchmark.cs
+++ b/src/Lynx.Benchmark/IsDarkSquare_IsLightSquare_Benchmark.cs
@@ -1,0 +1,61 @@
+﻿using BenchmarkDotNet.Attributes;
+using Lynx.Model;
+using System.Runtime.CompilerServices;
+
+namespace Lynx.Benchmark;
+public class IsDarkSquare_IsLightSquare_Benchmark : BaseBenchmark
+{
+    [Benchmark(Baseline = true)]
+    public bool GetBit()
+    {
+        bool result = false;
+        for (int i = 0; i < 64; ++i)
+        {
+            result ^= IsLightSquare_GetBit(i);
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public bool Lookup()
+    {
+        bool result = false;
+        for (int i = 0; i < 64; ++i)
+        {
+            result ^= IsLightSquare_Lookup(i);
+        }
+
+        return result;
+    }
+
+    [Benchmark]
+    public bool AntiDiagonals()
+    {
+        bool result = false;
+        for (int i = 0; i < 64; ++i)
+        {
+            result ^= IsLightSquare_AntiDiagonals(i);
+        }
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsLightSquare_GetBit(int square)
+    {
+        return Masks.LightSquaresMask.GetBit(square);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsLightSquare_Lookup(int square)
+    {
+        return ((Masks.LightSquaresMask >> square) & 1) != 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsLightSquare_AntiDiagonals(int square)
+    {
+        return (((9 * square) + 8) & 8) != 0;
+    }
+}

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -92,6 +92,10 @@
       "MG": 30,
       "EG": 88
     },
+    "KnightOutpostBonus": {
+      "MG": 5,
+      "EG": 5
+    },
     "PassedPawnBonus": {
       "Rank0": {
         "MG": 0,

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -48,7 +48,8 @@ using System.Threading.Channels;
 //RookEvaluation();
 //TranspositionTable();
 //UnmakeMove();
-PieceSquareTables();
+//PieceSquareTables();
+SidePassedPawnMasks();
 
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
 const string TrickyPosition = Constants.TrickyTestPositionFEN;
@@ -1148,4 +1149,29 @@ static void PieceSquareTables()
         }
         Console.Write("\n    a\tb\tc\td\te\tf\tg\th\n\n\n");
     }
+}
+
+static void SidePassedPawnMasks()
+{
+    Masks.WhiteSidePassedPawnMasks[(int)BoardSquare.c4].Print();
+    Masks.BlackSidePassedPawnMasks[(int)BoardSquare.c5].Print();
+
+    PrintBitBoardArray(Masks.WhitePassedPawnMasks);
+    PrintBitBoardArray(Masks.WhiteSidePassedPawnMasks);
+    PrintBitBoardArray(Masks.BlackSidePassedPawnMasks);
+}
+
+static void PrintBitBoardArray(ulong[] bb)
+{
+    for (int i = 0; i < 64; ++i)
+    {
+        Console.Write($"{bb[i]}UL, ");
+
+        if ((i + 1) % 8 == 0)
+        {
+            Console.WriteLine();
+        }
+    }
+
+    Console.WriteLine();
 }

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1159,6 +1159,9 @@ static void SidePassedPawnMasks()
     PrintBitBoardArray(Masks.WhitePassedPawnMasks);
     PrintBitBoardArray(Masks.WhiteSidePassedPawnMasks);
     PrintBitBoardArray(Masks.BlackSidePassedPawnMasks);
+
+    Masks.WhiteKnightOutpostMask.Print();
+    Masks.BlackKnightOutpostMask.Print();
 }
 
 static void PrintBitBoardArray(ulong[] bb)

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1162,6 +1162,10 @@ static void SidePassedPawnMasks()
 
     Masks.WhiteKnightOutpostMask.Print();
     Masks.BlackKnightOutpostMask.Print();
+
+    Masks.LightSquaresMask.Print();
+    Masks.DarkSquaresMask.Print();
+    (Masks.DarkSquaresMask ^ Masks.LightSquaresMask).Print();
 }
 
 static void PrintBitBoardArray(ulong[] bb)

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -188,6 +188,8 @@ public sealed class EngineSettings
 
     public TaperedEvaluationTerm BishopPairBonus { get; set; } = new(30, 88);
 
+    public TaperedEvaluationTerm KnightOutpostBonus { get; set; } = new(5, 5);
+
     public TaperedEvaluationTermByRank PassedPawnBonus { get; set; } = new(
         new(0),
         new(-1, 5),

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -52,7 +52,7 @@ public static class Masks
     /// 7  0 1 1 1 0 0 0 0
     /// 6  0 1 1 1 0 0 0 0
     /// 5  0 1 1 1 0 0 0 0
-    /// 4  0 0 0 0 0 0 0 0
+    /// 4  0 0 x 0 0 0 0 0
     /// 3  0 0 0 0 0 0 0 0
     /// 2  0 0 0 0 0 0 0 0
     /// 1  0 0 0 0 0 0 0 0
@@ -65,7 +65,7 @@ public static class Masks
     /// 8  0 0 0 0 0 0 0 0
     /// 7  0 0 0 0 0 0 0 0
     /// 6  0 0 0 0 0 0 0 0
-    /// 5  0 0 0 0 0 0 0 0
+    /// 5  0 0 x 0 0 0 0 0
     /// 4  0 1 1 1 0 0 0 0
     /// 3  0 1 1 1 0 0 0 0
     /// 2  0 1 1 1 0 0 0 0
@@ -73,6 +73,34 @@ public static class Masks
     ///    a b c d e f g h
     /// </summary>
     public static BitBoard[] BlackPassedPawnMasks { get; } = new BitBoard[64];
+
+    /// <summary>
+    /// Passed 'side' pawn mask for square c4
+    /// 8  0 1 0 1 0 0 0 0
+    /// 7  0 1 0 1 0 0 0 0
+    /// 6  0 1 0 1 0 0 0 0
+    /// 5  0 1 0 1 0 0 0 0
+    /// 4  0 0 x 0 0 0 0 0
+    /// 3  0 0 0 0 0 0 0 0
+    /// 2  0 0 0 0 0 0 0 0
+    /// 1  0 0 0 0 0 0 0 0
+    ///    a b c d e f g h
+    /// </summary>
+    public static BitBoard[] WhiteSidePassedPawnMasks { get; } = new BitBoard[64];
+
+    /// <summary>
+    /// Passed 'side' pawn mask for square c5
+    /// 8  0 0 0 0 0 0 0 0
+    /// 7  0 0 0 0 0 0 0 0
+    /// 6  0 0 0 0 0 0 0 0
+    /// 5  0 0 x 0 0 0 0 0
+    /// 4  0 1 1 1 0 0 0 0
+    /// 3  0 1 1 1 0 0 0 0
+    /// 2  0 1 1 1 0 0 0 0
+    /// 1  0 1 1 1 0 0 0 0
+    ///    a b c d e f g h
+    /// </summary>
+    public static BitBoard[] BlackSidePassedPawnMasks { get; } = new BitBoard[64];
 
     /// <summary>
     /// [12][64]
@@ -115,12 +143,16 @@ public static class Masks
                 WhitePassedPawnMasks[squareIndex] |= SetFileRankMask(file, -1);
                 WhitePassedPawnMasks[squareIndex] |= SetFileRankMask(file + 1, -1);
 
+                WhiteSidePassedPawnMasks[squareIndex] |= SetFileRankMask(file - 1, -1);
+                WhiteSidePassedPawnMasks[squareIndex] |= SetFileRankMask(file + 1, -1);
+
                 // Reset bits behind the pawn
                 for (int i = 7; i >= rank; --i)
                 {
                     for (int j = 0; j < 8; ++j)
                     {
                         WhitePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
+                        WhiteSidePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
                     }
                 }
 
@@ -128,12 +160,16 @@ public static class Masks
                 BlackPassedPawnMasks[squareIndex] |= SetFileRankMask(file, -1);
                 BlackPassedPawnMasks[squareIndex] |= SetFileRankMask(file + 1, -1);
 
+                BlackSidePassedPawnMasks[squareIndex] |= SetFileRankMask(file - 1, -1);
+                BlackSidePassedPawnMasks[squareIndex] |= SetFileRankMask(file + 1, -1);
+
                 // Reset bits behind the pawn
                 for (int i = 0; i < rank + 1; ++i)
                 {
                     for (int j = 0; j < 8; ++j)
                     {
                         BlackPassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
+                        BlackSidePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
                     }
                 }
             }

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -75,6 +75,26 @@ public static class Masks
     public static BitBoard[] BlackPassedPawnMasks { get; } = new BitBoard[64];
 
     /// <summary>
+    /// [12][64]
+    /// </summary>
+    public static readonly BitBoard[][] PassedPawns =
+    [
+        WhitePassedPawnMasks,
+        [],
+        [],
+        [],
+        [],
+        [],
+        BlackPassedPawnMasks,
+        [],
+        [],
+        [],
+        [],
+        [],
+    ];
+
+
+    /// <summary>
     /// Passed 'side' pawn mask for square c4
     /// 8  0 1 0 1 0 0 0 0
     /// 7  0 1 0 1 0 0 0 0
@@ -131,23 +151,14 @@ public static class Masks
     public static BitBoard[] BlackSidePassedPawnMasks { get; } = new BitBoard[64];
 
     /// <summary>
-    /// [12][64]
+    /// __builtin_bswap64(<see cref="LightSquaresMask"/>)
     /// </summary>
-    public static readonly BitBoard[][] PassedPawns =
-    [
-        WhitePassedPawnMasks,
-        [],
-        [],
-        [],
-        [],
-        [],
-        BlackPassedPawnMasks,
-        [],
-        [],
-        [],
-        [],
-        [],
-    ];
+    public const BitBoard DarkSquaresMask = 0x55AA_55AA_55AA_55AA;
+
+    /// <summary>
+    /// https://www.chessprogramming.org/Color_of_a_Square
+    /// </summary>
+    public const BitBoard LightSquaresMask = 0xAA55_AA55_AA55_AA55;
 
     static Masks()
     {

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -89,6 +89,34 @@ public static class Masks
     public static BitBoard[] WhiteSidePassedPawnMasks { get; } = new BitBoard[64];
 
     /// <summary>
+    /// 8   0 1 1 1 1 1 1 0
+    /// 7   0 1 1 1 1 1 1 0
+    /// 6   0 1 1 1 1 1 1 0
+    /// 5   0 1 1 1 1 1 1 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    ///     Bitboard: 2122219134 (0x7E7E7E7E)
+    /// </summary>
+    public static BitBoard WhiteKnightOutpostMask { get; }
+
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 1 1 1 1 1 1 0
+    /// 3   0 1 1 1 1 1 1 0
+    /// 2   0 1 1 1 1 1 1 0
+    /// 1   0 1 1 1 1 1 1 0
+    ///     a b c d e f g h
+    ///     Bitboard: 9114861775475441664 (0x7E7E7E7E00000000)
+    /// </summary>
+    public static BitBoard BlackKnightOutpostMask { get; }
+
+    /// <summary>
     /// Passed 'side' pawn mask for square c5
     /// 8  0 0 0 0 0 0 0 0
     /// 7  0 0 0 0 0 0 0 0
@@ -124,6 +152,24 @@ public static class Masks
     static Masks()
     {
         InitializeMasks();
+
+        ulong whiteKnightOutpostMask = 0, blackKnightOutpostMask = 0;
+        for (int rank = 0; rank < 8; ++rank)
+        {
+            for (int file = 0; file < 8; ++file)
+            {
+                if (rank < 4 && file > 0 && file < 7)
+                {
+                    var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+
+                    whiteKnightOutpostMask.SetBit(squareIndex);
+                    blackKnightOutpostMask.SetBit(squareIndex ^ 56);
+                }
+            }
+        }
+
+        WhiteKnightOutpostMask = whiteKnightOutpostMask;
+        BlackKnightOutpostMask = blackKnightOutpostMask;
     }
 
     private static void InitializeMasks()

--- a/src/Lynx/Model/BoardSquare.cs
+++ b/src/Lynx/Model/BoardSquare.cs
@@ -25,3 +25,28 @@ public enum BoardSquare
     a1, b1, c1, d1, e1, f1, g1, h1,
     noSquare = -1
 }
+
+public static class BoardSquareExtensions
+{
+    /// <summary>
+    /// https://www.chessprogramming.org/Color_of_a_Square
+    /// </summary>
+    /// <param name="squareIndex1"></param>
+    /// <param name="squareIndex2"></param>
+    /// <returns></returns>
+    public static bool DifferentColor(int squareIndex1, int squareIndex2)
+    {
+        return ((9 * (squareIndex1 ^ squareIndex2)) & 8) != 0;
+    }
+
+    /// <summary>
+    /// https://www.chessprogramming.org/Color_of_a_Square
+    /// </summary>
+    /// <param name="squareIndex1"></param>
+    /// <param name="squareIndex2"></param>
+    /// <returns></returns>
+    public static bool SameColor(int squareIndex1, int squareIndex2)
+    {
+        return ((9 * (squareIndex1 ^ squareIndex2)) & 8) == 0;
+    }
+}

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -935,8 +935,10 @@ public class Position
         return pieceIndex switch
         {
             (int)Piece.P or (int)Piece.p => PawnAdditionalEvaluation(pieceSquareIndex, pieceIndex),
-            (int)Piece.R or (int)Piece.r => RookAdditonalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.R or (int)Piece.r => RookAdditionalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex, pieceCount),
+            (int)Piece.N => WhiteKnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.n => BlackKnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex),
             _ => (0, 0)
         };
@@ -981,13 +983,57 @@ public class Position
     }
 
     /// <summary>
+    /// Knight outposts
+    /// </summary>
+    /// <param name="squareIndex"></param>
+    /// <param name="pieceIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private (int MiddleGameScore, int EndGameScore) WhiteKnightAdditionalEvaluation(int squareIndex, int pieceIndex)
+    {
+        int middleGameBonus = 0, endGameBonus = 0;
+
+        if ((PieceBitBoards[(int)Piece.p] & Masks.WhiteSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
+        {
+            var ownPawnProtectersCount = (PieceBitBoards[(int)Piece.P] & Attacks.PawnAttacks[(int)Side.Black][squareIndex]).CountBits();
+
+            middleGameBonus = Configuration.EngineSettings.KnightOutpostBonus.MG * ownPawnProtectersCount;
+            endGameBonus = Configuration.EngineSettings.KnightOutpostBonus.EG * ownPawnProtectersCount;
+        }
+
+        return (middleGameBonus, endGameBonus);
+    }
+
+    /// <summary>
+    /// Knight outposts
+    /// </summary>
+    /// <param name="squareIndex"></param>
+    /// <param name="pieceIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private (int MiddleGameScore, int EndGameScore) BlackKnightAdditionalEvaluation(int squareIndex, int pieceIndex)
+    {
+        int middleGameBonus = 0, endGameBonus = 0;
+
+        if ((PieceBitBoards[(int)Piece.P] & Masks.BlackSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
+        {
+            var ownPawnProtectersCount = (PieceBitBoards[(int)Piece.p] & Attacks.PawnAttacks[(int)Side.White][squareIndex]).CountBits();
+
+            middleGameBonus = Configuration.EngineSettings.KnightOutpostBonus.MG * ownPawnProtectersCount;
+            endGameBonus = Configuration.EngineSettings.KnightOutpostBonus.EG * ownPawnProtectersCount;
+        }
+
+        return (middleGameBonus, endGameBonus);
+    }
+
+    /// <summary>
     /// Open and semiopen file bonus
     /// </summary>
     /// <param name="squareIndex"></param>
     /// <param name="pieceIndex"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private (int MiddleGameScore, int EndGameScore) RookAdditonalEvaluation(int squareIndex, int pieceIndex)
+    private (int MiddleGameScore, int EndGameScore) RookAdditionalEvaluation(int squareIndex, int pieceIndex)
     {
         var attacksCount = Attacks.RookAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -993,7 +993,8 @@ public class Position
     {
         int middleGameBonus = 0, endGameBonus = 0;
 
-        if ((PieceBitBoards[(int)Piece.p] & Masks.WhiteSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
+        if (Masks.WhiteKnightOutpostMask.GetBit(squareIndex) != default     // Knight is centered and in the opponent's side of the board
+            && (PieceBitBoards[(int)Piece.p] & Masks.WhiteSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
         {
             var ownPawnProtectersCount = (PieceBitBoards[(int)Piece.P] & Attacks.PawnAttacks[(int)Side.Black][squareIndex]).CountBits();
 
@@ -1015,7 +1016,8 @@ public class Position
     {
         int middleGameBonus = 0, endGameBonus = 0;
 
-        if ((PieceBitBoards[(int)Piece.P] & Masks.BlackSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
+        if (Masks.BlackKnightOutpostMask.GetBit(squareIndex) != default     // Knight is centered and in the opponent's side of the board
+            && (PieceBitBoards[(int)Piece.P] & Masks.BlackSidePassedPawnMasks[squareIndex]) == default)  // Knight has no potential opponent pawn attackers
         {
             var ownPawnProtectersCount = (PieceBitBoards[(int)Piece.p] & Attacks.PawnAttacks[(int)Side.White][squareIndex]).CountBits();
 

--- a/tests/Lynx.Test/MasksTest.cs
+++ b/tests/Lynx.Test/MasksTest.cs
@@ -84,4 +84,90 @@ internal class MasksTest
 
         Assert.AreEqual(expectedBitBoard, actualBitBoard);
     }
+
+    [TestCase(BoardSquare.e4, "3p1p2/3p1p2/3p1p2/3p1p2/8/8/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.e5, "3p1p2/3p1p2/3p1p2/8/8/8/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.e7, "3p1p2/8/8/8/8/8/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.a7, "1p6/8/8/8/8/8/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.a2, "1p6/1p6/1p6/1p6/1p6/1p6/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.h3, "6p1/6p1/6p1/6p1/6p1/8/8/8 w - - 0 1")]
+    [TestCase(BoardSquare.h1, "6p1/6p1/6p1/6p1/6p1/6p1/6p1/8 w - - 0 1")]
+    [TestCase(BoardSquare.h8, "8/8/8/8/8/8/8/8 w - - 0 1")]
+    public void WhiteSidePassedPawnMask(BoardSquare square, string fen)
+    {
+        var position = new Position(fen);
+
+        var expectedBitBoard = position.PieceBitBoards[(int)Piece.P] | position.PieceBitBoards[(int)Piece.p];
+        var actualBitBoard = Masks.WhiteSidePassedPawnMasks[(int)square];
+
+        Assert.AreEqual(expectedBitBoard, actualBitBoard);
+    }
+
+    [TestCase(BoardSquare.e4, "8/8/8/8/8/3p1p2/3p1p2/3p1p2 w - - 0 1")]
+    [TestCase(BoardSquare.e5, "8/8/8/8/3p1p2/3p1p2/3p1p2/3p1p2 w - - 0 1")]
+    [TestCase(BoardSquare.e2, "8/8/8/8/8/8/8/3p1p2 w - - 0 1")]
+    [TestCase(BoardSquare.a7, "8/8/1p6/1p6/1p6/1p6/1p6/1p6 w - - 0 1")]
+    [TestCase(BoardSquare.a2, "8/8/8/8/8/8/8/1p6 w - - 0 1")]
+    [TestCase(BoardSquare.h3, "8/8/8/8/8/8/6p1/6p1 w - - 0 1")]
+    [TestCase(BoardSquare.h8, "8/6p1/6p1/6p1/6p1/6p1/6p1/6p1 w - - 0 1")]
+    [TestCase(BoardSquare.h1, "8/8/8/8/8/8/8/8 w - - 0 1")]
+    public void BlackSidePassedPawnMasks(BoardSquare square, string fen)
+    {
+        var position = new Position(fen);
+
+        var expectedBitBoard = position.PieceBitBoards[(int)Piece.P] | position.PieceBitBoards[(int)Piece.p];
+        var actualBitBoard = Masks.BlackSidePassedPawnMasks[(int)square];
+
+        Assert.AreEqual(expectedBitBoard, actualBitBoard);
+    }
+
+    [TestCase(BoardSquare.a1)]
+    [TestCase(BoardSquare.a3)]
+    [TestCase(BoardSquare.a5)]
+    [TestCase(BoardSquare.a7)]
+    [TestCase(BoardSquare.c1)]
+    [TestCase(BoardSquare.e1)]
+    [TestCase(BoardSquare.g1)]
+    [TestCase(BoardSquare.b2)]
+    [TestCase(BoardSquare.c3)]
+    [TestCase(BoardSquare.d4)]
+    [TestCase(BoardSquare.e5)]
+    [TestCase(BoardSquare.f6)]
+    [TestCase(BoardSquare.g7)]
+    [TestCase(BoardSquare.h8)]
+    public void DarkSquareMask(BoardSquare square)
+    {
+        Assert.True(Masks.DarkSquaresMask.GetBit(square));
+        Assert.False(Masks.LightSquaresMask.GetBit(square));
+    }
+
+    [TestCase(BoardSquare.a2)]
+    [TestCase(BoardSquare.a4)]
+    [TestCase(BoardSquare.a6)]
+    [TestCase(BoardSquare.a8)]
+    [TestCase(BoardSquare.b1)]
+    [TestCase(BoardSquare.d1)]
+    [TestCase(BoardSquare.f1)]
+    [TestCase(BoardSquare.h1)]
+    [TestCase(BoardSquare.b3)]
+    [TestCase(BoardSquare.c4)]
+    [TestCase(BoardSquare.d5)]
+    [TestCase(BoardSquare.e6)]
+    [TestCase(BoardSquare.f7)]
+    [TestCase(BoardSquare.g8)]
+    [TestCase(BoardSquare.h7)]
+    public void LightSquareMask(BoardSquare square)
+    {
+        Assert.True(Masks.LightSquaresMask.GetBit(square));
+        Assert.False(Masks.DarkSquaresMask.GetBit(square));
+    }
+
+    [Test]
+    public void DarkLightSquareMask()
+    {
+        for (int i = 0; i < 64; ++i)
+        {
+            Assert.True(Masks.DarkSquaresMask.GetBit(i) ^ Masks.LightSquaresMask.GetBit(i));
+        }
+    }
 }

--- a/tests/Lynx.Test/Model/BoardSquareTest.cs
+++ b/tests/Lynx.Test/Model/BoardSquareTest.cs
@@ -1,0 +1,46 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test.Model;
+public class BoardSquareTest : BaseTest
+{
+    [TestCase(BoardSquare.a1, BoardSquare.a3)]
+    [TestCase(BoardSquare.a1, BoardSquare.a5)]
+    [TestCase(BoardSquare.a1, BoardSquare.a7)]
+    [TestCase(BoardSquare.a1, BoardSquare.c1)]
+    [TestCase(BoardSquare.a1, BoardSquare.e1)]
+    [TestCase(BoardSquare.a1, BoardSquare.g1)]
+    [TestCase(BoardSquare.a1, BoardSquare.b2)]
+    [TestCase(BoardSquare.a1, BoardSquare.c3)]
+    [TestCase(BoardSquare.a1, BoardSquare.d4)]
+    [TestCase(BoardSquare.a1, BoardSquare.e5)]
+    [TestCase(BoardSquare.a1, BoardSquare.f6)]
+    [TestCase(BoardSquare.a1, BoardSquare.g7)]
+    [TestCase(BoardSquare.a1, BoardSquare.h8)]
+    public void SameColor(BoardSquare square1, BoardSquare square2)
+    {
+        Assert.True(BoardSquareExtensions.SameColor((int)square1, (int)square2));
+        Assert.False(BoardSquareExtensions.DifferentColor((int)square1, (int)square2));
+    }
+
+    [TestCase(BoardSquare.a1, BoardSquare.a2)]
+    [TestCase(BoardSquare.a1, BoardSquare.a4)]
+    [TestCase(BoardSquare.a1, BoardSquare.a6)]
+    [TestCase(BoardSquare.a1, BoardSquare.a8)]
+    [TestCase(BoardSquare.a1, BoardSquare.b1)]
+    [TestCase(BoardSquare.a1, BoardSquare.d1)]
+    [TestCase(BoardSquare.a1, BoardSquare.f1)]
+    [TestCase(BoardSquare.a1, BoardSquare.h1)]
+    [TestCase(BoardSquare.a1, BoardSquare.b3)]
+    [TestCase(BoardSquare.a1, BoardSquare.c4)]
+    [TestCase(BoardSquare.a1, BoardSquare.d5)]
+    [TestCase(BoardSquare.a1, BoardSquare.e6)]
+    [TestCase(BoardSquare.a1, BoardSquare.f7)]
+    [TestCase(BoardSquare.a1, BoardSquare.g8)]
+    [TestCase(BoardSquare.a1, BoardSquare.h7)]
+    public void DifferentColor(BoardSquare square1, BoardSquare square2)
+    {
+        Assert.True(BoardSquareExtensions.DifferentColor((int)square1, (int)square2));
+        Assert.False(BoardSquareExtensions.SameColor((int)square1, (int)square2));
+    }
+}

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1014,12 +1014,28 @@ public class PositionTest
     /// 1   k . . . . . . .
     ///     a b c d e f g h
     /// </summary>
-    [TestCase("K7/4p3/8/8/8/4N3/3P1P2/k7 w - - 0 1", 2)]
+    [TestCase("K7/4p3/8/8/8/4N3/3P1P2/k7 w - - 0 1", 0)]
 
     // Previous one mirrored
-    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 w - - 0 1", -2)]
-    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 b - - 0 1", 2)]
+    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 w - - 0 1", 0)]
+    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 b - - 0 1", 0)]
 
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . p . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . . N . . .
+    /// 4   . . . p . p . .
+    /// 3   . . . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/4p3/8/4N3/3P1P2/8/8/k7 w - - 0 1", 2)]
+
+    // Previous one mirrored
+    [TestCase("K7/8/8/3p1p2/4n3/8/4P3/k7 w - - 0 1", -2)]
+    [TestCase("K7/8/8/3p1p2/4n3/8/4P3/k7 b - - 0 1", 2)]
 
     /// <summary>
     /// 8   K . . . . . . .
@@ -1036,6 +1052,20 @@ public class PositionTest
     // Previous one mirrored
     [TestCase("K7/4p3/4N3/3P4/3p1p2/4n3/4P3/k7 w - - 0 1", -1)]
 
+    /// <summary>
+    /// 8   k . . . . . . .
+    /// 7   N . . . . . . .
+    /// 6   . P . . . . . N
+    /// 5   . . . . . . P .
+    /// 4   . . . . . . . .
+    /// 3   . . . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   K . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("k7/N7/1P5N/6P1/8/8/8/K7 w - - 0 1", 0)]
+    // Previous one mirrored
+    [TestCase("k7/8/8/8/6p1/1p5n/n7/K7 b - - 0 1", 0)]
     public void StaticEvaluation_KnightOutpostBonus(string fen, int bonusCount)
     {
         Position position = new Position(fen);

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -912,6 +912,145 @@ public class PositionTest
     }
 
     /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . . . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . p N . . .
+    /// 4   . . . P . n . .
+    /// 3   . . . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/8/8/3pN3/3P1n2/8/8/k7 w - - 0 1", 1)]
+    // Previous one mirrored
+    [TestCase("K7/8/8/3pN3/4n3/8/8/k7 w - - 0 1", -1)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . . . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . p N . . .
+    /// 4   . n . P . P . .
+    /// 3   . . . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/8/8/3pN3/1n1P1P2/8/8/k7 w - - 0 1", 2)]
+
+    // Previous one mirrored
+    [TestCase("K7/8/8/3pNp2/4n3/8/8/k7 w - - 0 1", -2)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . . . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . p N . . .
+    /// 4   . n . P . P . .
+    /// 3   . . . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/8/8/3pN3/p1pP1P2/1n6/8/k7 w - - 0 1", 0)]
+    // Previous one mirrored
+    [TestCase("K7/8/8/3pN3/p1pP1P2/1n6/8/k7 w - - 0 1", 0)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . . . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . p N . . .
+    /// 4   p . p P . . . .
+    /// 3   . n . . . . . .
+    /// 2   . . . . . . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/8/8/3pN3/p1pP4/1n6/8/k7 w - - 0 1", -1)]
+    // Previous one mirrored
+    [TestCase("K7/8/8/3pN3/p2P1P2/1n6/8/k7 b - - 0 1", -1)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . p . . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . . . . . .
+    /// 4   . . . . . . . .
+    /// 3   . . . . N . . .
+    /// 2   . . . P . P . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/3p4/8/8/8/4N3/3P1P2/k7 w - - 0 1", 0)]
+
+    // Previous one mirrored
+    [TestCase("K7/3p1p2/8/4n3/8/8/3P4/k7 b - - 0 1", 0)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . . p . .
+    /// 6   . . . . . . . .
+    /// 5   . . . . . . . .
+    /// 4   . . . . . . . .
+    /// 3   . . . . N . . .
+    /// 2   . . . P . P . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/5p2/8/8/8/4N3/3P1P2/k7 w - - 0 1", 0)]
+    // Previous one mirrored
+    [TestCase("K7/3p1p2/8/4n3/8/8/5P2/k7 b - - 0 1", 0)]
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . p . . .
+    /// 6   . . . . . . . .
+    /// 5   . . . . . . . .
+    /// 4   . . . . . . . .
+    /// 3   . . . . N . . .
+    /// 2   . . . P . P . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/4p3/8/8/8/4N3/3P1P2/k7 w - - 0 1", 2)]
+
+    // Previous one mirrored
+    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 w - - 0 1", -2)]
+    [TestCase("K7/3p1p2/4n3/8/8/8/4P3/k7 b - - 0 1", 2)]
+
+
+    /// <summary>
+    /// 8   K . . . . . . .
+    /// 7   . . . . p . . .
+    /// 6   . . . . N . . .
+    /// 5   . . . P . P . .
+    /// 4   . . . p . . . .
+    /// 3   . . . . n . . .
+    /// 2   . . . . P . . .
+    /// 1   k . . . . . . .
+    ///     a b c d e f g h
+    /// </summary>
+    [TestCase("K7/4p3/4N3/3P1P2/3p4/4n3/4P3/k7 w - - 0 1", 1)]
+    // Previous one mirrored
+    [TestCase("K7/4p3/4N3/3P4/3p1p2/4n3/4P3/k7 w - - 0 1", -1)]
+
+    public void StaticEvaluation_KnightOutpostBonus(string fen, int bonusCount)
+    {
+        Position position = new Position(fen);
+        int evaluation = AdditionalPieceEvaluation(position, Piece.N)
+            - AdditionalPieceEvaluation(position, Piece.n);
+
+        if (position.Side == Side.Black)
+        {
+            evaluation = -evaluation;
+        }
+
+        Assert.AreEqual(Configuration.EngineSettings.KnightOutpostBonus.MG * bonusCount, evaluation);
+    }
+
+    /// <summary>
     /// https://github.com/lynx-chess/Lynx/pull/510
     /// </summary>
     /// <param name="fen"></param>


### PR DESCRIPTION
Continuation of https://github.com/lynx-chess/Lynx/pull/614
```
Score of Lynx-eval-knight-outposts-opponent-side-2431-win-x64 vs Lynx 2428 - main: 1123 - 1272 - 1379  [0.480] 3774
...      Lynx-eval-knight-outposts-opponent-side-2431-win-x64 playing White: 769 - 418 - 700  [0.593] 1887
...      Lynx-eval-knight-outposts-opponent-side-2431-win-x64 playing Black: 354 - 854 - 679  [0.368] 1887
...      White vs Black: 1623 - 772 - 1379  [0.613] 3774
Elo difference: -13.7 +/- 8.8, LOS: 0.1 %, DrawRatio: 36.5 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```