### PR TITLE
🔍 Use TT score as positional eval for pruning

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -115,18 +115,18 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Evaluation, ShortMove BestMove, NodeType NodeType) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
+    public static (int Evaluation, ShortMove BestMove, NodeType NodeType, int score) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         if (!Configuration.EngineSettings.TranspositionTableEnabled)
         {
-            return (EvaluationConstants.NoHashEntry, default, default);
+            return (EvaluationConstants.NoHashEntry, default, default, default);
         }
 
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         if ((position.UniqueIdentifier >> 48) != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default, default);
+            return (EvaluationConstants.NoHashEntry, default, default, default);
         }
 
         var eval = EvaluationConstants.NoHashEntry;
@@ -146,7 +146,7 @@ public static class TranspositionTableExtensions
             };
         }
 
-        return (eval, entry.Move, entry.Type);
+        return (eval, entry.Move, entry.Type, entry.Score);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -92,7 +92,7 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttElementType != default && ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
                 staticEval = ttEvaluation;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -42,10 +42,11 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
         NodeType ttElementType = default;
         int ttEvaluation = default;
+        int ttScore = default;
 
         if (!isRoot)
         {
-            (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
+            (ttEvaluation, ttBestMove, ttElementType, ttScore) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
             if (!pvNode && ttEvaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttEvaluation;
@@ -92,9 +93,9 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttElementType != default && ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttElementType != default && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
-                staticEval = ttEvaluation;
+                staticEval = ttScore;
             }
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Lynx;
 
@@ -85,6 +86,16 @@ public sealed partial class Engine
         if (!pvNode && !isInCheck)
         {
             var (staticEval, phase) = position.StaticEvaluation();
+
+            // From smol.cs
+            // ttEvaluation can be used as a better positional evaluation:
+            // If the score is outside what the current bounds are, but it did match flag and depth,
+            // then we can trust that this score is more accurate than the current static evaluation,
+            // and we can update our static evaluation for better accuracy in pruning
+            if (ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
+            {
+                staticEval = ttEvaluation;
+            }
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using static System.Formats.Asn1.AsnWriter;
 
 namespace Lynx;
 


### PR DESCRIPTION
[Use TT score as positional eval for better pruning](https://github.com/lynx-chess/Lynx/commit/52d1a6f04c8b730a42e0c98e37edd882c4d7e7a5)
```
Score of Lynx-experiment-tt-score-as-positional-eval-2765-win-x64 vs Lynx 2764 - main: 0 - 216 - 0  [0.000] 216
...      Lynx-experiment-tt-score-as-positional-eval-2765-win-x64 playing White: 0 - 108 - 0  [0.000] 108
...      Lynx-experiment-tt-score-as-positional-eval-2765-win-x64 playing Black: 0 - 108 - 0  [0.000] 108
...      White vs Black: 108 - 108 - 0  [0.500] 216
Elo difference: -inf +/- nan, LOS: 0.0 %, DrawRatio: 0.0 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Make sure there's a TT hit](https://github.com/lynx-chess/Lynx/commit/da50f8725e2f806455124874d9d36627490ee26d)
```
Score of Lynx-experiment-tt-score-as-positional-eval-2766-win-x64 vs Lynx 2764 - main: 65 - 231 - 124  [0.302] 420
...      Lynx-experiment-tt-score-as-positional-eval-2766-win-x64 playing White: 46 - 85 - 79  [0.407] 210
...      Lynx-experiment-tt-score-as-positional-eval-2766-win-x64 playing Black: 19 - 146 - 45  [0.198] 210
...      White vs Black: 192 - 104 - 124  [0.605] 420
Elo difference: -145.2 +/- 29.2, LOS: 0.0 %, DrawRatio: 29.5 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Use raw TT score](https://github.com/lynx-chess/Lynx/commit/f5088144839decaab604462fc84ae6b4b7c9e19e)
```
Score of Lynx-experiment-tt-score-as-positional-eval-2768-win-x64 vs Lynx 2764 - main: 2469 - 2227 - 2829  [0.516] 7525
...      Lynx-experiment-tt-score-as-positional-eval-2768-win-x64 playing White: 1691 - 666 - 1407  [0.636] 3764
...      Lynx-experiment-tt-score-as-positional-eval-2768-win-x64 playing Black: 778 - 1561 - 1422  [0.396] 3761
...      White vs Black: 3252 - 1444 - 2829  [0.620] 7525
Elo difference: 11.2 +/- 6.2, LOS: 100.0 %, DrawRatio: 37.6 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```