### PR TITLE
Tempo bonus (4th attempt)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -128,7 +128,7 @@
         "EG": 0
       }
     },
-    "TempoBonus": 10
+    "TempoBonus": 5
     // End of evaluation
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -128,7 +128,7 @@
         "EG": 0
       }
     },
-    "TempoBonus": 5
+    "TempoBonus": 15
     // End of evaluation
   },
 

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -127,7 +127,8 @@
         "MG": 0,
         "EG": 0
       }
-    }
+    },
+    "TempoBonus": 10
     // End of evaluation
   },
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -198,6 +198,8 @@ public sealed class EngineSettings
         new(98, 217),
         new(0, 0));
 
+    public int TempoBonus { get; set; } = 10;
+
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -198,7 +198,7 @@ public sealed class EngineSettings
         new(98, 217),
         new(0, 0));
 
-    public int TempoBonus { get; set; } = 10;
+    public int TempoBonus { get; set; } = 5;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -198,7 +198,7 @@ public sealed class EngineSettings
         new(98, 217),
         new(0, 0));
 
-    public int TempoBonus { get; set; } = 5;
+    public int TempoBonus { get; set; } = 15;
 
     #endregion
 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -805,6 +805,8 @@ public class Position
             ? eval
             : -eval;
 
+        sideEval += Configuration.EngineSettings.TempoBonus;
+
         return (sideEval, gamePhase);
     }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -805,7 +805,7 @@ public class Position
             ? eval
             : -eval;
 
-        sideEval += Configuration.EngineSettings.TempoBonus;
+        sideEval -= Configuration.EngineSettings.TempoBonus;
 
         return (sideEval, gamePhase);
     }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -97,8 +97,11 @@ public sealed class UCIHandler
                     await HandleStaticEval(rawCommand, cancellationToken);
                     HandleQuit();
                     break;
+                case "eval":
+                    await HandleEval(cancellationToken);
+                    break;
                 case "fen":
-                    await HandleFEN();
+                    await HandleFEN(cancellationToken);
                     break;
                 default:
                     _logger.Warn("Unknown command received: {0}", rawCommand);
@@ -528,13 +531,20 @@ public sealed class UCIHandler
         }
     }
 
-    private async Task HandleFEN()
+    private async Task HandleEval(CancellationToken cancellationToken)
+    {
+        var score = _engine.Game.CurrentPosition.StaticEvaluation().Score;
+
+        await _engineToUci.Writer.WriteAsync(score.ToString(), cancellationToken);
+    }
+
+    private async Task HandleFEN(CancellationToken cancellationToken)
     {
         const string fullMoveCounterString = " 1";
 
         var fen = _engine.Game.CurrentPosition.FEN()[..^3] + _engine.Game.HalfMovesWithoutCaptureOrPawnMove + fullMoveCounterString;
 
-        await _engineToUci.Writer.WriteAsync(fen);
+        await _engineToUci.Writer.WriteAsync(fen, cancellationToken);
     }
 
     #endregion

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -533,7 +533,7 @@ public sealed class UCIHandler
 
     private async Task HandleEval(CancellationToken cancellationToken)
     {
-        var score = _engine.Game.CurrentPosition.StaticEvaluation().Score;
+        var score = -_engine.Game.CurrentPosition.StaticEvaluation().Score;
 
         await _engineToUci.Writer.WriteAsync(score.ToString(), cancellationToken);
     }


### PR DESCRIPTION
Adding 10
```
Test  | eval/tempo-bonus
Elo   | -17.00 +- 11.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 5.00]
Games | 2066: +540 -641 =885
Penta | [91, 259, 391, 244, 48]
https://openbench.lynx-chess.com/test/284/
```

Substracting 10
```
Test  | eval/tempo-bonus
Elo   | -0.21 +- 3.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | 19840: +6003 -6015 =7822
Penta | [707, 2332, 3867, 2294, 720]
https://openbench.lynx-chess.com/test/286/
```

Substracting 5
```
Test  | eval/tempo-bonus
Elo   | -0.48 +- 3.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 17268: +5096 -5120 =7052
Penta | [632, 1996, 3373, 2030, 603]
https://openbench.lynx-chess.com/test/287/
```

Substracting 15
```
Test  | eval/tempo-bonus
Elo   | -0.79 +- 4.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 15346: +4641 -4676 =6029
Penta | [579, 1862, 2830, 1819, 583]
https://openbench.lynx-chess.com/test/288/
```