### PR TITLE
⚡ Use packed evaluation

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1150,13 +1150,16 @@ static void UnmakeMove()
 
 static void PieceSquareTables()
 {
+    short[] middleGamePawnTableBlack = EvaluationConstants.MiddleGamePawnTable.Select((_, index) => (short)-EvaluationConstants.MiddleGamePawnTable[index ^ 56]).ToArray();
+    short[] endGamePawnTableBlack = EvaluationConstants.EndGamePawnTable.Select((_, index) => (short)-EvaluationConstants.EndGamePawnTable[index ^ 56]).ToArray();
+
     PrintBitBoard(EvaluationConstants.MiddleGamePawnTable);
-    PrintBitBoard(EvaluationConstants.MiddleGamePawnTableBlack);
+    PrintBitBoard(middleGamePawnTableBlack);
 
     PrintBitBoard(EvaluationConstants.EndGamePawnTable);
-    PrintBitBoard(EvaluationConstants.EndGamePawnTableBlack);
+    PrintBitBoard(endGamePawnTableBlack);
 
-    static void PrintBitBoard(int[] bitboard)
+    static void PrintBitBoard<T>(T[] bitboard)
     {
         for (var rank = 0; rank < 8; ++rank)
         {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,18 +211,20 @@ public sealed class EngineSettings
 
 public sealed class TaperedEvaluationTerm
 {
-    public int MG { get; set; }
+    public int PackedEvaluation { get; }
 
-    public int EG { get; set; }
+    public int MG => Utils.UnpackMG(PackedEvaluation);
 
-    internal TaperedEvaluationTerm(int singleValue) : this(singleValue, singleValue)
+    public int EG => Utils.UnpackEG(PackedEvaluation);
+
+    internal TaperedEvaluationTerm(int singleValue)
     {
+        PackedEvaluation = Utils.Pack((short)singleValue, (short)singleValue);
     }
 
     public TaperedEvaluationTerm(int mg, int eg)
     {
-        MG = mg;
-        EG = eg;
+        PackedEvaluation = Utils.Pack((short)mg, (short)eg);
     }
 
     public override string ToString()

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,6 +211,7 @@ public sealed class EngineSettings
 
 public sealed class TaperedEvaluationTerm
 {
+    [JsonIgnore]
     public int PackedEvaluation { get; }
 
     public int MG => Utils.UnpackMG(PackedEvaluation);

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -1,5 +1,7 @@
 ﻿using Lynx.Model;
 
+#pragma warning disable IDE1006 // Naming Styles
+
 namespace Lynx;
 
 public static class EvaluationConstants
@@ -22,19 +24,19 @@ public static class EvaluationConstants
         0, 1, 1, 2, 4, 0
     ];
 
-public static readonly int[] MiddleGamePieceValues =
+internal static readonly short[] MiddleGamePieceValues =
 [
         +103, +386, +357, +475, +1084, 0,
         -103, -386, -357, -475, -1084, 0
 ];
 
-public static readonly int[] EndGamePieceValues =
+internal static readonly short[] EndGamePieceValues =
 [
         +149, +485, +434, +843, +1560, 0,
         -149, -485, -434, -843, -1560, 0
 ];
 
-public static readonly int[] MiddleGamePawnTable =
+internal static readonly short[] MiddleGamePawnTable =
 [
         0,      0,      0,      0,      0,      0,      0,      0,
         -26,    -23,    -15,    -9,     -3,     29,     31,     -15,
@@ -46,7 +48,7 @@ public static readonly int[] MiddleGamePawnTable =
         0,      0,      0,      0,      0,      0,      0,      0,
 ];
 
-public static readonly int[] EndGamePawnTable =
+internal static readonly short[] EndGamePawnTable =
 [
         0,      0,      0,      0,      0,      0,      0,      0,
         12,     12,     6,      -15,    6,      2,      -4,     -12,
@@ -58,7 +60,7 @@ public static readonly int[] EndGamePawnTable =
         0,      0,      0,      0,      0,      0,      0,      0,
 ];
 
-public static readonly int[] MiddleGameKnightTable =
+internal static readonly short[] MiddleGameKnightTable =
 [
         -153,   -23,    -52,    -32,    -12,    -21,    -9,     -98,
         -46,    -27,    -3,     15,     18,     25,     -14,    -17,
@@ -70,7 +72,7 @@ public static readonly int[] MiddleGameKnightTable =
         -168,   -24,    -49,    -21,    -9,     -12,    -17,    -91,
 ];
 
-public static readonly int[] EndGameKnightTable =
+internal static readonly short[] EndGameKnightTable =
 [
         -72,    -61,    -13,    -13,    -10,    -28,    -55,    -93,
         -22,    -2,     15,     9,      10,     7,      -13,    -21,
@@ -82,7 +84,7 @@ public static readonly int[] EndGameKnightTable =
         -78,    -60,    -9,     -17,    -11,    -26,    -53,    -93,
 ];
 
-public static readonly int[] MiddleGameBishopTable =
+internal static readonly short[] MiddleGameBishopTable =
 [
         -15,    16,     -2,     -15,    -10,    -16,    -23,    2,
         8,      3,      7,      -18,    1,      -1,     29,     -12,
@@ -94,7 +96,7 @@ public static readonly int[] MiddleGameBishopTable =
         10,     20,     12,     -29,    -13,    -21,    1,      -12,
 ];
 
-public static readonly int[] EndGameBishopTable =
+internal static readonly short[] EndGameBishopTable =
 [
         -14,    18,     -13,    3,      -3,     6,      1,      -31,
         -5,     -8,     -4,     5,      4,      -10,    -2,     -16,
@@ -106,7 +108,7 @@ public static readonly int[] EndGameBishopTable =
         -7,     -12,    -7,     7,      8,      9,      -2,     -22,
 ];
 
-public static readonly int[] MiddleGameRookTable =
+internal static readonly short[] MiddleGameRookTable =
 [
         -4,     -10,    -5,     2,      14,     3,      10,     0,
         -27,    -17,    -14,    -14,    -2,     3,      21,     0,
@@ -118,7 +120,7 @@ public static readonly int[] MiddleGameRookTable =
         -2,     -3,     1,      12,     23,     8,      17,     12,
 ];
 
-public static readonly int[] EndGameRookTable =
+internal static readonly short[] EndGameRookTable =
 [
         6,      3,      7,      -2,     -11,    4,      0,      -5,
         15,     20,     21,     11,     0,      -2,     -6,     2,
@@ -130,7 +132,7 @@ public static readonly int[] EndGameRookTable =
         1,      -3,     2,      -8,     -18,    -4,     -9,     -15,
 ];
 
-public static readonly int[] MiddleGameQueenTable =
+internal static readonly short[] MiddleGameQueenTable =
 [
         -15,    -10,    -5,     9,      3,      -32,    14,     1,
         0,      -10,    7,      -2,     2,      6,      22,     51,
@@ -142,7 +144,7 @@ public static readonly int[] MiddleGameQueenTable =
         -11,    -11,    5,      11,     6,      -39,    -12,    28,
 ];
 
-public static readonly int[] EndGameQueenTable =
+internal static readonly short[] EndGameQueenTable =
 [
         -27,    -24,    -10,    -9,     -19,    -11,    -46,    6,
         -22,    -13,    -28,    0,      -2,     -17,    -48,    -5,
@@ -154,7 +156,7 @@ public static readonly int[] EndGameQueenTable =
         -15,    -18,    -17,    -2,     -9,     21,     13,     -9,
 ];
 
-public static readonly int[] MiddleGameKingTable =
+internal static readonly short[] MiddleGameKingTable =
 [
         34,     55,     30,     -72,    12,     -58,    44,     57,
         -3,     -12,    -33,    -74,    -88,    -58,    -7,     23,
@@ -166,7 +168,7 @@ public static readonly int[] MiddleGameKingTable =
         49,     82,     43,     -55,    25,     -47,    58,     70,
 ];
 
-public static readonly int[] EndGameKingTable =
+internal static readonly short[] EndGameKingTable =
 [
         -85,    -49,    -22,    4,      -36,    -3,     -41,    -96,
         -21,    16,     30,     43,     51,     36,     14,     -24,
@@ -180,73 +182,10 @@ public static readonly int[] EndGameKingTable =
 
 #pragma warning restore IDE0055
 
-    public static readonly int[] MiddleGamePawnTableBlack = MiddleGamePawnTable.Select((_, index) => -MiddleGamePawnTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGamePawnTableBlack = EndGamePawnTable.Select((_, index) => -EndGamePawnTable[index ^ 56]).ToArray();
-
-    public static readonly int[] MiddleGameKnightTableBlack = MiddleGameKnightTable.Select((_, index) => -MiddleGameKnightTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGameKnightTableBlack = EndGameKnightTable.Select((_, index) => -EndGameKnightTable[index ^ 56]).ToArray();
-
-    public static readonly int[] MiddleGameBishopTableBlack = MiddleGameBishopTable.Select((_, index) => -MiddleGameBishopTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGameBishopTableBlack = EndGameBishopTable.Select((_, index) => -EndGameBishopTable[index ^ 56]).ToArray();
-
-    public static readonly int[] MiddleGameRookTableBlack = MiddleGameRookTable.Select((_, index) => -MiddleGameRookTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGameRookTableBlack = EndGameRookTable.Select((_, index) => -EndGameRookTable[index ^ 56]).ToArray();
-
-    public static readonly int[] MiddleGameQueenTableBlack = MiddleGameQueenTable.Select((_, index) => -MiddleGameQueenTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGameQueenTableBlack = EndGameQueenTable.Select((_, index) => -EndGameQueenTable[index ^ 56]).ToArray();
-
-    public static readonly int[] MiddleGameKingTableBlack = MiddleGameKingTable.Select((_, index) => -MiddleGameKingTable[index ^ 56]).ToArray();
-    public static readonly int[] EndGameKingTableBlack = EndGameKingTable.Select((_, index) => -EndGameKingTable[index ^ 56]).ToArray();
-
-    /// <summary>
-    /// [12][64]
-    /// </summary>
-    public static readonly int[][] MiddleGamePositionalTables =
-    [
-        MiddleGamePawnTable,
-        MiddleGameKnightTable,
-        MiddleGameBishopTable,
-        MiddleGameRookTable,
-        MiddleGameQueenTable,
-        MiddleGameKingTable,
-
-        MiddleGamePawnTableBlack,
-        MiddleGameKnightTableBlack,
-        MiddleGameBishopTableBlack,
-        MiddleGameRookTableBlack,
-        MiddleGameQueenTableBlack,
-        MiddleGameKingTableBlack
-    ];
-
-    /// <summary>
-    /// [12][64]
-    /// </summary>
-    public static readonly int[][] EndGamePositionalTables =
-    [
-        EndGamePawnTable,
-        EndGameKnightTable,
-        EndGameBishopTable,
-        EndGameRookTable,
-        EndGameQueenTable,
-        EndGameKingTable,
-
-        EndGamePawnTableBlack,
-        EndGameKnightTableBlack,
-        EndGameBishopTableBlack,
-        EndGameRookTableBlack,
-        EndGameQueenTableBlack,
-        EndGameKingTableBlack
-    ];
-
     /// <summary>
     /// 12x64
     /// </summary>
-    public static readonly int[][] MiddleGameTable = new int[12][];
-
-    /// <summary>
-    /// 12x64
-    /// </summary>
-    public static readonly int[][] EndGameTable = new int[12][];
+    public static readonly int[][] PackedPSQT = new int[12][];
 
     /// <summary>
     /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
@@ -260,14 +199,66 @@ public static readonly int[] EndGameKingTable =
 
     static EvaluationConstants()
     {
+        short[] middleGamePawnTableBlack = MiddleGamePawnTable.Select((_, index) => (short)-MiddleGamePawnTable[index ^ 56]).ToArray();
+        short[] endGamePawnTableBlack = EndGamePawnTable.Select((_, index) => (short)-EndGamePawnTable[index ^ 56]).ToArray();
+
+        short[] middleGameKnightTableBlack = MiddleGameKnightTable.Select((_, index) => (short)-MiddleGameKnightTable[index ^ 56]).ToArray();
+        short[] endGameKnightTableBlack = EndGameKnightTable.Select((_, index) => (short)-EndGameKnightTable[index ^ 56]).ToArray();
+
+        short[] middleGameBishopTableBlack = MiddleGameBishopTable.Select((_, index) => (short)-MiddleGameBishopTable[index ^ 56]).ToArray();
+        short[] endGameBishopTableBlack = EndGameBishopTable.Select((_, index) => (short)-EndGameBishopTable[index ^ 56]).ToArray();
+
+        short[] middleGameRookTableBlack = MiddleGameRookTable.Select((_, index) => (short)-MiddleGameRookTable[index ^ 56]).ToArray();
+        short[] endGameRookTableBlack = EndGameRookTable.Select((_, index) => (short)-EndGameRookTable[index ^ 56]).ToArray();
+
+        short[] middleGameQueenTableBlack = MiddleGameQueenTable.Select((_, index) => (short)-MiddleGameQueenTable[index ^ 56]).ToArray();
+        short[] EndGameQueenTableBlack = EndGameQueenTable.Select((_, index) => (short)-EndGameQueenTable[index ^ 56]).ToArray();
+
+        short[] middleGameKingTableBlack = MiddleGameKingTable.Select((_, index) => (short)-MiddleGameKingTable[index ^ 56]).ToArray();
+        short[] endGameKingTableBlack = EndGameKingTable.Select((_, index) => (short)-EndGameKingTable[index ^ 56]).ToArray();
+
+        short[][] mgPositionalTables =
+        [
+            MiddleGamePawnTable,
+            MiddleGameKnightTable,
+            MiddleGameBishopTable,
+            MiddleGameRookTable,
+            MiddleGameQueenTable,
+            MiddleGameKingTable,
+
+            middleGamePawnTableBlack,
+            middleGameKnightTableBlack,
+            middleGameBishopTableBlack,
+            middleGameRookTableBlack,
+            middleGameQueenTableBlack,
+            middleGameKingTableBlack
+        ];
+
+        short[][] egPositionalTables =
+        [
+            EndGamePawnTable,
+            EndGameKnightTable,
+            EndGameBishopTable,
+            EndGameRookTable,
+            EndGameQueenTable,
+            EndGameKingTable,
+
+            endGamePawnTableBlack,
+            endGameKnightTableBlack,
+            endGameBishopTableBlack,
+            endGameRookTableBlack,
+            EndGameQueenTableBlack,
+            endGameKingTableBlack
+        ];
+
         for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
         {
-            MiddleGameTable[piece] = new int[64];
-            EndGameTable[piece] = new int[64];
+            PackedPSQT[piece] = new int[64];
             for (int sq = 0; sq < 64; ++sq)
             {
-                MiddleGameTable[piece][sq] = MiddleGamePieceValues[piece] + MiddleGamePositionalTables[piece][sq];
-                EndGameTable[piece][sq] = EndGamePieceValues[piece] + EndGamePositionalTables[piece][sq];
+                PackedPSQT[piece][sq] = Utils.Pack(
+                    (short)(MiddleGamePieceValues[piece] + mgPositionalTables[piece][sq]),
+                    (short)(EndGamePieceValues[piece] + egPositionalTables[piece][sq]));
             }
         }
 
@@ -389,3 +380,5 @@ public static readonly int[] EndGameKingTable =
     /// </summary>
     public const int SingleMoveEvaluation = 200;
 }
+
+#pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -738,7 +738,7 @@ public class Position
         }
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 5 && pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
+        if (gamePhase <= 3 && pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
         {
             switch (gamePhase)
             {

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -742,34 +742,34 @@ public class Position
         {
             switch (gamePhase)
             {
-                case 5:
-                    {
-                        // RB vs R, RN vs R - escale it down due to the chances of it being a draw
-                        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                        {
-                            packedScore >>= 1; // /2
-                        }
+                //case 5:
+                //    {
+                //        // RB vs R, RN vs R - escale it down due to the chances of it being a draw
+                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                //        {
+                //            packedScore >>= 1; // /2
+                //        }
 
-                        break;
-                    }
-                case 3:
-                    {
-                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                //        break;
+                //    }
+                //case 3:
+                //    {
+                //        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                        if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
-                        {
-                            return (0, gamePhase);
-                        }
+                //        if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
+                //        {
+                //            return (0, gamePhase);
+                //        }
 
-                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                        if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                        {
-                            packedScore >>= 1; // /2
-                        }
+                //        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                //        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                //        if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                //        {
+                //            packedScore >>= 1; // /2
+                //        }
 
-                        break;
-                    }
+                //        break;
+                //    }
                 case 2:
                     {
                         if (pieceCount[(int)Piece.N] + pieceCount[(int)Piece.n] == 2            // NN vs -, N vs N

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -752,24 +752,24 @@ public class Position
 
                 //        break;
                 //    }
-                //case 3:
-                //    {
-                //        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                case 3:
+                    {
+                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                //        if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
-                //        {
-                //            return (0, gamePhase);
-                //        }
+                        if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
+                        {
+                            return (0, gamePhase);
+                        }
 
-                //        // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                //        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                //        if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                //        {
-                //            packedScore >>= 1; // /2
-                //        }
+                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                        //{
+                        //    packedScore >>= 1; // /2
+                        //}
 
-                //        break;
-                //    }
+                        break;
+                    }
                 case 2:
                     {
                         if (pieceCount[(int)Piece.N] + pieceCount[(int)Piece.n] == 2            // NN vs -, N vs N

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -180,6 +180,40 @@ public static class Utils
         return Convert.ToInt64(Math.Clamp(nodes / ((0.001 * elapsedMilliseconds) + 1), 0, long.MaxValue));
     }
 
+    /// <summary>
+    /// https://minuskelvin.net/chesswiki/content/packed-eval.html
+    /// </summary>
+    /// <param name="mg"></param>
+    /// <param name="eg"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int Pack(short mg, short eg)
+    {
+        return (eg << 16) + mg;
+    }
+
+    /// <summary>
+    /// https://minuskelvin.net/chesswiki/content/packed-eval.html
+    /// </summary>
+    /// <param name="packed"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static short UnpackMG(int packed)
+    {
+        return (short)packed;
+    }
+
+    /// <summary>
+    /// https://minuskelvin.net/chesswiki/content/packed-eval.html
+    /// </summary>
+    /// <param name="packed"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static short UnpackEG(int packed)
+    {
+        return (short)((packed + 0x8000) >> 16);
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -9,12 +9,12 @@ public class EvaluationConstantsTest
     /// Shy from 14k
     /// </summary>
     private readonly int _sensibleEvaluation =
-        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.B].Max(), EndGamePositionalTables[(int)Piece.B].Max()) + Configuration.EngineSettings.BishopMobilityBonus.MG * 64) +
-        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.N].Max(), EndGamePositionalTables[(int)Piece.N].Max())) +
-        2 * (Math.Max(MiddleGamePositionalTables[(int)Piece.R].Max(), EndGamePositionalTables[(int)Piece.R].Max()) + Configuration.EngineSettings.OpenFileRookBonus.MG + Configuration.EngineSettings.SemiOpenFileRookBonus.MG) +
-        9 * (Math.Max(MiddleGamePositionalTables[(int)Piece.Q].Max(), EndGamePositionalTables[(int)Piece.Q].Max()) + Configuration.EngineSettings.QueenMobilityBonus.MG * 64) +
-        1 * (Math.Max(MiddleGamePositionalTables[(int)Piece.K].Max(), EndGamePositionalTables[(int)Piece.K].Max()) + Configuration.EngineSettings.KingShieldBonus.MG * 8) +
-        MiddleGamePositionalTables[(int)Piece.Q].Max(); // just in case
+        (2 * (Math.Max(MiddleGameBishopTable.Max(), EndGameBishopTable.Max()) + (Configuration.EngineSettings.BishopMobilityBonus.MG * 64))) +
+        (2 * (Math.Max(MiddleGameKnightTable.Max(), EndGameKnightTable.Max()))) +
+        (2 * (Math.Max(MiddleGameRookTable.Max(), EndGameRookTable.Max()) + Configuration.EngineSettings.OpenFileRookBonus.MG + Configuration.EngineSettings.SemiOpenFileRookBonus.MG)) +
+        (9 * (Math.Max(MiddleGameQueenTable.Max(), EndGameQueenTable.Max()) + (Configuration.EngineSettings.QueenMobilityBonus.MG * 64))) +
+        (1 * (Math.Max(MiddleGameKingTable.Max(), EndGameKingTable.Max()) + (Configuration.EngineSettings.KingShieldBonus.MG * 8))) +
+        MiddleGameQueenTable.Max(); // just in case
 
     [TestCase(PositiveCheckmateDetectionLimit)]
     [TestCase(-NegativeCheckmateDetectionLimit)]
@@ -201,5 +201,73 @@ public class EvaluationConstantsTest
         Assert.NotZero(EvaluationConstants.SingleMoveEvaluation);
         Assert.Greater(EvaluationConstants.SingleMoveEvaluation, 100);
         Assert.Less(EvaluationConstants.SingleMoveEvaluation, 400);
+    }
+
+    [Test]
+    public void PackedEvaluation()
+    {
+        short[] middleGamePawnTableBlack = MiddleGamePawnTable.Select((_, index) => (short)-MiddleGamePawnTable[index ^ 56]).ToArray();
+        short[] endGamePawnTableBlack = EndGamePawnTable.Select((_, index) => (short)-EndGamePawnTable[index ^ 56]).ToArray();
+
+        short[] middleGameKnightTableBlack = MiddleGameKnightTable.Select((_, index) => (short)-MiddleGameKnightTable[index ^ 56]).ToArray();
+        short[] endGameKnightTableBlack = EndGameKnightTable.Select((_, index) => (short)-EndGameKnightTable[index ^ 56]).ToArray();
+
+        short[] middleGameBishopTableBlack = MiddleGameBishopTable.Select((_, index) => (short)-MiddleGameBishopTable[index ^ 56]).ToArray();
+        short[] endGameBishopTableBlack = EndGameBishopTable.Select((_, index) => (short)-EndGameBishopTable[index ^ 56]).ToArray();
+
+        short[] middleGameRookTableBlack = MiddleGameRookTable.Select((_, index) => (short)-MiddleGameRookTable[index ^ 56]).ToArray();
+        short[] endGameRookTableBlack = EndGameRookTable.Select((_, index) => (short)-EndGameRookTable[index ^ 56]).ToArray();
+
+        short[] middleGameQueenTableBlack = MiddleGameQueenTable.Select((_, index) => (short)-MiddleGameQueenTable[index ^ 56]).ToArray();
+        short[] EndGameQueenTableBlack = EndGameQueenTable.Select((_, index) => (short)-EndGameQueenTable[index ^ 56]).ToArray();
+
+        short[] middleGameKingTableBlack = MiddleGameKingTable.Select((_, index) => (short)-MiddleGameKingTable[index ^ 56]).ToArray();
+        short[] endGameKingTableBlack = EndGameKingTable.Select((_, index) => (short)-EndGameKingTable[index ^ 56]).ToArray();
+
+        short[][] mgPositionalTables =
+        [
+            MiddleGamePawnTable,
+            MiddleGameKnightTable,
+            MiddleGameBishopTable,
+            MiddleGameRookTable,
+            MiddleGameQueenTable,
+            MiddleGameKingTable,
+
+            middleGamePawnTableBlack,
+            middleGameKnightTableBlack,
+            middleGameBishopTableBlack,
+            middleGameRookTableBlack,
+            middleGameQueenTableBlack,
+            middleGameKingTableBlack
+        ];
+
+        short[][] egPositionalTables =
+        [
+            EndGamePawnTable,
+            EndGameKnightTable,
+            EndGameBishopTable,
+            EndGameRookTable,
+            EndGameQueenTable,
+            EndGameKingTable,
+
+            endGamePawnTableBlack,
+            endGameKnightTableBlack,
+            endGameBishopTableBlack,
+            endGameRookTableBlack,
+            EndGameQueenTableBlack,
+            endGameKingTableBlack
+        ];
+
+        for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
+        {
+            for (int sq = 0; sq < 64; ++sq)
+            {
+                var mg = (short)(MiddleGamePieceValues[piece] + mgPositionalTables[piece][sq]);
+                var eg = (short)(EndGamePieceValues[piece] + egPositionalTables[piece][sq]);
+
+                Assert.AreEqual(Utils.UnpackMG(PackedPSQT[piece][sq]), mg);
+                Assert.AreEqual(Utils.UnpackEG(PackedPSQT[piece][sq]), eg);
+            }
+        }
     }
 }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -989,7 +989,7 @@ public class PositionTest
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
             pieceCount[(int)piece]++;
-            eval += position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, pieceCount).MiddleGameScore;
+            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, pieceCount));
         }
 
         return eval;
@@ -1012,9 +1012,9 @@ public class PositionTest
 
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
-        return piece == Piece.K
-            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount).EndGameScore
-            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount).EndGameScore;
+        return Utils.UnpackEG(piece == Piece.K
+            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount)
+            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount));
     }
 
     private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -915,8 +915,10 @@ public class PositionTest
     /// </summary>
     /// <param name="fen"></param>
     /// <param name="expectedStaticEvaluation"></param>
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", EvaluationConstants.MinEval)]
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", EvaluationConstants.MaxEval)]
+    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", EvaluationConstants.MinEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", EvaluationConstants.MaxEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+    [TestCase("8/8/8/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", EvaluationConstants.MinEval)]
+    [TestCase("8/8/8/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", EvaluationConstants.MaxEval)]
     public void StaticEvaluation_Clamp(string fen, int expectedStaticEvaluation)
     {
         var position = new Position(fen);


### PR DESCRIPTION
* Make use of [Packed evaluation](https://minuskelvin.net/chesswiki/content/packed-eval.html)
* Reduce the amount of arrays stored in memory to the minimum in `EvaluationConstants`

[08a007b](https://github.com/lynx-chess/Lynx/pull/697/commits/08a007b0ad43cb8216efdb853ea7170478720879)
```
Score of Lynx-perf-packed-eval-2786-win-x64 vs Lynx 2784 - main: 2849 - 2611 - 3774  [0.513] 9234
...      Lynx-perf-packed-eval-2786-win-x64 playing White: 1980 - 806 - 1832  [0.627] 4618
...      Lynx-perf-packed-eval-2786-win-x64 playing Black: 869 - 1805 - 1942  [0.399] 4616
...      White vs Black: 3785 - 1675 - 3774  [0.614] 9234
Elo difference: 9.0 +/- 5.4, LOS: 99.9 %, DrawRatio: 40.9 %
SPRT: llr 2.89 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

Re-adding accidentally removed cases
[377b8a7](https://github.com/lynx-chess/Lynx/pull/697/commits/377b8a729ccf469d580a5011fc6dfdb5d7f8cfab)
[-5,0]
```
Score of Lynx-perf-packed-eval-2788-win-x64 vs Lynx-perf-packed-eval-2786-win-x64: 4704 - 4697 - 6319  [0.500] 15720
...      Lynx-perf-packed-eval-2788-win-x64 playing White: 3255 - 1421 - 3185  [0.617] 7861
...      Lynx-perf-packed-eval-2788-win-x64 playing Black: 1449 - 3276 - 3134  [0.384] 7859
...      White vs Black: 6531 - 2870 - 6319  [0.616] 15720
Elo difference: 0.2 +/- 4.2, LOS: 52.9 %, DrawRatio: 40.2 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```