### PR TITLE
🔍 LMP: Add min phase condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -257,6 +257,7 @@ public sealed partial class Engine
                     // Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
+                        && phase > 2
                         && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                     {
                         // After making a move


### PR DESCRIPTION
```
Test  | lmp/min-phase
Elo   | -1.22 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 28410: +8865 -8965 =10580
Penta | [1039, 3137, 5863, 3217, 949]
https://openbench.lynx-chess.com/test/438/
```