### PR TITLE
⚡ Make search config params constant

### DIFF
--- a/src/Lynx.Benchmark/UCI_Benchmark.cs
+++ b/src/Lynx.Benchmark/UCI_Benchmark.cs
@@ -45,6 +45,6 @@ public class UCI_Benchmark : BaseBenchmark
     public (long, long) Bench_DefaultDepth()
     {
         var engine = new Engine(_channel.Writer);
-        return engine.Bench(Configuration.EngineSettings.BenchDepth);
+        return engine.Bench(EngineSettings.BenchDepth);
     }
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -6,8 +6,8 @@ namespace Lynx;
 
 public static class Configuration
 {
-    public static EngineSettings EngineSettings { get; set; } = new EngineSettings();
-    public static GeneralSettings GeneralSettings { get; set; } = new GeneralSettings();
+    public static EngineSettings EngineSettings { get; } = new EngineSettings();
+    public static GeneralSettings GeneralSettings { get; } = new GeneralSettings();
 
     private static int _isDebug = 0;
 #pragma warning disable IDE1006 // Naming Styles
@@ -55,9 +55,9 @@ public static class Configuration
 
 public sealed class GeneralSettings
 {
-    public bool EnableLogging { get; set; } = false;
+    public bool EnableLogging = false;
 
-    public bool EnableTuning { get; set; } = false;
+    public bool EnableTuning = false;
 }
 
 public sealed class EngineSettings
@@ -68,124 +68,101 @@ public sealed class EngineSettings
     /// <summary>
     /// Depth for bench command
     /// </summary>
-    public int BenchDepth { get; set; } = 10;
+    public const int BenchDepth = 10;
 
     /// <summary>
     /// MB
     /// </summary>
-    public int TranspositionTableSize { get; set; } = 256;
+    public int TranspositionTableSize = 256;
 
-    public bool UseOnlineTablebaseInRootPositions { get; set; } = false;
+    public bool UseOnlineTablebaseInRootPositions = false;
 
     /// <summary>
     /// Experimental, might misbehave due to tablebase API limits
     /// </summary>
-    public bool UseOnlineTablebaseInSearch { get; set; } = false;
+    public bool UseOnlineTablebaseInSearch = false;
 
     /// <summary>
     /// This can also de used to reduce online probing
     /// </summary>
-    public int OnlineTablebaseMaxSupportedPieces { get; set; } = 7;
+    public const int OnlineTablebaseMaxSupportedPieces = 7;
 
-    public bool ShowWDL { get; set; } = false;
+    public bool ShowWDL = false;
 
-    public bool IsPonder { get; set; } = false;
+    public bool IsPonder = false;
 
-    public double SPSA_OB_R_end { get; set; } = 0.02;
+    public const double SPSA_OB_R_end = 0.02;
 
     #region Time management
 
-    public double HardTimeBoundMultiplier { get; set; } = 0.52;
+    public const double HardTimeBoundMultiplier = 0.52;
 
-    public double SoftTimeBoundMultiplier { get; set; } = 1;
+    public const double SoftTimeBoundMultiplier = 1;
 
-    public int DefaultMovesToGo { get; set; } = 45;
+    public const int DefaultMovesToGo = 45;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
+    public const double SoftTimeBaseIncrementMultiplier = 0.8;
 
     #endregion
 
-    [SPSAAttribute<int>(3, 10, 0.5)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public const int LMR_MinDepth = 3;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
+    public const int LMR_MinFullDepthSearchedMoves = 4;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
-    [SPSAAttribute<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.91;
+    public const double LMR_Base = 0.91;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
-    [SPSAAttribute<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.42;
+    public const double LMR_Divisor = 3.42;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int NMP_MinDepth { get; set; } = 2;
+    public const int NMP_MinDepth = 2;
 
-    [SPSAAttribute<int>(1, 5, 0.5)]
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public const int NMP_BaseDepthReduction = 2;
 
-    [SPSAAttribute<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public const int NMP_DepthIncrement = 1;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public const int NMP_DepthDivisor = 4;
 
-    [SPSAAttribute<int>(1, 100, 5)]
-    public int AspirationWindow_Delta { get; set; } = 13;
+    public const int AspirationWindow_Delta = 13;
 
-    [SPSAAttribute<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 8;
+    public const int AspirationWindow_MinDepth = 8;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public const int RFP_MaxDepth = 6;
 
-    [SPSAAttribute<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 82;
+    public const int RFP_DepthScalingFactor = 82;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public const int Razoring_MaxDepth = 1;
 
-    [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 129;
+    public const int Razoring_Depth1Bonus = 129;
 
-    [SPSAAttribute<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 178;
+    public const int Razoring_NotDepth1Bonus = 178;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 3;
+    public const int IIR_MinDepth = 3;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 7;
+    public const int LMP_MaxDepth = 7;
 
-    [SPSAAttribute<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public const int LMP_BaseMovesToTry = 0;
 
-    [SPSAAttribute<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 4;
+    public const int LMP_MovesDepthMultiplier = 4;
 
-    public int History_MaxMoveValue { get; set; } = 8_192;
+    public const int History_MaxMoveValue = 8_192;
 
     /// <summary>
     /// 1896: constant from depth 12
     /// </summary>
-    public int History_MaxMoveRawBonus { get; set; } = 1_896;
+    public const int History_MaxMoveRawBonus = 1_896;
 
-    [SPSAAttribute<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public const int SEE_BadCaptureReduction = 2;
 
-    [SPSAAttribute<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public const int FP_MaxDepth = 5;
 
-    [SPSAAttribute<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 78;
+    public const int FP_DepthScalingFactor = 78;
 
-    [SPSAAttribute<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 129;
+    public const int FP_Margin = 129;
 
     #region Evaluation
 
@@ -220,34 +197,34 @@ public sealed class EngineSettings
             new(0, 0));
 
     public TaperedEvaluationTermByCount27 VirtualKingMobilityBonus { get; set; } = new(
-            new(0, 0),
-            new(0, 0),
-            new(0, 0),
-            new(37, -5),
-            new(51, -8),
-            new(24, 24),
-            new(22, 13),
-            new(19, 3),
-            new(15, 6),
-            new(11, 5),
-            new(9, 9),
-            new(2, 13),
-            new(0, 9),
-            new(-5, 12),
-            new(-15, 15),
-            new(-26, 18),
-            new(-35, 15),
-            new(-46, 12),
-            new(-52, 10),
-            new(-60, 3),
-            new(-51, -5),
-            new(-46, -13),
-            new(-44, -24),
-            new(-39, -34),
-            new(-45, -44),
-            new(-22, -65),
-            new(-62, -72),
-            new(-36, -90));
+                new(0, 0),
+                new(0, 0),
+                new(0, 0),
+                new(37, -5),
+                new(51, -8),
+                new(24, 24),
+                new(22, 13),
+                new(19, 3),
+                new(15, 6),
+                new(11, 5),
+                new(9, 9),
+                new(2, 13),
+                new(0, 9),
+                new(-5, 12),
+                new(-15, 15),
+                new(-26, 18),
+                new(-35, 15),
+                new(-46, 12),
+                new(-52, 10),
+                new(-60, 3),
+                new(-51, -5),
+                new(-46, -13),
+                new(-44, -24),
+                new(-39, -34),
+                new(-45, -44),
+                new(-22, -65),
+                new(-62, -72),
+                new(-36, -90));
 
     public TaperedEvaluationTermByCount8 KnightMobilityBonus { get; set; } = new(
             new(0, 0),

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -198,16 +198,16 @@ public sealed partial class Engine
                 const int minSearchTime = 50;
 
                 var movesDivisor = goCommand.MovesToGo == 0
-                    ? Configuration.EngineSettings.DefaultMovesToGo
+                    ? EngineSettings.DefaultMovesToGo
                     : goCommand.MovesToGo;
 
                 millisecondsLeft -= engineGuiCommunicationTimeOverhead;
                 millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
 
-                hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
+                hardLimitTimeBound = (int)(millisecondsLeft * EngineSettings.HardTimeBoundMultiplier);
 
-                var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * Configuration.EngineSettings.SoftTimeBaseIncrementMultiplier);
-                softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * Configuration.EngineSettings.SoftTimeBoundMultiplier));
+                var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * EngineSettings.SoftTimeBaseIncrementMultiplier);
+                softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * EngineSettings.SoftTimeBoundMultiplier));
 
                 _logger.Info("Soft time bound: {0}s", 0.001 * softLimitTimeBound);
                 _logger.Info("Hard time bound: {0}s", 0.001 * hardLimitTimeBound);
@@ -261,7 +261,7 @@ public sealed partial class Engine
 
     private async ValueTask<SearchResult> SearchBestMove(int maxDepth, int softLimitTimeBound)
     {
-        if (!Configuration.EngineSettings.UseOnlineTablebaseInRootPositions || Game.CurrentPosition.CountPieces() > Configuration.EngineSettings.OnlineTablebaseMaxSupportedPieces)
+        if (!Configuration.EngineSettings.UseOnlineTablebaseInRootPositions || Game.CurrentPosition.CountPieces() > EngineSettings.OnlineTablebaseMaxSupportedPieces)
         {
             return IDDFS(maxDepth, softLimitTimeBound)!;
         }

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -269,11 +269,11 @@ internal static readonly short[] EndGameKingTable =
             for (int movesSearchedCount = 1; movesSearchedCount < Constants.MaxNumberOfPossibleMovesInAPosition; ++movesSearchedCount) // movesSearchedCount > 0 or we wouldn't be applying LMR
             {
                 LMRReductions[searchDepth][movesSearchedCount] = Convert.ToInt32(Math.Round(
-                    Configuration.EngineSettings.LMR_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Divisor)));
+                    EngineSettings.LMR_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / EngineSettings.LMR_Divisor)));
             }
 
             HistoryBonus[searchDepth] = Math.Min(
-                Configuration.EngineSettings.History_MaxMoveRawBonus,
+                EngineSettings.History_MaxMoveRawBonus,
                 (4 * searchDepth * searchDepth) + (120 * searchDepth) - 120);   // Sirius, originally from Berserk
         }
     }

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -350,7 +350,7 @@ public static class OnlineTablebaseProber
 
     public static int EvaluationSearch(Position position, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
-        if (!Configuration.EngineSettings.UseOnlineTablebaseInSearch || position.CountPieces() > Configuration.EngineSettings.OnlineTablebaseMaxSupportedPieces)
+        if (!Configuration.EngineSettings.UseOnlineTablebaseInSearch || position.CountPieces() > EngineSettings.OnlineTablebaseMaxSupportedPieces)
         {
             return NoResult;
         }

--- a/src/Lynx/SPSAAttribute.cs
+++ b/src/Lynx/SPSAAttribute.cs
@@ -55,7 +55,7 @@ internal class SPSAAttribute<T> : Attribute
     {
         T val = GetPropertyValue(property);
 
-        return $"{property.Name}, int, {val}, {MinValue}, {MaxValue}, {Step}, {Configuration.EngineSettings.SPSA_OB_R_end}";
+        return $"{property.Name}, int, {val}, {MinValue}, {MaxValue}, {Step}, {EngineSettings.SPSA_OB_R_end}";
     }
 
     internal static T GetPropertyValue(PropertyInfo property)
@@ -75,7 +75,7 @@ internal class SPSAAttribute<T> : Attribute
         T val = GetPropertyValue(property);
         var percentage = 100 * (Step / double.Parse((MaxValue - MinValue).ToString()!));
 
-        return $"{property.Name,-35} {"int",-5} {val,-5} {MinValue,-5} {MaxValue,-5} {Step,-5} {$"{percentage:F2}%",-8}{Configuration.EngineSettings.SPSA_OB_R_end,-5}";
+        return $"{property.Name,-35} {"int",-5} {val,-5} {MinValue,-5} {MaxValue,-5} {Step,-5} {$"{percentage:F2}%",-8}{EngineSettings.SPSA_OB_R_end,-5}";
     }
 
     public KeyValuePair<string, JsonNode?> ToWeatherFactoryString(PropertyInfo property)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -107,7 +107,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus)
     {
-        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
+        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / EngineSettings.History_MaxMoveValue);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -100,14 +100,14 @@ public sealed partial class Engine
                 _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                 _nodes = 0;
 
-                if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth || lastSearchResult?.Evaluation is null)
+                if (depth < EngineSettings.AspirationWindow_MinDepth || lastSearchResult?.Evaluation is null)
                 {
                     bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
                 }
                 else
                 {
                     // 🔍 Aspiration Windows
-                    var window = Configuration.EngineSettings.AspirationWindow_Delta;
+                    var window = EngineSettings.AspirationWindow_Delta;
 
                     alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
                     beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -269,196 +269,197 @@ public sealed class UCIHandler
 
             #region Search tuning
 
-            case "lmr_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMR_MinDepth = value;
-                    }
-                    break;
-                }
-            case "lmr_minfulldepthsearchedmoves":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves = value;
-                    }
-                    break;
-                }
-            case "lmr_base":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMR_Base = (value * 0.01);
-                    }
-                    break;
-                }
-            case "lmr_divisor":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMR_Divisor = (value * 0.01);
-                    }
-                    break;
-                }
+            //case "lmr_mindepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMR_MinDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "lmr_minfulldepthsearchedmoves":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves = value;
+            //        }
+            //        break;
+            //    }
+            //case "lmr_base":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMR_Base = (value * 0.01);
+            //        }
+            //        break;
+            //    }
+            //case "lmr_divisor":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMR_Divisor = (value * 0.01);
+            //        }
+            //        break;
+            //    }
 
-            case "nmp_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.NMP_MinDepth = value;
-                    }
-                    break;
-                }
-            case "nmp_basedepthreduction":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.NMP_BaseDepthReduction = value;
-                    }
-                    break;
-                }
-            case "nmp_depthincrement":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.NMP_DepthIncrement = value;
-                    }
-                    break;
-                }
-            case "nmp_depthdivisor":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.NMP_DepthDivisor = value;
-                    }
-                    break;
-                }
+            //case "nmp_mindepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.NMP_MinDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "nmp_basedepthreduction":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.NMP_BaseDepthReduction = value;
+            //        }
+            //        break;
+            //    }
+            //case "nmp_depthincrement":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.NMP_DepthIncrement = value;
+            //        }
+            //        break;
+            //    }
+            //case "nmp_depthdivisor":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.NMP_DepthDivisor = value;
+            //        }
+            //        break;
+            //    }
 
-            case "aspirationwindow_delta":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.AspirationWindow_Delta = value;
-                    }
-                    break;
-                }
-            case "aspirationwindow_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.AspirationWindow_MinDepth = value;
-                    }
-                    break;
-                }
+            //case "aspirationwindow_delta":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.AspirationWindow_Delta = value;
+            //        }
+            //        break;
+            //    }
+            //case "aspirationwindow_mindepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.AspirationWindow_MinDepth = value;
+            //        }
+            //        break;
+            //    }
 
-            case "rfp_maxdepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.RFP_MaxDepth = value;
-                    }
-                    break;
-                }
-            case "rfp_depthscalingfactor":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.RFP_DepthScalingFactor = value;
-                    }
-                    break;
-                }
+            //case "rfp_maxdepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.RFP_MaxDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "rfp_depthscalingfactor":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.RFP_DepthScalingFactor = value;
+            //        }
+            //        break;
+            //    }
 
-            case "razoring_maxdepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_MaxDepth = value;
-                    }
-                    break;
-                }
-            case "razoring_depth1bonus":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_Depth1Bonus = value;
-                    }
-                    break;
-                }
-            case "razoring_notdepth1bonus":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_NotDepth1Bonus = value;
-                    }
-                    break;
-                }
+            //case "razoring_maxdepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.Razoring_MaxDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "razoring_depth1bonus":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.Razoring_Depth1Bonus = value;
+            //        }
+            //        break;
+            //    }
+            //case "razoring_notdepth1bonus":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.Razoring_NotDepth1Bonus = value;
+            //        }
+            //        break;
+            //    }
 
-            case "iir_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.IIR_MinDepth = value;
-                    }
-                    break;
-                }
+            //case "iir_mindepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.IIR_MinDepth = value;
+            //        }
+            //        break;
+            //    }
 
-            case "lmp_maxdepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMP_MaxDepth = value;
-                    }
-                    break;
-                }
-            case "lmp_basemovestotry":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMP_BaseMovesToTry = value;
-                    }
-                    break;
-                }
-            case "lmp_movesdepthmultiplier":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMP_MovesDepthMultiplier = value;
-                    }
-                    break;
-                }
-            case "see_badcapturereduction":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.SEE_BadCaptureReduction = value;
-                    }
-                    break;
-                }
-            case "fp_maxdepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.FP_MaxDepth = value;
-                    }
-                    break;
-                }
-            case "fp_depthscalingfactor":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.FP_DepthScalingFactor = value;
-                    }
-                    break;
-                }
-            case "fp_margin":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.FP_Margin = value;
-                    }
-                    break;
-                }
+            //case "lmp_maxdepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMP_MaxDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "lmp_basemovestotry":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMP_BaseMovesToTry = value;
+            //        }
+            //        break;
+            //    }
+            //case "lmp_movesdepthmultiplier":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.LMP_MovesDepthMultiplier = value;
+            //        }
+            //        break;
+            //    }
+            //case "see_badcapturereduction":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.SEE_BadCaptureReduction = value;
+            //        }
+            //        break;
+            //    }
+            //case "fp_maxdepth":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.FP_MaxDepth = value;
+            //        }
+            //        break;
+            //    }
+            //case "fp_depthscalingfactor":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.FP_DepthScalingFactor = value;
+            //        }
+            //        break;
+            //    }
+            //case "fp_margin":
+            //    {
+            //        if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+            //        {
+            //            Configuration.EngineSettings.FP_Margin = value;
+            //        }
+            //        break;
+            //    }
+
 
             #endregion
 
@@ -518,7 +519,7 @@ public sealed class UCIHandler
 
         if (items.Length < 2 || !int.TryParse(items[1], out int depth))
         {
-            depth = Configuration.EngineSettings.BenchDepth;
+            depth = EngineSettings.BenchDepth;
         }
         var results = _engine.Bench(depth);
         await _engine.PrintBenchResults(results);

--- a/tests/Lynx.Test/ConfigurationValuesTest.cs
+++ b/tests/Lynx.Test/ConfigurationValuesTest.cs
@@ -14,7 +14,7 @@ public class ConfigurationValuesTest
     [Test]
     public void RazoringValues()
     {
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
+        Assert.Greater(EngineSettings.RFP_MaxDepth, EngineSettings.Razoring_MaxDepth);
 
         var config = new ConfigurationBuilder()
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
@@ -24,6 +24,6 @@ public class ConfigurationValuesTest
         Assert.IsNotNull(engineSettingsSection);
         engineSettingsSection.Bind(Configuration.EngineSettings);
 
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
+        Assert.Greater(EngineSettings.RFP_MaxDepth, EngineSettings.Razoring_MaxDepth);
     }
 }


### PR DESCRIPTION
Make search config params `const`, losing the abiliy to override them via `appsettings.json` (in exchange of let's see how much of a speedup/elo).

It wins, but worth merging 'only' for that elo?
It implies creating a mess for tuining, for instance
```
Test  | perf/constant-search-params
Elo   | 4.34 +- 3.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | 18726: +5996 -5762 =6968
Penta | [583, 2011, 4020, 2087, 662]
https://openbench.lynx-chess.com/test/448/
```