### PR TITLE
⚡ Micro-optimization in `MoveGenerator.IsAnyPieceMoveValid`

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -685,10 +685,12 @@ public static class MoveGenerator
                 targetSquare = attacks.GetLS1BIndex();
                 attacks.ResetLS1B();
 
-                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare)
-                    && IsValidMove(position, MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece)))
+                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
                 {
-                    return true;
+                    if(IsValidMove(position, MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece)))
+                    {
+                        return true;
+                    }
                 }
                 else if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece)))
                 {


### PR DESCRIPTION
This is also an enabler for further changes which assume that no pseudolegal move without a capture is generated when the target square has a piece.

```
Test  | perf/valid-moves-2
Elo   | 1.20 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | 32020: +10006 -9895 =12119
Penta | [1062, 3448, 6909, 3499, 1092]
https://openbench.lynx-chess.com/test/442/
```