### PR TITLE
Tweak aspiration windows increase

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -110,6 +110,7 @@ public sealed partial class Engine
                     alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
                     beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);
 
+                    int iter = 1;
                     while (true)
                     {
                         _isFollowingPV = true;
@@ -122,7 +123,7 @@ public sealed partial class Engine
 
                         _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
-                        window <<= 1;   // window *= 2
+                        window += (int)(window * (0.5 * iter));   // 0.5 x window, window, 1.5 x window, 2 x window...
 
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
                         if (alpha >= bestEvaluation)     // Fail low
@@ -134,6 +135,8 @@ public sealed partial class Engine
                         {
                             beta = Math.Min(bestEvaluation + window, MaxValue);
                         }
+
+                        ++iter;
                     }
                 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -110,7 +110,7 @@ public sealed partial class Engine
                     alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
                     beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);
 
-                    int iter = 1;
+                    double windowMultiplier = 0;
                     while (true)
                     {
                         _isFollowingPV = true;
@@ -123,7 +123,7 @@ public sealed partial class Engine
 
                         _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
-                        window += (int)(window * (0.5 * iter));   // 0.5 x window, window, 1.5 x window, 2 x window...
+                        window += (int)(window * (0.5 + windowMultiplier));   // 0.5 x window, 0.6 x window, 0.7 x window, etc.
 
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
                         if (alpha >= bestEvaluation)     // Fail low
@@ -136,7 +136,7 @@ public sealed partial class Engine
                             beta = Math.Min(bestEvaluation + window, MaxValue);
                         }
 
-                        ++iter;
+                        windowMultiplier += 0.1;
                     }
                 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -122,7 +122,7 @@ public sealed partial class Engine
 
                         _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
-                        window += window >> 1;   // window / 2
+                        window <<= 1;   // window *= 2
 
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
                         if (alpha >= bestEvaluation)     // Fail low


### PR DESCRIPTION
*=2
```
Test  | search/tweak-aspiration-windows
Elo   | -3.52 +- 6.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 5.00]
Games | 7492: +2210 -2286 =2996
Penta | [284, 890, 1436, 890, 246]
https://openbench.lynx-chess.com/test/289/
```

+= (int)(window * (0.5 * iter));
```
Test  | search/tweak-aspiration-windows
Elo   | -0.41 +- 3.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 17670: +5249 -5270 =7151
Penta | [587, 2072, 3536, 2055, 585]
https://openbench.lynx-chess.com/test/290/
```

+= (int)(window * (0.5 + windowMultiplier)); //(windowMultiplier = 0.1 * iter=
```
Test  | search/tweak-aspiration-windows
Elo   | -1.60 +- 4.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 11524: +3417 -3470 =4637
Penta | [392, 1389, 2271, 1300, 410]
https://openbench.lynx-chess.com/test/291/
```