### PR TITLE
⚡ Improve search logic

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,8 +82,7 @@ public sealed partial class Engine
             _tt.RecordHash(_ttMask, position, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
-
-        if (!pvNode && !isInCheck)
+        else if (!pvNode)
         {
             var (staticEval, phase) = position.StaticEvaluation();
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -71,7 +71,7 @@ public sealed partial class Engine
         {
             ++depth;
         }
-        if (depth <= 0)
+        else if (depth <= 0)
         {
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
             {


### PR DESCRIPTION
```
Test  | perf/elsif
Elo   | 0.12 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 68788: +20437 -20413 =27938
Penta | [2220, 7973, 13949, 8067, 2185]
https://openbench.lynx-chess.com/test/281/
```

```bash
python3 sprt.py -l 20413 -w 20437 -d 27938 -e0 -3 -e1 1
ELO: 0.121 +- 2.0 [-1.88, 2.12]
LLR: 3.06 [-3.0, 1.0] (-2.94, 2.94)
H1 Accepted
```