### PR TITLE
⚖ Scale down RX vs R endgames

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -751,10 +751,20 @@ public class Position
         }
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3 && pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
+        if (gamePhase <= 5 && pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
         {
             switch (gamePhase)
             {
+                case 5:
+                    {
+                        // RB vs R, RN vs R - escale it down due to the chances of it being a draw
+                        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                        {
+                            endGameScore >>= 1; // /2
+                        }
+
+                        break;
+                    }
                 case 3:
                     {
                         var winningSideOffset = Utils.PieceOffset(endGameScore >= 0);


### PR DESCRIPTION
vs base refactor


```
Test  | eval/endgames-RX-vs-R-sprt
Elo   | 2.41 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 61658 W: 19403 L: 18976 D: 23279
Penta | [2106, 6754, 12820, 6905, 2244]
https://openbench.lynx-chess.com/test/210/
```