### PR TITLE
Move `Prefetch` method to `Engine`

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -230,23 +230,6 @@ public static class TranspositionTableExtensions
         return items;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void Prefetch(this TranspositionTable transpositionTable, int ttMask, long positionUniqueIdentifier)
-    {
-        if (Sse.IsSupported)
-        {
-            var index = positionUniqueIdentifier & ttMask;
-
-            unsafe
-            {
-                fixed (TranspositionTableElement* ttPtr = &transpositionTable[0])
-                {
-                    Sse.Prefetch0(ttPtr + index);
-                }
-            }
-        }
-    }
-
     /// <summary>
     /// Exact TT occupancy per mill
     /// </summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Text;
 
 namespace Lynx;
@@ -107,6 +108,26 @@ public sealed partial class Engine
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
         return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PrefetchTTEntry()
+    {
+        if (Sse.IsSupported)
+        {
+            var index = Game.CurrentPosition.UniqueIdentifier & _ttMask;
+
+            unsafe
+            {
+                // Since _tt is a pinned array
+                // This is no-op pinning as it does not influence the GC compaction
+                // https://tooslowexception.com/pinned-object-heap-in-net-5/
+                fixed (TranspositionTableElement* ttPtr = _tt)
+                {
+                    Sse.Prefetch0(ttPtr + index);
+                }
+            }
+        }
     }
 
 #pragma warning disable RCS1226 // Add paragraph to documentation comment

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,7 +234,7 @@ public sealed partial class Engine
             }
             else if (pvNode && movesSearched == 0)
             {
-                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
+                PrefetchTTEntry();
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
             }
             else
@@ -255,7 +255,7 @@ public sealed partial class Engine
                     break;
                 }
 
-                _tt.Prefetch(_ttMask, position.UniqueIdentifier);
+                PrefetchTTEntry();
 
                 int reduction = 0;
 


### PR DESCRIPTION
```
Test  | perf/move-prefetch-to-engine
Elo   | 1.04 +- 2.87 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 37130 W: 12337 L: 12226 D: 12567
Penta | [1626, 4023, 7165, 4116, 1635]
https://openbench.lynx-chess.com/test/200/
```