### PR TITLE
⌛ Increase soft bound

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,9 +15,9 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "DefaultMovesToGo": 30,
     "HardTimeBoundMultiplier": 0.25,
-    "SoftTimeBoundMultiplier": 0.4,
+    "SoftTimeBoundMultiplier": 1,
+    "DefaultMovesToGo": 30,
     "SoftTimeBaseIncrementMultiplier": 1,
 
     "LMR_MinDepth": 3,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -17,7 +17,7 @@
 
     "HardTimeBoundMultiplier": 0.25,
     "SoftTimeBoundMultiplier": 1,
-    "DefaultMovesToGo": 30,
+    "DefaultMovesToGo": 40,
     "SoftTimeBaseIncrementMultiplier": 1,
 
     "LMR_MinDepth": 3,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -117,7 +117,7 @@ public sealed class EngineSettings
 
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
-    public int DefaultMovesToGo { get; set; } = 30;
+    public int DefaultMovesToGo { get; set; } = 40;
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 1;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,11 +113,11 @@ public sealed class EngineSettings
 
     #region Time management
 
-    public int DefaultMovesToGo { get; set; } = 30;
-
     public double HardTimeBoundMultiplier { get; set; } = 0.25;
 
-    public double SoftTimeBoundMultiplier { get; set; } = 0.4;
+    public double SoftTimeBoundMultiplier { get; set; } = 1;
+
+    public int DefaultMovesToGo { get; set; } = 30;
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 1;
 


### PR DESCRIPTION
```
1/20, 8+0.08
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx 2645 - main: 68 - 121 - 91  [0.405] 280
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 51 - 44 - 46  [0.525] 141
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 17 - 77 - 45  [0.284] 139
...      White vs Black: 128 - 61 - 91  [0.620] 280
Elo difference: -66.6 +/- 33.8, LOS: 0.0 %, DrawRatio: 32.5 %
SPRT: llr -1.2 (-41.4%), lbound -2.25, ubound 2.89

1/30, 8+0.08
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx 2645 - main: 1166 - 1235 - 1498  [0.491] 3899
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 828 - 420 - 701  [0.605] 1949
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 338 - 815 - 797  [0.378] 1950
...      White vs Black: 1643 - 758 - 1498  [0.613] 3899
Elo difference: -6.1 +/- 8.5, LOS: 8.0 %, DrawRatio: 38.4 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted

1/30, 0.75 increment, 8+0.08 (Hinting there's some potential to explore in #667 )
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx-time-management-increase-soft-bound-2647-win-x64base: 2689 - 2720 - 3493  [0.498] 8902
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 1879 - 835 - 1737  [0.617] 4451
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 810 - 1885 - 1756  [0.379] 4451
...      White vs Black: 3764 - 1645 - 3493  [0.619] 8902
Elo difference: -1.2 +/- 5.6, LOS: 33.7 %, DrawRatio: 39.2 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted

1/40, 8+0.08
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx 2645 - main: 2332 - 2154 - 2634  [0.512] 7120
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 1626 - 720 - 1214  [0.627] 3560
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 706 - 1434 - 1420  [0.398] 3560
...      White vs Black: 3060 - 1426 - 2634  [0.615] 7120
Elo difference: 8.7 +/- 6.4, LOS: 99.6 %, DrawRatio: 37.0 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted

1/40, 40+0.4 (aborted :( )
Score of Lynx-time-management-increase-soft-bound-2647-win-x64 vs Lynx 2645 - main: 2018 - 1861 - 2651  [0.512] 6530
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing White: 1453 - 535 - 1278  [0.641] 3266
...      Lynx-time-management-increase-soft-bound-2647-win-x64 playing Black: 565 - 1326 - 1373  [0.383] 3264
...      White vs Black: 2779 - 1100 - 2651  [0.629] 6530
Elo difference: 8.4 +/- 6.5, LOS: 99.4 %, DrawRatio: 40.6 %
SPRT: llr 1.87 (64.8%), lbound -2.25, ubound 2.89
```