### PR TITLE
Perf: Pass move span as ref to `MoveGenerator`

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -88,6 +88,38 @@ public static class MoveGenerator
     }
 
     /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="moveList"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GenerateAllMoves(Position position, ref Span<Move> moveList)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            moveList = [];
+            return;
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GenerateAllPawnMoves(ref localIndex, moveList, position, offset);
+        GenerateCastlingMoves(ref localIndex, moveList, position);
+        GenerateAllPieceMoves(ref localIndex, moveList, (int)Piece.K + offset, position, offset);
+        GenerateAllPieceMoves(ref localIndex, moveList, (int)Piece.N + offset, position, offset);
+        GenerateAllPieceMoves(ref localIndex, moveList, (int)Piece.B + offset, position, offset);
+        GenerateAllPieceMoves(ref localIndex, moveList, (int)Piece.R + offset, position, offset);
+        GenerateAllPieceMoves(ref localIndex, moveList, (int)Piece.Q + offset, position, offset);
+
+        moveList = moveList[..localIndex];
+    }
+
+    /// <summary>
     /// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
     /// </summary>
     /// <param name="position"></param>
@@ -147,6 +179,38 @@ public static class MoveGenerator
         GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position, offset);
 
         return movePool[..localIndex];
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <param name="moveList"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void GenerateAllCaptures(Position position, ref Span<Move> moveList)
+    {
+#if DEBUG
+        if (position.Side == Side.Both)
+        {
+            moveList = [];
+            return;
+        }
+#endif
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+
+        GeneratePawnCapturesAndPromotions(ref localIndex, moveList, position, offset);
+        GenerateCastlingMoves(ref localIndex, moveList, position);
+        GeneratePieceCaptures(ref localIndex, moveList, (int)Piece.K + offset, position, offset);
+        GeneratePieceCaptures(ref localIndex, moveList, (int)Piece.N + offset, position, offset);
+        GeneratePieceCaptures(ref localIndex, moveList, (int)Piece.B + offset, position, offset);
+        GeneratePieceCaptures(ref localIndex, moveList, (int)Piece.R + offset, position, offset);
+        GeneratePieceCaptures(ref localIndex, moveList, (int)Piece.Q + offset, position, offset);
+
+        moveList = moveList[..localIndex];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -41,7 +41,9 @@ public static class Perft
         if (depth != 0)
         {
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
+            MoveGenerator.GenerateAllMoves(position, ref moves);
+
+            foreach (var move in moves)
             {
                 var state = position.MakeMove(move);
 
@@ -63,7 +65,9 @@ public static class Perft
         if (depth != 0)
         {
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
+            MoveGenerator.GenerateAllMoves(position, ref moves);
+
+            foreach (var move in moves)
             {
                 var state = position.MakeMove(move);
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -204,11 +204,11 @@ public sealed partial class Engine
 
         static void TryParseMove(Position position, int i, int move)
         {
-            Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-
+            Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            MoveGenerator.GenerateAllMoves(position, ref moveList);
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               MoveGenerator.GenerateAllMoves(position, movePool),
+               moveList,
                out _))
             {
                 var message = $"Unexpected PV move {i}: {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -223,7 +223,8 @@ public sealed partial class Engine
         bool onlyOneLegalMove = false;
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
+        MoveGenerator.GenerateAllMoves(Game.CurrentPosition, ref moves);
+        foreach (var move in moves)
         {
             var gameState = Game.CurrentPosition.MakeMove(move);
             bool isPositionValid = Game.CurrentPosition.IsValid();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -163,8 +163,8 @@ public sealed partial class Engine
             }
         }
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);
+        Span<Move> pseudoLegalMoves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        MoveGenerator.GenerateAllMoves(position, ref pseudoLegalMoves);
 
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         if (_isFollowingPV)
@@ -499,8 +499,8 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, moves);
+        Span<Move> pseudoLegalMoves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        MoveGenerator.GenerateAllCaptures(position, ref pseudoLegalMoves);
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -64,11 +64,12 @@ public sealed class PositionCommand : GUIBaseCommand
         var moveString = positionCommand
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)[^1];
 
-        Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        Span<Move> moveList = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        MoveGenerator.GenerateAllMoves(game.CurrentPosition, ref moveList);
 
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            MoveGenerator.GenerateAllMoves(game.CurrentPosition, movePool),
+            moveList,
             out lastMove))
         {
             _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);


### PR DESCRIPTION
Add movegen overrides that accept the move list span as ref and slice it, instead of a movePool and return the slice
```
Test  | perft/movegen-movespan-by-ref
Elo   | -2.90 +- 4.13 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 16424: +4905 -5042 =6477
Penta | [556, 1960, 3321, 1815, 560]
https://openbench.lynx-chess.com/test/263/
```