### PR TITLE
🔍 LMP: Add min pawns count condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -67,6 +67,8 @@ public sealed partial class Engine
 
         bool isInCheck = position.IsInCheck();
         int staticEval = int.MaxValue, phase = int.MaxValue;
+        var offset = Utils.PieceOffset(position.Side);
+        var friendlyPawnsCount = position.PieceBitBoards[offset].CountBits();
 
         if (isInCheck)
         {
@@ -257,7 +259,7 @@ public sealed partial class Engine
                     // Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && phase > 2
+                        && friendlyPawnsCount >= 1
                         && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                     {
                         // After making a move

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -257,6 +257,7 @@ public sealed partial class Engine
                     // Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
+                        && phase > 2
                         && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                     {
                         // After making a move


### PR DESCRIPTION
```
Test  | lmp/min-pawns
Elo   | -0.95 +- 2.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 31910: +9933 -10020 =11957
Penta | [1090, 3525, 6781, 3500, 1059]
https://openbench.lynx-chess.com/test/439/
```