### PR TITLE
🔍 Prune in pvnodes during move loop

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
             }
             else
             {
-                if (!pvNode && !isInCheck
+                if (movesSearched > 0 && !isInCheck
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
                 {
                     // Late Move Pruning (LMP) - all quiet moves can be pruned

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
             }
             else
             {
-                if (movesSearched > 0 && !isInCheck
+                if (!isRoot && !isInCheck
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
                 {
                     // Late Move Pruning (LMP) - all quiet moves can be pruned


### PR DESCRIPTION
```
Test  | prune-in-pvnodes
Elo   | -107.65 +- 21.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 696: +116 -325 =255
Penta | [60, 132, 116, 37, 3]
https://openbench.lynx-chess.com/test/361/
```

First commit:
```
Test  | prune-in-pvnodes
Elo   | -134.45 +- 23.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 640: +104 -340 =196
Penta | [78, 123, 82, 31, 6]
https://openbench.lynx-chess.com/test/360/
```