### PR TITLE
`GetBit()` perf improvement

### DIFF
--- a/src/Lynx/Model/BitBoard.cs
+++ b/src/Lynx/Model/BitBoard.cs
@@ -58,7 +58,8 @@ public static class BitBoardExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool GetBit(this BitBoard board, int squareIndex)
     {
-        return (board & (1UL << squareIndex)) != default;
+        // Faster than (board & (1UL << squareIndex)) != default;
+        return ((board >> squareIndex) & 1) != 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Test  | perf/getbit
Elo   | -0.29 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | N: 48754 W: 15208 L: 15248 D: 18298
Penta | [1909, 5465, 9592, 5579, 1832]
https://openbench.lynx-chess.com/test/101/
```