### PR TITLE
⚡ Avoid double assignment in static eval

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -690,10 +690,9 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
                 gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
-
-                packedScore += AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex]
+                    + AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
             }
         }
 
@@ -707,10 +706,9 @@ public class Position
                 var pieceSquareIndex = bitboard.GetLS1BIndex();
                 bitboard.ResetLS1B();
 
-                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex];
                 gamePhase += EvaluationConstants.GamePhaseByPiece[pieceIndex];
-
-                packedScore -= AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
+                packedScore += EvaluationConstants.PackedPSQT[pieceIndex][pieceSquareIndex]
+                    - AdditionalPieceEvaluation(pieceSquareIndex, pieceIndex);
             }
         }
 


### PR DESCRIPTION
Noise?
```
Test  | perf/staticeval-remove-double-assignment
Elo   | -7.17 +- 6.07 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 7854: +2375 -2537 =2942
Penta | [271, 942, 1648, 810, 256]
https://openbench.lynx-chess.com/test/391/
```