### PR TITLE
⚡ Reimplement repetition detection

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -291,6 +291,8 @@ public static class Constants
     /// </summary>
     public const int MaxNumberOfPossibleMovesInAPosition = 250;
 
+    public const int MaxNumberMovesInAGame = 1024;
+
     public static readonly int SideLimit = Enum.GetValues(typeof(Piece)).Length / 2;
 
     public static readonly int[] Rank =

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -43,7 +43,7 @@ public static class OnlineTablebaseProber
         TypeInfoResolver = SourceGenerationContext.Default
     };
 
-    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, HashSet<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
+    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, List<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
         var fen = position.FEN(halfMovesWithoutCaptureOrPawnMove);
         _logger.Info("[{0}] Querying online tb for position {1}", nameof(RootSearch), fen);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -219,10 +219,10 @@ public sealed partial class Engine
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
             Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-            var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
+            Game.PositionHashHistory.Add(Game.CurrentPosition.UniqueIdentifier);
 
             int evaluation;
-            if (isThreeFoldRepetition)
+            if (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()) // Threefold first to update Game.PositionHashHistory
             {
                 evaluation = 0;
 
@@ -230,24 +230,10 @@ public sealed partial class Engine
                 // Since we won't be evaluating further down, we need to clear the PV table because those moves there
                 // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
                 Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
-
-                // This is the only case were we don't clear position.UniqueIdentifier from Game.PositionHashHistory, because it was already there before making the move
-            }
-            else if (Game.Is50MovesRepetition())
-            {
-                evaluation = 0;
-
-                // We don't need to evaluate further down to know it's a draw.
-                // Since we won't be evaluating further down, we need to clear the PV table because those moves there
-                // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
-                Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
-
-                Game.PositionHashHistory.Remove(position.UniqueIdentifier);
             }
             else if (pvNode && movesSearched == 0)
             {
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
-                Game.PositionHashHistory.Remove(position.UniqueIdentifier);
             }
             else
             {
@@ -261,7 +247,7 @@ public sealed partial class Engine
                 {
                     // After making a move
                     Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-                    Game.PositionHashHistory.Remove(position.UniqueIdentifier); // We know that there's no triple repetition here
+                    Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1); // We know that there's no triple repetition here
                     position.UnmakeMove(move, gameState);
 
                     break;
@@ -323,14 +309,13 @@ public sealed partial class Engine
                     // PVS Hipothesis invalidated -> search with full depth and full score bandwidth
                     evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
                 }
-
-                Game.PositionHashHistory.Remove(position.UniqueIdentifier);
             }
 
             // After making a move
             // Game.PositionHashHistory is update above
             Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
             position.UnmakeMove(move, gameState);
+            Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
 
             PrintMove(ply, move, evaluation);
 
@@ -549,10 +534,10 @@ public sealed partial class Engine
             // Before making a move
             var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
             Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-            var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
+            Game.PositionHashHistory.Add(Game.CurrentPosition.UniqueIdentifier);
 
             int evaluation;
-            if (isThreeFoldRepetition || Game.Is50MovesRepetition())
+            if (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()) // Threefold first to update Game.PositionHashHistory
             {
                 evaluation = 0;
 
@@ -568,10 +553,7 @@ public sealed partial class Engine
 
             // After making a move
             Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-            if (!isThreeFoldRepetition)
-            {
-                Game.PositionHashHistory.Remove(position.UniqueIdentifier);
-            }
+            Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
             position.UnmakeMove(move, gameState);
 
             PrintMove(ply, move, evaluation);

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace Lynx;
 public sealed partial class Engine
 {
-    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, HashSet<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
+    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, List<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
     {
         var stopWatch = Stopwatch.StartNew();
 

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -26,25 +26,20 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[1]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
-        var newPosition = new Position(game.CurrentPosition, repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[3]));
+        game.MakeMove(repeatedMoves[3]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
+        game.MakeMove(repeatedMoves[4]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
+        game.MakeMove(repeatedMoves[5]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
+        game.MakeMove(repeatedMoves[6]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[7]));
+        game.MakeMove(repeatedMoves[7]);
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -70,25 +65,20 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[1]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
-        var newPosition = new Position(game.CurrentPosition, repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[3]));
+        game.MakeMove(repeatedMoves[3]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
+        game.MakeMove(repeatedMoves[4]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
+        game.MakeMove(repeatedMoves[5]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
+        game.MakeMove(repeatedMoves[6]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[7]));
+        game.MakeMove(repeatedMoves[7]);
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -116,20 +106,19 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[1]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
-        var newPosition = new Position(game.CurrentPosition, repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
+        game.MakeMove(repeatedMoves[3]);
+        Assert.True(game.IsThreefoldRepetition());
 
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[3]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
+        game.MakeMove(repeatedMoves[6]);
+        Assert.True(game.IsThreefoldRepetition());
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
+        game.MakeMove(repeatedMoves[7]);
+        Assert.True(game.IsThreefoldRepetition());
 
         // Position with castling rights, lost in move Ke1d1
         winningPosition = new Position("1n2k2r/8/8/8/8/8/4PPPP/1N2K2R w Kk - 0 1");
@@ -153,21 +142,21 @@ public class GameTest : BaseTest
             Assert.DoesNotThrow(() => game.MakeMove(move));
         }
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[^1]);
-        Assert.False(game.IsThreefoldRepetition(newPosition));                      // Same position, but white not can't castle
-        Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[^1]));
+        game.MakeMove(repeatedMoves[^1]);
+        Assert.False(game.IsThreefoldRepetition());                      // Same position, but white not can't castle
 
 #if DEBUG
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
 #endif
+        Assert.AreEqual(repeatedMoves.Count + 1, game.PositionHashHistory.Count);
 
         var eval = winningPosition.StaticEvaluation().Score;
         Assert.AreNotEqual(0, eval);
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
-        newPosition = new Position(game.CurrentPosition, repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(newPosition));
+        game.MakeMove(repeatedMoves[6]);
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -196,6 +185,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(101, game.MoveHistory.Count);
 #endif
+        Assert.AreEqual(101 + 1, game.PositionHashHistory.Count);
 
         // If the checkmate is in the move when it's claimed, checkmate remains
         Assert.False(game.Is50MovesRepetition());
@@ -224,6 +214,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(100, game.MoveHistory.Count);
 #endif
+        Assert.AreEqual(100 + 1, game.PositionHashHistory.Count);
 
         Assert.True(game.Is50MovesRepetition());
     }
@@ -255,6 +246,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(51, game.MoveHistory.Count);
 #endif
+        Assert.AreEqual(51 + 1, game.PositionHashHistory.Count);
 
         Assert.False(game.Is50MovesRepetition());
     }

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -386,8 +386,8 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual(0, result.MateScore);
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
-        var lastPosition = new Position(position, result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(lastPosition));
+        game.MakeMove(result.BestMove);
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()
@@ -412,8 +412,8 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual(0, result.MateScore);
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
-        var lastPosition = new Position(position, result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(lastPosition));
+        game.MakeMove(result.BestMove);
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()


### PR DESCRIPTION
Reimplement repetition detection following the 'regular' method described in https://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf

```
Test  | perf/repetition-detection
Elo   | -6.26 +- 7.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4940 W: 1543 L: 1632 D: 1765
Penta | [209, 554, 1011, 509, 187]
https://openbench.lynx-chess.com/test/174/

Test  | perf/repetition-detection
Elo   | -6.45 +- 7.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4580 W: 1317 L: 1402 D: 1861
Penta | [145, 552, 969, 491, 133]
https://openbench.lynx-chess.com/test/175/

Again 8+0.08, just in case
Test  | perf/repetition-detection
Elo   | -9.34 +- 9.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3050 W: 899 L: 981 D: 1170
Penta | [108, 377, 630, 309, 101]
https://openbench.lynx-chess.com/test/177/
```

Including https://github.com/lynx-chess/Lynx/pull/674 (Check IsCapture() and Move.Piece() type before checking 50 moves rule)

```
Test  | perf/repetition-detection-and-check-capture-and-move-Piece-before-repetition
Elo   | -3.58 +- 4.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13974 W: 4280 L: 4424 D: 5270
Penta | [494, 1627, 2877, 1507, 482]
https://openbench.lynx-chess.com/test/181/
```