### PR TITLE
🐛 Don't search with fixed depth when cutechess provides 0s to move

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -155,21 +155,28 @@ public sealed partial class Engine
             millisecondsIncrement = goCommand.BlackIncrement;
         }
 
-        if (millisecondsLeft != 0)  // Cutechess sometimes sends negative wtime/btime
+        if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
         {
+            const int minSearchTime = 50;
+
             if (goCommand.MovesToGo == default)
             {
                 // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
-                millisecondsLeft -= 50;
-                millisecondsLeft = Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
+                const int engineGuiCommunicationTimeOverhead = 50;
+
+                millisecondsLeft -= engineGuiCommunicationTimeOverhead;
+                millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
 
                 // 1/30, suggested by Serdra (EP discord)
                 decisionTime = Convert.ToInt32(Math.Min(0.5 * millisecondsLeft, (millisecondsLeft * 0.03333) + millisecondsIncrement));
             }
             else
             {
-                millisecondsLeft -= 500;
-                millisecondsLeft = Math.Clamp(millisecondsLeft, 50, int.MaxValue); // Avoiding 0/negative values
+                // I prefer to leave some 'just in case' time apart to avoid losing in the last move before the control
+                const int movesToGoTimeOverhead = 500;
+
+                millisecondsLeft -= movesToGoTimeOverhead;
+                millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
 
                 decisionTime = Convert.ToInt32((millisecondsLeft / goCommand.MovesToGo) + millisecondsIncrement);
             }


### PR DESCRIPTION
In case the time left (wtime, btime) is 0, default to 50ms base time instead of doing default fixed depth of 5.

If both times are zero, we have no way of knowing with the current engine structure if a time was provided, so we'll log the warning and search with default fixed depth

It's a concern that it uses more time than the increment, but I'll tackle that in a separated PR
```
15:29:19 [DEBUG] | [GUI]        go wtime 0 btime -2 winc 20 binc 20
15:29:19 [INFO] | Time to move: 0.022s
```