### PR TITLE
Join static eval white and black piece value loops into one

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -682,37 +682,34 @@ public class Position
         int packedScore = 0;
         int gamePhase = 0;
 
-        for (int pieceIndex = (int)Piece.P; pieceIndex < (int)Piece.K; ++pieceIndex)
+        for (int whitePieceIndex = (int)Piece.P; whitePieceIndex < (int)Piece.K; ++whitePieceIndex)
         {
-            // Bitboard copy that we 'empty'
-            var bitboard = PieceBitBoards[pieceIndex];
+            var blackPieceIndex = whitePieceIndex + 6;
 
-            while (bitboard != default)
+            // Bitboard copies that we 'empty'
+            var whiteBitboard = PieceBitBoards[whitePieceIndex];
+            var blackBitBoard = PieceBitBoards[blackPieceIndex];
+
+            while (whiteBitboard != default)
             {
-                var pieceSquareIndex = bitboard.GetLS1BIndex();
-                bitboard.ResetLS1B();
+                var whitePieceSquareIndex = whiteBitboard.GetLS1BIndex();
+                whiteBitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += EvaluationConstants.PackedPSQT[whitePieceIndex][whitePieceSquareIndex];
+                gamePhase += EvaluationConstants.GamePhaseByPiece[whitePieceIndex];
 
-                packedScore += AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                packedScore += AdditionalPieceEvaluation(whitePieceSquareIndex, whitePieceIndex);
             }
-        }
 
-        for (int pieceIndex = (int)Piece.p; pieceIndex < (int)Piece.k; ++pieceIndex)
-        {
-            // Bitboard copy that we 'empty'
-            var bitboard = PieceBitBoards[pieceIndex];
-
-            while (bitboard != default)
+            while (blackBitBoard != default)
             {
-                var pieceSquareIndex = bitboard.GetLS1BIndex();
-                bitboard.ResetLS1B();
+                var blackPieceSquareIndex = blackBitBoard.GetLS1BIndex();
+                blackBitBoard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += EvaluationConstants.PackedPSQT[blackPieceIndex][blackPieceSquareIndex];
+                gamePhase += EvaluationConstants.GamePhaseByPiece[blackPieceIndex];
 
-                packedScore -= AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                packedScore -= AdditionalPieceEvaluation(blackPieceSquareIndex, blackPieceIndex);
             }
         }
 


### PR DESCRIPTION
```
Test  | perf/eval-join-wb-loops
Elo   | -1.31 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26750 W: 7975 L: 8076 D: 10699
Penta | [858, 3072, 5567, 3069, 809]
https://openbench.lynx-chess.com/test/230/
```