### PR TITLE
⚡ Check `IsCapture()` and `Move.Piece()` type before checking 50 moves rule

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -213,6 +213,7 @@ public sealed partial class Engine
 
             ++_nodes;
             isAnyMoveValid = true;
+            var isCapture = move.IsCapture();
 
             PrintPreMove(position, ply, move);
 
@@ -233,7 +234,7 @@ public sealed partial class Engine
 
                 // This is the only case were we don't clear position.UniqueIdentifier from Game.PositionHashHistory, because it was already there before making the move
             }
-            else if (Game.Is50MovesRepetition())
+            else if (!isCapture && (move.Piece() + 6) % 6 != 0 && move.Piece() != 6 && Game.Is50MovesRepetition())
             {
                 evaluation = 0;
 
@@ -274,7 +275,7 @@ public sealed partial class Engine
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
                     && !isInCheck
-                    && !move.IsCapture())
+                    && !isCapture)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];
 
@@ -339,7 +340,7 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough");
 
-                if (move.IsCapture())
+                if (isCapture)
                 {
                     var piece = move.Piece();
                     var targetSquare = move.TargetSquare();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,7 +234,7 @@ public sealed partial class Engine
 
                 // This is the only case were we don't clear position.UniqueIdentifier from Game.PositionHashHistory, because it was already there before making the move
             }
-            else if (!isCapture && (move.Piece() + 6) % 6 != 0 && move.Piece() != 6 && Game.Is50MovesRepetition())
+            else if (!isCapture && (move.Piece() + 6) % 6 != 0 && Game.Is50MovesRepetition())
             {
                 evaluation = 0;
 


### PR DESCRIPTION
```
Test  | perf/check-capture-and-move-Piece-before-repetition
Elo   | -1.26 +- 3.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28074 W: 8658 L: 8760 D: 10656
Penta | [1038, 3177, 5685, 3123, 1014]
https://openbench.lynx-chess.com/test/180/
```