### PR TITLE
Make sure to continue the search until depth == 2*mate distance.

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -123,7 +123,7 @@ public sealed partial class Engine
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
 
                 Array.Copy(_killerMoves, _previousKillerMoves, _killerMoves.Length);
-            } while (StopSearchCondition(++depth, maxDepth, isMateDetected, decisionTime));
+            } while (StopSearchCondition(++depth, maxDepth, isMateDetected, lastSearchResult.Mate, decisionTime));
         }
         catch (OperationCanceledException)
         {
@@ -157,11 +157,11 @@ public sealed partial class Engine
         return finalSearchResult;
     }
 
-    private bool StopSearchCondition(int depth, int? maxDepth, bool isMateDetected, int? decisionTime)
+    private bool StopSearchCondition(int depth, int? maxDepth, bool isMateDetected, int mateDistance, int? decisionTime)
     {
-        if (isMateDetected)
+        if (isMateDetected && depth > 2 * mateDistance)
         {
-            _logger.Info($"Stopping at depth {depth - 1}: mate detected");
+            _logger.Info($"Stopping at depth {depth - 1}: mate in {mateDistance} detected");
             return false;
         }
 


### PR DESCRIPTION
8+0.08
```
Score of Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 vs Lynx 2435 - main: 46 - 137 - 102  [0.340] 285
...      Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 playing White: 35 - 51 - 57  [0.444] 143
...      Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 playing Black: 11 - 86 - 45  [0.236] 142
...      White vs Black: 121 - 62 - 102  [0.604] 285
Elo difference: -115.0 +/- 33.1, LOS: 0.0 %, DrawRatio: 35.8 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

40+0.4
```
Score of Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 vs Lynx 2435 - main: 76 - 157 - 185  [0.403] 418
...      Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 playing White: 63 - 48 - 98  [0.536] 209
...      Lynx-bugfix-triple-repetition-instead-of-mate-2452-win-x64 playing Black: 13 - 109 - 87  [0.270] 209
...      White vs Black: 172 - 61 - 185  [0.633] 418
Elo difference: -68.2 +/- 25.0, LOS: 0.0 %, DrawRatio: 44.3 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```