### PR TITLE
🐛 Prevent illegal moves when low in time

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,12 +67,13 @@ public sealed partial class Engine
         int depth = 1;
         bool isCancelled = false;
         bool isMateDetected = false;
+        Move firstLegalMove = default;
 
         try
         {
             _stopWatch.Start();
 
-            if (OnlyOneLegalMove(out var onlyOneLegalMoveSearchResult))
+            if (OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
             {
                 _engineWriter.TryWrite(InfoCommand.SearchResultInfo(onlyOneLegalMoveSearchResult));
 
@@ -166,7 +167,7 @@ public sealed partial class Engine
             _stopWatch.Stop();
         }
 
-        var finalSearchResult = GenerateFinalSearchResult(lastSearchResult, bestEvaluation, alpha, beta, depth, isCancelled);
+        var finalSearchResult = GenerateFinalSearchResult(lastSearchResult, bestEvaluation, alpha, beta, depth, firstLegalMove, isCancelled);
 
         if (isMateDetected && finalSearchResult.Mate + Game.HalfMovesWithoutCaptureOrPawnMove < 96)
         {
@@ -211,10 +212,9 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool OnlyOneLegalMove([NotNullWhen(true)] out SearchResult? result)
+    private bool OnlyOneLegalMove(ref Move firstLegalMove, [NotNullWhen(true)] out SearchResult? result)
     {
         bool onlyOneLegalMove = false;
-        Move firstLegalMove = default;
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
@@ -296,12 +296,13 @@ public sealed partial class Engine
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private SearchResult GenerateFinalSearchResult(SearchResult? lastSearchResult,
-        int bestEvaluation, int alpha, int beta, int depth, bool isCancelled)
+        int bestEvaluation, int alpha, int beta, int depth, Move firstLegalMove, bool isCancelled)
     {
         SearchResult finalSearchResult;
         if (lastSearchResult is null)
         {
-            finalSearchResult = new(default, bestEvaluation, depth, [], alpha, beta);
+            _logger.Warn("Search cancelled at depth 1, choosing first found legal move as best one");
+            finalSearchResult = new(firstLegalMove, 0, 0, [firstLegalMove], alpha, beta);
         }
         else
         {


### PR DESCRIPTION
Prevent illegal moves when low in time by simply returning the first legal move found before the search