### PR TITLE
Age capture history

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -308,7 +308,16 @@ public sealed partial class Engine
                 Array.Clear(_quietHistory[i]);
             }
 
-            // Not clearing _captureHistory on purpose
+            for (int i = 0; i < _captureHistory.Length; i++)
+            {
+                for (int j = 0; j < _captureHistory[i].Length; j++)
+                {
+                    for (int k = 0; k < _captureHistory[i][j].Length; ++k)
+                    {
+                        _captureHistory[i][j][k] = a * 3 / 4;
+                    }
+                }
+            }
         }
 
         return depth;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -314,7 +314,7 @@ public sealed partial class Engine
                 {
                     for (int k = 0; k < _captureHistory[i][j].Length; ++k)
                     {
-                        _captureHistory[i][j][k] = a * 3 / 4;
+                        _captureHistory[i][j][k] = _captureHistory[i][j][k] * 9 / 10;
                     }
                 }
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -311,7 +311,7 @@ public sealed partial class Engine
                 {
                     for (int k = 0; k < _captureHistory[i][j].Length; ++k)
                     {
-                        _captureHistory[i][j][k] = _captureHistory[i][j][k] * 9 / 10;
+                        _captureHistory[i][j][k] = _captureHistory[i][j][k] * 1 / 10;
                     }
                 }
             }


### PR DESCRIPTION
90%

```
Test  | search/age-capture-history
Elo   | -3.44 +- 4.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14832 W: 4554 L: 4701 D: 5577
Penta | [611, 1770, 2787, 1651, 597]
https://openbench.lynx-chess.com/test/127/
```

10%

```
Score of Lynx-search-age-capture-history-2532-win-x64 vs Lynx 2528 - main: 1059 - 1181 - 1447  [0.483] 3687
...      Lynx-search-age-capture-history-2532-win-x64 playing White: 723 - 370 - 750  [0.596] 1843
...      Lynx-search-age-capture-history-2532-win-x64 playing Black: 336 - 811 - 697  [0.371] 1844
...      White vs Black: 1534 - 706 - 1447  [0.612] 3687
Elo difference: -11.5 +/- 8.7, LOS: 0.5 %, DrawRatio: 39.2 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

