### PR TITLE
Perf: Avoid generating captures in case of QSearch final positions, when looking for valid moves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -584,7 +584,7 @@ public sealed partial class Engine
 
         if (bestMove is null
             && !isThereAnyValidCapture
-            && !MoveGenerator.CanGenerateAtLeastAValidMove(position, isInCheck))
+            && !MoveGenerator.CanGenerateAtLeastAValidMoveExcludingCaptures(position, isInCheck))
         {
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
             _tt.RecordHash(_ttMask, position, 0, ply, finalEval, NodeType.Exact);


### PR DESCRIPTION
* Avoid generating captures in case of QSearch final positions, when looking for valid moves
* 
```
Score of Lynx-perf-no-capture-generation-final-position-qsearch-2873-win-x64 vs Lynx-perf-castling-move-generation-3-2869-win-x64: 637 - 747 - 938  [0.476] 2322
...      Lynx-perf-no-capture-generation-final-position-qsearch-2873-win-x64 playing White: 443 - 239 - 479  [0.588] 1161
...      Lynx-perf-no-capture-generation-final-position-qsearch-2873-win-x64 playing Black: 194 - 508 - 459  [0.365] 1161
...      White vs Black: 951 - 433 - 938  [0.612] 2322
Elo difference: -16.5 +/- 10.9, LOS: 0.2 %, DrawRatio: 40.4 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```