### PR TITLE
Aspiration windows simplification

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -115,11 +115,6 @@ public sealed partial class Engine
                         _isFollowingPV = true;
                         bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
-                        if (alpha < bestEvaluation && beta > bestEvaluation)
-                        {
-                            break;
-                        }
-
                         _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
 
                         window += window >> 1;   // window / 2
@@ -133,6 +128,10 @@ public sealed partial class Engine
                         else if (beta <= bestEvaluation)     // Fail high
                         {
                             beta = Math.Min(bestEvaluation + window, MaxValue);
+                        }
+                        else
+                        {
+                            break;
                         }
                     }
                 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -132,7 +132,8 @@ public sealed partial class Engine
                             break;
                         }
 
-                        _logger.Debug("Eval ({0}) (depth {1}, nodes {2}) outside of aspiration window, new window [{3}, {4}] ", bestEvaluation, alpha, beta, depth, _nodes);
+                        _logger.Debug("Eval ({0}) (depth {1}, nodes {2}) outside of aspiration window, new window [{3}, {4}] ",
+                            bestEvaluation, depth, _nodes, alpha, beta);
                     }
                 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -115,8 +115,6 @@ public sealed partial class Engine
                         _isFollowingPV = true;
                         bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
-                        _logger.Debug("Eval ({0}) outside of aspiration window [{1}, {2}] (depth {3}, nodes {4})", bestEvaluation, alpha, beta, depth, _nodes);
-
                         window += window >> 1;   // window / 2
 
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
@@ -133,6 +131,8 @@ public sealed partial class Engine
                         {
                             break;
                         }
+
+                        _logger.Debug("Eval ({0}) (depth {1}, nodes {2}) outside of aspiration window, new window [{3}, {4}] ", bestEvaluation, alpha, beta, depth, _nodes);
                     }
                 }
 


### PR DESCRIPTION
```
Test  | perf/aspiration-windows-simplification
Elo   | 0.22 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.10 (-2.25, 2.89) [-3.00, 1.00]
Games | 25106: +7651 -7635 =9820
Penta | [797, 2824, 5338, 2754, 840]
https://openbench.lynx-chess.com/test/384/
```

```bash
> python .\sprt.py -w 7640 -d 9797 -l 7619 -e0 -5 -e1 0
ELO: 0.291 +- 3.35 [-3.06, 3.64]
LLR: 3.48 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```