### PR TITLE
⌛ Increase hard bound

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -18,7 +18,7 @@
     "DefaultMovesToGo": 30,
     "HardTimeBoundMultiplier": 0.25,
     "SoftTimeBoundMultiplier": 0.4,
-    "SoftTimeBaseIncrementMultiplier": 1,
+    "SoftTimeBaseIncrementMultiplier": 0.75,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,7 +15,7 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "HardTimeBoundMultiplier": 0.25,
+    "HardTimeBoundMultiplier": 0.5,
     "SoftTimeBoundMultiplier": 1,
     "DefaultMovesToGo": 40,
     "SoftTimeBaseIncrementMultiplier": 0.75,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,7 +113,7 @@ public sealed class EngineSettings
 
     #region Time management
 
-    public double HardTimeBoundMultiplier { get; set; } = 0.25;
+    public double HardTimeBoundMultiplier { get; set; } = 0.5;
 
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -119,7 +119,7 @@ public sealed class EngineSettings
 
     public double SoftTimeBoundMultiplier { get; set; } = 0.4;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 1;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
 
     #endregion
 


### PR DESCRIPTION
vs 1/40 soft, 0.75 inc, 0.25 hard (#667)
```
8+0.08
Score of Lynx-time-management-drecrease-increment-mult-2661-win-x64 vs Lynx-time-management-drecrease-increment-mult-2661-win-x64 - base: 1764 - 1530 - 1928  [0.522] 5222
...      Lynx-time-management-drecrease-increment-mult-2661-win-x64 playing White: 1198 - 465 - 948  [0.640] 2611
...      Lynx-time-management-drecrease-increment-mult-2661-win-x64 playing Black: 566 - 1065 - 980  [0.404] 2611
...      White vs Black: 2263 - 1031 - 1928  [0.618] 5222
Elo difference: 15.6 +/- 7.5, LOS: 100.0 %, DrawRatio: 36.9 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted

40+0.4
Score of Lynx-time-management-drecrease-increment-mult-2661-win-x64 vs Lynx-time-management-drecrease-increment-mult-2661-win-x64 - base: 3601 - 3360 - 5482  [0.510] 12443
...      Lynx-time-management-drecrease-increment-mult-2661-win-x64 playing White: 2678 - 839 - 2705  [0.648] 6222
...      Lynx-time-management-drecrease-increment-mult-2661-win-x64 playing Black: 923 - 2521 - 2777  [0.372] 6221
...      White vs Black: 5199 - 1762 - 5482  [0.638] 12443
Elo difference: 6.7 +/- 4.6, LOS: 99.8 %, DrawRatio: 44.1 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```