### PR TITLE
QSearch: generate all moves when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -557,7 +557,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // Prune bad captures
-            if (scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!position.IsInCheck() && scores[i] < EvaluationConstants.PromotionMoveScoreValue && scores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -518,8 +518,13 @@ public sealed partial class Engine
             alpha = staticEvaluation;
         }
 
+        bool isInCheck = position.IsInCheck();
+
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, moves);
+        var pseudoLegalMoves = isInCheck
+            ? MoveGenerator.GenerateAllMoves(position, moves)
+            : MoveGenerator.GenerateAllCaptures(position, moves);
+
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358


### PR DESCRIPTION
```
Test  | qsearch/generate-all-moves-when-in-check
Elo   | -11.04 +- 7.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 5634: +1670 -1849 =2115
Penta | [249, 703, 1059, 590, 216]
https://openbench.lynx-chess.com/test/426/
```

Also #825: not pruning when in check
```
Test  | qsearch/generate-all-moves-when-in-check
Elo   | -18.81 +- 9.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 3328: +939 -1119 =1270
Penta | [154, 417, 647, 347, 99]
https://openbench.lynx-chess.com/test/427/
```