### PR TITLE
⚡  QSearch mate detection movegen optimization

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -363,6 +364,11 @@ public class Position
         //}
     }
 
+    /// <summary>
+    /// Special version of <see cref="MakeMove(Move)"/> for those cases when we know the capture piece isn't already included in the move
+    /// </summary>
+    /// <param name="move">Move that doesn't have the capture piece encoded</param>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMoveCalculatingCapturedPiece(ref Move move)
     {
@@ -507,6 +513,69 @@ public class Position
         //}
     }
 
+    /// <summary>
+    /// Special version of <see cref="MakeMove(Move)"/> optimized for quiet moves
+    /// </summary>
+    /// <param name="move">Not a capture, en-passant, promotion or castling move</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public GameState MakeQuietMove(Move move)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        byte castleCopy = Castle;
+        BoardSquare enpassantCopy = EnPassant;
+        long uniqueIdentifierCopy = UniqueIdentifier;
+
+        var oldSide = (int)Side;
+        var oppositeSide = Utils.OppositeSide(oldSide);
+
+        int sourceSquare = move.SourceSquare();
+        int targetSquare = move.TargetSquare();
+        int piece = move.Piece();
+
+        PieceBitBoards[piece].PopBit(sourceSquare);
+        OccupancyBitBoards[oldSide].PopBit(sourceSquare);
+
+        PieceBitBoards[piece].SetBit(targetSquare);
+        OccupancyBitBoards[oldSide].SetBit(targetSquare);
+
+        UniqueIdentifier ^=
+            ZobristTable.SideHash()
+            ^ ZobristTable.PieceHash(sourceSquare, piece)
+            ^ ZobristTable.PieceHash(targetSquare, piece)
+            ^ ZobristTable.EnPassantHash((int)EnPassant)            // We clear the existing enpassant square, if any
+            ^ ZobristTable.CastleHash(Castle);                      // We clear the existing castle rights
+
+        EnPassant = BoardSquare.noSquare;
+
+        if (move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush)
+        {
+            var pawnPush = +8 - (oldSide * 16);
+            var enPassantSquare = sourceSquare + pawnPush;
+            Utils.Assert(Constants.EnPassantCaptureSquares.Length > enPassantSquare && Constants.EnPassantCaptureSquares[enPassantSquare] != 0, $"Unexpected en passant square : {(BoardSquare)enPassantSquare}");
+
+            EnPassant = (BoardSquare)enPassantSquare;
+            UniqueIdentifier ^= ZobristTable.EnPassantHash(enPassantSquare);
+        }
+
+        Side = (Side)oppositeSide;
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
+
+        // Updating castling rights
+        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare];
+        Castle &= Constants.CastlingRightsUpdateConstants[targetSquare];
+
+        UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
+
+        return new GameState(uniqueIdentifierCopy, enpassantCopy, castleCopy);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void UnmakeMove(Move move, GameState gameState)
     {
@@ -589,6 +658,43 @@ public class Position
                     break;
                 }
         }
+
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
+
+        // Updating saved values
+        Castle = gameState.Castle;
+        EnPassant = gameState.EnPassant;
+        UniqueIdentifier = gameState.ZobristKey;
+    }
+
+    /// <summary>
+    /// Special case of <see cref="UnmakeMove(Move)"/> optimized quiet moves
+    /// </summary>
+    /// <param name="move">Not a capture, en-passant, promotion or castling move</param>
+    /// /// <param name="gameState"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UnmakeQuietMove(Move move, GameState gameState)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        var oppositeSide = (int)Side;
+        var side = Utils.OppositeSide(oppositeSide);
+        Side = (Side)side;
+
+        int sourceSquare = move.SourceSquare();
+        int targetSquare = move.TargetSquare();
+        int piece = move.Piece();
+
+        PieceBitBoards[piece].PopBit(targetSquare);
+        OccupancyBitBoards[side].PopBit(targetSquare);
+
+        PieceBitBoards[piece].SetBit(sourceSquare);
+        OccupancyBitBoards[side].SetBit(sourceSquare);
 
         OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -65,12 +65,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<Move> GenerateAllMoves(Position position, Span<Move> movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -96,12 +91,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Move[] GenerateAllCaptures(Position position, Move[] movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -127,12 +117,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<Move> GenerateAllCaptures(Position position, Span<Move> movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -467,12 +452,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool CanGenerateAtLeastAValidMove(Position position)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return false;
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         var offset = Utils.PieceOffset(position.Side);
 
@@ -492,6 +472,38 @@ public static class MoveGenerator
         catch (Exception e)
         {
             Debug.Fail($"Error in {nameof(CanGenerateAtLeastAValidMove)}", e.StackTrace);
+            return false;
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CanGenerateAtLeastAValidQuietMove(Position position)
+    {
+        Debug.Assert(position.Side != Side.Both);
+
+        var offset = Utils.PieceOffset(position.Side);
+
+#if DEBUG
+        try
+        {
+#endif
+            return IsAnyPawnQuietMoveValid(position, offset)
+                || IsAnyPieceQuietMoveValid((int)Piece.K + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.Q + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.B + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.N + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.R + offset, position);
+#if DEBUG
+        }
+        catch (Exception e)
+        {
+            Debug.Fail($"Error in {nameof(CanGenerateAtLeastAValidQuietMove)}", e.StackTrace);
             return false;
         }
 #endif
@@ -592,12 +604,55 @@ public static class MoveGenerator
         return false;
     }
 
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    /// <param name="position"></param>
-    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPawnQuietMoveValid(Position position, int offset)
+    {
+        int sourceSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+                {
+                    return true;
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
+                    && IsValidQuietMove(position, MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyCastlingMoveValid(Position position)
     {
@@ -662,12 +717,6 @@ public static class MoveGenerator
         return false;
     }
 
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="position"></param>
-    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyPieceMoveValid(int piece, Position position)
     {
@@ -703,6 +752,35 @@ public static class MoveGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPieceQuietMoveValid(int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & (~position.OccupancyBitBoards[(int)Side.Both]);
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsValidMove(Position position, Move move)
     {
         var gameState = position.MakeMoveCalculatingCapturedPiece(ref move);
@@ -723,6 +801,23 @@ public static class MoveGenerator
 
         bool result = position.WasProduceByAValidMove();
         position.UnmakeMove(move, gameState);
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsValidQuietMove(Position position, Move move)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        var gameState = position.MakeQuietMove(move);
+        bool result = position.WasProduceByAValidMove();
+        position.UnmakeQuietMove(move, gameState);
 
         return result;
     }


### PR DESCRIPTION
```
Test  | perf/qsearch-mate-detection-movegen-2-check-valid-before-pruning
Elo   | -1.06 +- 3.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 30062: +9076 -9168 =11818
Penta | [936, 3393, 6438, 3355, 909]
https://openbench.lynx-chess.com/test/375/
```