### PR TITLE
🔍 LMR on !pvNode: increase reduction (instead of the opposite) 

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -297,9 +297,9 @@ public sealed partial class Engine
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][movesSearched];
 
-                    if (pvNode)
+                    if (!pvNode)
                     {
-                        --reduction;
+                        ++reduction;
                     }
                     if (position.IsInCheck())   // i.e. move gives check
                     {


### PR DESCRIPTION
```
Test  | lmr-no-pvNode-incr
Elo   | -0.59 +- 3.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.55 (-2.25, 2.89) [0.00, 3.00]
Games | 26922: +8058 -8104 =10760
Penta | [978, 3153, 5204, 3189, 937]
https://openbench.lynx-chess.com/test/359/
```