### PR TITLE
Clear TT instead of re-allocating it

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -78,7 +78,7 @@ public sealed partial class Engine
         var sw = Stopwatch.StartNew();
 
         InitializeStaticClasses();
-        const string goWarmupCommand = "go depth 10";   // ~300 ms
+        const string goWarmupCommand = "go depth 10";
 
         AdjustPosition(Constants.SuperLongPositionCommand);
         BestMove(new(goWarmupCommand));
@@ -91,7 +91,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        InitializeTT(); // TODO SPRT clearing instead
+        _tt.ClearTranspositionTable();
 
         // Clear histories
         for (int i = 0; i < 12; ++i)


### PR DESCRIPTION
```
Score of Lynx-perf-clean-tt-table-2605-win-x64 vs Lynx 2604 - main: 1279 - 1404 - 1888  [0.486] 4571
...      Lynx-perf-clean-tt-table-2605-win-x64 playing White: 922 - 420 - 944  [0.610] 2286
...      Lynx-perf-clean-tt-table-2605-win-x64 playing Black: 357 - 984 - 944  [0.363] 2285
...      White vs Black: 1906 - 777 - 1888  [0.623] 4571
Elo difference: -9.5 +/- 7.7, LOS: 0.8 %, DrawRatio: 41.3 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```