### PR TITLE
⚡ Optimize `MoveGenerator.GeneratePieceCaptures()`

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -435,6 +435,7 @@ public static class MoveGenerator
     internal static void GeneratePieceCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position, int offset)
     {
         var bitboard = position.PieceBitBoards[piece];
+        var oppositeSide = (int)Utils.OppositeSide(position.Side);
         int sourceSquare, targetSquare;
 
         while (bitboard != default)
@@ -443,18 +444,15 @@ public static class MoveGenerator
             bitboard.ResetLS1B();
 
             var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-                & ~position.OccupancyBitBoards[(int)position.Side];
+                & position.OccupancyBitBoards[oppositeSide];
 
             while (attacks != default)
             {
                 targetSquare = attacks.GetLS1BIndex();
                 attacks.ResetLS1B();
 
-                if (position.OccupancyBitBoards[(int)Side.Both].GetBit(targetSquare))
-                {
-                    var capturedPiece = FindCapturedPiece(position, offset, targetSquare);
-                    movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece: capturedPiece);
-                }
+                var capturedPiece = FindCapturedPiece(position, offset, targetSquare);
+                movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece: capturedPiece);
             }
         }
     }


### PR DESCRIPTION
Only take into account attacks that land on an opponent piece.

```
Test  | perf/capture-generation
Elo   | 10.13 +- 6.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 5626: +1828 -1664 =2134
Penta | [163, 576, 1210, 662, 202]
https://openbench.lynx-chess.com/test/447/
```