### PR TITLE
⚖ Escale endgame eval with pawn count

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -744,7 +744,7 @@ public class Position
         if (gamePhase <= 3)
         {
             var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-            packedScore += totalPawnsCount * 6;
+            packedScore -= (16 - totalPawnsCount);
 
             if (totalPawnsCount == 0)
             {

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -741,62 +741,55 @@ public class Position
         }
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3)
+        if (gamePhase <= 3 && PieceBitBoards[(int)Piece.P] == 0 && PieceBitBoards[(int)Piece.p] == 0)
         {
-            var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-
-            packedScore *= (totalPawnsCount + 16) / 32;
-
-            if (totalPawnsCount == 0)
+            switch (gamePhase)
             {
-                switch (gamePhase)
-                {
-                    //case 5:
-                    //    {
-                    //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
-                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                    //        {
-                    //            packedScore >>= 1; // /2
-                    //        }
+                //case 5:
+                //    {
+                //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
+                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                //        {
+                //            packedScore >>= 1; // /2
+                //        }
 
-                    //        break;
-                    //    }
-                    case 3:
-                        {
-                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                //        break;
+                //    }
+                case 3:
+                    {
+                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                            if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                            //{
-                            //    packedScore >>= 1; // /2
-                            //}
-
-                            break;
-                        }
-                    case 2:
-                        {
-                            var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
-
-                            if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
-                                    || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            break;
-                        }
-                    case 1:
-                    case 0:
+                        if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
                         {
                             return (0, gamePhase);
                         }
-                }
+
+                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                        //{
+                        //    packedScore >>= 1; // /2
+                        //}
+
+                        break;
+                    }
+                case 2:
+                    {
+                        var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
+
+                        if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
+                                || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
+                        {
+                            return (0, gamePhase);
+                        }
+
+                        break;
+                    }
+                case 1:
+                case 0:
+                    {
+                        return (0, gamePhase);
+                    }
             }
         }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -741,55 +741,62 @@ public class Position
         }
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3 && PieceBitBoards[(int)Piece.P] == 0 && PieceBitBoards[(int)Piece.p] == 0)
+        if (gamePhase <= 3)
         {
-            switch (gamePhase)
+            var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
+
+            packedScore *= (totalPawnsCount + 16) / 32;
+
+            if (totalPawnsCount == 0)
             {
-                //case 5:
-                //    {
-                //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
-                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                //        {
-                //            packedScore >>= 1; // /2
-                //        }
+                switch (gamePhase)
+                {
+                    //case 5:
+                    //    {
+                    //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
+                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                    //        {
+                    //            packedScore >>= 1; // /2
+                    //        }
 
-                //        break;
-                //    }
-                case 3:
-                    {
-                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                    //        break;
+                    //    }
+                    case 3:
+                        {
+                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                        if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                            //{
+                            //    packedScore >>= 1; // /2
+                            //}
+
+                            break;
+                        }
+                    case 2:
+                        {
+                            var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
+
+                            if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
+                                    || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            break;
+                        }
+                    case 1:
+                    case 0:
                         {
                             return (0, gamePhase);
                         }
-
-                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                        //{
-                        //    packedScore >>= 1; // /2
-                        //}
-
-                        break;
-                    }
-                case 2:
-                    {
-                        var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
-
-                        if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
-                                || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
-                        {
-                            return (0, gamePhase);
-                        }
-
-                        break;
-                    }
-                case 1:
-                case 0:
-                    {
-                        return (0, gamePhase);
-                    }
+                }
             }
         }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -740,59 +740,62 @@ public class Position
             gamePhase = maxPhase;
         }
 
-        var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-        packedScore += totalPawnsCount * 6;
-
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3 && totalPawnsCount == 0)
+        if (gamePhase <= 3)
         {
-            switch (gamePhase)
+            var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
+            packedScore += totalPawnsCount * 6;
+
+            if (totalPawnsCount == 0)
             {
-                //case 5:
-                //    {
-                //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
-                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                //        {
-                //            packedScore >>= 1; // /2
-                //        }
+                switch (gamePhase)
+                {
+                    //case 5:
+                    //    {
+                    //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
+                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                    //        {
+                    //            packedScore >>= 1; // /2
+                    //        }
 
-                //        break;
-                //    }
-                case 3:
-                    {
-                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                    //        break;
+                    //    }
+                    case 3:
+                        {
+                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                        if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                            //{
+                            //    packedScore >>= 1; // /2
+                            //}
+
+                            break;
+                        }
+                    case 2:
+                        {
+                            var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
+
+                            if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
+                                    || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
+                            {
+                                return (0, gamePhase);
+                            }
+
+                            break;
+                        }
+                    case 1:
+                    case 0:
                         {
                             return (0, gamePhase);
                         }
-
-                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                        //{
-                        //    packedScore >>= 1; // /2
-                        //}
-
-                        break;
-                    }
-                case 2:
-                    {
-                        var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
-
-                        if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
-                                || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
-                        {
-                            return (0, gamePhase);
-                        }
-
-                        break;
-                    }
-                case 1:
-                case 0:
-                    {
-                        return (0, gamePhase);
-                    }
+                }
             }
         }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -740,8 +740,11 @@ public class Position
             gamePhase = maxPhase;
         }
 
+        var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
+        packedScore += totalPawnsCount * 6;
+
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3 && PieceBitBoards[(int)Piece.P] == 0 && PieceBitBoards[(int)Piece.p] == 0)
+        if (gamePhase <= 3 && totalPawnsCount == 0)
         {
             switch (gamePhase)
             {


### PR DESCRIPTION
Add 0-96cp, benefiting more pawns
```
```

Add 0-96cp, benefiting more pawns when phase <=3
```
```

Remove 0-96cp, benefiting more pawns when phase <=3
```
```