### PR TITLE
🔍 Stop clearing quiet history

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -303,10 +303,7 @@ public sealed partial class Engine
             Array.Clear(_killerMoves[2]);
             Debug.Assert(_killerMoves.Length == 3);
 
-            for (int i = 0; i < _quietHistory.Length; i++)
-            {
-                Array.Clear(_quietHistory[i]);
-            }
+            // Not clearing _quietHistory on purpose
 
             // Not clearing _captureHistory on purpose
         }


### PR DESCRIPTION
```
Score of Lynx-search-stop-clearing-quiet-history-2523-win-x64 vs Lynx 2522 - main: 2049 - 1819 - 2551  [0.518] 6419
...      Lynx-search-stop-clearing-quiet-history-2523-win-x64 playing White: 1417 - 531 - 1262  [0.638] 3210
...      Lynx-search-stop-clearing-quiet-history-2523-win-x64 playing Black: 632 - 1288 - 1289  [0.398] 3209
...      White vs Black: 2705 - 1163 - 2551  [0.620] 6419
Elo difference: 12.5 +/- 6.6, LOS: 100.0 %, DrawRatio: 39.7 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```