### PR TITLE
⌛ Make soft and hard bounds explicit, simplifying the existing logic

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -16,9 +16,9 @@
     "ShowWDL": false,
 
     "DefaultMovesToGo": 30,
-    "HardTimeBoundMultiplier": 0.25,
-    "SoftTimeBoundMultiplier": 0.033333,
-    "SoftLimitBaseIncrementMultiplier": 0.75,
+    "HardTimeBoundMultiplier": 0.0333333,
+    "SoftTimeBoundMultiplier": 0.4,
+    "SoftTimeBaseIncrementMultiplier": 1,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,8 +15,8 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "MinElapsedTimeToConsiderStopSearching": 0,
-    "DecisionTimePercentageToStopSearching": 0.4,
+    "HardTimeBound": 0.25,
+    "SoftTimeBound": 0.03333,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,8 +15,8 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "HardTimeBound": 0.25,
-    "SoftTimeBound": 0.03333,
+    "HardTimeBound": 0.033333,
+    "SoftTimeBound": 0.013333,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,8 +15,10 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "HardTimeBound": 0.033333,
-    "SoftTimeBound": 0.013333,
+    "DefaultMovesToGo": 30,
+    "HardTimeBoundMultiplier": 0.25,
+    "SoftTimeBoundMultiplier": 0.033333,
+    "SoftLimitBaseIncrementMultiplier": 0.75,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,15 +111,9 @@ public sealed class EngineSettings
 
     public bool ShowWDL { get; set; } = false;
 
-    /// <summary>
-    /// 1/4, suggested by MinusKelvin (EP discord)
-    /// </summary>
-    public double HardTimeBound { get; set; } = 0.25;
+    public double HardTimeBound { get; set; } = 0.033333;
 
-    /// <summary>
-    /// 1/30, suggested by Serdra (EP discord)
-    /// </summary>
-    public double SoftTimeBound { get; set; } = 0.03333;
+    public double SoftTimeBound { get; set; } = 0.013333;
 
     public int LMR_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,9 +111,23 @@ public sealed class EngineSettings
 
     public bool ShowWDL { get; set; } = false;
 
-    public double HardTimeBound { get; set; } = 0.033333;
+    #region Time management
 
-    public double SoftTimeBound { get; set; } = 0.013333;
+    public int DefaultMovesToGo { get; set; } = 30;
+
+    /// <summary>
+    /// 1/4
+    /// </summary>
+    public double HardTimeBoundMultiplier { get; set; } = 0.25;
+
+    /// <summary>
+    /// 1/30
+    /// </summary>
+    public double SoftTimeBoundMultiplier { get; set; } = 0.033333;
+
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
+
+    #endregion
 
     public int LMR_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -125,7 +125,7 @@ public sealed class EngineSettings
     /// </summary>
     public double SoftTimeBoundMultiplier { get; set; } = 0.4;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 1;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -118,12 +118,12 @@ public sealed class EngineSettings
     /// <summary>
     /// 1/4
     /// </summary>
-    public double HardTimeBoundMultiplier { get; set; } = 0.25;
+    public double HardTimeBoundMultiplier { get; set; } = 0.0333333;
 
     /// <summary>
     /// 1/30
     /// </summary>
-    public double SoftTimeBoundMultiplier { get; set; } = 0.033333;
+    public double SoftTimeBoundMultiplier { get; set; } = 0.4;
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,9 +111,15 @@ public sealed class EngineSettings
 
     public bool ShowWDL { get; set; } = false;
 
-    public int MinElapsedTimeToConsiderStopSearching { get; set; } = 0;
+    /// <summary>
+    /// 1/4, suggested by MinusKelvin (EP discord)
+    /// </summary>
+    public double HardTimeBound { get; set; } = 0.25;
 
-    public double DecisionTimePercentageToStopSearching { get; set; } = 0.4;
+    /// <summary>
+    /// 1/30, suggested by Serdra (EP discord)
+    /// </summary>
+    public double SoftTimeBound { get; set; } = 0.03333;
 
     public int LMR_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -142,7 +142,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
 
-        int maxDepth = Configuration.EngineSettings.MaxDepth;
+        int maxDepth = -1;
         int hardLimitTimeBound;
         int softLimitTimeBound = int.MaxValue;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -172,11 +172,11 @@ public sealed partial class Engine
                 millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
 
                 softLimitTimeBound = Convert.ToInt32(Math.Min(
-                    millisecondsLeft * Configuration.EngineSettings.SoftTimeBound + millisecondsIncrement,
+                    (millisecondsLeft * Configuration.EngineSettings.SoftTimeBound) + millisecondsIncrement,
                     millisecondsLeft * 0.5));
 
                 hardLimitTimeBound = Convert.ToInt32(Math.Min(
-                    millisecondsLeft * Configuration.EngineSettings.HardTimeBound + millisecondsIncrement,
+                    (millisecondsLeft * Configuration.EngineSettings.HardTimeBound) + millisecondsIncrement,
                     millisecondsLeft * 0.5));
             }
             else

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -188,10 +188,16 @@ public sealed partial class Engine
             return false;
         }
 
-        if (depth >= maxDepth)
+        if (maxDepth > 0)
         {
-            _logger.Info("Stopping at depth {0}: max. depth reached", depth - 1);
-            return false;
+            var shouldContinue = depth <= maxDepth;
+
+            if (!shouldContinue)
+            {
+                _logger.Info("Stopping at depth {0}: max. depth reached", depth - 1);
+            }
+
+            return shouldContinue;
         }
 
         var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;


### PR DESCRIPTION
Reimplementation of https://github.com/lynx-chess/Lynx/pull/447.
This is an attempt to standarize time management using the hard/soft bound technique, where different values are used to stop the search after each IDDFS iteration (soft bound) and to stop the search at any moment (hard bound).

We were already using this technique via applying `DecisionTimePercentageToStopSearching` coefficient to the hard bound to get the soft one.
Last tm revision was done in https://github.com/lynx-chess/Lynx/pull/288


I run this non-ref tests, but I'm trully merging this together with https://github.com/lynx-chess/Lynx/pull/665, I just want to make clear the separation between the implementation and the value tweaking (fixing even, lol)

```
8+0.08
Score of Lynx-time-management-soft-hard-bounds-2-2633-win-x64 vs Lynx 2630 - main: 1080 - 981 - 1318  [0.515] 3379
...      Lynx-time-management-soft-hard-bounds-2-2633-win-x64 playing White: 762 - 291 - 637  [0.639] 1690
...      Lynx-time-management-soft-hard-bounds-2-2633-win-x64 playing Black: 318 - 690 - 681  [0.390] 1689
...      White vs Black: 1452 - 609 - 1318  [0.625] 3379
Elo difference: 10.2 +/- 9.1, LOS: 98.5 %, DrawRatio: 39.0 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted

40+0.4, cancelled
Score of Lynx-time-management-soft-hard-bounds-2-2633-win-x64 vs Lynx 2630 - main: 401 - 399 - 640  [0.501] 1440
...      Lynx-time-management-soft-hard-bounds-2-2633-win-x64 playing White: 306 - 90 - 323  [0.650] 719
...      Lynx-time-management-soft-hard-bounds-2-2633-win-x64 playing Black: 95 - 309 - 317  [0.352] 721
...      White vs Black: 615 - 185 - 640  [0.649] 1440
Elo difference: 0.5 +/- 13.4, LOS: 52.8 %, DrawRatio: 44.4 %
SPRT: llr 0.32 (11.1%), lbound -2.25, ubound 2.89
```