### PR TITLE
🐛 Error when searching at max depth

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -251,12 +251,12 @@ public static readonly int[] EndGameKingTable =
     /// <summary>
     /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
     /// </summary>
-    public static readonly int[][] LMRReductions = new int[Constants.AbsoluteMaxDepth][];
+    public static readonly int[][] LMRReductions = new int[Configuration.EngineSettings.MaxDepth][];
 
     /// <summary>
     /// [0, 4, 136, 276, 424, 580, 744, 916, 1096, 1284, 1480, 1684, 1896, 1896, 1896, 1896, ...]
     /// </summary>
-    public static readonly int[] HistoryBonus = new int[Constants.AbsoluteMaxDepth];
+    public static readonly int[] HistoryBonus = new int[Configuration.EngineSettings.MaxDepth];
 
     static EvaluationConstants()
     {
@@ -271,7 +271,7 @@ public static readonly int[] EndGameKingTable =
             }
         }
 
-        for (int searchDepth = 1; searchDepth < Constants.AbsoluteMaxDepth; ++searchDepth)    // Depth > 0 or we'd be in QSearch
+        for (int searchDepth = 1; searchDepth < Configuration.EngineSettings.MaxDepth; ++searchDepth)    // Depth > 0 or we'd be in QSearch
         {
             LMRReductions[searchDepth] = new int[Constants.MaxNumberOfPossibleMovesInAPosition];
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -188,6 +188,12 @@ public sealed partial class Engine
             return false;
         }
 
+        if (depth >= Configuration.EngineSettings.MaxDepth)
+        {
+            _logger.Info("Max depth reached: {0}", Configuration.EngineSettings.MaxDepth);
+            return false;
+        }
+
         if (maxDepth > 0)
         {
             var shouldContinue = depth <= maxDepth;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -31,7 +31,7 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[][][] _captureHistory;
 
-    private readonly int[] _maxDepthReached = new int[Constants.AbsoluteMaxDepth];
+    private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth];
     private TranspositionTable _tt = [];
     private int _ttMask;
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -368,4 +368,21 @@ public class RegressionTest : BaseTest
     {
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
     }
+
+    /// <summary>
+    /// Unfortunately or not, it doesn't crash IDDFS, so the test is mostly useless, but let's have it in place just in case
+    /// </summary>
+    [Test]
+    public void MaxDepthCrash()
+    {
+        var engine = GetEngine();
+
+        engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3");
+
+        engine.BestMove(new("go wtime 10000 btime 10000 winc 80 binc 80"));
+
+        engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3 f6f7 d3c3");
+
+        Assert.DoesNotThrow(() => engine.BestMove(new("go wtime 100000 btime 100000 winc 80 binc 80")));
+    }
 }


### PR DESCRIPTION
- Stop IDDFS before searching for depth `Configuration.EngineSettings.MaxDepth`
- Limit some arrays to that value

This should avoid some out of bounds error that was being logged in an scenario such as:

```
position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3

go wtime 10000 btime 10000 winc 80 binc 80

position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3 f6f7 d3c3

go wtime 100000 btime 100000 winc 80 binc 80
```