### PR TITLE
Perf/movegen: Avoid generating non-king moves in case of double check

### DIFF
--- a/src/Lynx.Benchmark/ParseGame_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseGame_Benchmark.cs
@@ -666,7 +666,8 @@ public partial class ParseGame_Benchmark : BaseBenchmark
                     break;
                 }
                 var moveString = rawMoves[rangeSpan[i]];
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, CurrentPosition.IsInCheck());
+                var (isInCheck, isNotInDoubleCheck) = CurrentPosition.IsInCheckAndDoubleCheck();
+                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, isInCheck, isNotInDoubleCheck);
 
                 if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
                 {

--- a/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
+++ b/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
@@ -208,7 +208,8 @@ public class TryParseFromUCIString_Benchmark : BaseBenchmark
                     break;
                 }
                 var moveString = rawMoves[rangeSpan[i]];
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, CurrentPosition.IsInCheck());
+                var (isInCheck, isNotInDoubleCheck) = CurrentPosition.IsInCheckAndDoubleCheck();
+                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, isInCheck, isNotInDoubleCheck);
 
                 if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
                 {

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -90,6 +90,12 @@ public partial class Engine
         "8/q5rk/8/8/8/8/Q5RK/7N w - - 0 1",                             // Endgame that can lead to QN vs Q or RN vs R positions
         "1kr5/2bp3q/Q7/1K6/6q1/6B1/8/8 w - - 0 1",                      // Endgame where triple repetition can and needs to be forced by white
         "1kr5/2bp3q/R7/1K6/6q1/6B1/8/8 w - - 96 200",                   // Endgame where 50 moves draw can and needs to be forced by white
+        "rnbqk2r/pppp1ppp/5n2/8/Bb2N3/8/PPPPQPPP/RNB1K2R w KQkq - 2 1", // Petroff defense alike position with double check Q and N
+        "rnb1kb1r/pppp1ppp/5n2/8/4N3/8/PPPP1PPP/RNB1R1K1 w kq - 2 5",   // Double check R and N
+        "rnbqk2r/ppp2ppp/3p4/8/1b2Bn2/8/PPPPQPPP/RNB1K2R w KQkq - 2 5", // Double check Q and B
+        "rnbqk2r/ppp2ppp/3p4/8/1b2B3/3n4/PPPP1PPP/RNBQR1K1 w kq - 2 5", // Double check R and B
+        "r3k2r/ppp2ppp/n7/1N1p4/Bb6/8/PPPP1PPP/RNBQ1RK1 w kq - 2 1",    // Double check B and N, castling rights
+        "r3k2r/ppp2ppp/n7/1N1p4/Bb6/8/PPPP1PPP/RNBQ1RK1 w - - 2 1",     // Double check B and N, no castling rights
         "4Q3/8/1p4pk/1PbB1p1p/7P/p3P1PK/P3qP2/8 w - - 99 88",           // Mate in 1 that takes prececen over 50 moves rule, from https://github.com/PGG106/Alexandria/issues/213
         "8/7B/8/7k/5KR1/8/4R3/8 w - - 0 1",                             // 50 moves rule needs to be forced in a losing position
         "r6k/p3b1pp/2pq4/Qp2n1NK/4P1P1/P3Br1P/1P2RP2/8 b - - 0 1",      // 50 moves rule needs to be avoided in a winning position

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -51,7 +51,8 @@ public sealed class Game
                 break;
             }
             var moveString = rawMoves[rangeSpan[i]];
-            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, CurrentPosition.IsInCheck());
+            var (isInCheck, isNotInDoubleCheck) = CurrentPosition.IsInCheckAndDoubleCheck();
+            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, movePool, isInCheck, isNotInDoubleCheck);
 
             // TODO: consider creating moves on the fly
             if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
@@ -146,9 +147,9 @@ public sealed class Game
             return false;
         }
 
-        var isInCheck = CurrentPosition.IsInCheck();
+        var (isInCheck, isNotInDoubleCheck) = CurrentPosition.IsInCheckAndDoubleCheck();
 
-        return !isInCheck || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, isInCheck);
+        return !isInCheck || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, isInCheck, isNotInDoubleCheck);
     }
 
     /// <summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1082,6 +1082,30 @@ public class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public (bool IsInCheck, bool IsNotInDoubleCheck) IsInCheckAndDoubleCheck()
+    {
+        var oppositeSideInt = Utils.OppositeSide(Side);
+        var oppositeSideOffset = Utils.PieceOffset(oppositeSideInt);
+
+        var kingSquare = PieceBitBoards[(int)Piece.k - oppositeSideOffset].GetLS1BIndex();
+
+        var rookAttacks = Attacks.RookAttacks(kingSquare, OccupancyBitBoards[(int)Side.Both]);
+        var bishopAttacks = Attacks.BishopAttacks(kingSquare, OccupancyBitBoards[(int)Side.Both]);
+        var queenAttacks = Attacks.QueenAttacks(rookAttacks, bishopAttacks);
+
+        var attacks =
+            (rookAttacks & PieceBitBoards[(int)Piece.R + oppositeSideOffset])
+            | (bishopAttacks & PieceBitBoards[(int)Piece.B + oppositeSideOffset])
+            | (queenAttacks & PieceBitBoards[(int)Piece.Q + oppositeSideOffset])
+            | (Attacks.KnightAttacks[kingSquare] & PieceBitBoards[(int)Piece.N + oppositeSideOffset])
+            | (Attacks.PawnAttacks[(int)Side][kingSquare] & PieceBitBoards[oppositeSideOffset]);
+
+        var attacksCount = attacks.CountBits();
+
+        return (attacksCount >= 1, attacksCount <= 1);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool IsSquareAttackedByPawns(int squareIndex, int sideToMove, int offset)
     {
         var oppositeColorIndex = sideToMove ^ 1;

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -40,8 +40,9 @@ public static class Perft
     {
         if (depth != 0)
         {
+            var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()))
+            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck))
             {
                 var state = position.MakeMove(move);
 
@@ -62,8 +63,9 @@ public static class Perft
     {
         if (depth != 0)
         {
+            var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()))
+            foreach (var move in MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck))
             {
                 var state = position.MakeMove(move);
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -205,10 +205,11 @@ public sealed partial class Engine
         static void TryParseMove(Position position, int i, int move)
         {
             Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+            var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               MoveGenerator.GenerateAllMoves(position, movePool, position.IsInCheck()),
+               MoveGenerator.GenerateAllMoves(position, movePool, isInCheck, isNotInDoubleCheck),
                out _))
             {
                 var message = $"Unexpected PV move {i}: {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -223,7 +223,8 @@ public sealed partial class Engine
         bool onlyOneLegalMove = false;
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves, Game.CurrentPosition.IsInCheck()))
+        var (isInCheck, isNotInDoubleCheck) = Game.CurrentPosition.IsInCheckAndDoubleCheck();
+        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves, isInCheck, isNotInDoubleCheck))
         {
             var gameState = Game.CurrentPosition.MakeMove(move);
             bool isPositionValid = Game.CurrentPosition.IsValid();

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -66,9 +66,11 @@ public sealed class PositionCommand : GUIBaseCommand
 
         Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
 
+        var (isInCheck, isNotInDoubleCheck) = game.CurrentPosition.IsInCheckAndDoubleCheck();
+
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            MoveGenerator.GenerateAllMoves(game.CurrentPosition, movePool, game.CurrentPosition.IsInCheck()),
+            MoveGenerator.GenerateAllMoves(game.CurrentPosition, movePool, isInCheck, isNotInDoubleCheck),
             out lastMove))
         {
             _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -215,7 +215,6 @@ public class GameTest : BaseTest
         Assert.AreEqual(100, game.MoveHistory.Count);
 #endif
         Assert.AreEqual(100 + 1, game.PositionHashHistory.Count);
-
         Assert.True(game.Is50MovesRepetition());
     }
 

--- a/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
@@ -13,11 +13,14 @@ public class GeneralMoveGeneratorTest
     {
         var originalPosition = new Position("8/8/8/k1pP3R/8/8/8/n4K2 w - c6 0 1");
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition, moves, originalPosition.IsInCheck()).ToArray().Single(m => m.IsEnPassant());
+        var (isInCheck, isNotInDoubleCheck) = originalPosition.IsInCheckAndDoubleCheck();
+        var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition, moves, isInCheck, isNotInDoubleCheck).ToArray().Single(m => m.IsEnPassant());
+
         var positionAferEnPassant = new Position(originalPosition, enPassantMove);
+        (isInCheck, isNotInDoubleCheck) = originalPosition.IsInCheckAndDoubleCheck();
 
         moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        foreach (var move in MoveGenerator.GenerateAllMoves(positionAferEnPassant, moves, positionAferEnPassant.IsInCheck()))
+        foreach (var move in MoveGenerator.GenerateAllMoves(positionAferEnPassant, moves, isInCheck, isNotInDoubleCheck))
         {
             if (new Position(positionAferEnPassant, move).IsValid())
             {

--- a/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
@@ -8,13 +8,15 @@ public class GenerateBishopMovesTest
     private static IEnumerable<Move> GenerateBishopMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }
 
     private static IEnumerable<Move> GenerateBishopCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
@@ -8,13 +8,15 @@ public class GenerateKingMovesTest
     private static IEnumerable<Move> GenerateKingMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }
 
     private static IEnumerable<Move> GenerateKingCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck() ).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck ).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
@@ -8,13 +8,15 @@ public class GenerateKnightMovesTest
     private static IEnumerable<Move> GenerateKnightMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }
 
     private static IEnumerable<Move> GenerateKnightCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }
 
     [TestCase(Constants.InitialPositionFEN, 4)]

--- a/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
@@ -10,13 +10,15 @@ public class GeneratePawnMovesTest
     private static IEnumerable<Move> GeneratePawnMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 
     private static IEnumerable<Move> GeneratePawnCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 
     [Test]

--- a/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
@@ -8,13 +8,15 @@ public class GenerateQueenMovesTest
     private static IEnumerable<Move> GenerateQueenMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 
     private static IEnumerable<Move> GenerateQueenCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
@@ -8,13 +8,15 @@ public class GenerateRookMovesTest
     private static IEnumerable<Move> GenerateRookMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllMoves(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllMoves(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
 
     private static IEnumerable<Move> GenerateRookCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        return MoveGenerator.GenerateAllCaptures(position, moves, position.IsInCheck()).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        return MoveGenerator.GenerateAllCaptures(position, moves, isInCheck, isNotInDoubleCheck).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
@@ -20,7 +20,8 @@ public class MoveGeneratorRegressionTest : BaseTest
         Assert.True(moves.Exists(m => m.IsDoublePawnPush()));
 
         Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var captures = MoveGenerator.GenerateAllCaptures(position, moveSpan, position.IsInCheck()).ToArray().ToList();
+        var (isInCheck, isNotInDoubleCheck) = position.IsInCheckAndDoubleCheck();
+        var captures = MoveGenerator.GenerateAllCaptures(position, moveSpan, isInCheck, isNotInDoubleCheck).ToArray().ToList();
 
         Assert.True(moves.Exists(m => m.IsShortCastle()));
         Assert.True(moves.Exists(m => m.IsLongCastle()));


### PR DESCRIPTION
* Avoid generating non-king moves in case of double check
```
Test  | movegen/double-checks
Elo   | -4.97 +- 5.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 10410: +3019 -3168 =4223
Penta | [342, 1204, 2228, 1123, 308]
https://openbench.lynx-chess.com/test/270/
```