### PR TITLE
⚖ Do pawn scaling with pawn count regardless of the phase

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -740,62 +740,59 @@ public class Position
             gamePhase = maxPhase;
         }
 
+        var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
+        packedScore -= (16 - totalPawnsCount);
+
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3)
+        if (gamePhase <= 3 && totalPawnsCount == 0)
         {
-            var totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-            packedScore -= (16 - totalPawnsCount);
-
-            if (totalPawnsCount == 0)
+            switch (gamePhase)
             {
-                switch (gamePhase)
-                {
-                    //case 5:
-                    //    {
-                    //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
-                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                    //        {
-                    //            packedScore >>= 1; // /2
-                    //        }
+                //case 5:
+                //    {
+                //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
+                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                //        {
+                //            packedScore >>= 1; // /2
+                //        }
 
-                    //        break;
-                    //    }
-                    case 3:
-                        {
-                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                //        break;
+                //    }
+                case 3:
+                    {
+                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                            if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                            //{
-                            //    packedScore >>= 1; // /2
-                            //}
-
-                            break;
-                        }
-                    case 2:
-                        {
-                            var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
-
-                            if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
-                                    || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            break;
-                        }
-                    case 1:
-                    case 0:
+                        if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
                         {
                             return (0, gamePhase);
                         }
-                }
+
+                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                        //{
+                        //    packedScore >>= 1; // /2
+                        //}
+
+                        break;
+                    }
+                case 2:
+                    {
+                        var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
+
+                        if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
+                                || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
+                        {
+                            return (0, gamePhase);
+                        }
+
+                        break;
+                    }
+                case 1:
+                case 0:
+                    {
+                        return (0, gamePhase);
+                    }
             }
         }
 


### PR DESCRIPTION
```
Score of Lynx-eval-eg-pawn-scaling-any-material-3220-win-x64 vs Lynx 3221 - main: 5912 - 5997 - 6879  [0.498] 18788
...      Lynx-eval-eg-pawn-scaling-any-material-3220-win-x64 playing White: 4104 - 1715 - 3575  [0.627] 9394
...      Lynx-eval-eg-pawn-scaling-any-material-3220-win-x64 playing Black: 1808 - 4282 - 3304  [0.368] 9394
...      White vs Black: 8386 - 3523 - 6879  [0.629] 18788
Elo difference: -1.6 +/- 3.9, LOS: 21.8 %, DrawRatio: 36.6 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```