### PR TITLE
Try to optimize additional piece evaluation

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -848,9 +848,11 @@ public class Position
     {
         return pieceIndex switch
         {
-            (int)Piece.P or (int)Piece.p => PawnAdditionalEvaluation(pieceSquareIndex, pieceIndex),
-            (int)Piece.R or (int)Piece.r => RookAdditionalEvaluation(pieceSquareIndex, pieceIndex),
-            (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.P => WhitePawnAdditionalEvaluation(pieceSquareIndex),
+            (int)Piece.p => BlackPawnAdditionalEvaluation(pieceSquareIndex),
+            (int)Piece.R => WhiteRookAdditionalEvaluation(pieceSquareIndex),
+            (int)Piece.r => BlackRookAdditionalEvaluation(pieceSquareIndex),
+            (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex),
             (int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex),
             _ => 0
         };
@@ -859,26 +861,51 @@ public class Position
     /// <summary>
     /// Doubled pawns penalty, isolated pawns penalty, passed pawns bonus
     /// </summary>
-    /// <param name = "squareIndex" ></ param >
-    /// < param name="pieceIndex"></param>
+    /// <param name="squareIndex"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int PawnAdditionalEvaluation(int squareIndex, int pieceIndex)
+    private int WhitePawnAdditionalEvaluation(int squareIndex)
     {
         int packedBonus = 0;
 
-        if ((PieceBitBoards[pieceIndex] & Masks.IsolatedPawnMasks[squareIndex]) == default) // isIsolatedPawn
+        var rank = Constants.Rank[squareIndex];
+        var whitePawns = PieceBitBoards[(int)Piece.P];
+        var blackPawns = PieceBitBoards[(int)Piece.p];
+
+        if ((whitePawns & Masks.IsolatedPawnMasks[squareIndex]) == 0) // isIsolatedPawn
         {
             packedBonus += Configuration.EngineSettings.IsolatedPawnPenalty.PackedEvaluation;
         }
 
-        if ((PieceBitBoards[(int)Piece.p - pieceIndex] & Masks.PassedPawns[pieceIndex][squareIndex]) == default)    // isPassedPawn
+        if ((blackPawns & Masks.PassedPawns[(int)Piece.P][squareIndex]) == 0)    // isPassedPawn
         {
-            var rank = Constants.Rank[squareIndex];
-            if (pieceIndex == (int)Piece.p)
-            {
-                rank = 7 - rank;
-            }
+            packedBonus += Configuration.EngineSettings.PassedPawnBonus[rank].PackedEvaluation;
+        }
+
+        return packedBonus;
+    }
+
+    /// <summary>
+    /// Doubled pawns penalty, isolated pawns penalty, passed pawns bonus
+    /// </summary>
+    /// <param name="squareIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int BlackPawnAdditionalEvaluation(int squareIndex)
+    {
+        int packedBonus = 0;
+
+        var rank = 7 - Constants.Rank[squareIndex];
+        var whitePawns = PieceBitBoards[(int)Piece.P];
+        var blackPawns = PieceBitBoards[(int)Piece.p];
+
+        if ((blackPawns & Masks.IsolatedPawnMasks[squareIndex]) == 0) // isIsolatedPawn
+        {
+            packedBonus += Configuration.EngineSettings.IsolatedPawnPenalty.PackedEvaluation;
+        }
+
+        if ((whitePawns & Masks.PassedPawns[(int)Piece.p][squareIndex]) == 0)    // isPassedPawn
+        {
             packedBonus += Configuration.EngineSettings.PassedPawnBonus[rank].PackedEvaluation;
         }
 
@@ -889,22 +916,51 @@ public class Position
     /// Open and semiopen file bonus
     /// </summary>
     /// <param name="squareIndex"></param>
-    /// <param name="pieceIndex"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int RookAdditionalEvaluation(int squareIndex, int pieceIndex)
+    private int WhiteRookAdditionalEvaluation(int squareIndex)
     {
         var attacksCount = Attacks.RookAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
 
         var packedBonus = attacksCount * Configuration.EngineSettings.RookMobilityBonus.PackedEvaluation;
 
-        const int pawnToRookOffset = (int)Piece.R - (int)Piece.P;
+        var fileMask = Masks.FileMasks[squareIndex];
+        var whitePawns = PieceBitBoards[(int)Piece.P];
+        var blackPawns = PieceBitBoards[(int)Piece.p];
 
-        if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMasks[squareIndex]) == default)  // isOpenFile
+        if (((whitePawns | blackPawns) & fileMask) == 0)  // isOpenFile
         {
             packedBonus += Configuration.EngineSettings.OpenFileRookBonus.PackedEvaluation;
         }
-        else if ((PieceBitBoards[pieceIndex - pawnToRookOffset] & Masks.FileMasks[squareIndex]) == default)  // isSemiOpenFile
+        else if ((whitePawns & fileMask) == 0)  // isSemiOpenFile
+        {
+            packedBonus += Configuration.EngineSettings.SemiOpenFileRookBonus.PackedEvaluation;
+        }
+
+        return packedBonus;
+    }
+
+    /// <summary>
+    /// Open and semiopen file bonus
+    /// </summary>
+    /// <param name="squareIndex"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int BlackRookAdditionalEvaluation(int squareIndex)
+    {
+        var attacksCount = Attacks.RookAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
+
+        var packedBonus = attacksCount * Configuration.EngineSettings.RookMobilityBonus.PackedEvaluation;
+
+        var fileMask = Masks.FileMasks[squareIndex];
+        var whitePawns = PieceBitBoards[(int)Piece.P];
+        var blackPawns = PieceBitBoards[(int)Piece.p];
+
+        if (((whitePawns | blackPawns) & fileMask) == 0)  // isOpenFile
+        {
+            packedBonus += Configuration.EngineSettings.OpenFileRookBonus.PackedEvaluation;
+        }
+        else if ((blackPawns & fileMask) == 0)  // isSemiOpenFile
         {
             packedBonus += Configuration.EngineSettings.SemiOpenFileRookBonus.PackedEvaluation;
         }
@@ -916,10 +972,9 @@ public class Position
     /// Mobility and bishop pair bonus
     /// </summary>
     /// <param name="squareIndex"></param>
-    /// <param name="pieceIndex"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int BishopAdditionalEvaluation(int squareIndex, int pieceIndex)
+    private int BishopAdditionalEvaluation(int squareIndex)
     {
         var attacksCount = Attacks.BishopAttacks(squareIndex, OccupancyBitBoards[(int)Side.Both]).CountBits();
 


### PR DESCRIPTION
I've attempted this before, but just in case

```
Test  | perf/additional-eval
Elo   | -2.88 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 16300: +4916 -5051 =6333
Penta | [572, 1828, 3410, 1843, 497]
https://openbench.lynx-chess.com/test/325/
```