### PR TITLE
NMP: tweak reduction using `eval - beta`

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -32,7 +32,7 @@
     "NMP_BaseDepthReduction": 2,
     "NMP_DepthIncrement": 1,
     "NMP_DepthDivisor": 4,
-    "NMP_StaticEvalBetaDivisor": 250,
+    "NMP_StaticEvalBetaDivisor": 350,
 
     "AspirationWindow_Delta": 13,
     "AspirationWindow_MinDepth": 8,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -32,6 +32,7 @@
     "NMP_BaseDepthReduction": 2,
     "NMP_DepthIncrement": 1,
     "NMP_DepthDivisor": 4,
+    "NMP_StaticEvalBetaDivisor": 250,
 
     "AspirationWindow_Delta": 13,
     "AspirationWindow_MinDepth": 8,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -136,7 +136,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 4;
 
     [SPSAAttribute<int>(1, 1000, 50)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 250;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 350;
 
     [SPSAAttribute<int>(1, 100, 5)]
     public int AspirationWindow_Delta { get; set; } = 13;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -135,6 +135,9 @@ public sealed class EngineSettings
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int NMP_DepthDivisor { get; set; } = 4;
 
+    [SPSAAttribute<int>(1, 1000, 50)]
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 250;
+
     [SPSAAttribute<int>(1, 100, 5)]
     public int AspirationWindow_Delta { get; set; } = 13;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -147,10 +147,10 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
-
-                // Inspired by Ethereal, Stormphrax, and Sirius
-                nmpReduction += (staticEval - beta) / 256;
+                var nmpReduction =
+                    Configuration.EngineSettings.NMP_BaseDepthReduction
+                    + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
+                    + ((staticEval - beta) / Configuration.EngineSettings.NMP_StaticEvalBetaDivisor);   // Ethereal, Stormphrax, and Sirius
 
                 var gameState = position.MakeNullMove();
                 var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -147,12 +147,8 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
-
-                // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
-                //var nmpReduction = Math.Min(
-                //    depth,
-                //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
+                // Formula suggested by Sirius author
+                var nmpReduction = Math.Min(3, (staticEval - beta) / 256);
 
                 var gameState = position.MakeNullMove();
                 var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -147,8 +147,10 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttEvaluation >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                // Formula suggested by Sirius author
-                var nmpReduction = Math.Min(3, (staticEval - beta) / 256);
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+
+                // Inspired by Ethereal, Stormphrax, and Sirius
+                nmpReduction += (staticEval - beta) / 256;
 
                 var gameState = position.MakeNullMove();
                 var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -334,6 +334,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "nmp_staticevalbetadivisor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NMP_StaticEvalBetaDivisor = value;
+                    }
+                    break;
+                }
 
             case "aspirationwindow_delta":
                 {


### PR DESCRIPTION
☠️ [Tweak NMP reduction formula to take into account staticEval instead of depth](https://github.com/lynx-chess/Lynx/commit/412f4e91a4e13b8d5cb59a3effc2815681699f77):
```
Test  | nmp/tweak-reduction-staticeval
Elo   | -134.64 +- 23.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 650: +99 -339 =212
Penta | [77, 127, 88, 25, 8]
https://openbench.lynx-chess.com/test/432/
```

❌ [Don't fully replace the previous formula, just reduce extra](https://github.com/lynx-chess/Lynx/commit/5a0612ec9dd660c93ca79c5a755b6256fe3dcab7)
```
Test  | nmp/tweak-reduction-staticeval
Elo   | -3.94 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 13242: +4040 -4190 =5012
Penta | [504, 1575, 2585, 1481, 476]
https://openbench.lynx-chess.com/test/433/
```

Re-tune - 350
<details>

<Summary>Tuning</Summary>

```json
{
   "t":117680,
   "spsa_params":{
      "a":1.0,
      "c":1.0,
      "A":200,
      "alpha":0.601,
      "gamma":0.102
   },
   "uci_params":[
      {
         "name":"NMP_MinDepth",
         "value":1.9432242527362957,
         "min_value":1,
         "max_value":10,
         "step":0.5
      },
      {
         "name":"NMP_BaseDepthReduction",
         "value":2.182859894044508,
         "min_value":1,
         "max_value":5,
         "step":0.5
      },
      {
         "name":"NMP_DepthIncrement",
         "value":0.5546069862046185,
         "min_value":0,
         "max_value":10,
         "step":0.5
      },
      {
         "name":"NMP_DepthDivisor",
         "value":3.824344890054039,
         "min_value":1,
         "max_value":10,
         "step":0.5
      },
      {
         "name":"NMP_StaticEvalBetaDivisor",
         "value":320.12052530695627,
         "min_value":1,
         "max_value":1000,
         "step":100
      }
   ]
}
```

</details>

8 0.08
```
Score of Lynx-nmp-tweak-reduction-staticeval-3363-win-x64 vs Lynx 3362 - main: 16663 - 16599 - 19586  [0.501] 52848
...      Lynx-nmp-tweak-reduction-staticeval-3363-win-x64 playing White: 11846 - 4784 - 9795  [0.634] 26425
...      Lynx-nmp-tweak-reduction-staticeval-3363-win-x64 playing Black: 4817 - 11815 - 9791  [0.368] 26423
...      White vs Black: 23661 - 9601 - 19586  [0.633] 52848
Elo difference: 0.4 +/- 2.3, LOS: 63.7 %, DrawRatio: 37.1 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

40 0.4
```
Test  | nmp/tweak-reduction-staticeval
Elo   | 1.08 +- 2.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.09 (-2.25, 2.89) [0.00, 3.00]
Games | 52710: +15549 -15385 =21776
Penta | [1565, 6156, 10782, 6254, 1598]
https://openbench.lynx-chess.com/test/490/
```