### PR TITLE
🐛 Revert "🐛 Detect threefold repetition on `pvNode` (#796)"

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -118,43 +118,20 @@ public sealed class Game
 
     /// <summary>
     /// Basic algorithm described in https://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
-    /// Appart from that, tests for three fold repetition if <paramref name="requiresThreefold"/> is true, two otherwise
     /// </summary>
-    /// <param name="requiresThreefold">Whether real threefold repetition is required, 'two-fold' will be checked otherwise. Usual strategy is to do threefold only for pv nodes</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsThreefoldRepetition(bool requiresThreefold)
+    public bool IsThreefoldRepetition()
     {
         var currentHash = CurrentPosition.UniqueIdentifier;
 
         // [Count - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
         var limit = Math.Max(0, PositionHashHistory.Count - 1 - HalfMovesWithoutCaptureOrPawnMove);
-
-        if (!requiresThreefold)
+        for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
         {
-            for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
+            if (currentHash == PositionHashHistory[i])
             {
-                if (currentHash == PositionHashHistory[i])
-                {
-                    return true;
-                }
-            }
-        }
-        else
-        {
-            for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
-            {
-                if (currentHash == PositionHashHistory[i])
-                {
-                    if (requiresThreefold)
-                    {
-                        requiresThreefold = false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
-                }
+                return true;
             }
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -235,7 +235,7 @@ public sealed partial class Engine
             Game.PositionHashHistory.Add(position.UniqueIdentifier);
 
             int evaluation;
-            if (canBeRepetition && (Game.IsThreefoldRepetition(pvNode) || Game.Is50MovesRepetition()))
+            if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
             {
                 evaluation = 0;
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -249,6 +249,8 @@ public class RegressionTest : BaseTest
         engine.AdjustPosition(positionCommand);
 
         var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
+        Assert.Zero(bestMove.Evaluation);
+        Assert.AreEqual(1, bestMove.Moves.Count);
         Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
     }
 
@@ -391,39 +393,5 @@ public class RegressionTest : BaseTest
     public void PawnlessEndgames(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
     {
         TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
-    }
-
-    [Test]
-    public void FalseThreefoldRepetitionDetected()
-    {
-        const string positionCommand =
-            "position fen rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQK1NR w KQq - 0 1 " +
-            "moves b1c3 c7c5 d2d4 c5d4 d1d4 b8c6 d4a4 d7d5 g1f3 g8f6 c1g5 c8d7 g5f6 e7f6 e1c1 c6b4 a4b3 d7e6 d1d4 " +
-            "d8b6 a2a3 b4c6 b3b6 a7b6 d4d2 f8c5 e2e3 c6e7 h1d1 c5d6 c3b5 e8d7 b5d6 d7d6 f3d4 h8c8 e3e4 c8c5 b2b4 c5c4 " +
-            "e4d5 e7d5 c1b2 g7g6 d4b5 d6c6 b5d4 c6d7 d4b5 d7c6 b5d4 c6d6 d4b5 d6e5 d2e2 e5f4 e2d2 f4e5 d2e2 e5f4 e2d2 " +
-            "d5e7 b5d6 c4c7 d1e1 f4g4 c2c3 g4g5 d6e4 g5h6 e4f6 h6g7 f6e4 h7h6 g2g3 e7d5 d2d4 d5f6 e4d6 c7d7 e1e2 a8d8 " +
-            "d6b5 e6d5 h2h4 d8c8 e2e1 c8d8 e1e3 d8c8";
-
-        var engine = GetEngine();
-
-        engine.AdjustPosition(positionCommand);
-
-        var bestMove = engine.BestMove(new GoCommand("go depth 1"));
-        Assert.Less(bestMove.Evaluation, -150);
-
-        engine.NewGame();
-        engine.AdjustPosition(positionCommand);
-        bestMove = engine.BestMove(new GoCommand("go depth 5"));
-        Assert.Less(bestMove.Evaluation, -150);
-
-        engine.NewGame();
-        engine.AdjustPosition(positionCommand);
-        bestMove = engine.BestMove(new GoCommand("go depth 2"));
-        Assert.Less(bestMove.Evaluation, -150);
-
-        engine.NewGame();
-        engine.AdjustPosition(positionCommand);
-        bestMove = engine.BestMove(new GoCommand("go depth 10"));
-        Assert.Less(bestMove.Evaluation, -150);
     }
 }

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -27,19 +27,19 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -66,46 +66,19 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
-        Assert.False(game.IsThreefoldRepetition(true));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
-        Assert.True(game.IsThreefoldRepetition(true));
-    }
-
-    [Test]
-    public void EvaluateFinalPosition_Threefold_PVNode()
-    {
-        const string winningPosition = "7k/8/5KR1/8/8/8/5R2/8 w - - 0 1";
-
-        var game = new Game(winningPosition);
-        var repeatedMoves = new List<Move>
-            {
-                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),
-                MoveExtensions.Encode((int)BoardSquare.f2, (int)BoardSquare.e2, (int)Piece.R),
-                MoveExtensions.Encode((int)BoardSquare.h8, (int)BoardSquare.h7, (int)Piece.k),
-                MoveExtensions.Encode((int)BoardSquare.e2, (int)BoardSquare.f2, (int)Piece.R),
-                MoveExtensions.Encode((int)BoardSquare.h7, (int)BoardSquare.h8, (int)Piece.k),   // Triple position repetition
-            };
-
-        repeatedMoves.ForEach(move => Assert.DoesNotThrow(() => game.MakeMove(move)));
-
-        Assert.AreEqual(repeatedMoves.Count + 1, game.PositionHashHistory.Count);
-        Assert.True(game.IsThreefoldRepetition(requiresThreefold: true));
-        Assert.True(game.IsThreefoldRepetition(requiresThreefold: false));
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -134,18 +107,18 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Position with castling rights, lost in move Ke1d1
         winningPosition = new Position("1n2k2r/8/8/8/8/8/4PPPP/1N2K2R w Kk - 0 1");
@@ -170,7 +143,7 @@ public class GameTest : BaseTest
         }
 
         game.MakeMove(repeatedMoves[^1]);
-        Assert.False(game.IsThreefoldRepetition(false));                      // Same position, but white not can't castle
+        Assert.False(game.IsThreefoldRepetition());                      // Same position, but white not can't castle
 
 #if DEBUG
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
@@ -183,7 +156,7 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -387,7 +387,7 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()
@@ -413,7 +413,7 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()


### PR DESCRIPTION
This reverts commit 49b926fc649110ea431b84643bd1cae6db797e05.

This is an attempt to fix Lynx 1.5.0 inability to convert some completely won endgames, allowing threefold repetitions instead.
Concrete examples:
- https://lichess.org/XB4q079W/white#135
- https://lichess.org/F0VcRwsn/black#163
- https://lichess.org/48ylW0sA/black#129
- https://lichess.org/MpHsNLVL/white#138
- https://lichess.org/qyzvj68s/black
- https://lichess.org/puU6wF11/white
- https://lichess.org/WEI9JMJL/white
- https://lichess.org/K1iROCRy/white
- https://lichess.org/NUjmzsYJ/black#263

No adjudication/draws:
```
Test  | revert-threefold-pvnode
Elo   | 23.54 +- 10.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | 2188: +692 -544 =952
Penta | [42, 232, 428, 320, 72]
https://openbench.lynx-chess.com/test/406/
```

with adjudication/draws
```
Score of Lynx-revert-threefold-pvnode-3179-win-x64 vs Lynx 3164 - main: 5574 - 5287 - 6256  [0.508] 17117
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing White: 3853 - 1590 - 3116  [0.632] 8559
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing Black: 1721 - 3697 - 3140  [0.385] 8558
...      White vs Black: 7550 - 3311 - 6256  [0.624] 17117
Elo difference: 5.8 +/- 4.1, LOS: 99.7 %, DrawRatio: 36.5 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4, 256MB, no adj/draws
```
Score of Lynx-revert-threefold-pvnode-3179-win-x64 vs Lynx 3164 - main: 1553 - 1352 - 2583  [0.518] 5488
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing White: 1180 - 338 - 1227  [0.653] 2745
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing Black: 373 - 1014 - 1356  [0.383] 2743
...      White vs Black: 2194 - 711 - 2583  [0.635] 5488
Elo difference: 12.7 +/- 6.7, LOS: 100.0 %, DrawRatio: 47.1 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4, 32MB, no adj/draws
```
Score of Lynx-revert-threefold-pvnode-3179-win-x64 vs Lynx 3164 - main: 1061 - 864 - 1620  [0.528] 3545
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing White: 816 - 200 - 756  [0.674] 1772
...      Lynx-revert-threefold-pvnode-3179-win-x64 playing Black: 245 - 664 - 864  [0.382] 1773
...      White vs Black: 1480 - 445 - 1620  [0.646] 3545
Elo difference: 19.3 +/- 8.4, LOS: 100.0 %, DrawRatio: 45.7 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```