### PR TITLE
Unify `movesSearched` and `visitedMovesCounter`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -192,7 +192,6 @@ public sealed partial class Engine
         }
 
         var nodeType = NodeType.Alpha;
-        int movesSearched = 0;
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 
@@ -222,7 +221,7 @@ public sealed partial class Engine
                 continue;
             }
 
-            visitedMoves[visitedMovesCounter++] = move;
+            visitedMoves[visitedMovesCounter] = move;
 
             ++_nodes;
             isAnyMoveValid = true;
@@ -245,7 +244,7 @@ public sealed partial class Engine
                 // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
                 Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
             }
-            else if (pvNode && movesSearched == 0)
+            else if (pvNode && visitedMovesCounter == 0)
             {
                 PrefetchTTEntry();
                 evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
@@ -270,7 +269,7 @@ public sealed partial class Engine
 
                     // Futility Pruning (FP) - all quiet moves can be pruned
                     // once it's considered that they don't have potential to raise alpha
-                    if (movesSearched > 0
+                    if (visitedMovesCounter > 0
                         //&& alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
                         //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && depth <= Configuration.EngineSettings.FP_MaxDepth
@@ -291,11 +290,11 @@ public sealed partial class Engine
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth
                 // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
-                if (movesSearched >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
+                if (visitedMovesCounter >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
                     && !isCapture)
                 {
-                    reduction = EvaluationConstants.LMRReductions[depth][movesSearched];
+                    reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
 
                     if (pvNode)
                     {
@@ -375,7 +374,7 @@ public sealed partial class Engine
 
                     // 🔍 Capture history penalty/malus
                     // When a capture fails high, penalize previous visited captures
-                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
+                    for (int i = 0; i < visitedMovesCounter; ++i)
                     {
                         var visitedMove = visitedMoves[i];
 
@@ -404,7 +403,7 @@ public sealed partial class Engine
 
                     // 🔍 Quiet history penalty/malus
                     // When a quiet move fails high, penalize previous visited quiet moves
-                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
+                    for (int i = 0; i < visitedMovesCounter; ++i)
                     {
                         var visitedMove = visitedMoves[i];
 
@@ -448,7 +447,7 @@ public sealed partial class Engine
                 nodeType = NodeType.Exact;
             }
 
-            ++movesSearched;
+            ++visitedMovesCounter;
         }
 
         if (bestMove is null && !isAnyMoveValid)


### PR DESCRIPTION
Replace  `movesSearched` with `visitedMovesCounter`, which should have been equivalent given that the pruning always breaks and never continues