### PR TITLE
Make `Engine` arrays pinned

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -43,20 +43,19 @@ public sealed partial class Engine
         _absoluteSearchCancellationTokenSource = new();
         _engineWriter = engineWriter;
 
-        // Update ResetEngine() after any changes here
-        _quietHistory = new int[12][];
+        _quietHistory = PerformanceUtils.AllocatePinnedArray<int[]>(12);
         for (int i = 0; i < _quietHistory.Length; ++i)
         {
-            _quietHistory[i] = new int[64];
+            _quietHistory[i] = PerformanceUtils.AllocatePinnedArray<int>(64);
         }
 
-        _captureHistory = new int[12][][];
+        _captureHistory = PerformanceUtils.AllocatePinnedArray<int[][]>(12);
         for (int i = 0; i < 12; ++i)
         {
-            _captureHistory[i] = new int[64][];
+            _captureHistory[i] = PerformanceUtils.AllocatePinnedArray<int[]>(64);
             for (var j = 0; j < 64; ++j)
             {
-                _captureHistory[i][j] = new int[12];
+                _captureHistory[i][j] = PerformanceUtils.AllocatePinnedArray<int>(12);
             }
         }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -301,7 +301,7 @@ public sealed partial class Engine
         if (Configuration.EngineSettings.TranspositionTableEnabled)
         {
             (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-            _tt = new TranspositionTableElement[ttLength];
+            _tt = PerformanceUtils.AllocatePinnedArray<TranspositionTableElement>(ttLength);
         }
     }
 

--- a/src/Lynx/PerformanceUtils.cs
+++ b/src/Lynx/PerformanceUtils.cs
@@ -1,0 +1,8 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Lynx;
+public static class PerformanceUtils
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static T[] AllocatePinnedArray<T>(int length) => GC.AllocateArray<T>(length, pinned: true);
+}

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -9,16 +9,17 @@ namespace Lynx;
 public sealed partial class Engine
 {
     private readonly Stopwatch _stopWatch = new();
-    private readonly Move[] _pVTable = new Move[Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2];
+    private readonly Move[] _pVTable = PerformanceUtils.AllocatePinnedArray<int>(
+        Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2);
 
     /// <summary>
     /// 3x<see cref="Configuration.EngineSettings.MaxDepth"/>
     /// </summary>
     private readonly int[][] _killerMoves =
     [
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth]
+        PerformanceUtils.AllocatePinnedArray<int>(Configuration.EngineSettings.MaxDepth),
+        PerformanceUtils.AllocatePinnedArray<int>(Configuration.EngineSettings.MaxDepth),
+        PerformanceUtils.AllocatePinnedArray<int>(Configuration.EngineSettings.MaxDepth)
     ];
 
     /// <summary>
@@ -31,7 +32,7 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[][][] _captureHistory;
 
-    private readonly int[] _maxDepthReached = new int[Constants.AbsoluteMaxDepth];
+    private readonly int[] _maxDepthReached = PerformanceUtils.AllocatePinnedArray<int>(Constants.AbsoluteMaxDepth);
     private TranspositionTable _tt = [];
     private int _ttMask;
 


### PR DESCRIPTION
Only engine stuff:
```
Score of Lynx-perf-pinned-arrays-2612-win-x64 vs Lynx 2611 - main: 10225 - 10236 - 13510  [0.500] 33971
...      Lynx-perf-pinned-arrays-2612-win-x64 playing White: 7167 - 3087 - 6732  [0.620] 16986
...      Lynx-perf-pinned-arrays-2612-win-x64 playing Black: 3058 - 7149 - 6778  [0.380] 16985
...      White vs Black: 14316 - 6145 - 13510  [0.620] 33971
Elo difference: -0.1 +/- 2.9, LOS: 46.9 %, DrawRatio: 39.8 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Engine stuff + TT
```
Test  | perf/pinned-arrays
Elo   | -0.18 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52254 W: 15875 L: 15902 D: 20477
Penta | [1876, 6113, 10184, 6070, 1884]
https://openbench.lynx-chess.com/test/170/
```