### PR TITLE
⚡ Simplify `TaperedEvaluationTermByRank`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -291,15 +291,15 @@ public sealed class TaperedEvaluationTerm
 
 public sealed class TaperedEvaluationTermByRank
 {
-    private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
+    private readonly TaperedEvaluationTerm[] _evaluationTermsIndexedByPiece;
 
     public TaperedEvaluationTerm Rank0 => _evaluationTermsIndexedByPiece[0];
-    public TaperedEvaluationTerm Rank1  => _evaluationTermsIndexedByPiece[1];
-    public TaperedEvaluationTerm Rank2  => _evaluationTermsIndexedByPiece[2];
-    public TaperedEvaluationTerm Rank3  => _evaluationTermsIndexedByPiece[3];
-    public TaperedEvaluationTerm Rank4  => _evaluationTermsIndexedByPiece[4];
-    public TaperedEvaluationTerm Rank5  => _evaluationTermsIndexedByPiece[5];
-    public TaperedEvaluationTerm Rank6  => _evaluationTermsIndexedByPiece[6];
+    public TaperedEvaluationTerm Rank1 => _evaluationTermsIndexedByPiece[1];
+    public TaperedEvaluationTerm Rank2 => _evaluationTermsIndexedByPiece[2];
+    public TaperedEvaluationTerm Rank3 => _evaluationTermsIndexedByPiece[3];
+    public TaperedEvaluationTerm Rank4 => _evaluationTermsIndexedByPiece[4];
+    public TaperedEvaluationTerm Rank5 => _evaluationTermsIndexedByPiece[5];
+    public TaperedEvaluationTerm Rank6 => _evaluationTermsIndexedByPiece[6];
     public TaperedEvaluationTerm Rank7 => _evaluationTermsIndexedByPiece[7];
 
     public TaperedEvaluationTermByRank(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -293,36 +293,24 @@ public sealed class TaperedEvaluationTermByRank
 {
     private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByPiece;
 
-    public TaperedEvaluationTerm Rank0 { get; set; }
-    public TaperedEvaluationTerm Rank1 { get; set; }
-    public TaperedEvaluationTerm Rank2 { get; set; }
-    public TaperedEvaluationTerm Rank3 { get; set; }
-    public TaperedEvaluationTerm Rank4 { get; set; }
-    public TaperedEvaluationTerm Rank5 { get; set; }
-    public TaperedEvaluationTerm Rank6 { get; set; }
-    public TaperedEvaluationTerm Rank7 { get; set; }
+    public TaperedEvaluationTerm Rank0 => _evaluationTermsIndexedByPiece[0];
+    public TaperedEvaluationTerm Rank1  => _evaluationTermsIndexedByPiece[1];
+    public TaperedEvaluationTerm Rank2  => _evaluationTermsIndexedByPiece[2];
+    public TaperedEvaluationTerm Rank3  => _evaluationTermsIndexedByPiece[3];
+    public TaperedEvaluationTerm Rank4  => _evaluationTermsIndexedByPiece[4];
+    public TaperedEvaluationTerm Rank5  => _evaluationTermsIndexedByPiece[5];
+    public TaperedEvaluationTerm Rank6  => _evaluationTermsIndexedByPiece[6];
+    public TaperedEvaluationTerm Rank7 => _evaluationTermsIndexedByPiece[7];
 
     public TaperedEvaluationTermByRank(
         TaperedEvaluationTerm rank0, TaperedEvaluationTerm rank1, TaperedEvaluationTerm rank2,
         TaperedEvaluationTerm rank3, TaperedEvaluationTerm rank4, TaperedEvaluationTerm rank5,
         TaperedEvaluationTerm rank6, TaperedEvaluationTerm rank7)
     {
-        Rank0 = rank0;
-        Rank1 = rank1;
-        Rank2 = rank2;
-        Rank3 = rank3;
-        Rank4 = rank4;
-        Rank5 = rank5;
-        Rank6 = rank6;
-        Rank7 = rank7;
-
         _evaluationTermsIndexedByPiece = [rank0, rank1, rank2, rank3, rank4, rank5, rank6, rank7];
     }
 
-    public TaperedEvaluationTerm this[int i]
-    {
-        get { return _evaluationTermsIndexedByPiece[i]; }
-    }
+    public TaperedEvaluationTerm this[int i] => _evaluationTermsIndexedByPiece[i];
 
     public override string ToString()
     {


### PR DESCRIPTION
* Remove duplicated backing field
* Make inner list an array

Getter properties need to remain for automatic configuration binding purposes.

This is a code simplification that _might_ imply a speed up in practice

[-5, 0], 8+0.08
```
Score of Lynx-simplify-taperedevaluationtermbyrank-2996-win-x64 vs Lynx 2980 - main: 1383 - 1294 - 1771  [0.510] 4448
...      Lynx-simplify-taperedevaluationtermbyrank-2996-win-x64 playing White: 976 - 369 - 879  [0.636] 2224
...      Lynx-simplify-taperedevaluationtermbyrank-2996-win-x64 playing Black: 407 - 925 - 892  [0.384] 2224
...      White vs Black: 1901 - 776 - 1771  [0.626] 4448
Elo difference: 7.0 +/- 7.9, LOS: 95.7 %, DrawRatio: 39.8 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```