### PR TITLE
🐛 Fix index out of range exception

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -327,6 +327,11 @@ public static class Constants
     public const int AbsoluteMaxDepth = 255;
 
     /// <summary>
+    /// To take into account array access by depth and depth extensions
+    /// </summary>
+    public const int ArrayDepthMargin = 16;
+
+    /// <summary>
     /// From https://lichess.org/RViT3UWL
     /// Failes input parsing fail if default input buffer size is used (see Lynx.Cli.Listener
     /// </summary>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -190,12 +190,12 @@ internal static readonly short[] EndGameKingTable =
     /// <summary>
     /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
     /// </summary>
-    public static readonly int[][] LMRReductions = new int[Configuration.EngineSettings.MaxDepth][];
+    public static readonly int[][] LMRReductions = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
 
     /// <summary>
     /// [0, 4, 136, 276, 424, 580, 744, 916, 1096, 1284, 1480, 1684, 1896, 1896, 1896, 1896, ...]
     /// </summary>
-    public static readonly int[] HistoryBonus = new int[Configuration.EngineSettings.MaxDepth];
+    public static readonly int[] HistoryBonus = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
 
     static EvaluationConstants()
     {
@@ -262,7 +262,7 @@ internal static readonly short[] EndGameKingTable =
             }
         }
 
-        for (int searchDepth = 1; searchDepth < Configuration.EngineSettings.MaxDepth; ++searchDepth)    // Depth > 0 or we'd be in QSearch
+        for (int searchDepth = 1; searchDepth < Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin; ++searchDepth)    // Depth > 0 or we'd be in QSearch
         {
             LMRReductions[searchDepth] = new int[Constants.MaxNumberOfPossibleMovesInAPosition];
 

--- a/src/Lynx/Model/PVTable.cs
+++ b/src/Lynx/Model/PVTable.cs
@@ -8,7 +8,7 @@ public static class PVTable
 
     private static ImmutableArray<int> Initialize()
     {
-        var indexes = new int[Configuration.EngineSettings.MaxDepth + 1];
+        var indexes = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
         int previousPVIndex = 0;
         indexes[0] = previousPVIndex;
 
@@ -18,6 +18,6 @@ public static class PVTable
             previousPVIndex = indexes[depth + 1];
         }
 
-        return indexes.ToImmutableArray();
+        return [.. indexes];
     }
 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -16,9 +16,9 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[][] _killerMoves =
     [
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth],
-        new int[Configuration.EngineSettings.MaxDepth]
+        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
+        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
+        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin]
     ];
 
     /// <summary>
@@ -31,7 +31,7 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[][][] _captureHistory;
 
-    private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth];
+    private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
     private TranspositionTable _tt = [];
     private int _ttMask;
 


### PR DESCRIPTION
* Add a buffer to array size for those ones accessed by depth or ply

[-5. 0]
```
Test  | bugfix/index-out-of-range
Elo   | -0.32 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.25, 2.89) [-5.00, 0.00]
Games | 35728: +10617 -10650 =14461
Penta | [1021, 4118, 7658, 4007, 1060]
https://openbench.lynx-chess.com/test/251/
```