### PR TITLE
🔍 Add 'modern' razoring implementation II

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -57,6 +57,10 @@
     "FP_DepthScalingFactor": 60,
     "FP_Margin": 250,
 
+    "Razoring2_MaxDepth": 4,
+    "Razoring2_AlphaMargin": 2000,
+    "Razoring2_DepthScalingFactor": 250,
+
     // Evaluation
     "IsolatedPawnPenalty": {
       "MG": -21,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -155,7 +155,10 @@ public sealed class EngineSettings
     [SPSAAttribute<int>(1, 20, 1)]
     public int AspirationWindow_MinDepth { get; set; } = 7;
 
-    [SPSAAttribute<int>(1, 20, 1)]
+    /// <summary>
+    /// Min 2 due to existing logic that assumes RFP_MaxDepth >= Razoring_MaxDepth
+    /// </summary>
+    [SPSAAttribute<int>(2, 20, 1)]
     public int RFP_MaxDepth { get; set; } = 6;
 
     [SPSAAttribute<int>(1, 300, 10)]
@@ -200,6 +203,15 @@ public sealed class EngineSettings
 
     [SPSAAttribute<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 250;
+
+    [SPSAAttribute<int>(1, 10, 1)]
+    public int Razoring2_MaxDepth { get; set; } = 4;
+
+    [SPSAAttribute<int>(1000, 5000, 500)]
+    public int Razoring2_AlphaMargin { get; set; } = 2000;
+
+    [SPSAAttribute<int>(50, 500, 50)]
+    public int Razoring2_DepthScalingFactor { get; set; } = 250;
 
     #region Evaluation
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -97,6 +97,17 @@ public sealed partial class Engine
                 staticEval = ttScore;
             }
 
+            // Razoring implementation, according to modern standards. Based on Ciekce + JW
+            if (depth <= Configuration.EngineSettings.Razoring2_MaxDepth
+                && Math.Abs(alpha) < 2000
+                && staticEval + (Configuration.EngineSettings.Razoring2_DepthScalingFactor * depth) <= alpha)
+            {
+                var score = QuiescenceSearch(ply, alpha, alpha + 1);
+
+                if (score <= alpha)
+                    return score;
+            }
+
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -118,37 +118,6 @@ public sealed partial class Engine
                     return (staticEval + beta) / 2;
 #pragma warning restore S3949 // Calculations should not overflow
                 }
-
-                // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
-                if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
-                {
-                    var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
-
-                    if (score < beta)               // Static evaluation + bonus indicates fail-low node
-                    {
-                        if (depth == 1)
-                        {
-                            var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-
-                            return qSearchScore > score
-                                ? qSearchScore
-                                : score;
-                        }
-
-                        score += Configuration.EngineSettings.Razoring_NotDepth1Bonus;
-
-                        if (score < beta)               // Static evaluation indicates fail-low node
-                        {
-                            var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-                            if (qSearchScore < beta)    // Quiescence score also indicates fail-low node
-                            {
-                                return qSearchScore > score
-                                    ? qSearchScore
-                                    : score;
-                            }
-                        }
-                    }
-                }
             }
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -108,16 +108,13 @@ public sealed partial class Engine
                     return score;
             }
 
-            if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
+            // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+            // Return formula by Ciekce, instead of just returning static eval
+            if (depth <= Configuration.EngineSettings.RFP_MaxDepth && staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
             {
-                // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-                // Return formula by Ciekce, instead of just returning static eval
-                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
-                {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
-                    return (staticEval + beta) / 2;
+                return (staticEval + beta) / 2;
 #pragma warning restore S3949 // Calculations should not overflow
-                }
             }
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -456,6 +456,30 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "razoring2_maxdepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.Razoring2_MaxDepth = value;
+                    }
+                    break;
+                }
+            case "razoring2_alphamargin":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.Razoring2_AlphaMargin = value;
+                    }
+                    break;
+                }
+            case "razoring2_depthscalingfactor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.Razoring2_DepthScalingFactor = value;
+                    }
+                    break;
+                }
 
             #endregion
 


### PR DESCRIPTION
Already attempted in https://github.com/lynx-chess/Lynx/pull/709

This time based directly on Ciekce 's implementation for Stormphrax.

Double checking that current razoring is still winning
```
Test  | no-old-razoring
Elo   | -6.98 +- 5.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 8262: +2434 -2600 =3228
Penta | [316, 1024, 1586, 920, 285]
https://openbench.lynx-chess.com/test/318/
```

Razoring2_MaxDepth = 1
```
Score of Lynx-search-razoring-modern-2970-win-x64-1 vs Lynx 2969 - main: 1758 - 1735 - 2197  [0.502] 5690
...      Lynx-search-razoring-modern-2970-win-x64-1 playing White: 1228 - 520 - 1097  [0.624] 2845
...      Lynx-search-razoring-modern-2970-win-x64-1 playing Black: 530 - 1215 - 1100  [0.380] 2845
...      White vs Black: 2443 - 1050 - 2197  [0.622] 5690
Elo difference: 1.4 +/- 7.1, LOS: 65.1 %, DrawRatio: 38.6 %
SPRT: llr -0.0221 (-0.8%), lbound -2.25, ubound 2.89
```

4
```
Score of Lynx-search-razoring-modern-2970-win-x64-4 vs Lynx 2969 - main: 1073 - 1119 - 1388  [0.494] 3580
...      Lynx-search-razoring-modern-2970-win-x64-4 playing White: 747 - 330 - 713  [0.616] 1790
...      Lynx-search-razoring-modern-2970-win-x64-4 playing Black: 326 - 789 - 675  [0.371] 1790
...      White vs Black: 1536 - 656 - 1388  [0.623] 3580
Elo difference: -4.5 +/- 8.9, LOS: 16.3 %, DrawRatio: 38.8 %
SPRT: llr -0.867 (-30.0%), lbound -2.25, ubound 2.89
```

4 without old impl
```
Score of Lynx-search-razoring-modern-2979-win-x64 vs Lynx 2969 - main: 360 - 416 - 494  [0.478] 1270
...      Lynx-search-razoring-modern-2979-win-x64 playing White: 259 - 127 - 249  [0.604] 635
...      Lynx-search-razoring-modern-2979-win-x64 playing Black: 101 - 289 - 245  [0.352] 635
...      White vs Black: 548 - 228 - 494  [0.626] 1270
Elo difference: -15.3 +/- 14.9, LOS: 2.2 %, DrawRatio: 38.9 %
SPRT: llr -0.87 (-30.1%), lbound -2.25, ubound 2.89
```

2 without old impl
```
Score of Lynx-search-razoring-modern-2979-win-x64 vs Lynx 2969 - main: 787 - 849 - 1084  [0.489] 2720
...      Lynx-search-razoring-modern-2979-win-x64 playing White: 574 - 266 - 521  [0.613] 1361
...      Lynx-search-razoring-modern-2979-win-x64 playing Black: 213 - 583 - 563  [0.364] 1359
...      White vs Black: 1157 - 479 - 1084  [0.625] 2720
Elo difference: -7.9 +/- 10.1, LOS: 6.3 %, DrawRatio: 39.9 %
SPRT: llr -1.06 (-36.6%), lbound -2.25, ubound 2.89
```