### PR TITLE
Move tiered compilation options to binary project file

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,9 +16,6 @@ jobs:
     env:
       DOTNET_VERSION: 8.0.x
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      DOTNET_TieredPGO: 1
-      DOTNET_ReadyToRun: 0
-      DOTNET_TC_QuickJitForLoops: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,9 +21,6 @@ jobs:
     env:
       DOTNET_VERSION: 8.0.x
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      DOTNET_TieredPGO: 1
-      DOTNET_ReadyToRun: 0
-      DOTNET_TC_QuickJitForLoops: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,6 @@ env:
     DOTNET_VERSION: 8.0.x
     PROJECT_NAME: Lynx
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    DOTNET_TieredPGO: 1
-    DOTNET_ReadyToRun: 0
-    DOTNET_TC_QuickJitForLoops: 1
 
 jobs:
 

--- a/.github/workflows/on-demand-tests.yml
+++ b/.github/workflows/on-demand-tests.yml
@@ -21,9 +21,6 @@ jobs:
     env:
       DOTNET_VERSION: 8.0.x
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      DOTNET_TieredPGO: 1
-      DOTNET_ReadyToRun: 0
-      DOTNET_TC_QuickJitForLoops: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/perft.yml
+++ b/.github/workflows/perft.yml
@@ -24,9 +24,6 @@ jobs:
     env:
       DOTNET_VERSION: 8.0.x
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      DOTNET_TieredPGO: 1
-      DOTNET_ReadyToRun: 0
-      DOTNET_TC_QuickJitForLoops: 1
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,6 @@ on:
 env:
   DOTNET_VERSION: 8.0.x
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
-  DOTNET_TieredPGO: 1
-  DOTNET_ReadyToRun: 0
-  DOTNET_TC_QuickJitForLoops: 1
 
 jobs:
   publish-artifacts:

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -15,6 +15,8 @@
     <PublishTrimmed>true</PublishTrimmed>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <TieredPGO>true</TieredPGO>
+    <TieredCompilationQuickJitForLoops>true</TieredCompilationQuickJitForLoops>
     <!--In favour of tiered compilation-->
     <PublishReadyToRun>false</PublishReadyToRun>
   </PropertyGroup>


### PR DESCRIPTION
Use MSBuild properties for tiered compilation options, instead of env variables