### PR TITLE
Remove extra comparisons that made IsSquareAttackedByX boolean

### DIFF
--- a/src/Lynx/Attacks.cs
+++ b/src/Lynx/Attacks.cs
@@ -146,12 +146,12 @@ public static class Attacks
 
         // I tried to order them from most to least likely
         return
-            IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition)
-            || IsSquareAttackedByKing(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
-            || IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition);
+            SquarePawnAttacks(squareIndex, sideToMoveInt, offset, piecePosition) > 0
+            || SquareKingAttacks(squareIndex, offset, piecePosition) > 0
+            || SquareKnightAttacks(squareIndex, offset, piecePosition) > 0
+            || SquareBishopAttacks(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks) > 0
+            || SquareRookAttacks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks) > 0
+            || SquareQueenAttacks(offset, bishopAttacks, rookAttacks, piecePosition) > 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -164,52 +164,52 @@ public static class Attacks
 
         // I tried to order them from most to least likely
         return
-            IsSquareAttackedByRooks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks)
-            || IsSquareAttackedByBishops(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks, piecePosition)
-            || IsSquareAttackedByKnights(squareIndex, offset, piecePosition)
-            || IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset, piecePosition);
+            SquareRookAttacks(squareIndex, offset, piecePosition, occupancy, out var rookAttacks) > 0
+            || SquareBishopAttacks(squareIndex, offset, piecePosition, occupancy, out var bishopAttacks) > 0
+            || SquareQueenAttacks(offset, bishopAttacks, rookAttacks, piecePosition) > 0
+            || SquareKnightAttacks(squareIndex, offset, piecePosition) > 0
+            || SquarePawnAttacks(squareIndex, sideToMoveInt, offset, piecePosition) > 0;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByPawns(int squareIndex, int sideToMove, int offset, BitBoard[] pieces)
+    private static ulong SquarePawnAttacks(int squareIndex, int sideToMove, int offset, BitBoard[] pieces)
     {
         var oppositeColorIndex = sideToMove ^ 1;
 
-        return (PawnAttacks[oppositeColorIndex][squareIndex] & pieces[offset]) != default;
+        return PawnAttacks[oppositeColorIndex][squareIndex] & pieces[offset];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByKnights(int squareIndex, int offset, BitBoard[] piecePosition)
+    private static ulong SquareKnightAttacks(int squareIndex, int offset, BitBoard[] piecePosition)
     {
-        return (KnightAttacks[squareIndex] & piecePosition[(int)Piece.N + offset]) != default;
+        return KnightAttacks[squareIndex] & piecePosition[(int)Piece.N + offset];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByKing(int squareIndex, int offset, BitBoard[] piecePosition)
+    private static ulong SquareKingAttacks(int squareIndex, int offset, BitBoard[] piecePosition)
     {
-        return (KingAttacks[squareIndex] & piecePosition[(int)Piece.K + offset]) != default;
+        return KingAttacks[squareIndex] & piecePosition[(int)Piece.K + offset];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByBishops(int squareIndex, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard bishopAttacks)
+    private static ulong SquareBishopAttacks(int squareIndex, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard bishopAttacks)
     {
         bishopAttacks = BishopAttacks(squareIndex, occupancy[(int)Side.Both]);
-        return (bishopAttacks & piecePosition[(int)Piece.B + offset]) != default;
+        return bishopAttacks & piecePosition[(int)Piece.B + offset];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByRooks(int squareIndex, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard rookAttacks)
+    private static ulong SquareRookAttacks(int squareIndex, int offset, BitBoard[] piecePosition, BitBoard[] occupancy, out BitBoard rookAttacks)
     {
         rookAttacks = RookAttacks(squareIndex, occupancy[(int)Side.Both]);
-        return (rookAttacks & piecePosition[(int)Piece.R + offset]) != default;
+        return rookAttacks & piecePosition[(int)Piece.R + offset];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsSquareAttackedByQueens(int offset, BitBoard bishopAttacks, BitBoard rookAttacks, BitBoard[] piecePosition)
+    private static ulong SquareQueenAttacks(int offset, BitBoard bishopAttacks, BitBoard rookAttacks, BitBoard[] piecePosition)
     {
         var queenAttacks = QueenAttacks(rookAttacks, bishopAttacks);
-        return (queenAttacks & piecePosition[(int)Piece.Q + offset]) != default;
+        return queenAttacks & piecePosition[(int)Piece.Q + offset];
     }
 
     /// <summary>


### PR DESCRIPTION
```
Score of Lynx-perf-attacks-unneeded-comparisons-2481-win-x64 vs Lynx 2477 - main: 4667 - 4765 - 5672  [0.497] 15104
...      Lynx-perf-attacks-unneeded-comparisons-2481-win-x64 playing White: 3210 - 1458 - 2884  [0.616] 7552
...      Lynx-perf-attacks-unneeded-comparisons-2481-win-x64 playing Black: 1457 - 3307 - 2788  [0.378] 7552
...      White vs Black: 6517 - 2915 - 5672  [0.619] 15104
Elo difference: -2.3 +/- 4.4, LOS: 15.6 %, DrawRatio: 37.6 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```