### PR TITLE
⚡ Simplify `TaperedEvaluationTermByCount`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -348,7 +348,7 @@ public sealed class TaperedEvaluationTermByRank
 /// </summary>
 public sealed class TaperedEvaluationTermByCount
 {
-    private readonly List<TaperedEvaluationTerm> _evaluationTermsIndexedByCount;
+    private readonly TaperedEvaluationTerm[] _evaluationTermsIndexedByCount;
 
     public TaperedEvaluationTerm Count0 => _evaluationTermsIndexedByCount[0];
     public TaperedEvaluationTerm Count1 => _evaluationTermsIndexedByCount[1];


### PR DESCRIPTION
Followup of https://github.com/lynx-chess/Lynx/pull/757 

- Use array inside of `TaperedEvaluationTermByCount` as well

Quick non-reg
```
Test  | perf/TaperedEvaluationTermByCount-array
Elo   | 3.11 +- 5.31 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | 10598: +3475 -3380 =3743
Penta | [436, 1157, 2059, 1170, 477]
https://openbench.lynx-chess.com/test/343/
```