### PR TITLE
Reorder `IsSquareInCheck` so that sliding pieces come last

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -164,11 +164,11 @@ public static class Attacks
 
         // I tried to order them from most to least likely
         return
-            IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
-            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
+            IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition)
             || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition);
+            || IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
+            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
+            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Score of Lynx-perf-reorder-incheck-2482-win-x64 vs Lynx 2477 - main: 11546 - 11547 - 14208  [0.500] 37301
...      Lynx-perf-reorder-incheck-2482-win-x64 playing White: 7955 - 3608 - 7088  [0.617] 18651
...      Lynx-perf-reorder-incheck-2482-win-x64 playing Black: 3591 - 7939 - 7120  [0.383] 18650
...      White vs Black: 15894 - 7199 - 14208  [0.617] 37301
Elo difference: -0.0 +/- 2.8, LOS: 49.7 %, DrawRatio: 38.1 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```