### PR TITLE
⚡ Stop checking for two/threefold repetition and 50 moves draws in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -549,35 +549,6 @@ public sealed partial class Engine
             // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
             // Theoretically there could be a castling move that caused the 50 moves repetitions, but it's highly unlikely
 
-            /*
-             *  var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
-             *  Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-             *  var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
-             *
-             *  int evaluation;
-             *  if (isThreeFoldRepetition || Game.Is50MovesRepetition())
-             *  {
-             *      evaluation = 0;
-             *
-             *      // We don't need to evaluate further down to know it's a draw.
-             *      // Since we won't be evaluating further down, we need to clear the PV table because those moves there
-             *      // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
-             *      Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
-             *  }
-             *  else
-             *  {
-             *      evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
-             *  }
-             *
-             *  // After making a move
-             *  Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-             *  if (!isThreeFoldRepetition)
-             *  {
-             *      Game.PositionHashHistory.Remove(position.UniqueIdentifier);
-             *  }
-             *  position.UnmakeMove(move, gameState);
-             */
-
             int evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
             position.UnmakeMove(move, gameState);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -546,32 +546,39 @@ public sealed partial class Engine
 
             PrintPreMove(position, ply, move, isQuiescence: true);
 
-            // Before making a move
-            var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
-            Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
-            var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
+            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
+            // Theoretically there could be a castling move that caused the 50 moves repetitions, but it's highly unlikely
 
-            int evaluation;
-            if (isThreeFoldRepetition || Game.Is50MovesRepetition())
-            {
-                evaluation = 0;
+            /*
+             *  var oldValue = Game.HalfMovesWithoutCaptureOrPawnMove;
+             *  Game.HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(move, Game.HalfMovesWithoutCaptureOrPawnMove);
+             *  var isThreeFoldRepetition = !Game.PositionHashHistory.Add(position.UniqueIdentifier);
+             *
+             *  int evaluation;
+             *  if (isThreeFoldRepetition || Game.Is50MovesRepetition())
+             *  {
+             *      evaluation = 0;
+             *
+             *      // We don't need to evaluate further down to know it's a draw.
+             *      // Since we won't be evaluating further down, we need to clear the PV table because those moves there
+             *      // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
+             *      Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
+             *  }
+             *  else
+             *  {
+             *      evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
+             *  }
+             *
+             *  // After making a move
+             *  Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
+             *  if (!isThreeFoldRepetition)
+             *  {
+             *      Game.PositionHashHistory.Remove(position.UniqueIdentifier);
+             *  }
+             *  position.UnmakeMove(move, gameState);
+             */
 
-                // We don't need to evaluate further down to know it's a draw.
-                // Since we won't be evaluating further down, we need to clear the PV table because those moves there
-                // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
-                Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
-            }
-            else
-            {
-                evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
-            }
-
-            // After making a move
-            Game.HalfMovesWithoutCaptureOrPawnMove = oldValue;
-            if (!isThreeFoldRepetition)
-            {
-                Game.PositionHashHistory.Remove(position.UniqueIdentifier);
-            }
+            int evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
             position.UnmakeMove(move, gameState);
 
             PrintMove(ply, move, evaluation);


### PR DESCRIPTION
As of now, QSearch only searches captures, pawn promotions and castling moves.
Only the latter could produce a 50 moves repetition, and none of them could produce a two/threefold one.

So it's pointless to check for repetition inside of QSearch.

```
Test  | search/no-repetition-in-qsearch
Elo   | 0.61 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 33522 W: 10468 L: 10409 D: 12645
Penta | [1180, 3828, 6779, 3701, 1273]
https://openbench.lynx-chess.com/test/179/

> python.exe .\sprt.py -w 10468 -l 10409 -d 12645 -e0 -5 -e1 0
ELO: 0.612 +- 2.93 [-2.32, 3.54]
LLR: 5.27 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```