### PR TITLE
Use `isQuiet` instead of `isCapture` for LMR

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -214,7 +214,8 @@ public sealed partial class Engine
             ++_nodes;
             isAnyMoveValid = true;
             var isCapture = move.IsCapture();
-            var isQuiet = !isCapture && move.PromotedPiece() == default && !position.IsInCheck();
+            var isNotPromotion = move.PromotedPiece() == default;
+            var isQuiet = !isCapture && isNotPromotion && !position.IsInCheck();
 
             PrintPreMove(position, ply, move);
 
@@ -326,7 +327,7 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough");
 
-                if (!isQuiet)
+                if (isCapture)
                 {
                     var piece = move.Piece();
                     var targetSquare = move.TargetSquare();
@@ -383,7 +384,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 Killer moves
-                    if (move != _killerMoves[0][ply])
+                    if (isNotPromotion && move != _killerMoves[0][ply])
                     {
                         if (move != _killerMoves[1][ply])
                         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -214,6 +214,7 @@ public sealed partial class Engine
             ++_nodes;
             isAnyMoveValid = true;
             var isCapture = move.IsCapture();
+            var isQuiet = !isCapture && move.PromotedPiece() == default && !position.IsInCheck();
 
             PrintPreMove(position, ply, move);
 
@@ -261,7 +262,7 @@ public sealed partial class Engine
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
                     && !isInCheck
-                    && !isCapture)
+                    && isQuiet)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];
 
@@ -325,7 +326,7 @@ public sealed partial class Engine
             {
                 PrintMessage($"Pruning: {move} is enough");
 
-                if (isCapture)
+                if (!isQuiet)
                 {
                     var piece = move.Piece();
                     var targetSquare = move.TargetSquare();
@@ -382,7 +383,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 Killer moves
-                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
+                    if (move != _killerMoves[0][ply])
                     {
                         if (move != _killerMoves[1][ply])
                         {


### PR DESCRIPTION
```
Score of Lynx-search-replace-iscapture-with-isquiet-lmr-2710-win-x64 vs Lynx 2708 - main: 2852 - 2981 - 3242  [0.493] 9075
...      Lynx-search-replace-iscapture-with-isquiet-lmr-2710-win-x64 playing White: 1959 - 972 - 1606  [0.609] 4537
...      Lynx-search-replace-iscapture-with-isquiet-lmr-2710-win-x64 playing Black: 893 - 2009 - 1636  [0.377] 4538
...      White vs Black: 3968 - 1865 - 3242  [0.616] 9075
Elo difference: -4.9 +/- 5.7, LOS: 4.6 %, DrawRatio: 35.7 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```