### PR TITLE
🔍 Allow LMR when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -271,7 +271,7 @@ public sealed partial class Engine
                 int reduction = 0;
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth
-                // Impl. based on Ciekce advice (Stormphrax) and Stormphrax & Akimbo implementations
+                // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
                     && !isCapture)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -274,7 +274,6 @@ public sealed partial class Engine
                 // Impl. based on Ciekce advice (Stormphrax) and Stormphrax & Akimbo implementations
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isInCheck
                     && !isCapture)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];


### PR DESCRIPTION
Suggested by Martin Novák, Motor's author.
```
Test  | search/lmr-allow-check
Elo   | 4.73 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23042 W: 7114 L: 6800 D: 9128
Penta | [798, 2555, 4554, 2763, 851]
https://openbench.lynx-chess.com/test/231/
```