### PR TITLE
SPSA LTC

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -23,27 +23,27 @@
     "DefaultMovesToGo": 45,
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
-    "LMR_MinDepth": 3,
+    "LMR_MinDepth": 4,
     "LMR_MinFullDepthSearchedMoves": 3,
-    "LMR_Base": 0.83,
-    "LMR_Divisor": 3.43,
+    "LMR_Base": 0.76,
+    "LMR_Divisor": 3.54,
 
     "NMP_MinDepth": 2,
     "NMP_BaseDepthReduction": 2,
     "NMP_DepthIncrement": 1,
     "NMP_DepthDivisor": 4,
 
-    "AspirationWindow_Delta": 13,
-    "AspirationWindow_MinDepth": 8,
+    "AspirationWindow_Delta": 12,
+    "AspirationWindow_MinDepth": 9,
 
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 97,
+    "RFP_MaxDepth": 7,
+    "RFP_DepthScalingFactor": 90,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 127,
-    "Razoring_NotDepth1Bonus": 149,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 124,
+    "Razoring_NotDepth1Bonus": 144,
 
-    "IIR_MinDepth": 4,
+    "IIR_MinDepth": 2,
 
     "LMP_MaxDepth": 6,
     "LMP_BaseMovesToTry": 0,
@@ -52,11 +52,11 @@
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 1,
+    "SEE_BadCaptureReduction": 2,
 
     "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 62,
-    "FP_Margin": 170,
+    "FP_DepthScalingFactor": 79,
+    "FP_Margin": 196,
 
     // Evaluation
     "IsolatedPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -105,7 +105,7 @@ public sealed class EngineSettings
     #endregion
 
     [SPSAAttribute<int>(2, 10, 0.5)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public int LMR_MinDepth { get; set; } = 4;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
@@ -114,13 +114,13 @@ public sealed class EngineSettings
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSAAttribute<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.83;
+    public double LMR_Base { get; set; } = 0.76;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSAAttribute<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.43;
+    public double LMR_Divisor { get; set; } = 3.54;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
@@ -135,28 +135,28 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 4;
 
     [SPSAAttribute<int>(1, 100, 5)]
-    public int AspirationWindow_Delta { get; set; } = 13;
+    public int AspirationWindow_Delta { get; set; } = 12;
 
     [SPSAAttribute<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 8;
+    public int AspirationWindow_MinDepth { get; set; } = 9;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 97;
+    public int RFP_DepthScalingFactor { get; set; } = 90;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 127;
+    public int Razoring_Depth1Bonus { get; set; } = 124;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 149;
+    public int Razoring_NotDepth1Bonus { get; set; } = 144;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 4;
+    public int IIR_MinDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 6;
@@ -175,16 +175,16 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSAAttribute<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 1;
+    public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int FP_MaxDepth { get; set; } = 5;
 
     [SPSAAttribute<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 62;
+    public int FP_DepthScalingFactor { get; set; } = 79;
 
     [SPSAAttribute<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 170;
+    public int FP_Margin { get; set; } = 196;
 
     #region Evaluation
 


### PR DESCRIPTION
```
Test  | spsa/ltc
Elo   | -7.32 +- 5.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 7454: +2036 -2193 =3225
Penta | [232, 930, 1532, 829, 204]
https://openbench.lynx-chess.com/test/357/
```

![graph](https://github.com/lynx-chess/Lynx/assets/11148519/24589932-22fa-4efd-9103-9a64f5017f4d)
