### PR TITLE
🔍 QSearch: limit depth

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -58,6 +58,8 @@
     "FP_DepthScalingFactor": 62,
     "FP_Margin": 170,
 
+    "MaxQSearchRelativeDepth": 15,
+
     // Evaluation
     "IsolatedPawnPenalty": {
       "MG": -19,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -187,6 +187,9 @@ public sealed class EngineSettings
     [SPSAAttribute<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 170;
 
+    [SPSAAttribute<int>(10, 30, 5)]
+    public int MaxQSearchRelativeDepth { get; set; } = 15;
+
     #region Evaluation
 
     public TaperedEvaluationTerm IsolatedPawnPenalty { get; set; } = new(-19, -14);


### PR DESCRIPTION
10
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 37 - 175 - 59  [0.245] 271
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 28 - 66 - 41  [0.359] 135
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 9 - 109 - 18  [0.132] 136
...      White vs Black: 137 - 75 - 59  [0.614] 271
Elo difference: -195.1 +/- 40.7, LOS: 0.0 %, DrawRatio: 21.8 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

15
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 85 - 148 - 127  [0.412] 360
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 62 - 50 - 68  [0.533] 180
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 23 - 98 - 59  [0.292] 180
...      White vs Black: 160 - 73 - 127  [0.621] 360
Elo difference: -61.4 +/- 29.1, LOS: 0.0 %, DrawRatio: 35.3 %
SPRT: llr -1.12 (-38.9%), lbound -2.25, ubound 2.89
```

20
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 209 - 267 - 294  [0.462] 770
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 142 - 95 - 148  [0.561] 385
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 67 - 172 - 146  [0.364] 385
...      White vs Black: 314 - 162 - 294  [0.599] 770
Elo difference: -26.2 +/- 19.3, LOS: 0.4 %, DrawRatio: 38.2 %
SPRT: llr -1.04 (-36.1%), lbound -2.25, ubound 2.89
```

25
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 364 - 451 - 515  [0.467] 1330
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 260 - 142 - 264  [0.589] 666
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 104 - 309 - 251  [0.346] 664
...      White vs Black: 569 - 246 - 515  [0.621] 1330
Elo difference: -22.8 +/- 14.6, LOS: 0.1 %, DrawRatio: 38.7 %
SPRT: llr -1.57 (-54.2%), lbound -2.25, ubound 2.89
```

30
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 1034 - 1168 - 1282  [0.481] 3484
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 750 - 358 - 634  [0.613] 1742
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 284 - 810 - 648  [0.349] 1742
...      White vs Black: 1560 - 642 - 1282  [0.632] 3484
Elo difference: -13.4 +/- 9.2, LOS: 0.2 %, DrawRatio: 36.8 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```

35
```
Score of Lynx-qsearch-depth-limit-3238-win-x64 vs Lynx 3234 - main: 1274 - 1410 - 1568  [0.484] 4252
...      Lynx-qsearch-depth-limit-3238-win-x64 playing White: 909 - 417 - 800  [0.616] 2126
...      Lynx-qsearch-depth-limit-3238-win-x64 playing Black: 365 - 993 - 768  [0.352] 2126
...      White vs Black: 1902 - 782 - 1568  [0.632] 4252
Elo difference: -11.1 +/- 8.3, LOS: 0.4 %, DrawRatio: 36.9 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```