### PR TITLE
Increase max history value

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -42,8 +42,8 @@
     "LMP_BaseMovesToTry": 0,
     "LMP_MovesDepthMultiplier": 10,
 
-    "History_MaxMoveValue": 8192,
-    "History_MaxMoveRawBonus": 1896,
+    "History_MaxMoveValue": 16384,
+    "History_MaxMoveRawBonus": 3792,
 
     "SEE_BadCaptureReduction": 1,
 


### PR DESCRIPTION
```
    "History_MaxMoveValue": 16384,
    "History_MaxMoveRawBonus": 3792,

8+0.08
Score of Lynx-main-2528-win-x64 - Copy vs Lynx 2528 - main: 2038 - 2165 - 2780  [0.491] 6983
...      Lynx-main-2528-win-x64 - Copy playing White: 1411 - 681 - 1400  [0.605] 3492
...      Lynx-main-2528-win-x64 - Copy playing Black: 627 - 1484 - 1380  [0.377] 3491
...      White vs Black: 2895 - 1308 - 2780  [0.614] 6983
Elo difference: -6.3 +/- 6.3, LOS: 2.5 %, DrawRatio: 39.8 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted

40+0.4
Test  | search/double-max-history
Elo   | -2.74 +- 8.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.03 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3800 W: 1045 L: 1075 D: 1680
Penta | [103, 477, 780, 427, 113]
https://openbench.lynx-chess.com/test/135/
```

```
    "History_MaxMoveValue": 16384,
    "History_MaxMoveRawBonus": 1896, (same)

Cancelling, but not looking great
Score of Lynx-main-2528-win-x64 - 16384 vs Lynx 2528 - main: 3353 - 3410 - 4287  [0.497] 11050
...      Lynx-main-2528-win-x64 - 16384 playing White: 2363 - 1061 - 2101  [0.618] 5525
...      Lynx-main-2528-win-x64 - 16384 playing Black: 990 - 2349 - 2186  [0.377] 5525
...      White vs Black: 4712 - 2051 - 4287  [0.620] 11050
Elo difference: -1.8 +/- 5.1, LOS: 24.4 %, DrawRatio: 38.8 %
SPRT: llr -1.48 (-51.1%), lbound -2.25, ubound 2.89
```
