### PR TITLE
⚡ Remove option to disable TT

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace Lynx;
@@ -66,14 +65,7 @@ public static class Configuration
     public static int Hash
     {
         get => EngineSettings.TranspositionTableSize;
-        set
-        {
-            EngineSettings.TranspositionTableSize = value;
-            if (value == 0)
-            {
-                EngineSettings.TranspositionTableEnabled = false;
-            }
-        }
+        set => EngineSettings.TranspositionTableSize = value;
     }
 }
 
@@ -96,8 +88,6 @@ public sealed class EngineSettings
     /// MB
     /// </summary>
     public int TranspositionTableSize { get; set; } = 256;
-
-    public bool TranspositionTableEnabled { get; set; } = true;
 
     public bool UseOnlineTablebaseInRootPositions { get; set; } = false;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -290,6 +290,8 @@ public static class Constants
     /// </summary>
     public const int AbsoluteMaxTTSize = 8192;
 
+    public const int AbsoluteMinTTSize = 2;
+
     /// <summary>
     /// 218 or 224 seems to be the known limit
     /// https://www.reddit.com/r/chess/comments/9j70dc/position_with_the_most_number_of_legal_moves/

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -311,11 +311,8 @@ public sealed partial class Engine
 
     private void InitializeTT()
     {
-        if (Configuration.EngineSettings.TranspositionTableEnabled)
-        {
-            (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-            _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
-        }
+        (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
     private static void InitializeStaticClasses()

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -117,11 +117,6 @@ public static class TranspositionTableExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static (int Evaluation, ShortMove BestMove, NodeType NodeType, int score) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
-        if (!Configuration.EngineSettings.TranspositionTableEnabled)
-        {
-            return (EvaluationConstants.NoHashEntry, default, default, default);
-        }
-
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         if ((position.UniqueIdentifier >> 48) != entry.Key)
@@ -163,11 +158,6 @@ public static class TranspositionTableExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void RecordHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int eval, NodeType nodeType, Move? move = null)
     {
-        if (!Configuration.EngineSettings.TranspositionTableEnabled)
-        {
-            return;
-        }
-
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         //if (entry.Key != default && entry.Key != position.UniqueIdentifier)

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -128,7 +128,7 @@ public sealed class OptionCommand : EngineBaseCommand
         "option name UCI_Opponent type string",
         $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.EngineAuthor}, see https://github.com/lynx-chess/Lynx",
         $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL}",
-        $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min 0 max {Constants.AbsoluteMaxTTSize}",
+        $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min {Constants.AbsoluteMinTTSize} max {Constants.AbsoluteMaxTTSize}",
         $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
         "option name Threads type spin default 1 min 1 max 1",
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -189,7 +189,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.Hash = Math.Clamp(value, 0, Constants.AbsoluteMaxTTSize);
+                        Configuration.Hash = Math.Clamp(value, Constants.AbsoluteMinTTSize, Constants.AbsoluteMaxTTSize);
                     }
                     break;
                 }


### PR DESCRIPTION
- Remove `TranspositionTableEnabled`
- Add min TT size of 2MB

```
Test  | perf/remove-TranspositionTableEnabled
Elo   | 5.72 +- 5.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 9416: +2854 -2699 =3863
Penta | [260, 1067, 1942, 1136, 303]
https://openbench.lynx-chess.com/test/278/
```