### PR TITLE
SEE reduction: tweak reduction clamp for bad captures

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -325,7 +325,7 @@ public sealed partial class Engine
                     && scores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
                 {
                     reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
-                    reduction = Math.Clamp(reduction, 0, depth - 1);
+                    reduction = Math.Clamp(reduction, 0, Math.Max(0, depth - 2));
                 }
 
                 // Search with reduced depth


### PR DESCRIPTION
Clamp LMR to `depth - 2` when possible, to avoid dropping into QSearch.
The MadMax (:D) isn't required in the LMR because of the depth restriction to 3, but will experiment with that later.

```
Score of Lynx-lmr-see-tweak-clamp-3103-win-x64 vs Lynx 3100 - main: 5521 - 5603 - 7046  [0.498] 18170
...      Lynx-lmr-see-tweak-clamp-3103-win-x64 playing White: 3913 - 1660 - 3512  [0.624] 9085
...      Lynx-lmr-see-tweak-clamp-3103-win-x64 playing Black: 1608 - 3943 - 3534  [0.371] 9085
...      White vs Black: 7856 - 3268 - 7046  [0.626] 18170
Elo difference: -1.6 +/- 3.9, LOS: 21.8 %, DrawRatio: 38.8 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted

```