### PR TITLE
Pin TT table and clear it instead of re-intiializing it

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1078,7 +1078,7 @@ static void TranspositionTable()
     var hashKey2 = position.UniqueIdentifier & mask;
     Console.WriteLine(hashKey2);
 
-    transpositionTable.ClearTranspositionTable();
+    Array.Clear(transpositionTable);
 
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -78,7 +78,7 @@ public sealed partial class Engine
         var sw = Stopwatch.StartNew();
 
         InitializeStaticClasses();
-        const string goWarmupCommand = "go depth 10";   // ~300 ms
+        const string goWarmupCommand = "go depth 10";
 
         AdjustPosition(Constants.SuperLongPositionCommand);
         BestMove(new(goWarmupCommand));
@@ -91,7 +91,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        InitializeTT(); // TODO SPRT clearing instead
+        _tt.ClearTranspositionTable();
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -91,7 +91,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        _tt.ClearTranspositionTable();
+        Array.Clear(_tt);
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -302,7 +302,7 @@ public sealed partial class Engine
         if (Configuration.EngineSettings.TranspositionTableEnabled)
         {
             (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-            _tt = new TranspositionTableElement[ttLength];
+            _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
         }
     }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -49,15 +49,6 @@ public struct TranspositionTableElement
     public int Score { readonly get => _score; set => _score = (short)value; }
 
     public long Key { readonly get => _key; set => _key = (ShortMove)(value >> 48); }
-
-    public void Clear()
-    {
-        Key = 0;
-        Score = 0;
-        Depth = 0;
-        Move = 0;
-        Type = NodeType.Unknown;
-    }
 }
 
 public static class TranspositionTableExtensions
@@ -84,15 +75,6 @@ public static class TranspositionTableExtensions
         _logger.Info("TT mask:\t{0}", mask.ToString("X"));
 
         return (ttLength, mask);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ClearTranspositionTable(this TranspositionTable transpositionTable)
-    {
-        foreach (var element in transpositionTable)
-        {
-            element.Clear();
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Mix of https://github.com/lynx-chess/Lynx/pull/659 + https://github.com/lynx-chess/Lynx/pull/660.

Elo neutral, but just clearing failed with -9, so promising?

```
Score of Lynx-perf-pin-tt-table-and-clear-it-2615-win-x64 vs Lynx 2611 - main: 6075 - 6098 - 7933  [0.499] 20106
...      Lynx-perf-pin-tt-table-and-clear-it-2615-win-x64 playing White: 4266 - 1794 - 3993  [0.623] 10053
...      Lynx-perf-pin-tt-table-and-clear-it-2615-win-x64 playing Black: 1809 - 4304 - 3940  [0.376] 10053
...      White vs Black: 8570 - 3603 - 7933  [0.624] 20106
Elo difference: -0.4 +/- 3.7, LOS: 41.7 %, DrawRatio: 39.5 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```