### PR TITLE
⚡ Flatten countermoves array

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -75,12 +75,7 @@ public sealed partial class Engine
             }
         }
 
-        _counterMoves = new int[64][];
-
-        for (int i = 0; i < 64; ++i)
-        {
-            _counterMoves[i] = new int[64];
-        }
+        _counterMoves = new int[64 * 64];
 
         InitializeTT();
 
@@ -133,11 +128,7 @@ public sealed partial class Engine
         }
 
         Array.Clear(_continuationHistory);
-
-        for (int i = 0; i < _counterMoves.Length; ++i)
-        {
-            Array.Clear(_counterMoves[i]);
-        }
+        Array.Clear(_counterMoves);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -64,21 +64,18 @@ public sealed partial class Engine
         _quietHistory = new int[12][];
         _captureHistory = new int[12][][];
         _continuationHistory = new int[12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount];
-        _counterMoves = new int[12][];
+        _counterMoves = new int[12 * 64];
 
         for (int i = 0; i < 12; ++i)                                            // 12
         {
             _quietHistory[i] = new int[64];
             _captureHistory[i] = new int[64][];
-            _counterMoves[i] = new int[64];
 
             for (var j = 0; j < 64; ++j)                                        // 64
             {
                 _captureHistory[i][j] = new int[12];                            // 12
             }
         }
-
-        _counterMoves = new int[64 * 64];
 
         InitializeTT();
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -99,7 +99,7 @@ public sealed partial class Engine
                 var previousMoveTargetSquare = previousMove.TargetSquare();
 
                 // Countermove
-                if (_counterMoves[previousMove.SourceSquare()][previousMoveTargetSquare] == move)
+                if (_counterMoves[CounterMoveIndex(previousMove.SourceSquare(), previousMoveTargetSquare)] == move)
                 {
                     return EvaluationConstants.CounterMoveValue;
                 }
@@ -215,6 +215,21 @@ public sealed partial class Engine
             + (previousMovePiece * previousMovePieceOffset)
             + (previousMoveTargetSquare * previousMoveTargetSquareOffset)
             + ply;
+    }
+
+    /// <summary>
+    /// [64][64]
+    /// </summary>
+    /// <param name="previousMoveSourceSquare"></param>
+    /// <param name="previousMoveTargetSquare"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int CounterMoveIndex(int previousMoveSourceSquare, int previousMoveTargetSquare)
+    {
+        const int sourceSquareOffset = 64;
+
+        return (previousMoveSourceSquare * sourceSquareOffset)
+            + previousMoveTargetSquare;
     }
 
     #region Debugging

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -24,7 +24,7 @@ public sealed partial class Engine
     /// <summary>
     /// 64x64
     /// </summary>
-    private readonly int[][] _counterMoves;
+    private readonly int[] _counterMoves;
 
     /// <summary>
     /// 12x64

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -459,7 +459,7 @@ public sealed partial class Engine
                         _killerMoves[0][ply] = move;
 
                         // 🔍 Countermoves
-                        _counterMoves[previousMove.SourceSquare()][previousTargetSquare] = move;
+                        _counterMoves[CounterMoveIndex(previousMove.SourceSquare(), previousTargetSquare)] = move;
                     }
                 }
 


### PR DESCRIPTION
```
Test  | search/countermoves-flattened
Elo   | 4.49 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 23996: +7763 -7453 =8780
Penta | [799, 2546, 5072, 2708, 873]
https://openbench.lynx-chess.com/test/479/
```