### PR TITLE
🐛 Fix pawn escaling for negative scores

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -744,7 +744,16 @@ public class Position
         if (gamePhase <= 3)
         {
             var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-            packedScore -= (16 - totalPawnsCount);
+            var penalty = 16 - totalPawnsCount;
+
+            if (packedScore > 0)
+            {
+                packedScore -= penalty;
+            }
+            else if (packedScore < 0)
+            {
+                packedScore += penalty;
+            }
 
             if (totalPawnsCount == 0)
             {


### PR DESCRIPTION
When the score is negative, we want to bring it closer to 0 when there aren't any pawns.

```
Test  | bugfix/eg-pawn-scaling-negative-scores
Elo   | -0.55 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 40200: +12689 -12753 =14758
Penta | [1414, 4488, 8356, 4432, 1410]
https://openbench.lynx-chess.com/test/419/
```

But:
```
> python .\sprt.py -w 12689 -d 14758 -l 12753 -e0 -5 -e1 1
ELO: -0.553 +- 2.7 [-3.25, 2.14]
LLR: 3.22 [-5.0, 1.0] (-2.94, 2.94)
H1 Accepted
```