### PR TITLE
⚡ Speed up additional evaluation: pass sameSide to `XXXAdditionalEvaluation` methods

### DIFF
--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1002,7 +1002,8 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece));
+            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex,
+                (int)piece, position.OccupancyBitBoards[(int)piece < (int)Piece.p ? (int)Side.White : (int)Side.Black]));
         }
 
         return eval;

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1002,8 +1002,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex,
-                (int)piece, position.OccupancyBitBoards[(int)piece < (int)Piece.p ? (int)Side.White : (int)Side.Black]));
+            eval += Utils.UnpackMG(position.AdditionalPieceEvaluation(pieceSquareIndex, (int)piece));
         }
 
         return eval;


### PR DESCRIPTION
Idea 1: passing the right same side occupancy for rook and knight
```
Score of Lynx-perf-mobility-pass-side-3111-win-x64 vs Lynx 3107 - main: 5615 - 5638 - 6927  [0.499] 18180
...      Lynx-perf-mobility-pass-side-3111-win-x64 playing White: 3940 - 1661 - 3490  [0.625] 9091
...      Lynx-perf-mobility-pass-side-3111-win-x64 playing Black: 1675 - 3977 - 3437  [0.373] 9089
...      White vs Black: 7917 - 3336 - 6927  [0.626] 18180
Elo difference: -0.4 +/- 4.0, LOS: 41.4 %, DrawRatio: 38.1 %
SPRT: llr -1.42 (-49.0%), lbound -2.25, ubound 2.89
```

Idea 2: similar to #755: two differente switches and passing the `sameSide` bool directly
```
Score of Lynx-perf-mobility-pass-side-3112-win-x64 vs Lynx 3107 - main: 1168 - 1259 - 1423  [0.488] 3850
...      Lynx-perf-mobility-pass-side-3112-win-x64 playing White: 835 - 371 - 719  [0.621] 1925
...      Lynx-perf-mobility-pass-side-3112-win-x64 playing Black: 333 - 888 - 704  [0.356] 1925
...      White vs Black: 1723 - 704 - 1423  [0.632] 3850
Elo difference: -8.2 +/- 8.7, LOS: 3.2 %, DrawRatio: 37.0 %
SPRT: llr -1.47 (-51.0%), lbound -2.25, ubound 2.89
```