### PR TITLE
Use MakeQuiet/UnmakeQuiet when the move is quiet II

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -207,7 +207,7 @@ public sealed class Game
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move moveToPlay)
     {
-        var gameState = CurrentPosition.MakeMoveFast(moveToPlay);
+        var gameState = CurrentPosition.MakeMove(moveToPlay);
 
         if (CurrentPosition.WasProduceByAValidMove())
         {

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -184,7 +184,7 @@ public sealed class Game
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move moveToPlay)
     {
-        var gameState = CurrentPosition.MakeMove(moveToPlay);
+        var gameState = CurrentPosition.MakeMoveFast(moveToPlay);
 
         if (CurrentPosition.WasProduceByAValidMove())
         {
@@ -195,7 +195,7 @@ public sealed class Game
         else
         {
             _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-            CurrentPosition.UnmakeMove(moveToPlay, gameState);
+            CurrentPosition.UnmakeMoveFast(moveToPlay, gameState);
         }
 
         PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -5,6 +5,8 @@ public readonly struct GameState
 
     public readonly BoardSquare EnPassant;
 
+    public readonly bool Quiet;
+
     public readonly byte Castle;
 
     public GameState(long zobristKey, BoardSquare enpassant, byte castle)
@@ -12,5 +14,14 @@ public readonly struct GameState
         ZobristKey = zobristKey;
         EnPassant = enpassant;
         Castle = castle;
+        Quiet = false;
+    }
+
+    public GameState(long zobristKey, BoardSquare enpassant, bool isQuiet, byte castle)
+    {
+        ZobristKey = zobristKey;
+        EnPassant = enpassant;
+        Castle = castle;
+        Quiet = isQuiet;
     }
 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -231,6 +231,33 @@ public class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public GameState MakeMoveFast(Move move)
+    {
+        if (move.IsCapture()
+            || move.IsCastle()
+            || move.IsPromotion()
+            || move.IsEnPassant())
+        {
+            return MakeMove(move);
+        }
+
+        return MakeQuietMove(move);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UnmakeMoveFast(Move move, GameState gameState)
+    {
+        if (gameState.Quiet)
+        {
+            UnmakeQuietMove(move, gameState);
+        }
+        else
+        {
+            UnmakeMove(move, gameState);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move move)
     {
         byte castleCopy = Castle;
@@ -573,7 +600,7 @@ public class Position
 
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
 
-        return new GameState(uniqueIdentifierCopy, enpassantCopy, castleCopy);
+        return new GameState(uniqueIdentifierCopy, enpassantCopy, isQuiet: true, castleCopy);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -720,7 +747,7 @@ public class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnMakeNullMove(GameState gameState)
+    public void UnmakeNullMove(GameState gameState)
     {
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 
@@ -363,6 +364,11 @@ public class Position
         //}
     }
 
+    /// <summary>
+    /// Special version of <see cref="MakeMove(Move)"/> for those cases when we know the capture piece isn't already included in the move
+    /// </summary>
+    /// <param name="move">Move that doesn't have the capture piece encoded</param>
+    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMoveCalculatingCapturedPiece(ref Move move)
     {
@@ -507,6 +513,69 @@ public class Position
         //}
     }
 
+    /// <summary>
+    /// Special version of <see cref="MakeMove(Move)"/> optimized for quiet moves
+    /// </summary>
+    /// <param name="move">Not a capture, en-passant, promotion or castling move</param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public GameState MakeQuietMove(Move move)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        byte castleCopy = Castle;
+        BoardSquare enpassantCopy = EnPassant;
+        long uniqueIdentifierCopy = UniqueIdentifier;
+
+        var oldSide = (int)Side;
+        var oppositeSide = Utils.OppositeSide(oldSide);
+
+        int sourceSquare = move.SourceSquare();
+        int targetSquare = move.TargetSquare();
+        int piece = move.Piece();
+
+        PieceBitBoards[piece].PopBit(sourceSquare);
+        OccupancyBitBoards[oldSide].PopBit(sourceSquare);
+
+        PieceBitBoards[piece].SetBit(targetSquare);
+        OccupancyBitBoards[oldSide].SetBit(targetSquare);
+
+        UniqueIdentifier ^=
+            ZobristTable.SideHash()
+            ^ ZobristTable.PieceHash(sourceSquare, piece)
+            ^ ZobristTable.PieceHash(targetSquare, piece)
+            ^ ZobristTable.EnPassantHash((int)EnPassant)            // We clear the existing enpassant square, if any
+            ^ ZobristTable.CastleHash(Castle);                      // We clear the existing castle rights
+
+        EnPassant = BoardSquare.noSquare;
+
+        if (move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush)
+        {
+            var pawnPush = +8 - (oldSide * 16);
+            var enPassantSquare = sourceSquare + pawnPush;
+            Utils.Assert(Constants.EnPassantCaptureSquares.Length > enPassantSquare && Constants.EnPassantCaptureSquares[enPassantSquare] != 0, $"Unexpected en passant square : {(BoardSquare)enPassantSquare}");
+
+            EnPassant = (BoardSquare)enPassantSquare;
+            UniqueIdentifier ^= ZobristTable.EnPassantHash(enPassantSquare);
+        }
+
+        Side = (Side)oppositeSide;
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
+
+        // Updating castling rights
+        Castle &= Constants.CastlingRightsUpdateConstants[sourceSquare];
+        Castle &= Constants.CastlingRightsUpdateConstants[targetSquare];
+
+        UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
+
+        return new GameState(uniqueIdentifierCopy, enpassantCopy, castleCopy);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void UnmakeMove(Move move, GameState gameState)
     {
@@ -589,6 +658,43 @@ public class Position
                     break;
                 }
         }
+
+        OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
+
+        // Updating saved values
+        Castle = gameState.Castle;
+        EnPassant = gameState.EnPassant;
+        UniqueIdentifier = gameState.ZobristKey;
+    }
+
+    /// <summary>
+    /// Special case of <see cref="UnmakeMove(Move)"/> optimized quiet moves
+    /// </summary>
+    /// <param name="move">Not a capture, en-passant, promotion or castling move</param>
+    /// /// <param name="gameState"></param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UnmakeQuietMove(Move move, GameState gameState)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        var oppositeSide = (int)Side;
+        var side = Utils.OppositeSide(oppositeSide);
+        Side = (Side)side;
+
+        int sourceSquare = move.SourceSquare();
+        int targetSquare = move.TargetSquare();
+        int piece = move.Piece();
+
+        PieceBitBoards[piece].PopBit(targetSquare);
+        OccupancyBitBoards[side].PopBit(targetSquare);
+
+        PieceBitBoards[piece].SetBit(sourceSquare);
+        OccupancyBitBoards[side].SetBit(sourceSquare);
 
         OccupancyBitBoards[2] = OccupancyBitBoards[1] | OccupancyBitBoards[0];
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -65,12 +65,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<Move> GenerateAllMoves(Position position, Span<Move> movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -96,12 +91,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Move[] GenerateAllCaptures(Position position, Move[] movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -127,12 +117,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Span<Move> GenerateAllCaptures(Position position, Span<Move> movePool)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return [];
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         int localIndex = 0;
 
@@ -467,12 +452,7 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool CanGenerateAtLeastAValidMove(Position position)
     {
-#if DEBUG
-        if (position.Side == Side.Both)
-        {
-            return false;
-        }
-#endif
+        Debug.Assert(position.Side != Side.Both);
 
         var offset = Utils.PieceOffset(position.Side);
 
@@ -492,6 +472,38 @@ public static class MoveGenerator
         catch (Exception e)
         {
             Debug.Fail($"Error in {nameof(CanGenerateAtLeastAValidMove)}", e.StackTrace);
+            return false;
+        }
+#endif
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+    /// </summary>
+    /// <param name="position"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool CanGenerateAtLeastAValidQuietMove(Position position)
+    {
+        Debug.Assert(position.Side != Side.Both);
+
+        var offset = Utils.PieceOffset(position.Side);
+
+#if DEBUG
+        try
+        {
+#endif
+            return IsAnyPawnQuietMoveValid(position, offset)
+                || IsAnyPieceQuietMoveValid((int)Piece.K + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.Q + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.B + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.N + offset, position)
+                || IsAnyPieceQuietMoveValid((int)Piece.R + offset, position);
+#if DEBUG
+        }
+        catch (Exception e)
+        {
+            Debug.Fail($"Error in {nameof(CanGenerateAtLeastAValidQuietMove)}", e.StackTrace);
             return false;
         }
 #endif
@@ -592,12 +604,55 @@ public static class MoveGenerator
         return false;
     }
 
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    /// <param name="position"></param>
-    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPawnQuietMoveValid(Position position, int offset)
+    {
+        int sourceSquare;
+
+        var piece = (int)Piece.P + offset;
+        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+        var bitboard = position.PieceBitBoards[piece];
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var sourceRank = (sourceSquare >> 3) + 1;
+
+#if DEBUG
+            if (sourceRank == 1 || sourceRank == 8)
+            {
+                _logger.Warn("There's a non-promoted {0} pawn in rank {1}", position.Side, sourceRank);
+                continue;
+            }
+#endif
+            // Pawn pushes
+            var singlePushSquare = sourceSquare + pawnPush;
+            if (!position.OccupancyBitBoards[2].GetBit(singlePushSquare))
+            {
+                // Single pawn push
+                if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+                {
+                    return true;
+                }
+
+                // Double pawn push
+                // Inside of the if because singlePush square cannot be occupied either
+
+                var doublePushSquare = sourceSquare + (2 * pawnPush);
+                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
+                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White))
+                    && IsValidQuietMove(position, MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyCastlingMoveValid(Position position)
     {
@@ -662,12 +717,6 @@ public static class MoveGenerator
         return false;
     }
 
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    /// <param name="position"></param>
-    /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyPieceMoveValid(int piece, Position position)
     {
@@ -703,6 +752,35 @@ public static class MoveGenerator
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsAnyPieceQuietMoveValid(int piece, Position position)
+    {
+        var bitboard = position.PieceBitBoards[piece];
+        int sourceSquare, targetSquare;
+
+        while (bitboard != default)
+        {
+            sourceSquare = bitboard.GetLS1BIndex();
+            bitboard.ResetLS1B();
+
+            var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+                & (~position.OccupancyBitBoards[(int)Side.Both]);
+
+            while (attacks != default)
+            {
+                targetSquare = attacks.GetLS1BIndex();
+                attacks.ResetLS1B();
+
+                if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsValidMove(Position position, Move move)
     {
         var gameState = position.MakeMoveCalculatingCapturedPiece(ref move);
@@ -723,6 +801,23 @@ public static class MoveGenerator
 
         bool result = position.WasProduceByAValidMove();
         position.UnmakeMove(move, gameState);
+
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsValidQuietMove(Position position, Move move)
+    {
+        Debug.Assert(!move.IsCapture(), "Quiet move expected");
+        Debug.Assert(!move.IsEnPassant(), "Quiet move expected");
+        Debug.Assert(!move.IsCastle(), "Quiet move expected");
+        Debug.Assert(!move.IsPromotion(), "Quiet move expected");
+        Debug.Assert(move.SpecialMoveFlag() == SpecialMoveType.None || move.SpecialMoveFlag() == SpecialMoveType.DoublePawnPush, "Quiet move expected");
+        Debug.Assert(move.CapturedPiece() == (int)Piece.None || move.CapturedPiece() == 0, "Quiet move expected");
+
+        var gameState = position.MakeQuietMove(move);
+        bool result = position.WasProduceByAValidMove();
+        position.UnmakeQuietMove(move, gameState);
 
         return result;
     }

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -549,7 +549,7 @@ public static class MoveGenerator
                         return true;
                     }
                 }
-                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
+                else if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, singlePushSquare, piece)))
                 {
                     return true;
                 }
@@ -741,7 +741,7 @@ public static class MoveGenerator
                 {
                     return true;
                 }
-                else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
+                else if (IsValidQuietMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
                 {
                     return true;
                 }

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -43,13 +43,13 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                var state = position.MakeMoveFast(move);
 
                 if (position.WasProduceByAValidMove())
                 {
                     nodes = ResultsImpl(position, depth - 1, nodes);
                 }
-                position.UnmakeMove(move, state);
+                position.UnmakeMoveFast(move, state);
             }
 
             return nodes;
@@ -65,7 +65,7 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                var state = position.MakeMoveFast(move);
 
                 if (position.WasProduceByAValidMove())
                 {
@@ -75,7 +75,7 @@ public static class Perft
                     write($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
                 }
 
-                position.UnmakeMove(move, state);
+                position.UnmakeMoveFast(move, state);
             }
 
             write(string.Empty);

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -43,7 +43,7 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMoveFast(move);
+                var state = position.MakeMove(move);
 
                 if (position.WasProduceByAValidMove())
                 {
@@ -65,7 +65,7 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMoveFast(move);
+                var state = position.MakeMove(move);
 
                 if (position.WasProduceByAValidMove())
                 {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -225,9 +225,9 @@ public sealed partial class Engine
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
         {
-            var gameState = Game.CurrentPosition.MakeMove(move);
+            var gameState = Game.CurrentPosition.MakeMoveFast(move);
             bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
-            Game.CurrentPosition.UnmakeMove(move, gameState);
+            Game.CurrentPosition.UnmakeMoveFast(move, gameState);
 
             if (isPositionValid)
             {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -225,7 +225,7 @@ public sealed partial class Engine
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
         {
-            var gameState = Game.CurrentPosition.MakeMoveFast(move);
+            var gameState = Game.CurrentPosition.MakeMove(move);
             bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
             Game.CurrentPosition.UnmakeMoveFast(move, gameState);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -156,7 +156,7 @@ public sealed partial class Engine
 
                 var gameState = position.MakeNullMove();
                 var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
-                position.UnMakeNullMove(gameState);
+                position.UnmakeNullMove(gameState);
 
                 if (evaluation >= beta)
                 {
@@ -213,11 +213,11 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[moveIndex];
 
-            var gameState = position.MakeMove(move);
+            var gameState = position.MakeMoveFast(move);
 
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMoveFast(move, gameState);
                 continue;
             }
 
@@ -262,7 +262,7 @@ public sealed partial class Engine
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
                         Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
-                        position.UnmakeMove(move, gameState);
+                        position.UnmakeMoveFast(move, gameState);
 
                         break;
                     }
@@ -278,7 +278,7 @@ public sealed partial class Engine
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
                         Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
-                        position.UnmakeMove(move, gameState);
+                        position.UnmakeMoveFast(move, gameState);
 
                         break;
                     }
@@ -353,7 +353,7 @@ public sealed partial class Engine
             // Game.PositionHashHistory is update above
             Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
             Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMoveFast(move, gameState);
 
             PrintMove(ply, move, evaluation);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -213,7 +213,7 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[moveIndex];
 
-            var gameState = position.MakeMoveFast(move);
+            var gameState = position.MakeMove(move);
 
             if (!position.WasProduceByAValidMove())
             {


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/797 without `MakeMoveFast` (https://github.com/lynx-chess/Lynx/commit/a022fb5a03aaa2b3255bbf1f22a829b10836dc35), to try to avoid the overhead of checking all the conditions beborehand

```
Test  | perf/make-unmake-quiet-vs-noisy-2
Elo   | -3.19 +- 4.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 15120: +4629 -4768 =5723
Penta | [537, 1680, 3219, 1633, 491]
https://openbench.lynx-chess.com/test/393/
```