### PR TITLE
Simplify QSearch move ordering

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -140,13 +140,6 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScoreMoveQuiescence(Move move, int ply, ShortMove bestMoveTTCandidate)
     {
-        if (_isScoringPV && move == _pVTable[ply])
-        {
-            _isScoringPV = false;
-
-            return EvaluationConstants.PVMoveScoreValue;
-        }
-
         if ((ShortMove)move == bestMoveTTCandidate)
         {
             return EvaluationConstants.TTMoveScoreValue;


### PR DESCRIPTION
```
Test  | move-ordering/simplify-negamax
Elo   | -2.33 +- 3.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19412 W: 6021 L: 6151 D: 7240
Penta | [761, 2283, 3721, 2207, 734]
https://openbench.lynx-chess.com/test/126/
```