### PR TITLE
Futility Pruning (FP): Add alpha and beta limits

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -271,9 +271,9 @@ public sealed partial class Engine
                     // Futility Pruning (FP) - all quiet moves can be pruned
                     // once it's considered that they don't have potential to raise alpha
                     if (movesSearched > 0
-                        //&& alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
-                        //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && depth <= Configuration.EngineSettings.FP_MaxDepth
+                        && alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
+                        && beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
                     {
                         // After making a move


### PR DESCRIPTION
Add `alpha < EvaluationConstants.PositiveCheckmateDetectionLimit` and `beta > EvaluationConstants.NegativeCheckmateDetectionLimit` limits

8+0.08
```
Score of Lynx-search-fp-no-mate-2930-win-x64 vs Lynx-search-fp-2929-win-x64: 2902 - 3020 - 3749  [0.494] 9671
...      Lynx-search-fp-no-mate-2930-win-x64 playing White: 2040 - 907 - 1889  [0.617] 4836
...      Lynx-search-fp-no-mate-2930-win-x64 playing Black: 862 - 2113 - 1860  [0.371] 4835
...      White vs Black: 4153 - 1769 - 3749  [0.623] 9671
Elo difference: -4.2 +/- 5.4, LOS: 6.3 %, DrawRatio: 38.8 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```