### PR TITLE
Add ponder support

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -15,6 +15,7 @@
     "UseOnlineTablebaseInSearch": false,
     "OnlineTablebaseMaxSupportedPieces": 7,
     "ShowWDL": false,
+    "IsPonder": false,
     "SPSA_OB_R_end": 0.02,
 
     "HardTimeBoundMultiplier": 0.52,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -12,7 +12,6 @@ public static class Configuration
 #pragma warning disable IDE1006 // Naming Styles
     private static int _UCI_AnalyseMode = 0;
 #pragma warning restore IDE1006 // Naming Styles
-    private static int _ponder = 0;
 
     public static bool IsDebug
     {
@@ -42,22 +41,6 @@ public static class Configuration
             else
             {
                 Interlocked.CompareExchange(ref _UCI_AnalyseMode, 0, 1);
-            }
-        }
-    }
-
-    public static bool IsPonder
-    {
-        get => Interlocked.CompareExchange(ref _ponder, 1, 1) == 1;
-        set
-        {
-            if (value)
-            {
-                Interlocked.CompareExchange(ref _ponder, 1, 0);
-            }
-            else
-            {
-                Interlocked.CompareExchange(ref _ponder, 0, 1);
             }
         }
     }
@@ -104,6 +87,8 @@ public sealed class EngineSettings
     public int OnlineTablebaseMaxSupportedPieces { get; set; } = 7;
 
     public bool ShowWDL { get; set; } = false;
+
+    public bool IsPonder { get; set; } = false;
 
     public double SPSA_OB_R_end { get; set; } = 0.02;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -306,13 +306,12 @@ public sealed partial class Engine
 
         try
         {
+            _isPondering = goCommand.Ponder;
             var searchResult = BestMove(goCommand);
 
-            // Checking settings in case the implementation inside was costly
-            if (Configuration.EngineSettings.IsPonder)
+            if (_isPondering)
             {
                 // Using either field or local copy for the rest of the method, since goCommand.Ponder could change
-                _isPondering = goCommand.Ponder;
 
                 // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
                 // before a potential ponderhit command

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -307,7 +307,12 @@ public sealed partial class Engine
         SearchResult finalSearchResult;
         if (lastSearchResult is null)
         {
-            _logger.Warn("Search cancelled at depth 1, choosing first found legal move as best one");
+            // In the event of a quick ponderhit/stop while pondering because the opponent moved quickly, we don't want no warning triggered here
+            // when cancelling the pondering search
+            if (!_isPondering)
+            {
+                _logger.Warn("Search cancelled at depth 1, choosing first found legal move as best one");
+            }
             finalSearchResult = new(firstLegalMove, 0, 0, [firstLegalMove], alpha, beta);
         }
         else

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -131,6 +131,7 @@ public sealed class OptionCommand : EngineBaseCommand
             $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min {Constants.AbsoluteMinTTSize} max {Constants.AbsoluteMaxTTSize}",
             $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
             "option name Threads type spin default 1 min 1 max 1",
+            $"option name Ponder type check default {Configuration.EngineSettings.IsPonder}",
             .. Configuration.GeneralSettings.EnableTuning ? SPSAAttributeHelpers.GenerateOptionStrings() : []
         ];
 

--- a/src/Lynx/UCI/Commands/GUI/GoCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/GoCommand.cs
@@ -64,7 +64,7 @@ public sealed partial class GoCommand : GUIBaseCommand
     public int Depth { get; }
     public int MoveTime { get; }
     public bool Infinite { get; }
-    public bool Ponder { get; }
+    public bool Ponder { get; private set; }
 
     public int Nodes => throw new NotImplementedException();
     public int Mate => throw new NotImplementedException();
@@ -104,7 +104,10 @@ public sealed partial class GoCommand : GUIBaseCommand
                             Infinite = true;
                             break;
                         case "ponder":
-                            Ponder = true;
+                            if (Configuration.EngineSettings.IsPonder)
+                            {
+                                Ponder = true;
+                            }
                             break;
                         case "depth":
                             Depth = int.Parse(group.Value);
@@ -121,4 +124,6 @@ public sealed partial class GoCommand : GUIBaseCommand
     }
 
     public static string Init() => Id;
+
+    public void DisablePonder() => Ponder = false;
 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -3,10 +3,10 @@ using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.Intrinsics.X86;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Threading;
 using System.Threading.Channels;
 
 namespace Lynx;
@@ -161,9 +161,13 @@ public sealed class UCIHandler
 
     private void HandlePonderHit()
     {
-        if (Configuration.IsPonder)
+        if (Configuration.EngineSettings.IsPonder)
         {
             _engine.PonderHit();
+        }
+        else
+        {
+            _logger.Warn("Unexpected 'ponderhit' command, given pondering is disabled. Ignoring it");
         }
     }
 
@@ -186,9 +190,8 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.IsPonder = value;
+                        Configuration.EngineSettings.IsPonder = value;
                     }
-                    _logger.Warn("Ponder not supported yet");
                     break;
                 }
             case "uci_analysemode":
@@ -608,7 +611,7 @@ public sealed class UCIHandler
 
     private async ValueTask HandleOpenBenchSPSA(CancellationToken cancellationToken)
     {
-        foreach(var tunableValue in SPSAAttributeHelpers.GenerateOpenBenchStrings())
+        foreach (var tunableValue in SPSAAttributeHelpers.GenerateOpenBenchStrings())
         {
             await SendCommand(tunableValue, cancellationToken);
         }


### PR DESCRIPTION
Second, simplified attempt after https://github.com/lynx-chess/Lynx/pull/481

8+0.08, 64MB, concurrency = physical cores/2 (threads / 4), balanced book (`8moves_v3.epd`)
```
Score of Lynx-ponder-add-3045-win-x64 vs Lynx 3044 - main: 1198 - 718 - 1834  [0.564] 3750
...      Lynx-ponder-add-3045-win-x64 playing White: 656 - 321 - 898  [0.589] 1875
...      Lynx-ponder-add-3045-win-x64 playing Black: 542 - 397 - 936  [0.539] 1875
...      White vs Black: 1053 - 863 - 1834  [0.525] 3750
Elo difference: 44.7 +/- 7.9, LOS: 100.0 %, DrawRatio: 48.9 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf

Player: Lynx-ponder-add-3045-win-x64
   "Draw by 3-fold repetition": 1453
   "Draw by fifty moves rule": 57
   "Draw by insufficient mating material": 308
   "Draw by stalemate": 14
   "Draw by stalled connection": 2
   "Loss: Black mates": 320
   "Loss: White loses on time": 1
   "Loss: White mates": 397
   "Win: Black mates": 542
   "Win: White mates": 656
Player: Lynx 3044 - main
   "Draw by 3-fold repetition": 1453
   "Draw by fifty moves rule": 57
   "Draw by insufficient mating material": 308
   "Draw by stalemate": 14
   "Draw by stalled connection": 2
   "Loss: Black mates": 542
   "Loss: White mates": 656
   "Win: Black mates": 320
   "Win: White loses on time": 1
   "Win: White mates": 397
```

Non-reg
```
Test  | ponder-add
Elo   | -3.63 +- 4.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 16470: +4931 -5103 =6436
Penta | [584, 1880, 3435, 1796, 540]
https://openbench.lynx-chess.com/test/352/
```

After refactor

8+0.08, 64MB, concurrency = physical cores/2 (threads / 4), balanced book (`8moves_v3.epd`)
```
Score of Lynx-ponder-add-3051-win-x64 vs Lynx 3044 - main: 471 - 284 - 745  [0.562] 1500
...      Lynx-ponder-add-3051-win-x64 playing White: 254 - 125 - 371  [0.586] 750
...      Lynx-ponder-add-3051-win-x64 playing Black: 217 - 159 - 374  [0.539] 750
...      White vs Black: 413 - 342 - 745  [0.524] 1500
Elo difference: 43.5 +/- 12.5, LOS: 100.0 %, DrawRatio: 49.7 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf

Player: Lynx-ponder-add-3051-win-x64
   "Draw by 3-fold repetition": 581
   "Draw by fifty moves rule": 22
   "Draw by insufficient mating material": 138
   "Draw by stalemate": 4
   "Loss: Black mates": 123
   "Loss: White mates": 159
   "Loss: White's connection stalls": 2
   "Win: Black mates": 217
   "Win: White mates": 254
Player: Lynx 3044 - main
   "Draw by 3-fold repetition": 581
   "Draw by fifty moves rule": 22
   "Draw by insufficient mating material": 138
   "Draw by stalemate": 4
   "Loss: Black mates": 217
   "Loss: White mates": 254
   "Win: Black mates": 123
   "Win: White mates": 159
   "Win: White's connection stalls": 2
```

40+0.4, 256MB, concurrency = physical cores/2 (threads / 4), balanced book (`8moves_v3.epd`)

```
Score of Lynx-ponder-add-3051-win-x64 vs Lynx 3044 - main: 61 - 23 - 106  [0.600] 190
...      Lynx-ponder-add-3051-win-x64 playing White: 31 - 6 - 58  [0.632] 95
...      Lynx-ponder-add-3051-win-x64 playing Black: 30 - 17 - 48  [0.568] 95
...      White vs Black: 48 - 36 - 106  [0.532] 190
Elo difference: 70.4 +/- 32.7, LOS: 100.0 %, DrawRatio: 55.8 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf

Player: Lynx-ponder-add-3051-win-x64
   "Draw by 3-fold repetition": 69
   "Draw by fifty moves rule": 6
   "Draw by insufficient mating material": 29
   "Draw by stalemate": 2
   "Loss: Black mates": 6
   "Loss: White mates": 17
   "Win: Black mates": 30
   "Win: White mates": 31
Player: Lynx 3044 - main
   "Draw by 3-fold repetition": 69
   "Draw by fifty moves rule": 6
   "Draw by insufficient mating material": 29
   "Draw by stalemate": 2
   "Loss: Black mates": 30
   "Loss: White mates": 31
   "Win: Black mates": 6
   "Win: White mates": 17
```

Non-reg
```
Test  | ponder-add
Elo   | 2.91 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | 17076: +5285 -5142 =6649
Penta | [527, 1900, 3604, 1917, 590]
https://openbench.lynx-chess.com/test/353/
```