### PR TITLE
🐛 `wf_spsa` serialization

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -429,6 +429,7 @@ public sealed class TaperedEvaluationTermByCount
 [JsonSerializable(typeof(EngineSettings))]
 [JsonSerializable(typeof(TaperedEvaluationTerm))]
 [JsonSerializable(typeof(TaperedEvaluationTermByRank))]
+[JsonSerializable(typeof(TaperedEvaluationTermByCount))]
 [JsonSerializable(typeof(SPSAAttribute<int>))]
 [JsonSerializable(typeof(SPSAAttribute<double>))]
 internal partial class EngineSettingsJsonSerializerContext : JsonSerializerContext;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -432,4 +432,6 @@ public sealed class TaperedEvaluationTermByCount
 [JsonSerializable(typeof(TaperedEvaluationTermByCount))]
 [JsonSerializable(typeof(SPSAAttribute<int>))]
 [JsonSerializable(typeof(SPSAAttribute<double>))]
+[JsonSerializable(typeof(WeatherFactoryOutput<int>))]
+[JsonSerializable(typeof(WeatherFactoryOutput<double>))]
 internal partial class EngineSettingsJsonSerializerContext : JsonSerializerContext;

--- a/src/Lynx/SPSAAttribute.cs
+++ b/src/Lynx/SPSAAttribute.cs
@@ -72,7 +72,6 @@ internal class SPSAAttribute<T> : Attribute
     {
         T val = GetPropertyValue(property);
 
-#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
         return KeyValuePair.Create(
             property.Name,
             JsonSerializer.SerializeToNode(new
@@ -81,8 +80,8 @@ internal class SPSAAttribute<T> : Attribute
                 min_value = MinValue,
                 max_value = MaxValue,
                 step = Step,
-            }));
-#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
+            },
+            EngineSettingsJsonSerializerContext.Default.EngineSettings));
     }
 }
 

--- a/src/Lynx/SPSAAttribute.cs
+++ b/src/Lynx/SPSAAttribute.cs
@@ -6,10 +6,20 @@ using System.Text.Json.Nodes;
 
 namespace Lynx;
 
+#pragma warning disable IDE1006 // Naming Styles
+internal record WeatherFactoryOutput<T>(T value, T min_value, T max_value, double step);
+#pragma warning restore IDE1006 // Naming Styles
+
 [AttributeUsage(AttributeTargets.Property, Inherited = false, AllowMultiple = false)]
 internal class SPSAAttribute<T> : Attribute
     where T : INumberBase<T>, IMultiplyOperators<T, T, T>, IConvertible, IParsable<T>, ISpanParsable<T>, IDivisionOperators<T, T, T>
 {
+#pragma warning disable S2743 // Static fields should not be used in generic types
+#pragma warning disable RCS1158 // Static member in generic type should use a type parameter
+    internal static readonly JsonSerializerOptions _jsonSerializerOptions = new() { TypeInfoResolver = EngineSettingsJsonSerializerContext.Default };
+#pragma warning restore RCS1158 // Static member in generic type should use a type parameter
+#pragma warning restore S2743 // Static fields should not be used in generic types
+
     private static readonly T _hundred;
 
     public T MinValue { get; }
@@ -72,16 +82,13 @@ internal class SPSAAttribute<T> : Attribute
     {
         T val = GetPropertyValue(property);
 
+#pragma warning disable IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
         return KeyValuePair.Create(
             property.Name,
-            JsonSerializer.SerializeToNode(new
-            {
-                value = val,
-                min_value = MinValue,
-                max_value = MaxValue,
-                step = Step,
-            },
-            EngineSettingsJsonSerializerContext.Default.EngineSettings));
+            JsonSerializer.SerializeToNode(
+                new WeatherFactoryOutput<T>(val, MinValue, MaxValue, Step),
+                _jsonSerializerOptions));
+#pragma warning restore IL2026 // Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code
     }
 }
 


### PR DESCRIPTION
```
wf_spsa
03:15:25 | [ERROR] Error trying to read/parse UCI command System.InvalidOperationException: Reflection-based serialization has been disabled for this application. Either use the source generator APIs or explicitly configure the 'JsonSerializerOptions.TypeInfoResolver' property.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_JsonSerializerIsReflectionDisabled()
   at System.Text.Json.JsonSerializerOptions.ConfigureForJsonSerializer()
   at System.Text.Json.JsonSerializerOptions.MakeReadOnly(Boolean)
   at System.Text.Json.JsonSerializer.GetTypeInfo(JsonSerializerOptions, Type)
   at System.Text.Json.JsonSerializer.GetTypeInfo[T](JsonSerializerOptions)
   at System.Text.Json.JsonSerializer.SerializeToNode[TValue](TValue , JsonSerializerOptions )
   at Lynx.SPSAAttribute`1.ToWeatherFactoryString(PropertyInfo)
   at Lynx.SPSAAttributeHelpers.GenerateWeatherFactoryStrings()+MoveNext()
   at System.Text.Json.Nodes.JsonObject..ctor(IEnumerable`1 , Nullable`1 )
   at Lynx.UCIHandler.HandleWeatherFactorySPSA(CancellationToken)
   at Lynx.UCIHandler.Handle(String, CancellationToken)
```