### PR TITLE
🔍 SEE QSearch: don't prune bad captures when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -552,7 +552,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!position.IsInCheck() && scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }


### PR DESCRIPTION
Don't prune SEE bad captures in QSearch while in check

```
Test  | see/no-qsearch-pruning-when-in-check
Elo   | -10.74 +- 7.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 5566: +1638 -1810 =2118
Penta | [235, 661, 1100, 615, 172]
https://openbench.lynx-chess.com/test/425/
```