### PR TITLE
SPSA OB tuning

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -23,40 +23,40 @@
     "DefaultMovesToGo": 45,
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
-    "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 3,
-    "LMR_Base": 0.83,
-    "LMR_Divisor": 3.43,
+    "LMR_MinDepth": 2,
+    "LMR_MinFullDepthSearchedMoves": 4,
+    "LMR_Base": 1.73,
+    "LMR_Divisor": 3.11,
 
-    "NMP_MinDepth": 2,
+    "NMP_MinDepth": 4,
     "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
+    "NMP_DepthIncrement": 0,
+    "NMP_DepthDivisor": 5,
 
-    "AspirationWindow_Delta": 13,
-    "AspirationWindow_MinDepth": 8,
+    "AspirationWindow_Delta": 24,
+    "AspirationWindow_MinDepth": 2,
 
     "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 97,
+    "RFP_DepthScalingFactor": 112,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 127,
-    "Razoring_NotDepth1Bonus": 149,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 20,
+    "Razoring_NotDepth1Bonus": 182,
 
-    "IIR_MinDepth": 4,
+    "IIR_MinDepth": 2,
 
-    "LMP_MaxDepth": 6,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 3,
+    "LMP_MaxDepth": 5,
+    "LMP_BaseMovesToTry": 7,
+    "LMP_MovesDepthMultiplier": 2,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 1,
+    "SEE_BadCaptureReduction": 2,
 
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 62,
-    "FP_Margin": 170,
+    "FP_MaxDepth": 10,
+    "FP_DepthScalingFactor": 188,
+    "FP_Margin": 473,
 
     // Evaluation
     "IsolatedPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -105,67 +105,67 @@ public sealed class EngineSettings
     #endregion
 
     [SPSAAttribute<int>(3, 10, 0.5)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public int LMR_MinDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSAAttribute<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.83;
+    public double LMR_Base { get; set; } = 1.73;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSAAttribute<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.43;
+    public double LMR_Divisor { get; set; } = 3.11;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int NMP_MinDepth { get; set; } = 2;
+    public int NMP_MinDepth { get; set; } = 4;
 
     [SPSAAttribute<int>(1, 5, 0.5)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
     [SPSAAttribute<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public int NMP_DepthIncrement { get; set; } = 0;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public int NMP_DepthDivisor { get; set; } = 5;
 
     [SPSAAttribute<int>(1, 100, 5)]
-    public int AspirationWindow_Delta { get; set; } = 13;
+    public int AspirationWindow_Delta { get; set; } = 24;
 
     [SPSAAttribute<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 8;
+    public int AspirationWindow_MinDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int RFP_MaxDepth { get; set; } = 6;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 97;
+    public int RFP_DepthScalingFactor { get; set; } = 112;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 127;
+    public int Razoring_Depth1Bonus { get; set; } = 20;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 149;
+    public int Razoring_NotDepth1Bonus { get; set; } = 182;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 4;
+    public int IIR_MinDepth { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 6;
+    public int LMP_MaxDepth { get; set; } = 5;
 
     [SPSAAttribute<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public int LMP_BaseMovesToTry { get; set; } = 7;
 
     [SPSAAttribute<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 3;
+    public int LMP_MovesDepthMultiplier { get; set; } = 2;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -175,16 +175,16 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSAAttribute<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 1;
+    public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public int FP_MaxDepth { get; set; } = 10;
 
     [SPSAAttribute<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 62;
+    public int FP_DepthScalingFactor { get; set; } = 188;
 
     [SPSAAttribute<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 170;
+    public int FP_Margin { get; set; } = 473;
 
     #region Evaluation
 


### PR DESCRIPTION
Add ob-tuned search values (https://openbench.lynx-chess.com/tune/327/)

```
Score of Lynx-ob-tuning-3176-win-x64 vs Lynx 3164 - main: 336 - 492 - 497  [0.441] 1325
...      Lynx-ob-tuning-3176-win-x64 playing White: 242 - 142 - 279  [0.575] 663
...      Lynx-ob-tuning-3176-win-x64 playing Black: 94 - 350 - 218  [0.307] 662
...      White vs Black: 592 - 236 - 497  [0.634] 1325
Elo difference: -41.1 +/- 14.8, LOS: 0.0 %, DrawRatio: 37.5 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```