### PR TITLE
Check `Is50MovesRepetition` before `IsThreefoldRepetition`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -235,7 +235,7 @@ public sealed partial class Engine
             Game.PositionHashHistory.Add(position.UniqueIdentifier);
 
             int evaluation;
-            if (canBeRepetition && (Game.IsThreefoldRepetition(pvNode) || Game.Is50MovesRepetition()))
+            if (canBeRepetition && (Game.Is50MovesRepetition() || Game.IsThreefoldRepetition(pvNode)))
             {
                 evaluation = 0;
 


### PR DESCRIPTION
```
Test  | perf/repetition-detection-order
Elo   | -0.89 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 32560: +9986 -10069 =12505
Penta | [990, 3717, 7026, 3480, 1067]
https://openbench.lynx-chess.com/test/404/
```