### PR TITLE
🐛 Clear history on `newgame`

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -2,8 +2,6 @@
 using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
-using System.Diagnostics;
-using System.Security.Cryptography;
 using System.Threading.Channels;
 
 namespace Lynx;
@@ -87,14 +85,7 @@ public sealed partial class Engine
             }
         }
 
-        // Clear killer moves
-        Debug.Assert(_killerMoves.Length == 3);
-        Array.Clear(_killerMoves[0]);
-        Array.Clear(_killerMoves[1]);
-        Array.Clear(_killerMoves[2]);
-        // No need to clear _previousKillerMoves
-
-        // _pVTable will be cleared on IDDFS, since it needs to be cleaned for every search as well, no matter what
+        // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }
 
     public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -2,6 +2,8 @@
 using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
+using System.Diagnostics;
+using System.Security.Cryptography;
 using System.Threading.Channels;
 
 namespace Lynx;
@@ -72,7 +74,27 @@ public sealed partial class Engine
         Game = new Game();
         _isNewGameComing = true;
         _isNewGameCommandSupported = true;
-        InitializeTT();
+
+        InitializeTT(); // TODO SPRT clearing instead
+
+        // Clear histories
+        for (int i = 0; i < 12; ++i)
+        {
+            Array.Clear(_quietHistory[i]);
+            for (var j = 0; j < 64; ++j)
+            {
+                Array.Clear(_captureHistory[i][j]);
+            }
+        }
+
+        // Clear killer moves
+        Debug.Assert(_killerMoves.Length == 3);
+        Array.Clear(_killerMoves[0]);
+        Array.Clear(_killerMoves[1]);
+        Array.Clear(_killerMoves[2]);
+        // No need to clear _previousKillerMoves
+
+        // _pVTable will be cleared on IDDFS, since it needs to be cleaned for every search as well, no matter what
     }
 
     public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -40,12 +40,6 @@ public sealed partial class Engine
     private bool _isScoringPV;
 
     private SearchResult? _previousSearchResult;
-    private readonly int[][] _previousKillerMoves =
-    [
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth]
-    ];
 
     private readonly Move _defaultMove = default;
 
@@ -151,8 +145,6 @@ public sealed partial class Engine
                 lastSearchResult = UpdateLastSearchResult(lastSearchResult, bestEvaluation, alpha, beta, depth, isMateDetected, bestEvaluationAbs);
 
                 await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
-
-                Array.Copy(_killerMoves, _previousKillerMoves, _killerMoves.Length);
             } while (StopSearchCondition(++depth, maxDepth, isMateDetected, decisionTime));
         }
         catch (OperationCanceledException)


### PR DESCRIPTION
It loses some elo, but life is hard

```
Test  | bugfix/clear-history-on-newgame
Elo   | -6.52 +- 7.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4794 W: 1418 L: 1508 D: 1868
Penta | [197, 574, 919, 536, 171]
https://openbench.lynx-chess.com/test/147/

Test  | bugfix/clear-history-on-newgame
Elo   | -1.31 +- 6.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.14 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 5852 W: 1645 L: 1667 D: 2540
Penta | [177, 690, 1188, 720, 151]
https://openbench.lynx-chess.com/test/149/
```