### PR TITLE
LMR: reduce less when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -286,6 +286,10 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+                    if (isInCheck)
+                    {
+                        --reduction;
+                    }
 
                     // -= history/(maxHistory/2)
                     reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -274,7 +274,6 @@ public sealed partial class Engine
                 // Impl. based on Ciekce advice (Stormphrax) and Stormphrax & Akimbo implementations
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isInCheck
                     && !isCapture)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];


### PR DESCRIPTION
```
Score of Lynx-search-lmr-reduce-less-when-in-check-2811-win-x64 vs Lynx-search-lmr-allow-check-2806-win-x64: 4326 - 4419 - 5930  [0.497] 14675
...      Lynx-search-lmr-reduce-less-when-in-check-2811-win-x64 playing White: 3029 - 1354 - 2954  [0.614] 7337
...      Lynx-search-lmr-reduce-less-when-in-check-2811-win-x64 playing Black: 1297 - 3065 - 2976  [0.380] 7338
...      White vs Black: 6094 - 2651 - 5930  [0.617] 14675
Elo difference: -2.2 +/- 4.3, LOS: 16.0 %, DrawRatio: 40.4 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```