### PR TITLE
🐛 Avoid node count overflow

### DIFF
--- a/src/Lynx.Benchmark/UCI_Benchmark.cs
+++ b/src/Lynx.Benchmark/UCI_Benchmark.cs
@@ -42,7 +42,7 @@ public class UCI_Benchmark : BaseBenchmark
     private readonly Channel<string> _channel = Channel.CreateBounded<string>(new BoundedChannelOptions(100_000) { SingleReader = true, SingleWriter = false });
 
     [Benchmark]
-    public (int, long) Bench_DefaultDepth()
+    public (long, long) Bench_DefaultDepth()
     {
         var engine = new Engine(_channel.Writer);
         return engine.Bench(Configuration.EngineSettings.BenchDepth);

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -103,11 +103,11 @@ public partial class Engine
     /// (https://github.com/JacquesRW/akimbo/blob/main/resources/fens.txt)
     /// plus random some endgame positions to ensure promotions with/without captures are well covered
     /// </summary>
-    public (int TotalNodes, long Nps) Bench(int depth)
+    public (long TotalNodes, long Nps) Bench(int depth)
     {
         var stopwatch = new Stopwatch();
 
-        int totalNodes = 0;
+        long totalNodes = 0;
         long totalTime = 0;
 
         foreach (var fen in _benchmarkFens)
@@ -132,7 +132,7 @@ public partial class Engine
         return (totalNodes, Utils.CalculateNps(totalNodes, totalTime));
     }
 
-    public async ValueTask PrintBenchResults((int TotalNodes, long Nps) benchResult) => await _engineWriter.WriteAsync($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
-    public static void PrintBenchResults((int TotalNodes, long Nps) benchResult, Action<string> write) => write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
-    public static async ValueTask PrintBenchResults((int TotalNodes, long Nps) benchResult, Func<string, ValueTask> write) => await write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public async ValueTask PrintBenchResults((long TotalNodes, long Nps) benchResult) => await _engineWriter.WriteAsync($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public static void PrintBenchResults((long TotalNodes, long Nps) benchResult, Action<string> write) => write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public static async ValueTask PrintBenchResults((long TotalNodes, long Nps) benchResult, Func<string, ValueTask> write) => await write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
 }

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -12,7 +12,7 @@ public class SearchResult
 
     public int DepthReached { get; set; }
 
-    public int Nodes { get; set; }
+    public long Nodes { get; set; }
 
     public long Time { get; set; }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -35,7 +35,7 @@ public sealed partial class Engine
     private TranspositionTable _tt = [];
     private int _ttMask;
 
-    private int _nodes;
+    private long _nodes;
     private bool _isFollowingPV;
     private bool _isScoringPV;
 

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -175,7 +175,7 @@ public static class Utils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long CalculateNps(int nodes, long elapsedMilliseconds)
+    public static long CalculateNps(long nodes, long elapsedMilliseconds)
     {
         return Convert.ToInt64(Math.Clamp(nodes / ((0.001 * elapsedMilliseconds) + 1), 0, long.MaxValue));
     }


### PR DESCRIPTION
Example before this PR:

```
position fen 8/8/3P1k2/p1K5/P5Pp/7r/6p1/4R3 w - - 1 84
go infinite
info depth 1 seldepth 3 multipv 1 score cp -34 nodes 33 nps 33 time 0 pv d6d7
info depth 2 seldepth 5 multipv 1 score cp -68 nodes 313 nps 313 time 1 pv d6d7 h3d3
...
info depth 39 seldepth 59 multipv 1 score cp -151 nodes 1081883535 nps 291665 time 3708341 pv c5d4 h3b3 d6d7 b3b8 d4e3 b8d8 e3f2 h4h3 f2g3 d8d7 g3h3 d7d2 h3h2 d2d4 g4g5 f6f5 h2g2 d4a4 g2f3 f5g5 e1e5 g5f6 e5h5 f6e6 f3e3 e6d6 e3d3 d6c6 d3c3 c6b6 h5h6 b6b5 h6h5 b5c6 h5h6 c6d7 c3b3 a4g4 b3a3 g4g5 h6h7 d7c6 h7e7
info depth 40 seldepth 65 multipv 1 score cp -162 nodes -1255046699 nps 0 time 6654273 pv c5d4 h3b3 d6d7 b3b8 d4e3 b8d8 e3f2 h4h3 f2g3 d8d7 g3h3 d7d2 h3h2 d2d4 g4g5 f6f5 h2g2 d4a4 g2f3 f5g5 e1e5 g5f6 e5h5 f6e6 f3e3 e6d6 e3d3 d6c6 d3c3 c6b6 h5h6 b6b5 h6h5 b5c6 h5h6 c6d7 h6a6 d7c8 a6h6 a4g4 h6h8 c8c7 h8h7 c7d6 h7b7
```