### PR TITLE
👷🏼 Make use of new available M1 runners in GH actions, 🐛 Fix makefile for ARM mac

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
       fail-fast: false
 
     env:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
       fail-fast: false
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-14]
       fail-fast: false
 
     steps:
@@ -49,7 +49,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
         include:
           - os: ubuntu-latest
             runtime-identifier: linux-x64
@@ -57,6 +57,8 @@ jobs:
             runtime-identifier: win-x64
           - os: macOS-latest
             runtime-identifier: osx-x64
+          - os: macos-14
+            runtime-identifier: osx-arm64
       fail-fast: false
 
     steps:
@@ -114,7 +116,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Debug, Release]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
         include:
           - os: ubuntu-latest
             runtime-identifier: linux-x64
@@ -122,6 +124,8 @@ jobs:
             runtime-identifier: win-x64
           - os: macOS-latest
             runtime-identifier: osx-x64
+          - os: macos-14
+            runtime-identifier: osx-arm64
       fail-fast: false
 
     steps:
@@ -178,7 +182,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
         category: [LongRunning]
       fail-fast: false
 
@@ -211,7 +215,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
         category: [Perft]
       fail-fast: false
 
@@ -244,7 +248,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
         category: [Configuration]
       fail-fast: false
 
@@ -359,7 +363,7 @@ jobs:
 
   #  strategy:
   #    matrix:
-  #      os: [ubuntu-latest, windows-latest, macOS-latest]
+  #      os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
   #    fail-fast: false
 
   #  env:

--- a/.github/workflows/on-demand-tests.yml
+++ b/.github/workflows/on-demand-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
       fail-fast: false
 
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           - runtime-identifier: osx-x64
             os: macos-latest
           - runtime-identifier: osx-arm64
-            os: macos-latest
+            os: macos-14
       fail-fast: false
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 			RUNTIME=linux-arm
 		endif
 	else ifneq ($(filter arm%,$(UNAME_P)),)
-		RUNTIME=osx.11.0-arm64
+		RUNTIME=osx-arm64
 	else
 		RUNTIME=osx-x64
 	endif


### PR DESCRIPTION
Make use of new available M1 runners
- Run tests there as well
- Publish mac arm version in them instead of in the intel macs

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

Fix makefile for arm mac