### PR TITLE
⚡ Force GC collection at the end of `Engine` constructor and after `ucinewgame`

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -69,7 +69,12 @@ public sealed partial class Engine
 
         _engineWriter = engineWriter;
         ResetEngine();
-# endif
+#endif
+
+#pragma warning disable S1215 // "GC.Collect" should not be called
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+#pragma warning restore S1215 // "GC.Collect" should not be called
     }
 
 #pragma warning disable S1144 // Unused private types or members should be removed - used in Release mode
@@ -121,6 +126,11 @@ public sealed partial class Engine
         _isNewGameCommandSupported = true;
 
         ResetEngine();
+
+#pragma warning disable S1215 // "GC.Collect" should not be called
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+#pragma warning restore S1215 // "GC.Collect" should not be called
     }
 
     public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)


### PR DESCRIPTION
Tested using:
```
ucinewgame
go depth 15
go depth 15
ucinewgame
ucinewgame
```

Before:

![image](https://github.com/lynx-chess/Lynx/assets/11148519/6e1671b4-36fb-41e8-b57f-8b42c1f1ea48)

After:

![image](https://github.com/lynx-chess/Lynx/assets/11148519/23f81d95-7734-409f-8db5-35f7f8bd47e1)

NPS looking good in `bench`
![image](https://github.com/lynx-chess/Lynx/assets/11148519/588c5b1e-3d61-49e3-931d-8df75176b929)
![image](https://github.com/lynx-chess/Lynx/assets/11148519/889fbfb7-a88a-4dae-832b-bdac437ed01f)

```
Test  | perf/force-gc-after-newgame
Elo   | -0.55 +- 2.73 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40842 W: 13403 L: 13468 D: 13971
Penta | [1818, 4392, 8026, 4407, 1778]
https://openbench.lynx-chess.com/test/203/
```
```bash
> python .\sprt.py -w 13403 -d 13971 -l 13468 -e0 -5 -e1 0
ELO: -0.553 +- 2.73 [-3.28, 2.18]
LLR: 3.76 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```

