### PR TITLE
⚖ Scale down all 2vs1 minor pieces endgame

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -764,6 +764,13 @@ public class Position
                             return (0, gamePhase);
                         }
 
+                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                        if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                        {
+                            endGameScore >>= 1; // /2
+                        }
+
                         break;
                     }
                 case 2:


### PR DESCRIPTION
vs base refactor

```
Test  | eval/endgame-XX-vs-X-sprt
Elo   | 3.01 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 43530 W: 14035 L: 13658 D: 15837
Penta | [1582, 4634, 9048, 4827, 1674]
https://openbench.lynx-chess.com/test/213/
```