### PR TITLE
LMR: reduce less when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -304,6 +304,10 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+                    if (isInCheck)
+                    {
+                        --reduction;
+                    }
 
                     if (ttBestMove != default && isCapture)
                     {


### PR DESCRIPTION
```
Test  | lmr-reduce-less-when-in-check
Elo   | -3.50 +- 4.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 14412: +4294 -4439 =5679
Penta | [547, 1731, 2757, 1662, 509]
https://openbench.lynx-chess.com/test/377/
```