### PR TITLE
⌛ Tune time management variables (SPRT)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,10 +15,10 @@
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
 
-    "HardTimeBoundMultiplier": 0.5,
+    "HardTimeBoundMultiplier": 0.52,
     "SoftTimeBoundMultiplier": 1,
-    "DefaultMovesToGo": 50,
-    "SoftTimeBaseIncrementMultiplier": 0.75,
+    "DefaultMovesToGo": 45,
+    "SoftTimeBaseIncrementMultiplier": 0.8,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,13 +113,13 @@ public sealed class EngineSettings
 
     #region Time management
 
-    public double HardTimeBoundMultiplier { get; set; } = 0.5;
+    public double HardTimeBoundMultiplier { get; set; } = 0.52;
 
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
-    public int DefaultMovesToGo { get; set; } = 50;
+    public int DefaultMovesToGo { get; set; } = 45;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.75;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     #endregion
 


### PR DESCRIPTION
They don't seem to have converged yet, but gave this intermediate values a try at 40+0.4:

```
Score of Lynx-main-2739-win-x64 vs Lynx-main-2739-win-x64 - Copy: 5377 - 5103 - 7389  [0.508] 17869
...      Lynx-main-2739-win-x64 playing White: 4004 - 1284 - 3647  [0.652] 8935
...      Lynx-main-2739-win-x64 playing Black: 1373 - 3819 - 3742  [0.363] 8934
...      White vs Black: 7823 - 2657 - 7389  [0.645] 17869
Elo difference: 5.3 +/- 3.9, LOS: 99.6 %, DrawRatio: 41.4 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```