### PR TITLE
🔍 RFP: 'fail medium'

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -100,11 +100,13 @@ public sealed partial class Engine
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
-                // Return formula by Ciekce, instead of just returning static eval
+                // Return formula by xu-shawn (Serendipity), instead of return (staticEval + beta) / 2 (Ciekce) or just returning static eval
                 if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
                 {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
-                    return (staticEval + beta) / 2;
+                    return beta > EvaluationConstants.NegativeCheckmateDetectionLimit
+                        ? beta + ((staticEval - beta) / 3)
+                        : staticEval;
 #pragma warning restore S3949 // Calculations should not overflow
                 }
 


### PR DESCRIPTION
```
Test  | rfp/fail-medium
Elo   | -1.25 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 27982: +8739 -8840 =10403
Penta | [1009, 3100, 5823, 3101, 958]
https://openbench.lynx-chess.com/test/430/
```
