### PR TITLE
🐛 Make `.ToEPDString()` fully PGN/EPD compliant

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -516,7 +516,7 @@ static void _32_Make_Move()
         {
             game.CurrentPosition.Print();
 
-            Console.WriteLine(move.ToMoveString());
+            Console.WriteLine(move.ToEPDString(game.CurrentPosition));
             var gameState = game.MakeMove(move);
             game.CurrentPosition.Print();
 
@@ -539,7 +539,7 @@ static void _32_Make_Move()
             {
                 game.CurrentPosition.Print();
 
-                Console.WriteLine(move.ToMoveString());
+                Console.WriteLine(move.ToEPDString(game.CurrentPosition));
                 var gameState = game.MakeMove(move);
                 game.CurrentPosition.Print();
                 game.CurrentPosition.UnmakeMove(move, gameState);

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1121,7 +1121,8 @@ static void UnmakeMove()
         var oldZobristKey = position.UniqueIdentifier;
         foreach (var move in allMoves)
         {
-            Console.WriteLine($"Trying {move.ToEPDString()} in\t{position.FEN()}");
+            var epdMoveString = move.ToEPDString(position);
+            Console.WriteLine($"Trying {epdMoveString} in\t{position.FEN()}");
 
             var newPosition = new Position(position, move);
             var savedState = position.MakeMove(move);
@@ -1129,7 +1130,7 @@ static void UnmakeMove()
             Console.WriteLine($"Position\t{newPosition.FEN()}, Zobrist key {newPosition.UniqueIdentifier}");
             Console.WriteLine($"Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}");
 
-            Console.WriteLine($"Unmaking {move.ToEPDString()} in\t{position.FEN()}");
+            Console.WriteLine($"Unmaking {epdMoveString} in\t{position.FEN()}");
 
             //position.UnmakeMove(move, savedState);
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -351,6 +351,8 @@ public static class Constants
         0, 1, 2, 3, 4, 5, 6, 7
     ];
 
+    public static readonly char[] FileString = [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' ];
+
     public const int AbsoluteMaxDepth = 255;
 
     /// <summary>

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -282,13 +282,13 @@ public sealed partial class Engine
         if (searchResult is not null)
         {
             _logger.Info("Search evaluation result - eval: {0}, mate: {1}, depth: {2}, pv: {3}",
-                searchResult.Evaluation, searchResult.Mate, searchResult.Depth, string.Join(", ", searchResult.Moves.Select(m => m.ToMoveString())));
+                searchResult.Evaluation, searchResult.Mate, searchResult.Depth, string.Join(", ", searchResult.Moves.Select(m => m.UCIString())));
         }
 
         if (tbResult is not null)
         {
             _logger.Info("Online tb probing result - mate: {0}, moves: {1}",
-                tbResult.Mate, string.Join(", ", tbResult.Moves.Select(m => m.ToMoveString())));
+                tbResult.Mate, string.Join(", ", tbResult.Moves.Select(m => m.UCIString())));
 
             if (searchResult?.Mate > 0 && searchResult.Mate <= tbResult.Mate && searchResult.Mate + currentHalfMovesWithoutCaptureOrPawnMove < 96)
             {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -355,8 +355,8 @@ public static class MoveExtensions
 #pragma warning disable S3358 // Ternary operators should not be nested
         return move.SpecialMoveFlag() switch
         {
-            SpecialMoveType.ShortCastle => "0-0",
-            SpecialMoveType.LongCastle => "0-0-O",
+            SpecialMoveType.ShortCastle => "O-O",
+            SpecialMoveType.LongCastle => "O-O-O",
             _ =>
                 (piece == (int)Model.Piece.P || piece == (int)Model.Piece.p
                     ? (move.IsCapture()
@@ -366,7 +366,6 @@ public static class MoveExtensions
                 + (move.IsCapture() == default ? "" : "x")
                 + Constants.Coordinates[move.TargetSquare()]
                 + (move.PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[move.PromotedPiece()])}")
-                + (move.IsEnPassant() == default ? "" : " e.p.")
         };
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
@@ -384,8 +383,8 @@ public static class MoveExtensions
 #pragma warning disable S3358 // Ternary operators should not be nested
         return move.SpecialMoveFlag() switch
         {
-            SpecialMoveType.ShortCastle => "0-0",
-            SpecialMoveType.LongCastle => "0-0-O",
+            SpecialMoveType.ShortCastle => "O-O",
+            SpecialMoveType.LongCastle => "O-O-O",
             _ =>
                 (piece == (int)Model.Piece.P || piece == (int)Model.Piece.p
                     ? (move.IsCapture()

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -389,14 +389,14 @@ public static class MoveExtensions
             _ =>
                 (piece == (int)Model.Piece.P || piece == (int)Model.Piece.p
                     ? (move.IsCapture()
-                        ? global::Lynx.Constants.Coordinates[move.SourceSquare()][..^1]  // exd5
+                        ? global::Lynx.Constants.FileString[global::Lynx.Constants.File[move.SourceSquare()]]  // exd5
                         : "")    // d5
-                    : char.ToUpperInvariant(global::Lynx.Constants.AsciiPieces[move.Piece()]))
-                + DisambiguateMove(move, position)
+                    : (char.ToUpperInvariant(global::Lynx.Constants.AsciiPieces[move.Piece()]))
+                        + DisambiguateMove(move, position))
                 + (move.IsCapture() == default ? "" : "x")
                 + Constants.Coordinates[move.TargetSquare()]
                 + (move.PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[move.PromotedPiece()])}")
-                + (move.IsEnPassant() == default ? "" : "e.p.")
+                + (move.IsEnPassant() == default ? "" : " e.p.")
         };
 #pragma warning restore S3358 // Ternary operators should not be nested
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -400,7 +400,8 @@ public static class MoveExtensions
         };
 #pragma warning restore S3358 // Ternary operators should not be nested
 
-        // https://chess.stackexchange.com/a/1819
+        // First file letter, then rank number and finally the whole square
+        // At least according to https://chess.stackexchange.com/a/1819
         static string DisambiguateMove(Move move, Position position)
         {
             var piece = move.Piece();
@@ -413,6 +414,7 @@ public static class MoveExtensions
                 .Where(m => m != move && m.Piece() == piece && m.TargetSquare() == targetSquare)
                 .Where(m =>
                 {
+                    // If any illegal moves exist with the same simple representation there's no need to disambiguate
                     var gameState = position.MakeMove(m);
                     var isLegal = position.WasProduceByAValidMove();
                     position.UnmakeMove(m, gameState);
@@ -437,7 +439,7 @@ public static class MoveExtensions
 
                 var ranks = movesWithSameSimpleRepresentation.Select(m => Constants.Rank[m.SourceSquare()]);
 
-                if (ranks.Any(f => f == moveRank))
+                if (ranks.Any(r => r == moveRank))
                 {
                     return Constants.Coordinates[sourceSquare];
                 }

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -366,7 +366,7 @@ public static class MoveExtensions
                 + (move.IsCapture() == default ? "" : "x")
                 + Constants.Coordinates[move.TargetSquare()]
                 + (move.PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[move.PromotedPiece()])}")
-                + (move.IsEnPassant() == default ? "" : "e.p.")
+                + (move.IsEnPassant() == default ? "" : " e.p.")
         };
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
@@ -396,7 +396,6 @@ public static class MoveExtensions
                 + (move.IsCapture() == default ? "" : "x")
                 + Constants.Coordinates[move.TargetSquare()]
                 + (move.PromotedPiece() == default ? "" : $"={char.ToUpperInvariant(Constants.AsciiPieces[move.PromotedPiece()])}")
-                + (move.IsEnPassant() == default ? "" : " e.p.")
         };
 #pragma warning restore S3358 // Ternary operators should not be nested
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -275,7 +275,7 @@ public static class TranspositionTableExtensions
         {
             if (transpositionTable[i].Key != default)
             {
-                Console.WriteLine($"{i}: Key = {transpositionTable[i].Key}, Depth: {transpositionTable[i].Depth}, Score: {transpositionTable[i].Score}, Move: {(transpositionTable[i].Move != 0 ? ((Move)transpositionTable[i].Move).ToMoveString() : "-")} {transpositionTable[i].Type}");
+                Console.WriteLine($"{i}: Key = {transpositionTable[i].Key}, Depth: {transpositionTable[i].Depth}, Score: {transpositionTable[i].Score}, Move: {(transpositionTable[i].Move != 0 ? ((Move)transpositionTable[i].Move).UCIString() : "-")} {transpositionTable[i].Type}");
             }
         }
         Console.WriteLine("");

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -233,7 +233,9 @@ public sealed partial class Engine
             //if (plies < Configuration.Parameters.Depth - 1)
             {
                 //Console.WriteLine($"{Environment.NewLine}{depthStr}{move} ({position.Side}, {depth})");
+#pragma warning disable CS0618 // Type or member is obsolete
                 _logger.Trace($"{Environment.NewLine}{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString()} ({position.Side}, {plies})");
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
     }
@@ -261,7 +263,9 @@ public sealed partial class Engine
             //Console.WriteLine($"{depthStr}{move} ({position.Side}, {depthLeft}) | {evaluation}");
             //Console.WriteLine($"{depthStr}{move} | {evaluation}");
 
+#pragma warning disable CS0618 // Type or member is obsolete
             _logger.Trace($"{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString(),-6} | {evaluation}{(prune ? " | prunning" : "")}");
+#pragma warning restore CS0618 // Type or member is obsolete
 
             //Console.ResetColor();
         }
@@ -311,6 +315,7 @@ public sealed partial class Engine
             Console.WriteLine($"Copying {movesToCopy} moves");
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         Console.WriteLine(
 (target != -1 ? $"src: {source}, tgt: {target}" + Environment.NewLine : "") +
 $" {0,-3} {_pVTable[0].ToEPDString(),-6} {_pVTable[1].ToEPDString(),-6} {_pVTable[2].ToEPDString(),-6} {_pVTable[3].ToEPDString(),-6} {_pVTable[4].ToEPDString(),-6} {_pVTable[5].ToEPDString(),-6} {_pVTable[6].ToEPDString(),-6} {_pVTable[7].ToEPDString(),-6} {_pVTable[8].ToEPDString(),-6} {_pVTable[9].ToEPDString(),-6} {_pVTable[10].ToEPDString(),-6}" + Environment.NewLine +
@@ -323,6 +328,7 @@ $" {369,-3}                                           {_pVTable[369].ToEPDString
 $" {427,-3}                                                  {_pVTable[427].ToEPDString(),-6} {_pVTable[428].ToEPDString(),-6} {_pVTable[429].ToEPDString(),-6} {_pVTable[430].ToEPDString(),-6}" + Environment.NewLine +
 $" {484,-3}                                                         {_pVTable[484].ToEPDString(),-6} {_pVTable[485].ToEPDString(),-6} {_pVTable[486].ToEPDString(),-6}" + Environment.NewLine +
 (target == -1 ? "------------------------------------------------------------------------------------" + Environment.NewLine : ""));
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [Conditional("DEBUG")]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -234,14 +234,14 @@ public sealed partial class Engine
             {
                 //Console.WriteLine($"{Environment.NewLine}{depthStr}{move} ({position.Side}, {depth})");
 #pragma warning disable CS0618 // Type or member is obsolete
-                _logger.Trace($"{Environment.NewLine}{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString()} ({position.Side}, {plies})");
+                _logger.Trace($"{Environment.NewLine}{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString(position)} ({position.Side}, {plies})");
 #pragma warning restore CS0618 // Type or member is obsolete
             }
         }
     }
 
     [Conditional("DEBUG")]
-    private static void PrintMove(int plies, Move move, int evaluation, bool isQuiescence = false, bool prune = false)
+    private static void PrintMove(Position position, int plies, Move move, int evaluation, bool isQuiescence = false, bool prune = false)
     {
         if (_logger.IsTraceEnabled)
         {
@@ -264,7 +264,7 @@ public sealed partial class Engine
             //Console.WriteLine($"{depthStr}{move} | {evaluation}");
 
 #pragma warning disable CS0618 // Type or member is obsolete
-            _logger.Trace($"{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString(),-6} | {evaluation}{(prune ? " | prunning" : "")}");
+            _logger.Trace($"{depthStr}{(isQuiescence ? "[Qui] " : "")}{move.ToEPDString(position),-6} | {evaluation}{(prune ? " | prnning" : "")}");
 #pragma warning restore CS0618 // Type or member is obsolete
 
             //Console.ResetColor();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -355,7 +355,7 @@ public sealed partial class Engine
             Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
             position.UnmakeMove(move, gameState);
 
-            PrintMove(ply, move, evaluation);
+            PrintMove(position, ply, move, evaluation);
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)
@@ -575,7 +575,7 @@ public sealed partial class Engine
             int evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
             position.UnmakeMove(move, gameState);
 
-            PrintMove(ply, move, evaluation);
+            PrintMove(position, ply, move, evaluation);
 
             // Fail-hard beta-cutoff
             if (evaluation >= beta)

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -230,7 +230,7 @@ public class RegressionTest : BaseTest
         Assert.False(engine.Game.Is50MovesRepetition());
         var bestMove = engine.BestMove(new GoCommand("go depth 1"));
 
-        engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.ToEPDString());
+        engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.UCIString());
         Assert.IsFalse(engine.Game.Is50MovesRepetition());
     }
 

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -37,6 +37,7 @@ public class WACSilver200 : BaseTest
     private static void VerifyBestMove(string fen, string bestMove, string id, GoCommand goCommand)
     {
         var engine = GetEngine(fen);
+        var currentPositionClone = new Position(engine.Game.CurrentPosition);
 
         var bestResult = engine.BestMove(goCommand);
 
@@ -44,11 +45,11 @@ public class WACSilver200 : BaseTest
         if (bestMoveArray.Length == 1)
         {
             var expectedMove = bestMoveArray[0].TrimEnd('+');
-            Assert.AreEqual(expectedMove, bestResult.BestMove.ToEPDString(), $"id {id} depth {bestResult.Depth} seldepth {bestResult.Depth} nodes {bestResult.Nodes}");
+            Assert.AreEqual(expectedMove, bestResult.BestMove.ToEPDString(currentPositionClone), $"id {id} depth {bestResult.Depth} seldepth {bestResult.Depth} nodes {bestResult.Nodes}");
         }
         else if (bestMoveArray.Length == 2)
         {
-            var bestResultGot = bestResult.BestMove.ToEPDString();
+            var bestResultGot = bestResult.BestMove.ToEPDString(currentPositionClone);
             Assert.True(
                 bestMoveArray[0].TrimEnd('+') == bestResultGot
                 || bestMoveArray[1].TrimEnd('+') == bestResultGot

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -77,6 +77,9 @@ public class MoveToEPDStringTest
     [TestCase("3k4/2R1R1N1/7b/6N1/8/8/3K4/8 w - - 1 1", Piece.N, BoardSquare.e6, "Ne6")]
     [TestCase("8/4K3/4QQ2/5Qb1/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Qee5", "Qfe5")]
     [TestCase("8/5K2/4QQ2/3b1Q2/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Q5e5", "Q6e5")]
+    // Pawn captures, where file is included instead of piece
+    [TestCase("3rr1k1/5ppp/p1p5/1P6/8/Q2B4/PK6/3b4 b - - 0 33", Piece.p, BoardSquare.b5, "axb5", "cxb5")]
+    [TestCase("rnbqkbnr/1pp2p2/p3p2p/2PpP1p1/3P4/8/PP3PPP/RNBQKBNR w KQkq d6 0 6", Piece.P, BoardSquare.d6, "cxd6 e.p.", "exd6 e.p.")]
     public void ToStrictEPDString(string fen, Piece piece, BoardSquare targetSquare, string m0, string? m1 = default, string? m2 = default)
     {
         var position = new Position(fen);

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -61,7 +61,9 @@ public class MoveToEPDStringTest
             }
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         Assert.AreEqual(expectedString, move.ToEPDString());
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     [TestCase("3K4/8/8/3k4/8/8/2Q1Q3/R6R w - - 0 1", Piece.R, BoardSquare.d1, "Rad1", "Rhd1")]

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -63,4 +63,57 @@ public class MoveToEPDStringTest
 
         Assert.AreEqual(expectedString, move.ToEPDString());
     }
+
+    [TestCase("3K4/8/8/3k4/8/8/2Q1Q3/R6R w - - 0 1", Piece.R, BoardSquare.d1, "Rad1", "Rhd1")]
+    [TestCase("3k4/2R1R1N1/3K4/8/3N4/8/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "Nde6", "Nge6")]
+    [TestCase("3k4/2R1R1N1/3K4/6N1/8/8/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "N5e6", "N7e6")]
+    [TestCase("3k4/2R1R1N1/4q3/6N1/8/4K3/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "N5xe6", "N7xe6")]
+    [TestCase("6QQ/7Q/8/8/8/8/8/3k1K2 w - - 0 1", Piece.Q, BoardSquare.g7, "Q7g7", "Qgg7", "Qh8g7")]
+    // Cases with pinned pieces
+    [TestCase("3k4/2R1R1N1/8/2b5/3N4/4K3/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "Ne6")]
+    [TestCase("3k4/2R1R1N1/8/3K2Nr/8/8/8/8 w - - 1 1", Piece.N, BoardSquare.e6, "Ne6")]
+    [TestCase("3k4/2R1R1N1/7b/6N1/8/8/3K4/8 w - - 1 1", Piece.N, BoardSquare.e6, "Ne6")]
+    [TestCase("8/4K3/4QQ2/5Qb1/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Qee5", "Qfe5")]
+    [TestCase("8/5K2/4QQ2/3b1Q2/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Q5e5", "Q6e5")]
+    public void ToStrictEPDString(string fen, Piece piece, BoardSquare targetSquare, string m0, string? m1 = default, string? m2 = default)
+    {
+        var position = new Position(fen);
+
+        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
+        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves).ToArray();
+
+        var ambiguousMoves = pseudoLegalMoves
+            .Where(m => m.Piece() == (int)piece && m.TargetSquare() == (int)targetSquare)
+            .Where(m =>
+            {
+                var gameState = position.MakeMove(m);
+                var isLegal = position.WasProduceByAValidMove();
+                position.UnmakeMove(m, gameState);
+
+                return isLegal;
+            })
+            .Select(m => m.ToEPDString(position))
+            .OrderBy(m => m)
+            .ToList();
+
+        Assert.AreEqual(m0, ambiguousMoves[0]);
+        if (m1 == default)
+        {
+            Assert.AreEqual(1, ambiguousMoves.Count);
+        }
+        else
+        {
+            Assert.AreEqual(m1, ambiguousMoves[1]);
+
+            if (m2 == default)
+            {
+                Assert.AreEqual(2, ambiguousMoves.Count);
+            }
+            else
+            {
+                Assert.AreEqual(3, ambiguousMoves.Count);
+                Assert.AreEqual(m2, ambiguousMoves[2]);
+            }
+        }
+    }
 }

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -14,7 +14,7 @@ public class MoveToEPDStringTest
     [TestCase("dxe5", (int)BoardSquare.d4, (int)BoardSquare.e5, (int)Piece.P, default, 1)]
     [TestCase("Bxe5", (int)BoardSquare.d4, (int)BoardSquare.e5, (int)Piece.B, default, 1)]
     [TestCase("Nxe5", (int)BoardSquare.d3, (int)BoardSquare.e5, (int)Piece.N, default, 1)]
-    [TestCase("dxe7e.p.", (int)BoardSquare.d6, (int)BoardSquare.e7, (int)Piece.P, default, 1, default, 1)]
+    [TestCase("dxe7", (int)BoardSquare.d6, (int)BoardSquare.e7, (int)Piece.P, default, 1, default, 1)]
     public void ToEPDString(string expectedString, int sourceSquare, int targetSquare, int piece,
         int promotedPiece = default,
         int isCapture = default, int isDoublePawnPush = default, int isEnPassant = default,
@@ -66,12 +66,13 @@ public class MoveToEPDStringTest
 #pragma warning restore CS0618 // Type or member is obsolete
     }
 
+    // Ambiguous move
     [TestCase("3K4/8/8/3k4/8/8/2Q1Q3/R6R w - - 0 1", Piece.R, BoardSquare.d1, "Rad1", "Rhd1")]
     [TestCase("3k4/2R1R1N1/3K4/8/3N4/8/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "Nde6", "Nge6")]
     [TestCase("3k4/2R1R1N1/3K4/6N1/8/8/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "N5e6", "N7e6")]
     [TestCase("3k4/2R1R1N1/4q3/6N1/8/4K3/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "N5xe6", "N7xe6")]
     [TestCase("6QQ/7Q/8/8/8/8/8/3k1K2 w - - 0 1", Piece.Q, BoardSquare.g7, "Q7g7", "Qgg7", "Qh8g7")]
-    // Cases with pinned pieces
+    // Not ambiguous moves because of pinned pieces
     [TestCase("3k4/2R1R1N1/8/2b5/3N4/4K3/8/8 w - - 0 1", Piece.N, BoardSquare.e6, "Ne6")]
     [TestCase("3k4/2R1R1N1/8/3K2Nr/8/8/8/8 w - - 1 1", Piece.N, BoardSquare.e6, "Ne6")]
     [TestCase("3k4/2R1R1N1/7b/6N1/8/8/3K4/8 w - - 1 1", Piece.N, BoardSquare.e6, "Ne6")]
@@ -79,8 +80,15 @@ public class MoveToEPDStringTest
     [TestCase("8/5K2/4QQ2/3b1Q2/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Q5e5", "Q6e5")]
     // Pawn captures, where file is included instead of piece
     [TestCase("3rr1k1/5ppp/p1p5/1P6/8/Q2B4/PK6/3b4 b - - 0 33", Piece.p, BoardSquare.b5, "axb5", "cxb5")]
+    // En-passant
     [TestCase("rnbqkbnr/1pp2p2/p3p2p/2PpP1p1/3P4/8/PP3PPP/RNBQKBNR w KQkq d6 0 6", Piece.P, BoardSquare.d6, "cxd6", "exd6")]
-    public void ToStrictEPDString(string fen, Piece piece, BoardSquare targetSquare, string m0, string? m1 = default, string? m2 = default)
+    // Promotion
+    [TestCase("3k4/P7/8/8/8/8/p7/3K4 b - - 0 1", Piece.p, BoardSquare.a1, "a1=B", "a1=N", "a1=Q", "a1=R")]
+    [TestCase("r2k3r/8/8/8/8/8/8/R3K2R w KQkq - 0 1", Piece.K, BoardSquare.g1, "O-O")]
+    [TestCase("r2k3r/8/8/8/8/8/8/R3K2R w KQkq - 0 1", Piece.K, BoardSquare.c1, "O-O-O")]
+    [TestCase("r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 0 1", Piece.k, BoardSquare.g8, "O-O")]
+    [TestCase("r3k2r/8/8/8/8/8/8/R3K2R b KQkq - 0 1", Piece.k, BoardSquare.c8, "O-O-O")]
+    public void ToStrictEPDString(string fen, Piece piece, BoardSquare targetSquare, string m0, string? m1 = default, string? m2 = default, string? m3 = default)
     {
         var position = new Position(fen);
 
@@ -116,8 +124,17 @@ public class MoveToEPDStringTest
             }
             else
             {
-                Assert.AreEqual(3, ambiguousMoves.Count);
                 Assert.AreEqual(m2, ambiguousMoves[2]);
+
+                if (m3 == default)
+                {
+                    Assert.AreEqual(3, ambiguousMoves.Count);
+                }
+                else
+                {
+                    Assert.AreEqual(4, ambiguousMoves.Count);
+                    Assert.AreEqual(m3, ambiguousMoves[3]);
+                }
             }
         }
     }

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -79,7 +79,7 @@ public class MoveToEPDStringTest
     [TestCase("8/5K2/4QQ2/3b1Q2/8/8/8/3k4 w - - 0 1", Piece.Q, BoardSquare.e5, "Q5e5", "Q6e5")]
     // Pawn captures, where file is included instead of piece
     [TestCase("3rr1k1/5ppp/p1p5/1P6/8/Q2B4/PK6/3b4 b - - 0 33", Piece.p, BoardSquare.b5, "axb5", "cxb5")]
-    [TestCase("rnbqkbnr/1pp2p2/p3p2p/2PpP1p1/3P4/8/PP3PPP/RNBQKBNR w KQkq d6 0 6", Piece.P, BoardSquare.d6, "cxd6 e.p.", "exd6 e.p.")]
+    [TestCase("rnbqkbnr/1pp2p2/p3p2p/2PpP1p1/3P4/8/PP3PPP/RNBQKBNR w KQkq d6 0 6", Piece.P, BoardSquare.d6, "cxd6", "exd6")]
     public void ToStrictEPDString(string fen, Piece piece, BoardSquare targetSquare, string m0, string? m1 = default, string? m2 = default)
     {
         var position = new Position(fen);


### PR DESCRIPTION
- Remove `e.p.` for en-passant moves
- Use `O` instead of `o` for castling moves
- Replace existing `ToEPDString()` method with one that accepts a `Position`. Keep the former as internal. This allows to:
  - Disambiguate `.ToEPDString()` result when both piece types and target squares match
- Remove `.ToMoveString()` method, because it's just confusing and a mixture between wanting the speed of UCI but in a easier to read but still not human form.

Fixes #840 