### PR TITLE
🐛 Fix consecutive `go` commands handling

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -212,6 +212,7 @@ public sealed partial class Engine
         if (resultToReturn.BestMove != default && !_absoluteSearchCancellationTokenSource.IsCancellationRequested)
         {
             Game.MakeMove(resultToReturn.BestMove);
+            Game.UpdateInitialPosition();
         }
 
         AverageDepth += (resultToReturn.Depth - AverageDepth) / Math.Ceiling(0.5 * Game.PositionHashHistory.Count);

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -16,7 +16,7 @@ public sealed class Game
     public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 
     public Position CurrentPosition { get; private set; }
-    private readonly Position _gameInitialPosition;
+    private Position _gameInitialPosition;
 
     public Game() : this(Constants.InitialPositionFEN)
     {
@@ -208,5 +208,7 @@ public sealed class Game
     /// (either by the engine time management logic or by external stop command)
     /// currentPosition won't be the initial one
     /// </summary>
-    public void ResetCurrentPositionToBeforeSearchState() => CurrentPosition = _gameInitialPosition;
+    public void ResetCurrentPositionToBeforeSearchState() => CurrentPosition = new (_gameInitialPosition);
+
+    public void UpdateInitialPosition() => _gameInitialPosition = new(CurrentPosition);
 }


### PR DESCRIPTION
Given the engine is stateful (it probably shouldn't, I know) and allows you to enter multiple go commands assuming the best move from the previous one was executed: fix game state by updating correctly game's current and initial position after a go command