### PR TITLE
Join eval ops

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -692,10 +692,10 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex]
+                    + AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
 
-                packedScore += AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
             }
         }
 
@@ -709,10 +709,10 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex]
+                     - AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
 
-                packedScore -= AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
             }
         }
 


### PR DESCRIPTION
```
Test  | perf/eval-join-ops
Elo   | -0.57 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 39376 W: 11856 L: 11921 D: 15599
Penta | [1283, 4508, 8187, 4411, 1299]
https://openbench.lynx-chess.com/test/229/
```