### PR TITLE
⚡ Use optimized method to check if a move was valid

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -226,7 +226,7 @@ public sealed partial class Engine
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
         {
             var gameState = Game.CurrentPosition.MakeMove(move);
-            bool isPositionValid = Game.CurrentPosition.IsValid();
+            bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
             Game.CurrentPosition.UnmakeMove(move, gameState);
 
             if (isPositionValid)


### PR DESCRIPTION
Replace `Position.IsValid()` usage with `Position.WasProduceByAValidMove()` in `OnlyOneLegalMove()` search method