### PR TITLE
⚡  Optimized threefold repetition by accessing lists internal array with `CollectionsMarshal.AsSpan`

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -1,5 +1,6 @@
 ﻿using NLog;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
 
@@ -126,8 +127,11 @@ public sealed class Game
         var currentHash = CurrentPosition.UniqueIdentifier;
 
         // [Count - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
-        var limit = Math.Max(0, PositionHashHistory.Count - 1 - HalfMovesWithoutCaptureOrPawnMove);
-        for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
+        var span = CollectionsMarshal.AsSpan(PositionHashHistory);
+        var start = span.Length - 3;
+        var end = Math.Max(0, PositionHashHistory.Count - 1 - HalfMovesWithoutCaptureOrPawnMove);
+
+        for (int i = start; i >= end; i -= 2)
         {
             if (currentHash == PositionHashHistory[i])
             {
@@ -161,8 +165,11 @@ public sealed class Game
         var currentHash = position.UniqueIdentifier;
 
         // Since positionHashHistory hasn't been updated with position, [Count] would be the last one, so we want to start searching 2 ealier
-        var limit = Math.Max(0, positionHashHistory.Count - halfMovesWithoutCaptureOrPawnMove);
-        for (int i = positionHashHistory.Count - 2; i >= limit; i -= 2)
+        var span = CollectionsMarshal.AsSpan(positionHashHistory);
+        var start = span.Length - 3;
+        var end = Math.Max(0, positionHashHistory.Count - 1 - halfMovesWithoutCaptureOrPawnMove);
+
+        for (int i = start; i >= end; i -= 2)
         {
             if (currentHash == positionHashHistory[i])
             {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -290,6 +290,12 @@ public static class MoveExtensions
     public static bool IsPromotion(this Move move) => (move & 0xF) != default;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsQueenPromotion(this Move move) => (move & 0xF & 0b100) == 0b100;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsQueenPromotion(this Move _, int promotedPiece) => (promotedPiece & 0b100) == 0b100;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int SourceSquare(this Move move) => (move & 0x3F0) >> SourceSquareOffset;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Test  | perf/threefold-repetition
Elo   | -0.16 +- 2.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 53562: +15896 -15920 =21746
Penta | [1629, 6108, 11342, 6062, 1640]
https://openbench.lynx-chess.com/test/282/
```