### PR TITLE
Prefetch TT entry right before NMP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -147,6 +147,8 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
+                PrefetchTTEntry();
+
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing


### PR DESCRIPTION
```
Test  | perft/prefetch-nmp
Elo   | -2.40 +- 3.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 18252: +5479 -5605 =7168
Penta | [584, 2098, 3862, 2024, 558]
https://openbench.lynx-chess.com/test/311/
```