### PR TITLE
Detect threefold repetition after root move

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -133,7 +133,9 @@ public sealed class Game
         bool repetitionDetected = false;
         for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
         {
-            bool requiresThreefold = repetitionDetected || i < ply;
+            // We want to detect threefold repetitions for moves ahead of root,
+            // that's why we pass ply and calculate PositionHashHistory.Count - ply -1
+            bool requiresThreefold = repetitionDetected || i >= PositionHashHistory.Count - ply;
             if (currentHash == PositionHashHistory[i])
             {
                 if (requiresThreefold && !repetitionDetected)

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -123,37 +123,26 @@ public sealed class Game
     /// <param name="requiresThreefold">Whether real threefold repetition is required, 'two-fold' will be checked otherwise. Usual strategy is to do threefold only for pv nodes</param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsThreefoldRepetition(bool requiresThreefold)
+    public bool IsThreefoldRepetition(int ply)
     {
         var currentHash = CurrentPosition.UniqueIdentifier;
 
         // [Count - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
         var limit = Math.Max(0, PositionHashHistory.Count - 1 - HalfMovesWithoutCaptureOrPawnMove);
 
-        if (!requiresThreefold)
+        bool repetitionDetected = false;
+        for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
         {
-            for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
+            bool requiresThreefold = repetitionDetected || i < ply;
+            if (currentHash == PositionHashHistory[i])
             {
-                if (currentHash == PositionHashHistory[i])
+                if (requiresThreefold && !repetitionDetected)
+                {
+                    repetitionDetected = true;
+                }
+                else
                 {
                     return true;
-                }
-            }
-        }
-        else
-        {
-            for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
-            {
-                if (currentHash == PositionHashHistory[i])
-                {
-                    if (requiresThreefold)
-                    {
-                        requiresThreefold = false;
-                    }
-                    else
-                    {
-                        return true;
-                    }
                 }
             }
         }

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -264,7 +264,8 @@ public static class MoveExtensions
                     var candidatePromotedPiece = candidateMove.PromotedPiece();
 
                     if (candidatePromotedPiece == promotedPiece
-                        || candidatePromotedPiece == promotedPiece - 6)
+                        || candidatePromotedPiece == promotedPiece - 6
+                        || candidatePromotedPiece == promotedPiece + 6) // pgn-extract output - h2h1Q
                     {
                         move = candidateMove;
                         return true;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -235,7 +235,7 @@ public sealed partial class Engine
             Game.PositionHashHistory.Add(position.UniqueIdentifier);
 
             int evaluation;
-            if (canBeRepetition && (Game.IsThreefoldRepetition(pvNode) || Game.Is50MovesRepetition()))
+            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition()))
             {
                 evaluation = 0;
 

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -27,19 +27,19 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -66,21 +66,21 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
-        Assert.False(game.IsThreefoldRepetition(true));
+        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
-        Assert.True(game.IsThreefoldRepetition(true));
+        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]
@@ -134,18 +134,18 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Position with castling rights, lost in move Ke1d1
         winningPosition = new Position("1n2k2r/8/8/8/8/8/4PPPP/1N2K2R w Kk - 0 1");
@@ -170,7 +170,7 @@ public class GameTest : BaseTest
         }
 
         game.MakeMove(repeatedMoves[^1]);
-        Assert.False(game.IsThreefoldRepetition(false));                      // Same position, but white not can't castle
+        Assert.False(game.IsThreefoldRepetition());                      // Same position, but white not can't castle
 
 #if DEBUG
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
@@ -183,7 +183,7 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
     }
 
     [Test]

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -387,7 +387,7 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()
@@ -413,7 +413,7 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition(false));
+        Assert.True(game.IsThreefoldRepetition());
 
         // Using local method due to async Span limitation
         static Game ParseGame()


### PR DESCRIPTION
It doesn't seem to be the solution

vs main
```
Score of Lynx-threefold-repetition-after-root-3177-win-x64 vs Lynx 3164 - main: 5489 - 5448 - 8053  [0.501] 18990
...      Lynx-threefold-repetition-after-root-3177-win-x64 playing White: 3860 - 1596 - 4039  [0.619] 9495
...      Lynx-threefold-repetition-after-root-3177-win-x64 playing Black: 1629 - 3852 - 4014  [0.383] 9495
...      White vs Black: 7712 - 3225 - 8053  [0.618] 18990
Elo difference: 0.8 +/- 3.7, LOS: 65.2 %, DrawRatio: 42.4 %
SPRT: llr -0.615 (-21.3%), lbound -2.25, ubound 2.89
```

experiment/triple-rep (https://github.com/lynx-chess/Lynx/commit/8d19790ee23833509171b6a87a9537cd911c069b, first commit in this branch) vs this one
```
Test  | experiment/triple-rep
Elo   | 12.44 +- 6.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 7430: +2329 -2063 =3038
Penta | [234, 802, 1443, 936, 300]
https://openbench.lynx-chess.com/test/405/
```