### PR TITLE
⚡ Remove manual piece count during static eval

### DIFF
--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -985,13 +985,11 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece];
         int eval = 0;
 
-        var pieceCount = new int[12];
         while (!bitBoard.Empty())
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            pieceCount[(int)piece]++;
-            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece, pieceCount));
+            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece));
         }
 
         return eval;
@@ -999,7 +997,6 @@ public class PositionTest
 
     private static int AdditionalKingEvaluation(Position position, Piece piece)
     {
-        var pieceCount = new int[position.PieceBitBoards.Length];
         for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.k; ++pieceIndex)
         {
             var bitboard = position.PieceBitBoards[pieceIndex];
@@ -1007,16 +1004,14 @@ public class PositionTest
             while (bitboard != default)
             {
                 bitboard.ResetLS1B();
-
-                ++pieceCount[pieceIndex];
             }
         }
 
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
         return Utils.UnpackEG(piece == Piece.K
-            ? position.KingAdditionalEvaluation(bitBoard, Side.White, pieceCount)
-            : position.KingAdditionalEvaluation(bitBoard, Side.Black, pieceCount));
+            ? position.KingAdditionalEvaluation(bitBoard, Side.White)
+            : position.KingAdditionalEvaluation(bitBoard, Side.Black));
     }
 
     private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)


### PR DESCRIPTION
* Remove manual piece count during static eval, accessing `Position.PieceBitBoards` when/wherever it's needed
* Move bishop pair detection outside of bishop additional eval

SPRT [-3, 1] exceeding expectations:
```
Test  | eval/no-manual-piece-count
Elo   | 9.50 +- 6.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 6106 W: 1950 L: 1783 D: 2373
Penta | [182, 671, 1226, 746, 228]
https://openbench.lynx-chess.com/test/228/
```