### PR TITLE
👷🏼 Use both Intel and ARM macOS runners in Actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macOS-13]
       fail-fast: false
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,16 +49,16 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macOS-13]
         include:
           - os: ubuntu-latest
             runtime-identifier: linux-x64
           - os: windows-latest
             runtime-identifier: win-x64
           - os: macOS-latest
-            runtime-identifier: osx-x64
-          - os: macos-14
             runtime-identifier: osx-arm64
+          - os: macOS-13
+            runtime-identifier: osx-x64
       fail-fast: false
 
     steps:

--- a/.github/workflows/on-demand-tests.yml
+++ b/.github/workflows/on-demand-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-13]
       fail-fast: false
 
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,9 @@ jobs:
           - runtime-identifier: linux-musl-x64
             os: ubuntu-latest
           - runtime-identifier: osx-x64
-            os: macos-latest
+            os: macos-13
           - runtime-identifier: osx-arm64
-            os: macos-14
+            os: macos-latest
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Since now `macOS-latest` points to `macOS-14`, we need to use `macOS-13` to choose intel macOS.