### PR TITLE
🔍 Move ordering improvement; penalize moves that put pieces under pawn attacks

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -172,7 +172,7 @@ public static class Attacks
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByPawns(int squareIndex, int sideToMove, int offset, BitBoard[] pieces)
+    internal static bool IsSquareAttackedByPawns(int squareIndex, int sideToMove, int offset, BitBoard[] pieces)
     {
         var oppositeColorIndex = sideToMove ^ 1;
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -253,6 +253,9 @@ public static readonly int[] EndGameKingTable =
     /// </summary>
     public static readonly int[][] LMRReductions = new int[Constants.AbsoluteMaxDepth][];
 
+    /// <summary>
+    /// [0, 4, 136, 276, 424, 580, 744, 916, 1096, 1284, 1480, 1684, 1896, 1896, 1896, 1896, ...]
+    /// </summary>
     public static readonly int[] HistoryBonus = new int[Constants.AbsoluteMaxDepth];
 
     static EvaluationConstants()

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -67,7 +67,7 @@ public sealed partial class Engine
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Position position, Move move, int depth, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int depth, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[depth])
         {
@@ -132,10 +132,10 @@ public sealed partial class Engine
             // History move or base score if not found
             var piece = move.Piece();
             var targetSquare = move.TargetSquare();
-            var sideToMove = (int)position.Side;
+            var sideToMove = (int)Game.CurrentPosition.Side;
 
             var eval = EvaluationConstants.BaseMoveScore + _historyMoves[piece][targetSquare];
-            if (Attacks.IsSquareAttackedByPawns(targetSquare, sideToMove, Utils.PieceOffset(sideToMove), position.PieceBitBoards))
+            if (Attacks.IsSquareAttackedByPawns(targetSquare, sideToMove, Utils.PieceOffset(sideToMove), Game.CurrentPosition.PieceBitBoards))
             {
                 eval /= 2;
             }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -137,7 +137,7 @@ public sealed partial class Engine
             var eval = EvaluationConstants.BaseMoveScore + _historyMoves[piece][targetSquare];
             if (Attacks.IsSquareAttackedByPawns(targetSquare, sideToMove, Utils.PieceOffset(sideToMove), Game.CurrentPosition.PieceBitBoards))
             {
-                eval /= 2;
+                eval -= _historyMoves[piece][targetSquare] / 2 - (2 * Configuration.EngineSettings.History_MaxMoveRawBonus) + EvaluationConstants.HistoryBonus[depth];
             }
 
             return eval;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -165,7 +165,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -178,7 +178,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
             }
         }
 
@@ -470,7 +470,7 @@ public sealed partial class Engine
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -165,7 +165,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -178,7 +178,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
             }
         }
 
@@ -470,7 +470,7 @@ public sealed partial class Engine
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            scores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/tests/Lynx.Test/BestMove/MatePositions.cs
+++ b/tests/Lynx.Test/BestMove/MatePositions.cs
@@ -105,4 +105,10 @@ public static class MatePositions
     [
         new object[] { "6r1/p1pq1p1p/1p1p1Qnk/3PrR2/2n1P1PP/P1P5/4R3/6K1 w - -           ", new[] { "f5h5" }, "https://talkchess.com/forum3/viewtopic.php?f=7&t=82648" },
     ];
+
+    public static readonly object[] Mates_in_74 =
+    [
+        new object[] { "k7/B3p1p1/PPp1P3/4P2b/p4p1P/P1p2p1K/2P2P2/7B w - -", new[] { "" }, "https://talkchess.com/forum3/viewtopic.php?f=2&t=83218" },
+        new object[] { "qn6/b1Kp3p/p1pB3p/p6p/P1NkP3/2pP4/2B5/8 w - - 0 1", new[] { "d6f4" }, "https://talkchess.com/forum3/viewtopic.php?f=2&t=83218" }
+    ];
 }


### PR DESCRIPTION
[score/2](https://github.com/lynx-chess/Lynx/commit/4c16e828a1a324e7a71bccfee6345f8fdadc560b)
```
Score of Lynx-move-ordering-quiets-square-attacked-by-pawns-2461-win-x64 vs Lynx 2458 - main: 169 - 239 - 252  [0.447] 660
...      Lynx-move-ordering-quiets-square-attacked-by-pawns-2461-win-x64 playing White: 109 - 92 - 129  [0.526] 330
...      Lynx-move-ordering-quiets-square-attacked-by-pawns-2461-win-x64 playing Black: 60 - 147 - 123  [0.368] 330
...      White vs Black: 256 - 152 - 252  [0.579] 660
Elo difference: -37.0 +/- 20.9, LOS: 0.0 %, DrawRatio: 38.2 %
SPRT: llr -1.53 (-53.0%), lbound -2.25, ubound 2.89
```

[Try less agressive, totally made up formula](https://github.com/lynx-chess/Lynx/commit/4bf0da10ea26263f42799be4b5855156e23c9ca4)