### PR TITLE
⚖️ Pawnless endgame penalization/scaling

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -379,6 +379,8 @@ internal static readonly short[] EndGameKingTable =
     /// Evaluation to be returned when there's one single legal move
     /// </summary>
     public const int SingleMoveEvaluation = 200;
+
+    public static int PackedPawnEvaluation = Utils.Pack(MiddleGamePieceValues[(int)Piece.P], EndGamePieceValues[(int)Piece.P]);
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -738,53 +738,58 @@ public class Position
         }
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3 && pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
+        if (pieceCount[(int)Piece.P] == 0 && pieceCount[(int)Piece.p] == 0)
         {
-            switch (gamePhase)
+            packedScore -= EvaluationConstants.PackedPawnEvaluation;
+
+            if (gamePhase <= 3)
             {
-                //case 5:
-                //    {
-                //        // RB vs R, RN vs R - escale it down due to the chances of it being a draw
-                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                //        {
-                //            packedScore >>= 1; // /2
-                //        }
+                switch (gamePhase)
+                {
+                    //case 5:
+                    //    {
+                    //        // RB vs R, RN vs R - escale it down due to the chances of it being a draw
+                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                    //        {
+                    //            packedScore >>= 1; // /2
+                    //        }
 
-                //        break;
-                //    }
-                case 3:
-                    {
-                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                    //        break;
+                    //    }
+                    case 3:
+                        {
+                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                        if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
+                            if (pieceCount[(int)Piece.N + winningSideOffset] == 2)      // NN vs N, NN vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                            //{
+                            //    packedScore >>= 1; // /2
+                            //}
+
+                            break;
+                        }
+                    case 2:
+                        {
+                            if (pieceCount[(int)Piece.N] + pieceCount[(int)Piece.n] == 2            // NN vs -, N vs N
+                                    || pieceCount[(int)Piece.N] + pieceCount[(int)Piece.B] == 1)    // B vs N, B vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            break;
+                        }
+                    case 1:
+                    case 0:
                         {
                             return (0, gamePhase);
                         }
-
-                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                        //{
-                        //    packedScore >>= 1; // /2
-                        //}
-
-                        break;
-                    }
-                case 2:
-                    {
-                        if (pieceCount[(int)Piece.N] + pieceCount[(int)Piece.n] == 2            // NN vs -, N vs N
-                                || pieceCount[(int)Piece.N] + pieceCount[(int)Piece.B] == 1)    // B vs N, B vs B
-                        {
-                            return (0, gamePhase);
-                        }
-
-                        break;
-                    }
-                case 1:
-                case 0:
-                    {
-                        return (0, gamePhase);
-                    }
+                }
             }
         }
 


### PR DESCRIPTION
Try to bring back EG scaling disabled in #697 due to lack of support of divisions

Latest:
```
Test  | perf/packed-eval-replace-divisions-1
Elo   | -5.48 +- 5.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9694 W: 2766 L: 2919 D: 4009
Penta | [332, 1144, 2003, 1081, 287]
https://openbench.lynx-chess.com/test/226/

Test  | perf/packed-eval-replace-divisions-2
Elo   | -3.10 +- 4.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15232 W: 4517 L: 4653 D: 6062
Penta | [530, 1725, 3167, 1739, 455]
https://openbench.lynx-chess.com/test/227/
```

Old:
```
Test  | eval/endgames-all-pawnless
Elo   | 0.31 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 85536 W: 26927 L: 26850 D: 31759
Penta | [3183, 9492, 17390, 9471, 3232]
https://openbench.lynx-chess.com/test/217/

Test  | eval/endgames-all-pawnless-2
Elo   | -1.99 +- 3.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21432 W: 6624 L: 6747 D: 8061
Penta | [734, 2502, 4372, 2369, 739]
https://openbench.lynx-chess.com/test/220/

Test  | eval/endgames-all-pawnless-3
Elo   | 0.30 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | N: 83340 W: 26211 L: 26140 D: 30989
Penta | [3079, 9166, 17087, 9281, 3057]
https://openbench.lynx-chess.com/test/221/