### PR TITLE
Revert search changes to make it async again

### DIFF
--- a/src/Lynx.Benchmark/UCI_Benchmark.cs
+++ b/src/Lynx.Benchmark/UCI_Benchmark.cs
@@ -42,9 +42,9 @@ public class UCI_Benchmark : BaseBenchmark
     private readonly Channel<string> _channel = Channel.CreateBounded<string>(new BoundedChannelOptions(100_000) { SingleReader = true, SingleWriter = false });
 
     [Benchmark]
-    public (int, long) Bench_DefaultDepth()
+    public async Task<(int, long)> Bench_DefaultDepth()
     {
         var engine = new Engine(_channel.Writer);
-        return engine.Bench(Configuration.EngineSettings.BenchDepth);
+        return await engine.Bench(Configuration.EngineSettings.BenchDepth);
     }
 }

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -86,7 +86,7 @@ public partial class Engine
     /// (https://github.com/JacquesRW/akimbo/blob/main/resources/fens.txt)
     /// plus random some endgame positions to ensure promotions with/without captures are well covered
     /// </summary>
-    public (int TotalNodes, long Nps) Bench(int depth)
+    public async Task<(int TotalNodes, long Nps)> Bench(int depth)
     {
         var stopwatch = new Stopwatch();
 
@@ -95,17 +95,17 @@ public partial class Engine
 
         foreach (var fen in _benchmarkFens)
         {
-            _engineWriter.TryWrite($"Benchmarking {fen} at depth {depth}");
+            await _engineWriter.WriteAsync($"Benchmarking {fen} at depth {depth}");
 
             AdjustPosition($"position fen {fen}");
             stopwatch.Restart();
 
-            var result = BestMove(new($"go depth {depth}"));
+            var result = await BestMove(new($"go depth {depth}"));
             totalTime += stopwatch.ElapsedMilliseconds;
             totalNodes += result.Nodes;
         }
 
-        _engineWriter.TryWrite($"Total time: {totalTime}");
+        await _engineWriter.WriteAsync($"Total time: {totalTime}");
 
         return (totalNodes, Utils.CalculateNps(totalNodes, totalTime));
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -49,7 +49,7 @@ public sealed partial class Engine
     /// <param name="maxDepth"></param>
     /// <param name="decisionTime"></param>
     /// <returns>Not null <see cref="SearchResult"/>, although made nullable in order to match online tb probing signature</returns>
-    public SearchResult IDDFS(int? maxDepth, int? decisionTime)
+    public async Task<SearchResult> IDDFS(int? maxDepth, int? decisionTime)
     {
         // Cleanup
         _nodes = 0;
@@ -74,7 +74,7 @@ public sealed partial class Engine
 
             if (OnlyOneLegalMove(out var onlyOneLegalMoveSearchResult))
             {
-                _engineWriter.TryWrite(InfoCommand.SearchResultInfo(onlyOneLegalMoveSearchResult));
+                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(onlyOneLegalMoveSearchResult));
 
                 return onlyOneLegalMoveSearchResult;
             }
@@ -88,7 +88,7 @@ public sealed partial class Engine
 
             if (lastSearchResult is not null)
             {
-                _engineWriter.TryWrite(InfoCommand.SearchResultInfo(lastSearchResult));
+                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
             }
 
             do
@@ -144,7 +144,7 @@ public sealed partial class Engine
 
                 lastSearchResult = UpdateLastSearchResult(lastSearchResult, bestEvaluation, alpha, beta, depth, isMateDetected, bestEvaluationAbs);
 
-                _engineWriter.TryWrite(InfoCommand.SearchResultInfo(lastSearchResult));
+                await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(lastSearchResult));
             } while (StopSearchCondition(++depth, maxDepth, isMateDetected, decisionTime));
         }
         catch (OperationCanceledException)
@@ -174,7 +174,7 @@ public sealed partial class Engine
             _searchCancellationTokenSource.Cancel();
         }
 
-        _engineWriter.TryWrite(InfoCommand.SearchResultInfo(finalSearchResult));
+        await _engineWriter.WriteAsync(InfoCommand.SearchResultInfo(finalSearchResult));
 
         return finalSearchResult;
     }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -27,7 +27,7 @@ public sealed class Searcher
                 {
                     if (_uciReader.TryRead(out var rawCommand))
                     {
-                        _engine.Search(new GoCommand(rawCommand));
+                        await _engine.Search(new GoCommand(rawCommand));
                     }
                 }
                 catch (Exception e)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -452,7 +452,7 @@ public sealed class UCIHandler
         {
             depth = Configuration.EngineSettings.BenchDepth;
         }
-        var results = _engine.Bench(depth);
+        var results = await _engine.Bench(depth);
         await _engine.PrintBenchResults(results);
     }
 

--- a/tests/Lynx.Test/BaseTest.cs
+++ b/tests/Lynx.Test/BaseTest.cs
@@ -14,9 +14,9 @@ public abstract class BaseTest
         Configuration.EngineSettings.TranspositionTableSize = 32;
     }
 
-    protected static SearchResult TestBestMove(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString, int depth = DefaultSearchDepth)
+    protected static async Task<SearchResult> TestBestMove(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString, int depth = DefaultSearchDepth)
     {
-        var seachResult = SearchBestMove(fen, depth);
+        var seachResult = await SearchBestMove(fen, depth);
         var bestMoveFound = seachResult.BestMove;
 
         if (allowedUCIMoveString is not null)
@@ -32,10 +32,10 @@ public abstract class BaseTest
         return seachResult;
     }
 
-    protected static SearchResult SearchBestMove(string fen, int depth = DefaultSearchDepth)
+    protected static async Task<SearchResult> SearchBestMove(string fen, int depth = DefaultSearchDepth)
     {
         var engine = GetEngine(fen);
-        return engine.BestMove(new($"go depth {depth}"));
+        return await engine.BestMove(new($"go depth {depth}"));
     }
 
     protected static Engine GetEngine(string fen)

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -12,9 +12,9 @@ public class ForceOrAvoidDrawTest : BaseTest
         Description = "Force stalemate - https://lichess.org/sM5ekwnW/black#103, Having issues with null pruning implemeneted")]
     [TestCase("8/8/4NQ2/7k/2P4p/4P2P/5PK1/3q4 b - - 7 53", new[] { "d1h1", "d1g1", "d1f1" },
         Description = "Force stalemate - https://lichess.org/sM5ekwnW/black#105")]
-    public void ForceStaleMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task ForceStaleMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 12);
+        var result = await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 12);
         Assert.AreEqual(0, result.Evaluation, "No drawn position detected");
     }
 
@@ -28,7 +28,7 @@ public class ForceOrAvoidDrawTest : BaseTest
     [TestCase(7)]
     [TestCase(8)]
     [TestCase(9)]
-    public void AvoidThreefoldRepetitionWhenWinningPosition(int depth)
+    public async Task AvoidThreefoldRepetitionWhenWinningPosition(int depth)
     {
         // Arrange
 
@@ -68,7 +68,7 @@ public class ForceOrAvoidDrawTest : BaseTest
 #endif
 
         // Act
-        var searchResult = engine.BestMove(new($"go depth {depth}"));
+        var searchResult = await engine.BestMove(new($"go depth {depth}"));
         var bestMoveFound = searchResult.BestMove;
 
         // Assert
@@ -76,7 +76,7 @@ public class ForceOrAvoidDrawTest : BaseTest
     }
 
     [Test]
-    public void ForceThreefoldRepetitionWhenLosingPosition()
+    public async Task ForceThreefoldRepetitionWhenLosingPosition()
     {
         // Arrange
 
@@ -117,7 +117,7 @@ public class ForceOrAvoidDrawTest : BaseTest
 #endif
 
         // Act
-        var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+        var searchResult = await engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
         var bestMoveFound = searchResult.BestMove;
 
         // Assert
@@ -126,7 +126,7 @@ public class ForceOrAvoidDrawTest : BaseTest
     }
 
     [Test]
-    public void Avoid50MovesRuleRepetitionWhenWinningPosition()
+    public async Task Avoid50MovesRuleRepetitionWhenWinningPosition()
     {
         // Arrange
 
@@ -167,7 +167,7 @@ public class ForceOrAvoidDrawTest : BaseTest
         engine.Game.PositionHashHistory.Clear(); // Make sure we don't take account threefold repetition
 
         // Act
-        var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+        var searchResult = await engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
         var bestMoveFound = searchResult.BestMove;
 
         // Assert
@@ -175,7 +175,7 @@ public class ForceOrAvoidDrawTest : BaseTest
     }
 
     [Test]
-    public void Force50MovesRuleRepetitionWhenLosingPosition()
+    public async Task Force50MovesRuleRepetitionWhenLosingPosition()
     {
         // Arrange
 
@@ -218,7 +218,7 @@ public class ForceOrAvoidDrawTest : BaseTest
         engine.Game.PositionHashHistory.Clear(); // Make sure we don't take account threefold repetition
 
         // Act
-        var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+        var searchResult = await engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
         var bestMoveFound = searchResult.BestMove;
 
         // Assert
@@ -231,12 +231,12 @@ public class ForceOrAvoidDrawTest : BaseTest
     /// </summary>
     /// <returns></returns>
     [Test]
-    public void CheckmateHasPrecedenceOver50MovesRule()
+    public async Task CheckmateHasPrecedenceOver50MovesRule()
     {
         // Source: https://github.com/PGG106/Alexandria/issues/213
         const string mateIn1Fen = "4Q3/8/1p4pk/1PbB1p1p/7P/p3P1PK/P3qP2/8 w - - 99 88";
 
-        var result = TestBestMove(mateIn1Fen, new[] { "e8h8" }, Array.Empty<string>(), depth: 1);
+        var result = await TestBestMove(mateIn1Fen, new[] { "e8h8" }, Array.Empty<string>(), depth: 1);
         Assert.AreEqual(1, result.Mate);
     }
 }

--- a/tests/Lynx.Test/BestMove/IncreaseDepthWhenInCheckTest.cs
+++ b/tests/Lynx.Test/BestMove/IncreaseDepthWhenInCheckTest.cs
@@ -17,12 +17,12 @@ public class IncreaseDepthWhenInCheckTest : BaseTest
     ///     a b c d e f g h
     /// </summary>
     [Test]
-    public void DepthLimit()
+    public async Task DepthLimit()
     {
         var engine = GetEngine("1r6/8/8/6kP/K7/5R1p/1q6/R5q1 w - - 0 2");
         Assert.AreEqual(Side.White, engine.Game.CurrentPosition.Side);
 
-        var searchResult = engine.BestMove(new GoCommand("go depth 1"));
+        var searchResult = await engine.BestMove(new GoCommand("go depth 1"));
 
         // In Quiescence search, which would be triggered after Rxg1+ without
         // the depth increase, Black would capture the pawn and get checkmated

--- a/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesInExactlyXTest.cs
@@ -12,58 +12,58 @@ namespace Lynx.Test.BestMove;
 public class MatesInExactlyXTest : BaseTest
 {
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_1))]
-    public void Mate_in_Exactly_1(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_1(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 1);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 1);
         Assert.AreEqual(1, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_2))]
-    public void Mate_in_Exactly_2(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_2(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 3);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 3);
         Assert.AreEqual(2, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
-    public void Mate_in_Exactly_3(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_3(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 5);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 5);
         Assert.AreEqual(3, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4))]
-    public void Mate_in_Exactly_4(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_4(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
         Assert.AreEqual(4, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection))]
-    public void Mate_in_Exactly_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 8);
         Assert.AreEqual(4, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5))]
-    public void Mate_in_Exactly_5(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_5(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 10);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 10);
         Assert.AreEqual(5, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6))]
-    public void Mate_in_Exactly_6(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_6(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 12);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 12);
         Assert.AreEqual(6, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7))]
-    public void Mate_in_Exactly_7(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_Exactly_7(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = TestBestMove(fen, allowedUCIMoveString, null, depth: 14);
+        var result = await TestBestMove(fen, allowedUCIMoveString, null, depth: 14);
         Assert.AreEqual(7, result.Mate);
     }
 }

--- a/tests/Lynx.Test/BestMove/MatesTest.cs
+++ b/tests/Lynx.Test/BestMove/MatesTest.cs
@@ -7,34 +7,34 @@ namespace Lynx.Test.BestMove;
 public class MatesTest : BaseTest
 {
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_1))]
-    public void Mate_in_1(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_1(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreEqual(1, result.Mate);
     }
 
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_2))]
-    public void Mate_in_2(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_2(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_3))]
-    public void Mate_in_3(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_3(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4))]
-    public void Mate_in_4(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_4(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
@@ -46,36 +46,36 @@ public class MatesTest : BaseTest
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_4_Collection))]
-    public void Mate_in_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_4_Collection(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_5))]
-    public void Mate_in_5(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_5(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_6))]
-    public void Mate_in_6(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_6(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen);
+        var result = await SearchBestMove(fen);
         Assert.AreNotEqual(default, result.Mate);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [TestCaseSource(typeof(MatePositions), nameof(MatePositions.Mates_in_7))]
-    public void Mate_in_7(string fen, string[]? allowedUCIMoveString, string description)
+    public async Task Mate_in_7(string fen, string[]? allowedUCIMoveString, string description)
     {
-        var result = SearchBestMove(fen, depth: 14);
+        var result = await SearchBestMove(fen, depth: 14);
         Assert.AreNotEqual(default, result.Mate);
     }
 }

--- a/tests/Lynx.Test/BestMove/QuiescenceTest.cs
+++ b/tests/Lynx.Test/BestMove/QuiescenceTest.cs
@@ -21,16 +21,16 @@ public class QuiescenceTest : BaseTest
         Description = "Mate in 6 with quiescence, https://gameknot.com/chess-puzzle.pl?pz=257112",
         Ignore = "Fails after fixing LMR implementation")]
 #pragma warning disable RCS1163, IDE0060 // Unused parameter.
-    public void Quiescence(string fen, int depth, int minQuiescenceSearchDepth, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task Quiescence(string fen, int depth, int minQuiescenceSearchDepth, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
 #pragma warning restore RCS1163, IDE0060 // Unused parameter.
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth);
     }
 
     [TestCase("7k/8/5NQ1/8/8/KN6/8/1r6 b - - 0 1", 1, new[] { "b1b3" })]
     [TestCase("5Rbk/8/5N2/6Q1/8/1r6/8/KN6 b - - 0 1", 1, new[] { "b3b1" })]
-    public void DetectDrawWhenNoCaptures(string fen, int depth, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task DetectDrawWhenNoCaptures(string fen, int depth, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth);
     }
 }

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -34,36 +34,36 @@ public class RegressionTest : BaseTest
     [TestCase("7k/1Q4r1/2q1B3/1P2QNN1/8/R7/nN6/K1R5 b - - 0 1", new[] { "c6c1" },
         Description = "Get stalemated vs winning a queen")]
 
-    public void GeneralRegression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task GeneralRegression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
     }
 
     [TestCase("r1bq2k1/1pp1n2p/2nppr1Q/p7/2PP2P1/5N2/PP3P1P/2KR1B1R w - - 0 15", new[] { "h6f6" },
         Description = "AlphaBeta/NegaMax depth 5 spends almost 3 minutes with a simple retake")]
-    public void SlowRecapture(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task SlowRecapture(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
     }
 
     [Explicit]
     [Category(Categories.NotGoodEnough)]
     [TestCase("6k1/1R6/5Kn1/3p1N2/1P6/8/8/3r4 b - - 10 37", new[] { "g6f8" }, new[] { "g6f4" },
         Description = "Avoid mate in 4 https://lichess.org/XkZsoXLA#74")]
-    public void AvoidMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task AvoidMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
     }
 
     [TestCase(5)]
     [TestCase(6)]
-    public void KeepNonGoodQuiescenceMoves(int depth)
+    public async Task KeepNonGoodQuiescenceMoves(int depth)
     {
         const string fen = Constants.InitialPositionFEN;
         var engine = GetEngine(fen);
         var goCommand = new GoCommand($"go depth {depth}");
 
-        var bestResult = engine.BestMove(goCommand);
+        var bestResult = await engine.BestMove(goCommand);
 
         switch (depth)
         {
@@ -81,12 +81,12 @@ public class RegressionTest : BaseTest
 
     [TestCase(5, Constants.InitialPositionFEN, "d8d5")]
     [TestCase(5, "rq2k2r/ppp2pb1/2n1pnpp/1Q1p1b2/3P1B2/2N1PNP1/PPP2PBP/R3K2R w KQkq - 0 1", "e5f4")]
-    public void TrashInPVTable(int depth, string fen, string notExpectedMove)
+    public async Task TrashInPVTable(int depth, string fen, string notExpectedMove)
     {
         var goCommand = new GoCommand($"go depth {depth}");
 
         var engine = GetEngine(fen);
-        var bestResult = engine.BestMove(goCommand);
+        var bestResult = await engine.BestMove(goCommand);
 
         if (bestResult.Moves.Count > depth)
         {
@@ -103,7 +103,7 @@ public class RegressionTest : BaseTest
         var engine = GetEngine();
 
         engine.AdjustPosition(positionCommand);
-        Assert.DoesNotThrow(() => engine.BestMove(goCommand));
+        Assert.DoesNotThrowAsync(async () => await engine.BestMove(goCommand));
     }
 
     [Explicit]
@@ -114,9 +114,9 @@ public class RegressionTest : BaseTest
         Description = "It failed at depth 6 in https://lichess.org/nZVw6G5D/black#19")]
     [TestCase("r1bqkb1r/ppp2ppp/2n1p3/3pP3/3Pn3/5P2/PPP1N1PP/R1BQKBNR b KQkq - 0 1", null, new[] { "f8b4" },
         Description = "It failed at depth 5 in https://lichess.org/rtTsj9Sr/black")]
-    public void GeneralFailures(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task GeneralFailures(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
     }
 
     /// <summary>
@@ -198,12 +198,12 @@ public class RegressionTest : BaseTest
         " h1g1 e6e5 g1h1 e5d5 h1g1 d5d4 g1h1 d4e4 h1g1 f6g6 g1f1 e4d3 f1e1 g6g1 e1f2 g1g2 f2e1 g2g6 e1f2 d3d2" +
         " f2f3 d2e1 f3f4 e1e2 f4f5 e2e6 f5f4 g6g4 f4f3 e6e8 f3f2 g4f4 f2g1 f4f6 g1h1 e8e6 h1g1 e6e5 g1h1 e5d5",
         Ignore = "Now that we detect 2 move repetitions, this should fail")]
-    public void FalseDrawnPositions(string positionCommand)
+    public async Task FalseDrawnPositions(string positionCommand)
     {
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {Engine.DefaultMaxDepth}"));
+        var bestMove = await engine.BestMove(new GoCommand($"go depth {Engine.DefaultMaxDepth}"));
         Assert.NotZero(bestMove.Evaluation);
 
         //engine.AdjustPosition(positionCommand);
@@ -223,12 +223,12 @@ public class RegressionTest : BaseTest
         " f4e3 e6d5 e3f4 d5f3 f4f5 d6d5 f5f4 d5d6 f4f5 d6d5 f5f4 f3d1 f4f5 d1e2 f5f4" +
         " d5d6 f4e4 d6e6 e4f4 e6d5 f4f5 d5c5 f5f6 c5b6 f6e7 b6a7 e7d8 a7a8 d8e7 a8b8" +
         " e7f8 b8a8 f8e7 a8b8 e7f8 b8a8")]
-    public void FalseDrawnPositionBy50MovesRule(string positionCommand)
+    public async Task FalseDrawnPositionBy50MovesRule(string positionCommand)
     {
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand);
         Assert.False(engine.Game.Is50MovesRepetition());
-        var bestMove = engine.BestMove(new GoCommand("go depth 1"));
+        var bestMove = await engine.BestMove(new GoCommand("go depth 1"));
 
         engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.ToEPDString());
         Assert.IsFalse(engine.Game.Is50MovesRepetition());
@@ -243,12 +243,12 @@ public class RegressionTest : BaseTest
         " e7d6 a5a4 e3e4 b5c4 f3e3 f8c8 h2h3 c4b5 e3f3 b5g5 f3g3 g5a5 g3d3 a5g5 d3g3 g5b5" +
         " g3f3 b5a5 f3d3 a5a8 d6b4 c8b8 b4c4 a4a3 d3d2 b8b2 d2b2 a3b2 c4b4 a8a2 b4b8 g8g7" +
         " b8e5 g7g8 e5b8 g8g7 b8e5 f7f6 e5c7 g7g8 c7b8 g8f7 b8c7 f7g8 c7b8 g8g7")]
-    public void InvalidPV(string positionCommand)
+    public async Task InvalidPV(string positionCommand)
     {
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
+        var bestMove = await engine.BestMove(new GoCommand($"go depth {5}"));
         Assert.Zero(bestMove.Evaluation);
         Assert.AreEqual(1, bestMove.Moves.Count);
         Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
@@ -262,16 +262,16 @@ public class RegressionTest : BaseTest
         " f2f3 a4h4 b6a6 h4h1 c1d2 h1h2 d2c3 h2f2 b2b3 h5h4 a6h6 f2f3 c3b4 f3f4 b4b5 f7g7 h6h5" +
         " g7f6 c2c4 f4f5 h5f5 f6f5 c4c5 f5e6 a2a4 h4h3 b5b6 h3h2 b3b4 h2h1q a4a5")]
 
-    public void InvalidPV2(string positionCommand)
+    public async Task InvalidPV2(string positionCommand)
     {
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand.AsSpan()[..^10]);  // 8/8/1K2k3/2P5/PP6/8/7p/8 b - - 0 46, ready to promote
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+        var bestMove = await engine.BestMove(new GoCommand($"go depth {7}"));
         Assert.AreEqual("h2h1q", bestMove.BestMove.UCIString());
 
         engine.AdjustPosition(positionCommand);
-        bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+        bestMove = await engine.BestMove(new GoCommand($"go depth {7}"));
         Assert.AreNotEqual("h2h1q", bestMove.BestMove.UCIString());
     }
 
@@ -279,19 +279,19 @@ public class RegressionTest : BaseTest
     [Category(Categories.LongRunning)]
     [TestCase(Constants.KillerTestPositionFEN)]
     [TestCase(Constants.TrickyTestPositionFEN)]
-    public void PVTableCrash(string fen)
+    public async Task PVTableCrash(string fen)
     {
         const int depthWhenMaxDepthInQuiescenceIsReached = 7;
         var engine = GetEngine(fen);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
+        var bestMove = await engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
         Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.Depth);
     }
 
     [Explicit]
     [Category(Categories.LongRunning)]
     [Test]
-    public void PonderingCrash()
+    public async Task PonderingCrash()
     {
         var engine = GetEngine();
         engine.AdjustPosition("position startpos moves" +
@@ -307,7 +307,7 @@ public class RegressionTest : BaseTest
             " d5d4 h5h6 f7a7 h6h5 d4d5 h5h6 d5d6 h6h5 a7f7 h5h6 d6d5 h6h5 f7a7 h5h6 d5d4 h6h5 g7g8 h5h6 d4d5 e2b2" +
             " d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8");
 
-        var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+        var searchResult = await engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
 
         engine.AdjustPosition("position startpos moves" +
             " e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 f2f3 e7e5 d4b3 c8e6 c1e3 h7h5 c3d5 e6d5 e4d5 b8d7" +
@@ -323,7 +323,7 @@ public class RegressionTest : BaseTest
             " d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8" +
             $" {searchResult.BestMove.UCIString()} {searchResult.Moves[1].UCIString()}");
 
-        searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+        searchResult = await engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
 
         Assert.NotZero(searchResult.BestMove);
     }
@@ -352,20 +352,20 @@ public class RegressionTest : BaseTest
         " f5f6 d7e6 f6f7 e6f5 f7f8q f5g5 f8c5 g5g4 g7f7 g4f4 c5b4 f4e3 b4c3 e3e4 c3b4 e4e3 f7f6 e3f3 b4d2" +
         " f3g4 f6f7 g4f3 d2d3 f3f2 f7f8 f2g1 d3e3 g1g2 e3e2 g2g3 f8e7 g3h3 e7d7 h3h4 e2g2 h4h5 d7e6 h5h6 e6d7",
         Description = "FEN 8/3K4/7k/8/8/8/6Q1/8 b - - 0 1")]
-    public void DepthOverflow(string positionCommand)
+    public async Task DepthOverflow(string positionCommand)
     {
         var engine = GetEngine();
 
         engine.AdjustPosition(positionCommand);
 
-        var result = engine.BestMove(new("go wtime 3600000 btime 3600000"));
+        var result = await engine.BestMove(new("go wtime 3600000 btime 3600000"));
         Assert.Less(result.DepthReached, Configuration.EngineSettings.MaxDepth);
     }
 
     [TestCase("4r3/5P1k/5K2/5N2/8/8/8/8 w - - 0 1", new[] { "f7e8b" },
         Description = "Position by Alex Brunetti, https://www.talkchess.com/forum3/viewtopic.php?f=2&t=31150&start=28")]
-    public void BishopUnderpromotion(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task BishopUnderpromotion(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
     }
 }

--- a/tests/Lynx.Test/BestMove/SacrificesTest.cs
+++ b/tests/Lynx.Test/BestMove/SacrificesTest.cs
@@ -8,8 +8,8 @@ public class SacrificesTest : BaseTest
     [Category(Categories.LongRunning)]
     [TestCase("4n3/1p2k2p/p2p2pP/P1bP1pP1/2P2P2/2BB4/3K4/8 w - - 0 43", new[] { "d3f5" },
         Description = "Actual Bishop sacrifice - https://lichess.org/VaY6zfHI/white#84")]
-    public void Sacrifices(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+    public async Task Sacrifices(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 20);
+        await TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 20);
     }
 }

--- a/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
+++ b/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
@@ -27,7 +27,7 @@ public class SingleLegalMoveTest : BaseTest
     [TestCase("8/8/8/8/8/K7/2b5/k1Q5 b - - 0 1")]
     [TestCase("8/8/8/8/8/K1n5/8/k1Q5 b - - 0 1")]
     [TestCase("1q6/8/8/8/8/K7/8/k1Q5 b - - 0 1")]
-    public void SingleMove(string fen)
+    public async Task SingleMove(string fen)
     {
         // Arrange
         const int depth = 61;
@@ -48,7 +48,7 @@ public class SingleLegalMoveTest : BaseTest
         Assert.LessOrEqual(depth, Configuration.EngineSettings.MaxDepth);
 
         // Act
-        var result = SearchBestMove(fen, depth);
+        var result = await SearchBestMove(fen, depth);
 
         Assert.AreEqual(singleMove, result.BestMove);
         Assert.AreEqual(singleMove, result.Moves.Single());

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -16,9 +16,9 @@ public class WACSilver200 : BaseTest
     /// </summary>
     /// <param name="fen"></param>
     /// <param name="bestMove"></param>
-    public void WinningAtChess_FixedTime(string fen, string bestMove, string id)
+    public async Task WinningAtChess_FixedTime(string fen, string bestMove, string id)
     {
-        VerifyBestMove(fen, bestMove, id, new GoCommand("go wtime 5500 btime 5500 winc 0 binc 0 movestogo 1"));
+        await VerifyBestMove(fen, bestMove, id, new GoCommand("go wtime 5500 btime 5500 winc 0 binc 0 movestogo 1"));
     }
 
     [Explicit]
@@ -29,16 +29,16 @@ public class WACSilver200 : BaseTest
     /// </summary>
     /// <param name="fen"></param>
     /// <param name="bestMove"></param>
-    public void WinningAtChess_DefaultSearchDepth(string fen, string bestMove, string id)
+    public async Task WinningAtChess_DefaultSearchDepth(string fen, string bestMove, string id)
     {
-        VerifyBestMove(fen, bestMove, id, new GoCommand($"go depth {DefaultSearchDepth}"));
+        await VerifyBestMove(fen, bestMove, id, new GoCommand($"go depth {DefaultSearchDepth}"));
     }
 
-    private static void VerifyBestMove(string fen, string bestMove, string id, GoCommand goCommand)
+    private static async Task VerifyBestMove(string fen, string bestMove, string id, GoCommand goCommand)
     {
         var engine = GetEngine(fen);
 
-        var bestResult = engine.BestMove(goCommand);
+        var bestResult = await engine.BestMove(goCommand);
 
         var bestMoveArray = bestMove.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         if (bestMoveArray.Length == 1)


### PR DESCRIPTION
Changed as part of #81, but there's literally no need

```
Test  | perf/async-search
Elo   | 0.10 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 77760 W: 23846 L: 23824 D: 30090
Penta | [2796, 9156, 15042, 9002, 2884]
https://openbench.lynx-chess.com/test/161/
```