### PR TITLE
🔍 Countermoves

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -75,6 +75,13 @@ public sealed partial class Engine
             }
         }
 
+        _counterMoves = new int[64][];
+
+        for (int i = 0; i < 64; ++i)
+        {
+            _counterMoves[i] = new int[64];
+        }
+
         InitializeTT();
 
 #if !DEBUG

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -64,13 +64,12 @@ public sealed partial class Engine
         _quietHistory = new int[12][];
         _captureHistory = new int[12][][];
         _continuationHistory = new int[12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount];
-        _counterMoves = new int[12][];
+        _counterMoves = new int[12 * 64];
 
         for (int i = 0; i < 12; ++i)                                            // 12
         {
             _quietHistory[i] = new int[64];
             _captureHistory[i] = new int[64][];
-            _counterMoves[i] = new int[64];
 
             for (var j = 0; j < 64; ++j)                                        // 64
             {
@@ -129,11 +128,7 @@ public sealed partial class Engine
         }
 
         Array.Clear(_continuationHistory);
-
-        for (int i = 0; i < _counterMoves.Length; ++i)
-        {
-            Array.Clear(_counterMoves[i]);
-        }
+        Array.Clear(_counterMoves);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -134,6 +134,11 @@ public sealed partial class Engine
 
         Array.Clear(_continuationHistory);
 
+        for (int i = 0; i < _counterMoves.Length; ++i)
+        {
+            Array.Clear(_counterMoves[i]);
+        }
+
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -63,23 +63,18 @@ public sealed partial class Engine
         _quietHistory = new int[12][];
         _captureHistory = new int[12][][];
         _continuationHistory = new int[12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount];
+        _counterMoves = new int[12][];
 
         for (int i = 0; i < 12; ++i)                                            // 12
         {
             _quietHistory[i] = new int[64];
             _captureHistory[i] = new int[64][];
+            _counterMoves[i] = new int[64];
 
             for (var j = 0; j < 64; ++j)                                        // 64
             {
                 _captureHistory[i][j] = new int[12];                            // 12
             }
-        }
-
-        _counterMoves = new int[64][];
-
-        for (int i = 0; i < 64; ++i)
-        {
-            _counterMoves[i] = new int[64];
         }
 
         InitializeTT();

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -356,10 +356,12 @@ internal static readonly short[] EndGameKingTable =
 
     public const int ThirdKillerMoveValue = 131_072;
 
-    // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
-    public const int PromotionMoveScoreValue = 65_536;
+    public const int CounterMoveValue = 65_536;
 
-    public const int BadCaptureMoveBaseScoreValue = 32_768;
+    // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
+    public const int PromotionMoveScoreValue = 32_768;
+
+    public const int BadCaptureMoveBaseScoreValue = 16_384;
 
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -100,7 +100,7 @@ public sealed partial class Engine
                 var previousMoveTargetSquare = previousMove.TargetSquare();
 
                 // Countermove
-                if (_counterMoves[previousMovePiece][previousMoveTargetSquare] == move)
+                if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
                 {
                     return EvaluationConstants.CounterMoveValue;
                 }
@@ -216,6 +216,21 @@ public sealed partial class Engine
             + (previousMovePiece * previousMovePieceOffset)
             + (previousMoveTargetSquare * previousMoveTargetSquareOffset)
             + ply;
+    }
+
+    /// <summary>
+    /// [64][64]
+    /// </summary>
+    /// <param name="previousMoveSourceSquare"></param>
+    /// <param name="previousMoveTargetSquare"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CounterMoveIndex(int previousMoveSourceSquare, int previousMoveTargetSquare)
+    {
+        const int sourceSquareOffset = 64;
+
+        return (previousMoveSourceSquare * sourceSquareOffset)
+            + previousMoveTargetSquare;
     }
 
     #region Debugging

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -96,10 +96,11 @@ public sealed partial class Engine
             {
                 var previousMove = Game.PopFromMoveStack(ply - 1);
                 Debug.Assert(previousMove != 0);
+                var previousMovePiece = previousMove.Piece();
                 var previousMoveTargetSquare = previousMove.TargetSquare();
 
                 // Countermove
-                if (_counterMoves[previousMove.SourceSquare()][previousMoveTargetSquare] == move)
+                if (_counterMoves[previousMovePiece][previousMoveTargetSquare] == move)
                 {
                     return EvaluationConstants.CounterMoveValue;
                 }
@@ -107,7 +108,7 @@ public sealed partial class Engine
                 // Counter move history
                 return EvaluationConstants.BaseMoveScore
                     + _quietHistory[move.Piece()][move.TargetSquare()]
-                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMoveTargetSquare, 0)];
+                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
             }
 
             // History move or 0 if not found

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -92,25 +92,22 @@ public sealed partial class Engine
                 return EvaluationConstants.ThirdKillerMoveValue;
             }
 
-            // Counter move history
             if (ply >= 1)
             {
                 var previousMove = Game.PopFromMoveStack(ply - 1);
                 Debug.Assert(previousMove != 0);
+                var previousMoveTargetSquare = previousMove.TargetSquare();
 
-                // Counter move and follow up history
-                //if (ply >= 2)
-                //{
-                //    var previousPreviousMove = Game.MoveStack[ply - 2];
+                // Countermove
+                if (_counterMoves[previousMove.SourceSquare()][previousMoveTargetSquare] == move)
+                {
+                    return EvaluationConstants.CounterMoveValue;
+                }
 
-                //    return EvaluationConstants.BaseMoveScore
-                //        + _quietHistory[move.Piece()][move.TargetSquare()]
-                //        + _continuationHistory[move.Piece()][move.TargetSquare()][0][previousMove.Piece()][previousMove.TargetSquare()]
-                //        + _continuationHistory[move.Piece()][move.TargetSquare()][1][previousPreviousMove.Piece()][previousPreviousMove.TargetSquare()];
-                //}
+                // Counter move history
                 return EvaluationConstants.BaseMoveScore
                     + _quietHistory[move.Piece()][move.TargetSquare()]
-                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
+                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMoveTargetSquare, 0)];
             }
 
             // History move or 0 if not found

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -22,6 +22,11 @@ public sealed partial class Engine
     ];
 
     /// <summary>
+    /// 64x64
+    /// </summary>
+    private readonly int[][] _counterMoves;
+
+    /// <summary>
     /// 12x64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -24,7 +24,7 @@ public sealed partial class Engine
     /// <summary>
     /// 12x64
     /// </summary>
-    private readonly int[][] _counterMoves;
+    private readonly int[] _counterMoves;
 
     /// <summary>
     /// 12x64

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -22,7 +22,7 @@ public sealed partial class Engine
     ];
 
     /// <summary>
-    /// 64x64
+    /// 12x64
     /// </summary>
     private readonly int[][] _counterMoves;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -459,7 +459,7 @@ public sealed partial class Engine
                         _killerMoves[0][ply] = move;
 
                         // 🔍 Countermoves
-                        _counterMoves[previousMove.SourceSquare()][previousTargetSquare] = move;
+                        _counterMoves[previousMovePiece][previousTargetSquare] = move;
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -460,7 +460,7 @@ public sealed partial class Engine
                         _killerMoves[0][ply] = move;
 
                         // 🔍 Countermoves
-                        _counterMoves[previousMovePiece][previousTargetSquare] = move;
+                        _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using NLog.Filters;
 
 namespace Lynx;
 
@@ -446,9 +447,9 @@ public sealed partial class Engine
                         }
                     }
 
-                    // 🔍 Killer moves
                     if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
                     {
+                        // 🔍 Killer moves
                         if (move != _killerMoves[1][ply])
                         {
                             _killerMoves[2][ply] = _killerMoves[1][ply];
@@ -456,6 +457,9 @@ public sealed partial class Engine
 
                         _killerMoves[1][ply] = _killerMoves[0][ply];
                         _killerMoves[0][ply] = move;
+
+                        // 🔍 Countermoves
+                        _counterMoves[previousMove.SourceSquare()][previousTargetSquare] = move;
                     }
                 }
 


### PR DESCRIPTION
✅ Identify move by `SourceSquare`, `TargetSquare`:
```
Test  | search/countermoves
Elo   | 4.89 +- 3.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 22944: +7352 -7029 =8563
Penta | [874, 2587, 4328, 2708, 975]
https://openbench.lynx-chess.com/test/478/
```

✅ Align with existing implementation of identifying moves by `Piece`, `TargetSquare`:
```
Test  | search/countermoves
Elo   | 2.01 +- 4.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 13338: +4217 -4140 =4981
Penta | [508, 1500, 2562, 1605, 494]
https://openbench.lynx-chess.com/test/485/
```

✅ Flatten countermoves array: https://github.com/lynx-chess/Lynx/pull/860 (4.49 +- 3.10)

❌ Clear countermoves per search instead of per new game
```
Test  | search/countermoves-clearing-2
Elo   | -0.38 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 45014: +14144 -14193 =16677
Penta | [1728, 5053, 8914, 5164, 1648]
https://openbench.lynx-chess.com/test/486/
```

Total:

8+0.08
```
Score of Lynx-search-countermoves-3342-win-x64 vs Lynx 3338 - main: 6644 - 6345 - 7854  [0.507] 20843
...      Lynx-search-countermoves-3342-win-x64 playing White: 4680 - 1849 - 3893  [0.636] 10422
...      Lynx-search-countermoves-3342-win-x64 playing Black: 1964 - 4496 - 3961  [0.379] 10421
...      White vs Black: 9176 - 3813 - 7854  [0.629] 20843
Elo difference: 5.0 +/- 3.7, LOS: 99.6 %, DrawRatio: 37.7 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx-search-countermoves-3342-win-x64 vs Lynx 3338 - main: 3921 - 3844 - 5535  [0.503] 13300
...      Lynx-search-countermoves-3342-win-x64 playing White: 2987 - 953 - 2711  [0.653] 6651
...      Lynx-search-countermoves-3342-win-x64 playing Black: 934 - 2891 - 2824  [0.353] 6649
...      White vs Black: 5878 - 1887 - 5535  [0.650] 13300
Elo difference: 2.0 +/- 4.5, LOS: 80.9 %, DrawRatio: 41.6 %
SPRT: llr 0.289 (10.0%), lbound -2.25, ubound 2.89

python3.exe .\sprt.py -w 3921 -l 3844 -d 5535 -e0 -5 -e1 0
ELO: 2.01 +- 4.51 [-2.49, 6.52]
LLR: 3.18 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```