### PR TITLE
Avoid using QSearch TT moves in regular search

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1084,21 +1084,23 @@ static void TranspositionTable()
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +19, nodeType: NodeType.Alpha, move: 1234);
-    var entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
-    Console.WriteLine(entry); // Expected 20
+    TranspositionTableElement ttEntry = default;
 
-    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +21, nodeType: NodeType.Alpha, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
-    Console.WriteLine(entry); // Expected 12_345_678
+    transpositionTable.Save(mask, position, depth: 5, ply: 3, eval: +19, nodeType: NodeType.Alpha, move: 1234);
+    var eval = transpositionTable.Read(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30, ref ttEntry);
+    Console.WriteLine(eval); // Expected 20
 
-    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +29, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
-    Console.WriteLine(entry); // Expected 12_345_678
+    transpositionTable.Save(mask, position, depth: 5, ply: 3, eval: +21, nodeType: NodeType.Alpha, move: 1234);
+    eval = transpositionTable.Read(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30, ref ttEntry);
+    Console.WriteLine(eval); // Expected 12_345_678
 
-    transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: +31, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30);
-    Console.WriteLine(entry); // Expected 30
+    transpositionTable.Save(mask, position, depth: 5, ply: 3, eval: +29, nodeType: NodeType.Beta, move: 1234);
+    eval = transpositionTable.Read(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30, ref ttEntry);
+    Console.WriteLine(eval); // Expected 12_345_678
+
+    transpositionTable.Save(mask, position, depth: 5, ply: 3, eval: +31, nodeType: NodeType.Beta, move: 1234);
+    eval = transpositionTable.Read(mask, position, depth: 5, ply: 3, alpha: 20, beta: 30, ref ttEntry);
+    Console.WriteLine(eval); // Expected 30
 }
 
 static void UnmakeMove()

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -44,7 +44,7 @@ public sealed partial class Engine
         if (!isRoot)
         {
             ttEvaluation = _tt.Read(_ttMask, position, depth, ply, alpha, beta, ref ttEntry);
-            if (ttEvaluation != EvaluationConstants.NoHashEntry)
+            if (ttEntry.Depth > 0 && ttEvaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttEvaluation;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -38,13 +38,12 @@ public sealed partial class Engine
 
         bool isRoot = ply == 0;
         bool pvNode = beta - alpha > 1;
-        ShortMove ttBestMove = default;
-        NodeType ttElementType = default;
+        TranspositionTableElement ttEntry = default;
         int ttEvaluation = default;
 
         if (!isRoot)
         {
-            (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
+            ttEvaluation = _tt.Read(_ttMask, position, depth, ply, alpha, beta, ref ttEntry);
             if (ttEvaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttEvaluation;
@@ -55,7 +54,7 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (ttEntry.Type == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }
@@ -78,7 +77,7 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(_ttMask, position, depth, ply, finalPositionEvaluation, NodeType.Exact);
+            _tt.Save(_ttMask, position, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
 
@@ -91,7 +90,7 @@ public sealed partial class Engine
                 && staticEval >= beta
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                && (ttEntry.Type != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + 1) / 3);   // Clarity
 
@@ -165,7 +164,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttEntry.Move);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -178,7 +177,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttEntry.Move);
             }
         }
 
@@ -378,7 +377,7 @@ public sealed partial class Engine
                     }
                 }
 
-                _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);
+                _tt.Save(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);
 
                 return beta;    // TODO return evaluation?
             }
@@ -401,11 +400,11 @@ public sealed partial class Engine
         {
             var eval = Position.EvaluateFinalPosition(ply, isInCheck);
 
-            _tt.RecordHash(_ttMask, position, depth, ply, eval, NodeType.Exact);
+            _tt.Save(_ttMask, position, depth, ply, eval, NodeType.Exact);
             return eval;
         }
 
-        _tt.RecordHash(_ttMask, position, depth, ply, alpha, nodeType, bestMove);
+        _tt.Save(_ttMask, position, depth, ply, alpha, nodeType, bestMove);
 
         // Node fails low
         return alpha;
@@ -441,12 +440,13 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(_ttMask, position, 0, ply, alpha, beta);
-        if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
+        TranspositionTableElement ttEntry = default;
+        var ttProbeEvaluation = _tt.Read(_ttMask, position, 0, ply, alpha, beta, ref ttEntry);
+        if (ttProbeEvaluation != EvaluationConstants.NoHashEntry)
         {
-            return ttProbeResult.Evaluation;
+            return ttProbeEvaluation;
         }
-        ShortMove ttBestMove = ttProbeResult.BestMove;
+        ShortMove ttBestMove = ttEntry.Move;
 
         _maxDepthReached[ply] = ply;
 
@@ -551,7 +551,7 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
+                _tt.Save(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
 
                 return evaluation; // The refutation doesn't matter, since it'll be pruned
             }
@@ -573,12 +573,12 @@ public sealed partial class Engine
             && !MoveGenerator.CanGenerateAtLeastAValidMove(position))
         {
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(_ttMask, position, 0, ply, finalEval, NodeType.Exact);
+            _tt.Save(_ttMask, position, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _tt.RecordHash(_ttMask, position, 0, ply, alpha, nodeType, bestMove);
+        _tt.Save(_ttMask, position, 0, ply, alpha, nodeType, bestMove);
 
         return alpha;
     }

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -84,9 +84,10 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
+        transpositionTable.Save(mask, position, depth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
+        TranspositionTableElement ttEntry = default;
+        Assert.AreEqual(expectedProbeEval, transpositionTable.Read(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta, ref ttEntry));
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor)]
@@ -98,9 +99,10 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, depth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        transpositionTable.Save(mask, position, depth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
+        TranspositionTableElement ttEntry = default;
+        Assert.AreEqual(recordedEval, transpositionTable.Read(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100, ref ttEntry));
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor, 5, 4, CheckMateBaseEvaluation - 7 * CheckmateDepthFactor)]
@@ -113,8 +115,9 @@ public class TranspositionTableTests
         var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
-        transpositionTable.RecordHash(mask, position, depth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        transpositionTable.Save(mask, position, depth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
+        TranspositionTableElement ttEntry = default;
+        Assert.AreEqual(expectedProbeEval, transpositionTable.Read(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100, ref ttEntry));
     }
 }


### PR DESCRIPTION
```
Score of Lynx-tt-negamax-not-qsearch-tt-entries-2491-win-x64 vs Lynx 2483 - main: 1452 - 1533 - 2035  [0.492] 5020
...      Lynx-tt-negamax-not-qsearch-tt-entries-2491-win-x64 playing White: 975 - 497 - 1038  [0.595] 2510
...      Lynx-tt-negamax-not-qsearch-tt-entries-2491-win-x64 playing Black: 477 - 1036 - 997  [0.389] 2510
...      White vs Black: 2011 - 974 - 2035  [0.603] 5020
Elo difference: -5.6 +/- 7.4, LOS: 6.9 %, DrawRatio: 40.5 %
SPRT: llr -1.49 (-51.6%), lbound -2.25, ubound 2.89
```