### PR TITLE
🔍  LMP: don't prune bad captures

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
             else
             {
                 if (!pvNode && !isInCheck
-                    && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
+                    && scores[moveIndex] < EvaluationConstants.BadCaptureMoveBaseScoreValue) // Quiet move
                 {
                     // Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm


### PR DESCRIPTION
Accidentally or not, the comment of quiet moves isn't right.

```
Test  | lmp/dont-skip-bad-captures
Elo   | -10.27 +- 6.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 5954: +1769 -1945 =2240
Penta | [262, 732, 1122, 642, 219]
https://openbench.lynx-chess.com/test/388/
```