### PR TITLE
Prefetch TT entry + pin TT

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1078,7 +1078,7 @@ static void TranspositionTable()
     var hashKey2 = position.UniqueIdentifier & mask;
     Console.WriteLine(hashKey2);
 
-    transpositionTable.ClearTranspositionTable();
+    Array.Clear(transpositionTable);
 
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -79,7 +79,7 @@ public sealed partial class Engine
         var sw = Stopwatch.StartNew();
 
         InitializeStaticClasses();
-        const string goWarmupCommand = "go depth 10";   // ~300 ms
+        const string goWarmupCommand = "go depth 10";
 
         AdjustPosition(Constants.SuperLongPositionCommand);
         BestMove(new(goWarmupCommand));
@@ -93,7 +93,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        InitializeTT(); // TODO SPRT clearing instead
+        Array.Clear(_tt);
 
         // Clear histories
         for (int i = 0; i < 12; ++i)
@@ -304,7 +304,7 @@ public sealed partial class Engine
         if (Configuration.EngineSettings.TranspositionTableEnabled)
         {
             (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-            _tt = new TranspositionTableElement[ttLength];
+            _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
         }
     }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,8 +1,11 @@
 ﻿using NLog;
+using NLog.Targets;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+using System.Threading.Tasks;
 
 namespace Lynx.Model;
 
@@ -225,6 +228,23 @@ public static class TranspositionTableExtensions
         }
 
         return items;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Prefetch(this TranspositionTable transpositionTable, int ttMask, long positionUniqueIdentifier)
+    {
+        if (Sse.IsSupported)
+        {
+            var index = positionUniqueIdentifier & ttMask;
+
+            unsafe
+            {
+                fixed (TranspositionTableElement* ttPtr = &transpositionTable[0])
+                {
+                    Sse.Prefetch0(ttPtr + index);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -212,22 +212,6 @@ public static class TranspositionTableExtensions
         return items;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Prefetch(this TranspositionTable transpositionTable, int ttMask, long positionUniqueIdentifier)
-    {
-        if (Sse.IsSupported)
-        {
-            var index = positionUniqueIdentifier & ttMask;
-
-            unsafe
-            {
-                fixed (TranspositionTableElement* ttPtr = &transpositionTable[0])
-                {
-                    Sse.Prefetch0(ttPtr + index);
-                }
-            }
-        }
-    }
 
     /// <summary>
     /// Exact TT occupancy per mill

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -52,15 +52,6 @@ public struct TranspositionTableElement
     public int Score { readonly get => _score; set => _score = (short)value; }
 
     public long Key { readonly get => _key; set => _key = (ShortMove)(value >> 48); }
-
-    public void Clear()
-    {
-        Key = 0;
-        Score = 0;
-        Depth = 0;
-        Move = 0;
-        Type = NodeType.Unknown;
-    }
 }
 
 public static class TranspositionTableExtensions
@@ -92,15 +83,6 @@ public static class TranspositionTableExtensions
         _logger.Info("TT mask:\t{0}", mask.ToString("X"));
 
         return ((int)ttLength, (int)mask);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ClearTranspositionTable(this TranspositionTable transpositionTable)
-    {
-        foreach (var element in transpositionTable)
-        {
-            element.Clear();
-        }
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,6 +234,7 @@ public sealed partial class Engine
             }
             else if (pvNode && movesSearched == 0)
             {
+                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
             }
             else
@@ -253,6 +254,8 @@ public sealed partial class Engine
 
                     break;
                 }
+
+                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
 
                 int reduction = 0;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,7 +234,7 @@ public sealed partial class Engine
             }
             else if (pvNode && movesSearched == 0)
             {
-                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
+                PrefetchTTEntry();
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
             }
             else
@@ -255,7 +255,7 @@ public sealed partial class Engine
                     break;
                 }
 
-                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
+                PrefetchTTEntry();
 
                 int reduction = 0;
 


### PR DESCRIPTION
Combine prefetch with [Pin TT table and clear it instead of re-intiializing it](https://github.com/lynx-chess/Lynx/pull/661)

Bench looks slightly better:

![image](https://github.com/lynx-chess/Lynx/assets/11148519/f63d7db9-2a9b-4119-bd8d-31e1ad7322a0)

```
Test  | perf/tt-prefetch-pinned-array
Elo   | -4.72 +- 6.91 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6410 W: 2076 L: 2163 D: 2171
Penta | [325, 701, 1193, 708, 278]
https://openbench.lynx-chess.com/test/199/
```

Only prefetch gained in #681 
