### PR TITLE
⚡ 🔍 Move RFP before NMP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -96,30 +96,6 @@ public sealed partial class Engine
                 staticEval = ttScore;
             }
 
-            // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
-            if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                && staticEval >= beta
-                && !parentWasNullMove
-                && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
-            {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
-
-                // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
-                //var nmpReduction = Math.Min(
-                //    depth,
-                //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
-
-                var gameState = position.MakeNullMove();
-                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
-                position.UnMakeNullMove(gameState);
-
-                if (evaluation >= beta)
-                {
-                    return evaluation;
-                }
-            }
-
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
@@ -158,6 +134,30 @@ public sealed partial class Engine
                             }
                         }
                     }
+                }
+            }
+
+            // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
+            if (depth >= Configuration.EngineSettings.NMP_MinDepth
+                && staticEval >= beta
+                && !parentWasNullMove
+                && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
+                && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+            {
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+
+                // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
+                //var nmpReduction = Math.Min(
+                //    depth,
+                //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
+
+                var gameState = position.MakeNullMove();
+                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
+                position.UnMakeNullMove(gameState);
+
+                if (evaluation >= beta)
+                {
+                    return evaluation;
                 }
             }
         }


### PR DESCRIPTION
Because it's cheaper (suggested by [@Mathmagician](Mathmagician8191/))

```
Test  | search/rfp-before-nmp
Elo   | 3.62 +- 2.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 33080: +10207 -9862 =13011
Penta | [1152, 3757, 6459, 3938, 1234]
https://openbench.lynx-chess.com/test/295/
```