### PR TITLE
⚡ Flatten continuation history jagged arrays

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -3,6 +3,7 @@ using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using System.Threading.Channels;
 
 namespace Lynx;
@@ -61,28 +62,16 @@ public sealed partial class Engine
         // Update ResetEngine() after any changes here
         _quietHistory = new int[12][];
         _captureHistory = new int[12][][];
-        _continuationHistory = new int[12][]/*[]*/[][];
+        _continuationHistory = new int[12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount];
 
         for (int i = 0; i < 12; ++i)                                            // 12
         {
             _quietHistory[i] = new int[64];
             _captureHistory[i] = new int[64][];
-            _continuationHistory[i] = new int[64]/*[]*/[][];
 
             for (var j = 0; j < 64; ++j)                                        // 64
             {
                 _captureHistory[i][j] = new int[12];                            // 12
-                //_continuationHistory[i][j] = new int[2][][];
-
-                //for (int contPly = 0; contPly < 2; ++contPly)                       // 2
-                //{
-                _continuationHistory[i][j]/*[contPly]*/ = new int[12][];
-
-                for (int k = 0; k < 12; ++k)                                    // 12
-                {
-                    _continuationHistory[i][j]/*[contPly]*/[k] = new int[64];       // 64
-                }
-                //}
             }
         }
 
@@ -133,17 +122,10 @@ public sealed partial class Engine
             for (var j = 0; j < 64; ++j)
             {
                 Array.Clear(_captureHistory[i][j]);
-
-                //for (int contPly = 0; contPly < 2; ++contPly)
-                //{
-
-                for (int k = 0; k < 12; ++k)
-                {
-                    Array.Clear(_continuationHistory[i][j]/*[contPly]*/[k]);
-                }
-                //}
             }
         }
+
+        Array.Clear(_continuationHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -110,7 +110,7 @@ public sealed partial class Engine
                 //}
                 return EvaluationConstants.BaseMoveScore
                     + _quietHistory[move.Piece()][move.TargetSquare()]
-                    + _continuationHistory[move.Piece()][move.TargetSquare()]/*[0]*/[previousMove.Piece()][previousMove.TargetSquare()];
+                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
             }
 
             // History move or 0 if not found
@@ -193,6 +193,32 @@ public sealed partial class Engine
         //PrintPvTable(target: target, source: source, movesToCopy: moveCountToCopy);
         Array.Copy(_pVTable, source, _pVTable, target, moveCountToCopy);
         //PrintPvTable();
+    }
+
+
+
+    /// <summary>
+    /// [12][64][12][64][1]
+    /// </summary>
+    /// <param name="piece"></param>
+    /// <param name="targetSquare"></param>
+    /// <param name="previousMovePiece"></param>
+    /// <param name="previousMoveTargetSquare"></param>
+    /// <param name="ply"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ContinuationHistoryIndex(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
+    {
+        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
+
+        return (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset)
+            + (previousMovePiece * previousMovePieceOffset)
+            + (previousMoveTargetSquare * previousMoveTargetSquareOffset)
+            + ply;
     }
 
     #region Debugging

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -196,9 +196,8 @@ public sealed partial class Engine
     }
 
 
-
     /// <summary>
-    /// [12][64][12][64][1]
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
     /// </summary>
     /// <param name="piece"></param>
     /// <param name="targetSquare"></param>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -39,7 +39,7 @@ public sealed partial class Engine
     /// ply 0 -> Continuation move history
     /// ply 1 -> Followup move history
     /// </summary>
-    private readonly int[][]/*[]*/[][] _continuationHistory;
+    private readonly int[] _continuationHistory;
 
     /// <summary>
     /// <see cref="Configuration.EngineSettings.MaxDepth"/>x12x64,

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -34,19 +34,12 @@ public sealed partial class Engine
     private readonly int[][][] _captureHistory;
 
     /// <summary>
-    /// 12x64x2x12x64,
-    /// piece x target square x 2 ply x last piece x last target square
+    /// 12 x 64 x 12 x 64 x ContinuationHistoryPlyCount
+    /// piece x target square x last piece x last target square x plies back
     /// ply 0 -> Continuation move history
-    /// ply 1 -> Followup move history
+    /// ply 1 -> Follow-up move history
     /// </summary>
     private readonly int[] _continuationHistory;
-
-    /// <summary>
-    /// <see cref="Configuration.EngineSettings.MaxDepth"/>x12x64,
-    /// depth x piece x target square
-    /// https://discord.com/channels/1132289356011405342/1134900681401176064/1152037164415205447
-    /// </summary>
-    //private readonly int[][][] _continuationHistory;
 
     private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
     private TranspositionTable _tt = [];

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -408,8 +408,10 @@ public sealed partial class Engine
                     var previousMovePiece = previousMove.Piece();
                     var previousTargetSquare = previousMove.TargetSquare();
 
-                    _continuationHistory[piece][targetSquare]/*[0]*/[previousMovePiece][previousTargetSquare] = ScoreHistoryMove(
-                        _continuationHistory[piece][targetSquare]/*[0]*/[previousMovePiece][previousTargetSquare],
+                    var continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
+
+                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
+                        _continuationHistory[continuationHistoryIndex],
                         EvaluationConstants.HistoryBonus[depth]);
 
                     //    var previousPreviousMove = Game.MoveStack[ply - 2];
@@ -436,8 +438,10 @@ public sealed partial class Engine
                                 -EvaluationConstants.HistoryBonus[depth]);
 
                             // 🔍 Continuation history penalty / malus
-                            _continuationHistory[visitedMovePiece][visitedMoveTargetSquare]/*[0]*/[previousMovePiece][previousTargetSquare] = ScoreHistoryMove(
-                                _continuationHistory[visitedMovePiece][visitedMoveTargetSquare]/*[0]*/[previousMovePiece][previousTargetSquare],
+                            continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
+
+                            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
+                                _continuationHistory[continuationHistoryIndex],
                                 -EvaluationConstants.HistoryBonus[depth]);
                         }
                     }


### PR DESCRIPTION
- Add extra dimension for continuation history, to be able to extend existing countermove history impl. (1-ply continuation history)
- Flatten array using a helper method to calculate index

```
Test  | search/continuation-history-1-ply-arrays-index
Elo   | 9.94 +- 5.01 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 9368: +3118 -2850 =3400
Penta | [309, 945, 1970, 1089, 371]
https://openbench.lynx-chess.com/test/470/
```