### PR TITLE
🐛 Fix `Game.MakeMove` behavior

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -191,15 +191,14 @@ public sealed class Game
 #if DEBUG
             MoveHistory.Add(moveToPlay);
 #endif
+            PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
+            Update50movesRule(moveToPlay, moveToPlay.IsCapture());
         }
         else
         {
             _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
             CurrentPosition.UnmakeMove(moveToPlay, gameState);
         }
-
-        PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
-        Update50movesRule(moveToPlay, moveToPlay.IsCapture());
 
         return gameState;
     }


### PR DESCRIPTION
In case of trying to make an illegal move, no position history or 50 moves rule should be affected.

AFAIK this doesn't change anything since no illegal moves should be send to Game during regular play