### PR TITLE
⚡ Avoid duplicated memory access

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -682,6 +682,9 @@ public class Position
 
         for (int pieceIndex = (int)Piece.P; pieceIndex < (int)Piece.K; ++pieceIndex)
         {
+            var pieceTable = EvaluationConstants.PackedPSQT[pieceIndex];
+            var piecePhase = EvaluationConstants.GamePhaseByPiece[pieceIndex];
+
             // Bitboard copy that we 'empty'
             var bitboard = PieceBitBoards[pieceIndex];
 
@@ -690,8 +693,8 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += pieceTable[pieceSquareIndex];
+                gamePhase += piecePhase;
 
                 packedScore += AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
             }
@@ -699,6 +702,9 @@ public class Position
 
         for (int pieceIndex = (int)Piece.p; pieceIndex < (int)Piece.k; ++pieceIndex)
         {
+            var pieceTable = EvaluationConstants.PackedPSQT[pieceIndex];
+            var piecePhase = EvaluationConstants.GamePhaseByPiece[pieceIndex];
+
             // Bitboard copy that we 'empty'
             var bitboard = PieceBitBoards[pieceIndex];
 
@@ -707,8 +713,8 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
-                gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
+                packedScore += pieceTable[pieceSquareIndex];
+                gamePhase += piecePhase;
 
                 packedScore -= AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
             }


### PR DESCRIPTION
Access tables as little as needed during static eval
```
Test  | perf/eval-table-access
Elo   | -3.31 +- 4.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 14490: +4325 -4463 =5702
Penta | [485, 1666, 3051, 1588, 455]
https://openbench.lynx-chess.com/test/336/
```