### PR TITLE
⚡  Prefetch TT entry in NegaMax search

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,8 +1,11 @@
 ﻿using NLog;
+using NLog.Targets;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
+using System.Threading.Tasks;
 
 namespace Lynx.Model;
 
@@ -225,6 +228,23 @@ public static class TranspositionTableExtensions
         }
 
         return items;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void Prefetch(this TranspositionTable transpositionTable, int ttMask, long positionUniqueIdentifier)
+    {
+        if (Sse.IsSupported)
+        {
+            var index = positionUniqueIdentifier & ttMask;
+
+            unsafe
+            {
+                fixed (TranspositionTableElement* ttPtr = &transpositionTable[0])
+                {
+                    Sse.Prefetch0(ttPtr + index);
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,6 +234,7 @@ public sealed partial class Engine
             }
             else if (pvNode && movesSearched == 0)
             {
+                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
             }
             else
@@ -253,6 +254,8 @@ public sealed partial class Engine
 
                     break;
                 }
+
+                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
 
                 int reduction = 0;
 


### PR DESCRIPTION
```
Test  | perf/tt-prefetch
Elo   | 6.08 +- 4.93 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12690 W: 4346 L: 4124 D: 4220
Penta | [549, 1294, 2469, 1452, 581]
https://openbench.lynx-chess.com/test/198/
```