### PR TITLE
Revisit razoring

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -135,7 +135,7 @@ public sealed partial class Engine
                 {
                     var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
 
-                    if (score < beta)               // Static evaluation + bonus indicates fail-low node
+                    if (score <= alpha)               // Static evaluation + bonus indicates fail-low node
                     {
                         if (depth == 1)
                         {
@@ -148,10 +148,10 @@ public sealed partial class Engine
 
                         score += Configuration.EngineSettings.Razoring_NotDepth1Bonus;
 
-                        if (score < beta)               // Static evaluation indicates fail-low node
+                        if (score <= alpha)               // Static evaluation indicates fail-low node
                         {
                             var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-                            if (qSearchScore < beta)    // Quiescence score also indicates fail-low node
+                            if (qSearchScore <= alpha)    // Quiescence score also indicates fail-low node
                             {
                                 return qSearchScore > score
                                     ? qSearchScore


### PR DESCRIPTION
[This branch - just replace beta with alpha (weirdly, no change in bench)](https://github.com/lynx-chess/Lynx/commit/c67ef6aea2cb8979c855e560b10b79c20b7d37c6)
```
Test  | search/lmr-revisit-use-alpha
Elo   | -1.54 +- 4.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 5.00]
Games | 11750: +3447 -3499 =4804
Penta | [354, 1374, 2473, 1318, 356]
https://openbench.lynx-chess.com/test/253/
```

[Reimplement razoring according to modern standards](https://github.com/lynx-chess/Lynx/commit/b2905f421c7e51b27b1e3c68a077bf50f8a64790) (search/lmr-revisit-reimplement)
Reached the game limit :(
```
Score of Lynx-search-lmr-revisit-reimplement-2837-win-x64 vs Lynx 2833 - main: 30010 - 29677 - 40313  [0.502] 100000
...      Lynx-search-lmr-revisit-reimplement-2837-win-x64 playing White: 20878 - 8816 - 20306  [0.621] 50000
...      Lynx-search-lmr-revisit-reimplement-2837-win-x64 playing Black: 9132 - 20861 - 20007  [0.383] 50000
...      White vs Black: 41739 - 17948 - 40313  [0.619] 100000
Elo difference: 1.2 +/- 1.7, LOS: 91.4 %, DrawRatio: 40.3 %
SPRT: llr -1.43 (-49.4%), lbound -2.25, ubound 2.89
```

40 0.4 with 450 value (semi-tuned)
```
Score of Lynx-search-lmr-revisit-reimplement-2882-win-x64 vs Lynx 2878 - main: 1506 - 1627 - 2496  [0.489] 5629
...      Lynx-search-lmr-revisit-reimplement-2882-win-x64 playing White: 1132 - 423 - 1259  [0.626] 2814
...      Lynx-search-lmr-revisit-reimplement-2882-win-x64 playing Black: 374 - 1204 - 1237  [0.353] 2815
...      White vs Black: 2336 - 797 - 2496  [0.637] 5629
Elo difference: -7.5 +/- 6.8, LOS: 1.5 %, DrawRatio: 44.3 %
SPRT: llr -2.26 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```