### PR TITLE
History malus: penalize also captures on quiet beta cutoffs

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -350,7 +350,7 @@ public sealed partial class Engine
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 Capture history penalty/malus
-                    // When a capture fails high, penalize previous visited captures
+                    // When a capture fails high, penalize previously visited captures
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
@@ -378,17 +378,24 @@ public sealed partial class Engine
                         _quietHistory[piece][targetSquare],
                         EvaluationConstants.HistoryBonus[depth]);
 
-                    // 🔍 Quiet history penalty/malus
-                    // When a quiet move fails high, penalize previous visited quiet moves
+                    // 🔍 Quiet and capture history penalty/malus
+                    // When a quiet move fails high, penalize both previously visited both captures and quiet moves
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
                         var visitedMove = visitedMoves[i];
+                        var visitedMovePiece = visitedMove.Piece();
+                        var visitedMoveTargetSquare = visitedMove.TargetSquare();
 
-                        if (!visitedMove.IsCapture())
+                        if (visitedMove.IsCapture())
                         {
-                            var visitedMovePiece = visitedMove.Piece();
-                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
+                            var visitedMoveCapturedPiece = visitedMove.CapturedPiece();
 
+                            _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece] = ScoreHistoryMove(
+                                _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece],
+                                -EvaluationConstants.HistoryBonus[depth]);
+                        }
+                        else
+                        {
                             _quietHistory[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
                                 _quietHistory[visitedMovePiece][visitedMoveTargetSquare],
                                 -EvaluationConstants.HistoryBonus[depth]);


### PR DESCRIPTION
8+0.08, looking terrible
```
Score of Lynx-search-quiet-history-malus-also-captures-2675-win-x64 vs Lynx 2673 - main: 315 - 401 - 467  [0.464] 1183
...      Lynx-search-quiet-history-malus-also-captures-2675-win-x64 playing White: 232 - 122 - 237  [0.593] 591
...      Lynx-search-quiet-history-malus-also-captures-2675-win-x64 playing Black: 83 - 279 - 230  [0.334] 592
...      White vs Black: 511 - 205 - 467  [0.629] 1183
Elo difference: -25.3 +/- 15.4, LOS: 0.1 %, DrawRatio: 39.5 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted

Score of Lynx-search-quiet-history-malus-also-captures-2675-win-x64 vs Lynx 2673 - main: 280 - 362 - 471  [0.463] 1113
...      Lynx-search-quiet-history-malus-also-captures-2675-win-x64 playing White: 210 - 90 - 257  [0.608] 557
...      Lynx-search-quiet-history-malus-also-captures-2675-win-x64 playing Black: 70 - 272 - 214  [0.318] 556
...      White vs Black: 482 - 160 - 471  [0.645] 1113
Elo difference: -25.6 +/- 15.5, LOS: 0.1 %, DrawRatio: 42.3 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```