### PR TITLE
⚡ Avoid `stackalloc` local initialization when allocating it for movegen

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -3,6 +3,7 @@ using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
 
@@ -151,6 +152,7 @@ public sealed partial class Engine
 #pragma warning restore S1215 // "GC.Collect" should not be called
     }
 
+    [SkipLocalsInit]
     public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -381,6 +381,7 @@ public static class MoveExtensions
 #pragma warning restore S3358 // Ternary operators should not be nested
     }
 
+    [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string UCIString(this Move move)
     {

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Lynx;
 
@@ -36,6 +37,7 @@ public static class Perft
     /// <param name="depth"></param>
     /// <param name="nodes"></param>
     /// <returns></returns>
+    [SkipLocalsInit]
     internal static long ResultsImpl(Position position, int depth, long nodes)
     {
         if (depth != 0)
@@ -58,6 +60,7 @@ public static class Perft
         return nodes + 1;
     }
 
+    [SkipLocalsInit]
     private static long DivideImpl(Position position, int depth, long nodes, Action<string> write)
     {
         if (depth != 0)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -59,6 +59,7 @@ public sealed partial class Engine
     /// <param name="maxDepth"></param>
     /// <param name="softLimitTimeBound"></param>
     /// <returns>Not null <see cref="SearchResult"/>, although made nullable in order to match online tb probing signature</returns>
+    [SkipLocalsInit]
     public SearchResult IDDFS(int maxDepth, int softLimitTimeBound)
     {
         // Cleanup
@@ -242,6 +243,7 @@ public sealed partial class Engine
         return true;
     }
 
+    [SkipLocalsInit]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool OnlyOneLegalMove(ref Move firstLegalMove, [NotNullWhen(true)] out SearchResult? result)
     {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Runtime.CompilerServices;
 
 namespace Lynx;
 
@@ -18,6 +19,7 @@ public sealed partial class Engine
     /// Defaults to the worse possible score for Side to move's opponent, Int.MaxValue
     /// </param>
     /// <returns></returns>
+    [SkipLocalsInit]
     private int NegaMax(int depth, int ply, int alpha, int beta, bool parentWasNullMove = false)
     {
         var position = Game.CurrentPosition;
@@ -505,6 +507,7 @@ public sealed partial class Engine
     /// Defaults to the works possible score for Black, Int.MaxValue
     /// </param>
     /// <returns></returns>
+    [SkipLocalsInit]
     public int QuiescenceSearch(int ply, int alpha, int beta)
     {
         var position = Game.CurrentPosition;


### PR DESCRIPTION
Sprinkle `[SkipLocalsInit]` in the methods that stackalloc for movegen

```
Test  | perf/skip-locals-init-stackalloc
Elo   | 3.92 +- 2.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 28992: +9382 -9055 =10555
Penta | [965, 3148, 6067, 3227, 1089]
https://openbench.lynx-chess.com/test/483/
```