### PR TITLE
🔍 Tune Futlity Pruning (FP)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -54,8 +54,8 @@
     "SEE_BadCaptureReduction": 2,
 
     "FP_MaxDepth": 6,
-    "FP_DepthScalingFactor": 60,
-    "FP_Margin": 250,
+    "FP_DepthScalingFactor": 53,
+    "FP_Margin": 351,
 
     // Evaluation
     "DoubledPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -196,10 +196,10 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 6;
 
     [SPSAAttribute<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 60;
+    public int FP_DepthScalingFactor { get; set; } = 53;
 
     [SPSAAttribute<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 250;
+    public int FP_Margin { get; set; } = 351;
 
     #region Evaluation
 


### PR DESCRIPTION
```
Test  | search/fp-tuning
Elo   | -0.11 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 54804: +16761 -16779 =21264
Penta | [2021, 6388, 10625, 6324, 2044]
https://openbench.lynx-chess.com/test/309/

Test  | search/fp-tuning
Elo   | -0.40 +- 4.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.71 (-2.25, 2.89) [0.00, 3.00]
Games | 13780: +3935 -3951 =5894
Penta | [406, 1665, 2772, 1633, 414]
https://openbench.lynx-chess.com/test/310/
```

```json
{
   "t":39424,
   "spsa_params":{
      "a":1.0,
      "c":1.0,
      "A":205,
      "alpha":0.601,
      "gamma":0.102
   },
   "uci_params":[
      {
         "name":"FP_MaxDepth",
         "value":5.535602332436792,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"FP_DepthScalingFactor",
         "value":53.24322930916915,
         "min_value":1,
         "max_value":200,
         "step":10
      },
      {
         "name":"FP_Margin",
         "value":351.01124738361426,
         "min_value":0,
         "max_value":500,
         "step":25
      }
   ]
}
```