### PR TITLE
🔍 Clear next ply killer moves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -36,9 +36,6 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        _killerMoves[0][ply + 1] = 0;
-        _killerMoves[1][ply + 1] = 0;
-
         bool isRoot = ply == 0;
         bool pvNode = beta - alpha > 1;
         ShortMove ttBestMove = default;
@@ -67,6 +64,9 @@ public sealed partial class Engine
 
         // Before any time-consuming operations
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+
+        _killerMoves[0][ply + 1] = 0;
+        _killerMoves[1][ply + 1] = 0;
 
         bool isInCheck = position.IsInCheck();
         int staticEval = int.MaxValue, phase = int.MaxValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -67,6 +67,7 @@ public sealed partial class Engine
 
         _killerMoves[0][ply + 1] = 0;
         _killerMoves[1][ply + 1] = 0;
+        _killerMoves[2][ply + 1] = 0;
 
         bool isInCheck = position.IsInCheck();
         int staticEval = int.MaxValue, phase = int.MaxValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -36,6 +36,9 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
+        _killerMoves[0][ply + 1] = 0;
+        _killerMoves[1][ply + 1] = 0;
+
         bool isRoot = ply == 0;
         bool pvNode = beta - alpha > 1;
         ShortMove ttBestMove = default;


### PR DESCRIPTION
Suggested by sroelants 

```
Test  | search/clear-killers-next-move
Elo   | -32.15 +- 11.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 2048: +553 -742 =753
Penta | [104, 287, 390, 180, 63]
https://openbench.lynx-chess.com/test/445/
```

```
Test  | search/clear-killers-next-move
Elo   | -28.50 +- 10.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 2248: +631 -815 =802
Penta | [111, 295, 441, 221, 56]
https://openbench.lynx-chess.com/test/446/
```

After I remembered I actually have 3 killers now:
```
Test  | search/clear-killers-next-move
Elo   | -29.13 +- 10.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 2224: +605 -791 =828
Penta | [119, 278, 442, 216, 57]
https://openbench.lynx-chess.com/test/456/
```