### PR TITLE
SPSA 2024-6-27

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -24,9 +24,9 @@
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
     "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 3,
-    "LMR_Base": 0.83,
-    "LMR_Divisor": 3.43,
+    "LMR_MinFullDepthSearchedMoves": 4,
+    "LMR_Base": 0.91,
+    "LMR_Divisor": 3.42,
 
     "NMP_MinDepth": 2,
     "NMP_BaseDepthReduction": 2,
@@ -37,26 +37,26 @@
     "AspirationWindow_MinDepth": 8,
 
     "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 97,
+    "RFP_DepthScalingFactor": 82,
 
     "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 127,
-    "Razoring_NotDepth1Bonus": 149,
+    "Razoring_Depth1Bonus": 129,
+    "Razoring_NotDepth1Bonus": 178,
 
-    "IIR_MinDepth": 4,
+    "IIR_MinDepth": 3,
 
-    "LMP_MaxDepth": 6,
+    "LMP_MaxDepth": 7,
     "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 3,
+    "LMP_MovesDepthMultiplier": 4,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 1,
+    "SEE_BadCaptureReduction": 2,
 
     "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 62,
-    "FP_Margin": 170,
+    "FP_DepthScalingFactor": 78,
+    "FP_Margin": 129,
 
     // Evaluation
     "IsolatedPawnPenalty": {

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -109,19 +109,19 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSAAttribute<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.83;
+    public double LMR_Base { get; set; } = 0.91;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSAAttribute<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.43;
+    public double LMR_Divisor { get; set; } = 3.42;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
@@ -145,28 +145,28 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 6;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 97;
+    public int RFP_DepthScalingFactor { get; set; } = 82;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 1;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 127;
+    public int Razoring_Depth1Bonus { get; set; } = 129;
 
     [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 149;
+    public int Razoring_NotDepth1Bonus { get; set; } = 178;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 4;
+    public int IIR_MinDepth { get; set; } = 3;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 6;
+    public int LMP_MaxDepth { get; set; } = 7;
 
     [SPSAAttribute<int>(0, 10, 0.5)]
     public int LMP_BaseMovesToTry { get; set; } = 0;
 
     [SPSAAttribute<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 3;
+    public int LMP_MovesDepthMultiplier { get; set; } = 4;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -176,16 +176,16 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSAAttribute<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 1;
+    public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSAAttribute<int>(1, 10, 0.5)]
     public int FP_MaxDepth { get; set; } = 5;
 
     [SPSAAttribute<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 62;
+    public int FP_DepthScalingFactor { get; set; } = 78;
 
     [SPSAAttribute<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 170;
+    public int FP_Margin { get; set; } = 129;
 
     #region Evaluation
 


### PR DESCRIPTION
40 0.4, [-3, 1] accidentally, but will merge
```
Score of Lynx-spsa-27-6-3250-win-x64 vs Lynx 3246 - main: 4509 - 4404 - 6218  [0.503] 15131
...      Lynx-spsa-27-6-3250-win-x64 playing White: 3393 - 1112 - 3062  [0.651] 7567
...      Lynx-spsa-27-6-3250-win-x64 playing Black: 1116 - 3292 - 3156  [0.356] 7564
...      White vs Black: 6685 - 2228 - 6218  [0.647] 15131
Elo difference: 2.4 +/- 4.2, LOS: 86.7 %, DrawRatio: 41.1 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```