### PR TITLE
🔍 Aspiration Windows: update window after updating alpha and beta

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -122,8 +122,6 @@ public sealed partial class Engine
 
                         _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
-                        window += window >> 1;   // window / 2
-
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
                         if (alpha >= bestEvaluation)     // Fail low
                         {
@@ -134,6 +132,8 @@ public sealed partial class Engine
                         {
                             beta = Math.Min(bestEvaluation + window, MaxValue);
                         }
+
+                        window += window >> 1;   // window / 2
                     }
                 }
 


### PR DESCRIPTION
Inspired by Simbelmyne

Doesn't work for me though, at least with this formula. Maybe it's a matter of re-tuning it though

```
Score of Lynx-perf-aspiration-windows-update-window-after-alpha-and-beta-3118-win-x64 vs Lynx 3107 - main: 1540 - 1680 - 1958  [0.486] 5178
...      Lynx-perf-aspiration-windows-update-window-after-alpha-and-beta-3118-win-x64 playing White: 1106 - 500 - 983  [0.617] 2589
...      Lynx-perf-aspiration-windows-update-window-after-alpha-and-beta-3118-win-x64 playing Black: 434 - 1180 - 975  [0.356] 2589
...      White vs Black: 2286 - 934 - 1958  [0.631] 5178
Elo difference: -9.4 +/- 7.5, LOS: 0.7 %, DrawRatio: 37.8 %
SPRT: llr -2.26 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```