### PR TITLE
⚡ Refactor `Update50movesRule()` method

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -7,7 +7,7 @@
   // Settings that affect the engine behavior
   "EngineSettings": {
     "MaxDepth": 128,
-    "BenchDepth": 5,
+    "BenchDepth": 8,
     "TranspositionTableSize": "256",
     "TranspositionTableEnabled": true,
     "UseOnlineTablebaseInRootPositions": false,

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -78,7 +78,9 @@ public partial class Engine
 
         "8/8/4k3/3n1n2/5P2/8/3K4/8 b - - 0 12",                         // NN vs P endgame
         "8/5R2/1n2RK2/8/8/7k/4r3/8 b - - 0 1",                          // RR vs RN endgame, where if black takes, they actually loses
-        "8/q5rk/8/8/8/8/Q5RK/7N w - - 0 1"                              // Endgame that can lead to QN vs Q or RN vs R positions
+        "8/q5rk/8/8/8/8/Q5RK/7N w - - 0 1",                             // Endgame that can lead to QN vs Q or RN vs R positions
+        "1kr5/2bp3q/Q7/1K6/6q1/6B1/8/8 w - - 0 1",                      // Endgame where triple repetition can and needs to be forced by white
+        "1kr5/2bp3q/R7/1K6/6q1/6B1/8/8 w - - 96 200"                    // Endgame where 50 moves draw can and needs to be forced by white
     ];
 
     /// <summary>

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -88,7 +88,7 @@ public sealed class EngineSettings
     /// <summary>
     /// Depth for bench command
     /// </summary>
-    public int BenchDepth { get; set; } = 5;
+    public int BenchDepth { get; set; } = 8;
 
     /// <summary>
     /// MB

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -160,7 +160,7 @@ public sealed class Game
         }
 
         PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
-        HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
+        Update50movesRule(moveToPlay, moveToPlay.IsCapture());
 
         return gameState;
     }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -65,6 +65,52 @@ public sealed class Game
         _gameInitialPosition = new Position(CurrentPosition);
     }
 
+    /// <summary>
+    /// Updates <paramref name="halfMovesWithoutCaptureOrPawnMove"/>.
+    /// See also <see cref="Utils.Update50movesRule(int, int)"/>
+    /// </summary>
+    /// <param name="moveToPlay"></param>
+    /// <param name="isCapture"></param>
+    /// <remarks>
+    /// Checking halfMovesWithoutCaptureOrPawnMove >= 100 since a capture/pawn move doesn't necessarily 'clear' the variable.
+    /// i.e. while the engine is searching:
+    ///     At depth 2, 50 rules move applied and eval is 0
+    ///     At depth 3, there's a capture, but the eval should still be 0
+    ///     At depth 4 there's no capture, but the eval should still be 0
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Update50movesRule(Move moveToPlay, bool isCapture)
+    {
+        if (isCapture)
+        {
+            if (HalfMovesWithoutCaptureOrPawnMove < 100)
+            {
+                HalfMovesWithoutCaptureOrPawnMove = 0;
+            }
+            else
+            {
+                ++HalfMovesWithoutCaptureOrPawnMove;
+            }
+        }
+        else
+        {
+            var pieceToMove = moveToPlay.Piece();
+
+            if ((pieceToMove == (int)Piece.P || pieceToMove == (int)Piece.p) && HalfMovesWithoutCaptureOrPawnMove < 100)
+            {
+                HalfMovesWithoutCaptureOrPawnMove = 0;
+            }
+            else
+            {
+                ++HalfMovesWithoutCaptureOrPawnMove;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Basic algorithm described in https://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
+    /// </summary>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsThreefoldRepetition(Position position) => PositionHashHistory.Contains(position.UniqueIdentifier);
 

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -129,7 +129,8 @@ public static class Utils
     }
 
     /// <summary>
-    /// Updates <paramref name="halfMovesWithoutCaptureOrPawnMove"/>
+    /// Updates <paramref name="halfMovesWithoutCaptureOrPawnMove"/>.
+    /// See also <see cref="Game.Update50movesRule(int, bool)"/>
     /// </summary>
     /// <param name="moveToPlay"></param>
     /// <param name="halfMovesWithoutCaptureOrPawnMove"></param>


### PR DESCRIPTION
- Move Utils.Update50movesRule to Game, since it updates the 50 moves counter there
- Increase `bench` depth to 8
- Add two more fens to `bench` that involve triple repetition and 50 moves draw

8+0.08, [-5, 0]
```
Score of Lynx-refactor-update50movesrule-2685-win-x64 vs Lynx 2680 - main: 2485 - 2419 - 3100  [0.504] 8004
...      Lynx-refactor-update50movesrule-2685-win-x64 playing White: 1716 - 751 - 1536  [0.621] 4003
...      Lynx-refactor-update50movesrule-2685-win-x64 playing Black: 769 - 1668 - 1564  [0.388] 4001
...      White vs Black: 3384 - 1520 - 3100  [0.616] 8004
Elo difference: 2.9 +/- 6.0, LOS: 82.7 %, DrawRatio: 38.7 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```