### PR TITLE
SEE reduction: don't allow it to fall into QSearch and make sure depth >=3

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -379,6 +379,11 @@ internal static readonly short[] EndGameKingTable =
     /// Evaluation to be returned when there's one single legal move
     /// </summary>
     public const int SingleMoveEvaluation = 200;
+
+    /// <summary>
+    /// Min depth to avoid reductions to fall into QSearch
+    /// </summary>
+    public const int ReductionsMinDepth = 3;
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -288,44 +288,46 @@ public sealed partial class Engine
 
                 int reduction = 0;
 
-                // 🔍 Late Move Reduction (LMR) - search with reduced depth
-                // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
-                if (visitedMovesCounter >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
-                    && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isCapture)
+                if (depth >= EvaluationConstants.ReductionsMinDepth)
                 {
-                    reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
-
-                    if (pvNode)
+                    // 🔍 Late Move Reduction (LMR) - search with reduced depth
+                    // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
+                    if (!isCapture
+                        //&& depth >= Configuration.EngineSettings.LMR_MinDepth
+                        && visitedMovesCounter >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1))
                     {
-                        --reduction;
+                        reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
+
+                        if (pvNode)
+                        {
+                            --reduction;
+                        }
+                        if (position.IsInCheck())   // i.e. move gives check
+                        {
+                            --reduction;
+                        }
+
+                        if (ttBestMove != default && isCapture)
+                        {
+                            ++reduction;
+                        }
+
+                        // -= history/(maxHistory/2)
+                        reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
                     }
-                    if (position.IsInCheck())   // i.e. move gives check
+
+                    // 🔍 Static Exchange Evaluation (SEE) reduction
+                    // Bad captures are reduced more
+                    if (!isInCheck
+                        && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue
+                        && scores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
                     {
-                        --reduction;
+                        reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
                     }
 
-                    if (ttBestMove != default && isCapture)
-                    {
-                        ++reduction;
-                    }
-
-                    // -= history/(maxHistory/2)
-                    reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
-
-                    // Don't allow LMR to drop into qsearch or increase the depth
+                    // Don't allow LMR or SEE reductions to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want
                     reduction = Math.Clamp(reduction, 0, depth - 2);
-                }
-
-                // 🔍 Static Exchange Evaluation (SEE) reduction
-                // Bad captures are reduced more
-                if (!isInCheck
-                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue
-                    && scores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
-                {
-                    reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
-                    reduction = Math.Clamp(reduction, 0, depth - 1);
                 }
 
                 // Search with reduced depth


### PR DESCRIPTION
Limit SEE reductions to min depth 3, not allowing it into QSearch, and cap it same as LMR
```
Score of Lynx-see-reductions-cap-3-3105-win-x64 vs Lynx 3100 - main: 11647 - 11789 - 1204  [0.497] 24640
...      Lynx-see-reductions-cap-3-3105-win-x64 playing White: 6027 - 5664 - 630  [0.515] 12321
...      Lynx-see-reductions-cap-3-3105-win-x64 playing Black: 5620 - 6125 - 574  [0.480] 12319
...      White vs Black: 12152 - 11284 - 1204  [0.518] 24640
Elo difference: -2.0 +/- 4.2, LOS: 17.7 %, DrawRatio: 4.9 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```


























































