### PR TITLE
(Poor) Lazy eval attempt

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -53,6 +53,8 @@
 
     "SEE_BadCaptureReduction": 2,
 
+    "LazyStaticEvaluationMargin": 100,
+
     // Evaluation
     "DoubledPawnPenalty": {
       "MG": -6,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -192,6 +192,8 @@ public sealed class EngineSettings
     [SPSAAttribute<int>(0, 6, 1)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
+    public int LazyStaticEvaluationMargin { get; set; } = 100;
+
     #region Evaluation
 
     public TaperedEvaluationTerm DoubledPawnPenalty { get; set; } = new(-6, -12);

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -182,6 +182,8 @@ internal static readonly short[] EndGameKingTable =
 
 #pragma warning restore IDE0055
 
+    internal static readonly int[] PackedPieceValues = new int[12];
+
     /// <summary>
     /// 12x64
     /// </summary>
@@ -253,6 +255,8 @@ internal static readonly short[] EndGameKingTable =
 
         for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
         {
+            PackedPieceValues[piece] = Utils.Pack(MiddleGamePieceValues[piece], EndGamePieceValues[piece]);
+
             PackedPSQT[piece] = new int[64];
             for (int sq = 0; sq < 64; ++sq)
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -484,6 +484,14 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
+        // Lazy fail-hard beta-cutoff (updating alpha after this check)
+        var lazyStaticEvaluation = position.SuperLazyStaticEvaluation().Score;
+        if (lazyStaticEvaluation >= beta + Configuration.EngineSettings.LazyStaticEvaluationMargin)
+        {
+            PrintMessage(ply - 1, "Pruning before starting quiescence search using lazy eval");
+            return lazyStaticEvaluation;
+        }
+
         var staticEvaluation = position.StaticEvaluation().Score;
 
         // Fail-hard beta-cutoff (updating alpha after this check)


### PR DESCRIPTION
Use material only evaluation for QS beta cutoffs

50:
```
Score of Lynx-eval-lazy-evaluation-2935-win-x64 vs Lynx 2936 - main: 2 - 19 - 9  [0.217] 30
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing White: 1 - 5 - 9  [0.367] 15
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing Black: 1 - 14 - 0  [0.067] 15
...      White vs Black: 15 - 6 - 9  [0.650] 30
Elo difference: -223.3 +/- 121.7, LOS: 0.0 %, DrawRatio: 30.0 %
SPRT: llr -0.271 (-9.4%), lbound -2.25, ubound 2.89
```

100:
```
Score of Lynx-eval-lazy-evaluation-2935-win-x64 vs Lynx 2936 - main: 23 - 65 - 32  [0.325] 120
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing White: 17 - 20 - 23  [0.475] 60
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing Black: 6 - 45 - 9  [0.175] 60
...      White vs Black: 62 - 26 - 32  [0.650] 120
Elo difference: -127.0 +/- 55.9, LOS: 0.0 %, DrawRatio: 26.7 %
SPRT: llr -0.53 (-18.3%), lbound -2.25, ubound 2.89200
```

200
```
Score of Lynx-eval-lazy-evaluation-2935-win-x64 vs Lynx 2936 - main: 36 - 63 - 51  [0.410] 150
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing White: 27 - 19 - 28  [0.554] 74
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing Black: 9 - 44 - 23  [0.270] 76
...      White vs Black: 71 - 28 - 51  [0.643] 150
Elo difference: -63.2 +/- 45.7, LOS: 0.3 %, DrawRatio: 34.0 %
SPRT: llr -0.369 (-12.8%), lbound -2.25, ubound 2.89
```

500
```
Score of Lynx-eval-lazy-evaluation-2935-win-x64 vs Lynx 2936 - main: 3602 - 3666 - 4682  [0.497] 11950
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing White: 2490 - 1114 - 2371  [0.615] 5975
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing Black: 1112 - 2552 - 2311  [0.379] 5975
...      White vs Black: 5042 - 2226 - 4682  [0.618] 11950
Elo difference: -1.9 +/- 4.9, LOS: 22.6 %, DrawRatio: 39.2 %
SPRT: llr -1.64 (-56.8%), lbound -2.25, ubound 2.89
```

900
```
Score of Lynx-eval-lazy-evaluation-2935-win-x64 vs Lynx 2936 - main: 1291 - 1369 - 1670  [0.491] 4330
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing White: 941 - 410 - 814  [0.623] 2165
...      Lynx-eval-lazy-evaluation-2935-win-x64 playing Black: 350 - 959 - 856  [0.359] 2165
...      White vs Black: 1900 - 760 - 1670  [0.632] 4330
Elo difference: -6.3 +/- 8.1, LOS: 6.5 %, DrawRatio: 38.6 %
SPRT: llr -1.36 (-47.0%), lbound -2.25, ubound 2.89
```