### PR TITLE
🧪 Pruning: `!isPv` ->`!isRoot`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -251,7 +251,7 @@ public sealed partial class Engine
             }
             else
             {
-                if (!pvNode && !isInCheck
+                if (!isRoot && !isInCheck
                     && scores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
                 {
                     // Late Move Pruning (LMP) - all quiet moves can be pruned


### PR DESCRIPTION
```
Test  | experiment/pruning-is-root
Elo   | -81.53 +- 18.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 972: +213 -437 =322
Penta | [97, 140, 163, 62, 24]
https://openbench.lynx-chess.com/test/440/
```