### PR TITLE
LMR: allow bad captures

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -274,7 +274,7 @@ public sealed partial class Engine
                 // Impl. based on Ciekce advice (Stormphrax) and Stormphrax & Akimbo implementations
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isCapture)
+                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -274,7 +274,6 @@ public sealed partial class Engine
                 // Impl. based on Ciekce advice (Stormphrax) and Stormphrax & Akimbo implementations
                 if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isInCheck
                     && !isCapture)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];


### PR DESCRIPTION
This branch:
```
Test  | search/lmr-allow-bad-captures
Elo   | -1.00 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31716 W: 9508 L: 9599 D: 12609
Penta | [1187, 3782, 5988, 3737, 1164]
https://openbench.lynx-chess.com/test/235/
```

Similar one, but leaving killers as they are: [Allow bad captures without allowing killers](https://github.com/lynx-chess/Lynx/commit/c9fff9bc1dd4ab89ea7ca4b585fa763d82e6d53c)
```
Score of Lynx-search-lmr-allow-bad-captures-2-2819-win-x64 vs Lynx 2813 - main: 4541 - 4627 - 6423  [0.497] 15591
...      Lynx-search-lmr-allow-bad-captures-2-2819-win-x64 playing White: 3153 - 1406 - 3236  [0.612] 7795
...      Lynx-search-lmr-allow-bad-captures-2-2819-win-x64 playing Black: 1388 - 3221 - 3187  [0.382] 7796
...      White vs Black: 6374 - 2794 - 6423  [0.615] 15591
Elo difference: -1.9 +/- 4.2, LOS: 18.5 %, DrawRatio: 41.2 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[Restrict LMR further history reductions to non captures](https://github.com/lynx-chess/Lynx/commit/eb282365dcd2d0a42ac0ed73773138d1aa8685a1)

```
Score of Lynx-search-lmr-allow-bad-captures-limit-reductions-to-noncaptures-2815-win-x64 vs Lynx 2813 - main: 5434 - 5509 - 7508  [0.498] 18451
...      Lynx-search-lmr-allow-bad-captures-limit-reductions-to-noncaptures-2815-win-x64 playing White: 3811 - 1635 - 3779  [0.618] 9225
...      Lynx-search-lmr-allow-bad-captures-limit-reductions-to-noncaptures-2815-win-x64 playing Black: 1623 - 3874 - 3729  [0.378] 9226
...      White vs Black: 7685 - 3258 - 7508  [0.620] 18451
Elo difference: -1.4 +/- 3.9, LOS: 23.7 %, DrawRatio: 40.7 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```


[Use capture history for capture moves](https://github.com/lynx-chess/Lynx/commit/009935a13bf286918ace5cf4855490ba4f01236c)
Had to cancel this one
```
Score of Lynx-search-lmr-allow-bad-captures-split-history-2816-win-x64 vs Lynx 2813 - main: 5988 - 5910 - 8122  [0.502] 20020
...      Lynx-search-lmr-allow-bad-captures-split-history-2816-win-x64 playing White: 4213 - 1781 - 4016  [0.621] 10010
...      Lynx-search-lmr-allow-bad-captures-split-history-2816-win-x64 playing Black: 1775 - 4129 - 4106  [0.382] 10010
...      White vs Black: 8342 - 3556 - 8122  [0.620] 20020
Elo difference: 1.4 +/- 3.7, LOS: 76.3 %, DrawRatio: 40.6 %
SPRT: llr -0.123 (-4.2%), lbound -2.25, ubound 2.89
```

```
Test  | search/lmr-allow-bad-captures-and-no-queen-promos
Elo   | -6.86 +- 5.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8414 W: 2421 L: 2587 D: 3406
Penta | [347, 1020, 1574, 984, 282]
https://openbench.lynx-chess.com/test/238/
```

Don't allow LMR for killers
```
Test  | search/lmr-exclude-killers
Elo   | 0.05 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63842 W: 19253 L: 19243 D: 25346
Penta | [2316, 7570, 12141, 7576, 2318]
https://openbench.lynx-chess.com/test/239/
```