### PR TITLE
🔍 Continuation history - follow-up history (2 ply)

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -380,7 +380,7 @@ internal static readonly short[] EndGameKingTable =
     /// </summary>
     public const int SingleMoveEvaluation = 200;
 
-    public const int ContinuationHistoryPlyCount = 1;
+    public const int ContinuationHistoryPlyCount = 2;
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -99,15 +99,19 @@ public sealed partial class Engine
                 Debug.Assert(previousMove != 0);
 
                 // Counter move and follow up history
-                //if (ply >= 2)
-                //{
-                //    var previousPreviousMove = Game.MoveStack[ply - 2];
+                if (ply >= 2)
+                {
+                    var piece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+                    var previousPreviousMove = Game.PopFromMoveStack(ply - 2);
+                    Debug.Assert(previousPreviousMove != 0);
 
-                //    return EvaluationConstants.BaseMoveScore
-                //        + _quietHistory[move.Piece()][move.TargetSquare()]
-                //        + _continuationHistory[move.Piece()][move.TargetSquare()][0][previousMove.Piece()][previousMove.TargetSquare()]
-                //        + _continuationHistory[move.Piece()][move.TargetSquare()][1][previousPreviousMove.Piece()][previousPreviousMove.TargetSquare()];
-                //}
+                    return EvaluationConstants.BaseMoveScore
+                        + _quietHistory[move.Piece()][move.TargetSquare()]
+                        + _continuationHistory[ContinuationHistoryIndex(piece, targetSquare, previousMove.Piece(), previousMove.TargetSquare(), 0)]
+                        + _continuationHistory[ContinuationHistoryIndex(piece, targetSquare, previousPreviousMove.Piece(), previousPreviousMove.TargetSquare(), 1)];
+                }
+
                 return EvaluationConstants.BaseMoveScore
                     + _quietHistory[move.Piece()][move.TargetSquare()]
                     + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -36,7 +36,7 @@ public sealed partial class Engine
     /// <summary>
     /// 12 x 64 x 12 x 64 x ContinuationHistoryPlyCount
     /// piece x target square x last piece x last target square x plies back
-    /// ply 0 -> Continuation move history
+    /// ply 0 -> Countermove history
     /// ply 1 -> Follow-up move history
     /// </summary>
     private readonly int[] _continuationHistory;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -403,24 +403,27 @@ public sealed partial class Engine
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 Continuation history
-                    // - Counter move history (continuation history, ply - 1)
+                    // - Countermove history (continuation history, ply - 1)
                     var previousMove = Game.PopFromMoveStack(ply - 1);
                     var previousMovePiece = previousMove.Piece();
                     var previousTargetSquare = previousMove.TargetSquare();
 
-                    var continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
+                    var counterMoveHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
 
-                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                        _continuationHistory[continuationHistoryIndex],
+                    _continuationHistory[counterMoveHistoryIndex] = ScoreHistoryMove(
+                        _continuationHistory[counterMoveHistoryIndex],
                         EvaluationConstants.HistoryBonus[depth]);
 
-                    //    var previousPreviousMove = Game.MoveStack[ply - 2];
-                    //    var previousPreviousMovePiece = previousPreviousMove.Piece();
-                    //    var previousPreviousMoveTargetSquare = previousPreviousMove.TargetSquare();
+                    // - Follow-up move history (continuation history, ply - 2)
+                    var previousPreviousMove = Game.PopFromMoveStack(ply - 2);
+                    var previousPreviousMovePiece = previousPreviousMove.Piece();
+                    var previousPreviousTargetSquare = previousPreviousMove.TargetSquare();
 
-                    //    _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare] = ScoreHistoryMove(
-                    //        _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare],
-                    //        EvaluationConstants.HistoryBonus[depth]);
+                    var followUpHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousPreviousMovePiece, previousPreviousTargetSquare, 1);
+
+                    _continuationHistory[followUpHistoryIndex] = ScoreHistoryMove(
+                        _continuationHistory[followUpHistoryIndex],
+                        EvaluationConstants.HistoryBonus[depth]);
 
                     for (int i = 0; i < visitedMovesCounter - 1; ++i)
                     {
@@ -438,10 +441,18 @@ public sealed partial class Engine
                                 -EvaluationConstants.HistoryBonus[depth]);
 
                             // 🔍 Continuation history penalty / malus
-                            continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
+                            // - Countermove history, ply - 1
+                            counterMoveHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
 
-                            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                                _continuationHistory[continuationHistoryIndex],
+                            _continuationHistory[counterMoveHistoryIndex] = ScoreHistoryMove(
+                                _continuationHistory[counterMoveHistoryIndex],
+                                -EvaluationConstants.HistoryBonus[depth]);
+
+                            // - Follow-up history, ply - 1
+                            followUpHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousPreviousMovePiece, previousPreviousTargetSquare, 1);
+
+                            _continuationHistory[followUpHistoryIndex] = ScoreHistoryMove(
+                                _continuationHistory[followUpHistoryIndex],
                                 -EvaluationConstants.HistoryBonus[depth]);
                         }
                     }


### PR DESCRIPTION
```
Test  | search/continuation-history-2-ply
Elo   | -2.63 +- 5.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.93 (-2.25, 2.89) [0.00, 3.00]
Games | 7404: +2334 -2390 =2680
Penta | [308, 844, 1431, 834, 285]
https://openbench.lynx-chess.com/test/474/
```

```
Test  | search/continuation-history-2-ply
Elo   | -6.71 +- 5.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 8186: +2364 -2522 =3300
Penta | [276, 1007, 1648, 923, 239]
https://openbench.lynx-chess.com/test/475/
```

```
Test  | search/continuation-history-2-ply-no-ops
Elo   | -5.49 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 10072: +3098 -3257 =3717
Penta | [418, 1168, 1961, 1133, 356]
https://openbench.lynx-chess.com/test/487/
```