### PR TITLE
⌛ Decrease increment % usage

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -18,7 +18,7 @@
     "DefaultMovesToGo": 30,
     "HardTimeBoundMultiplier": 0.25,
     "SoftTimeBoundMultiplier": 0.4,
-    "SoftTimeBaseIncrementMultiplier": 1,
+    "SoftTimeBaseIncrementMultiplier": 0.75,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -119,7 +119,7 @@ public sealed class EngineSettings
 
     public double SoftTimeBoundMultiplier { get; set; } = 0.4;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 1;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
 
     #endregion
 


### PR DESCRIPTION
Just after increasing hard bound, #665, failing:

```
8+0.08
Score of Lynx-time-management-drecrease-increment-mult-2646-win-x64 vs Lynx 2645 - main: 575 - 634 - 781  [0.485] 1990
...      Lynx-time-management-drecrease-increment-mult-2646-win-x64 playing White: 398 - 218 - 379  [0.590] 995
...      Lynx-time-management-drecrease-increment-mult-2646-win-x64 playing Black: 177 - 416 - 402  [0.380] 995
...      White vs Black: 814 - 395 - 781  [0.605] 1990
Elo difference: -10.3 +/- 11.9, LOS: 4.5 %, DrawRatio: 39.2 %
SPRT: llr -1.74 (-60.1%), lbound -2.25, ubound 2.89

40+0.4
Score of Lynx-time-management-drecrease-increment-mult-2646-win-x64 vs Lynx 2645 - main: 133 - 138 - 169  [0.494] 440
...      Lynx-time-management-drecrease-increment-mult-2646-win-x64 playing White: 102 - 39 - 79  [0.643] 220
...      Lynx-time-management-drecrease-increment-mult-2646-win-x64 playing Black: 31 - 99 - 90  [0.345] 220
...      White vs Black: 201 - 70 - 169  [0.649] 440
Elo difference: -3.9 +/- 25.5, LOS: 38.1 %, DrawRatio: 38.4 %
SPRT: llr -0.191 (-6.6%), lbound -2.25, ubound 2.89
```

After increasing soft bound, #668 
```
1/40, 0.75 vs 1/40, 1 - 8+0.08
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx-time-management-increase-soft-bound-2647-win-x64base: 649 - 515 - 776  [0.535] 1940
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 437 - 158 - 376  [0.644] 971
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 212 - 357 - 400  [0.425] 969
...      White vs Black: 794 - 370 - 776  [0.609] 1940
Elo difference: 24.0 +/- 12.0, LOS: 100.0 %, DrawRatio: 40.0 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89

1/40, 0.75 vs 1/40, 1 - 40+0.4
Finished game 10141 (Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx-time-management-increase-soft-bound-2647-win-x64base): * {No result}
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx-time-management-increase-soft-bound-2647-win-x64base: 2976 - 2743 - 4416  [0.511] 10135
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 2183 - 670 - 2215  [0.649] 5068
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 793 - 2073 - 2201  [0.374] 5067
...      White vs Black: 4256 - 1463 - 4416  [0.638] 10135
Elo difference: 8.0 +/- 5.1, LOS: 99.9 %, DrawRatio: 43.6 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```