### PR TITLE
Age quiet history

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -307,7 +307,7 @@ public sealed partial class Engine
             {
                 for (int j = 0; j < _quietHistory[i].Length; j++)
                 {
-                    _quietHistory[i][j] = _quietHistory[i][j] * 1 / 10;
+                    _quietHistory[i][j] = _quietHistory[i][j] * 8 / 10;
                 }
             }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -307,7 +307,7 @@ public sealed partial class Engine
             {
                 for (int j = 0; j < _quietHistory[i].Length; j++)
                 {
-                    _quietHistory[i][j] = _quietHistory[i][j] * 8 / 10;
+                    _quietHistory[i][j] = _quietHistory[i][j] * 1 / 10;
                 }
             }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -305,7 +305,10 @@ public sealed partial class Engine
 
             for (int i = 0; i < _quietHistory.Length; i++)
             {
-                Array.Clear(_quietHistory[i]);
+                for (int j = 0; j < _quietHistory[i].Length; j++)
+                {
+                    _quietHistory[i][j] = _quietHistory[i][j] * 8 / 10;
+                }
             }
 
             // Not clearing _captureHistory on purpose


### PR DESCRIPTION
80%
```
Test  | search/age-quiet-history
Elo   | -4.26 +- 4.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12630 W: 3829 L: 3984 D: 4817
Penta | [527, 1500, 2362, 1453, 473]
https://openbench.lynx-chess.com/test/132/
```

10%
```
Score of Lynx-search-age-quiet-history-2530-win-x64 vs Lynx 2528 - main: 1501 - 1638 - 2024  [0.487] 5163
...      Lynx-search-age-quiet-history-2530-win-x64 playing White: 1038 - 531 - 1012  [0.598] 2581
...      Lynx-search-age-quiet-history-2530-win-x64 playing Black: 463 - 1107 - 1012  [0.375] 2582
...      White vs Black: 2145 - 994 - 2024  [0.611] 5163
Elo difference: -9.2 +/- 7.4, LOS: 0.7 %, DrawRatio: 39.2 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```