### PR TITLE
🔍 Delta pruning in QS

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -49,7 +49,7 @@
 
     "SEE_BadCaptureReduction": 1,
 
-    "DeltaPruning_Margin": 150,
+    "DeltaPruning_Margin": 200,
 
     // Evaluation
     "DoubledPawnPenalty": {

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -49,6 +49,8 @@
 
     "SEE_BadCaptureReduction": 1,
 
+    "DeltaPruning_Margin": 150,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -6,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -164,7 +164,7 @@ public sealed class EngineSettings
 
     public int SEE_BadCaptureReduction { get; set; } = 1;
 
-    public int DeltaPruning_Margin { get; set; } = 150;
+    public int DeltaPruning_Margin { get; set; } = 200;
 
     #region Evaluation
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -164,6 +164,8 @@ public sealed class EngineSettings
 
     public int SEE_BadCaptureReduction { get; set; } = 1;
 
+    public int DeltaPruning_Margin { get; set; } = 150;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-6, -12);

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -201,7 +201,7 @@ public static class SEE
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int Gain(Move move)
+    public static int Gain(Move move)
     {
         if (move.IsCastle())
         {


### PR DESCRIPTION
150
```
Test  | search/delta-qs-pruning
Elo   | -5.21 +- 6.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 5598: +1614 -1698 =2286
Penta | [202, 683, 1097, 631, 186]
https://openbench.lynx-chess.com/test/292/
```

200
```
Test  | search/delta-qs-pruning
Elo   | -5.76 +- 7.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 5248: +1530 -1617 =2101
Penta | [203, 640, 1018, 567, 196]
https://openbench.lynx-chess.com/test/293/
```