### PR TITLE
⚡ Flatten killer moves array

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -75,6 +75,13 @@ public sealed partial class Engine
             }
         }
 
+        _killerMoves = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
+
+        for (int i = 0; i < Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin; ++i)
+        {
+            _killerMoves[i] = new Move[3];
+        }
+
         InitializeTT();
 
 #if !DEBUG

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -75,12 +75,7 @@ public sealed partial class Engine
             }
         }
 
-        _killerMoves = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
-
-        for (int i = 0; i < Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin; ++i)
-        {
-            _killerMoves[i] = new Move[3];
-        }
+        _killerMoves = new int[(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin) * 3];
 
         InitializeTT();
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -74,22 +74,22 @@ public sealed partial class Engine
 
         if (isNotQSearch)
         {
-            var thisPlyKillerMoves = _killerMoves[ply];
+            var thisPlyKillerMovesBaseIndex = ply * 3;
 
             // 1st killer move
-            if (thisPlyKillerMoves[0] == move)
+            if (_killerMoves[thisPlyKillerMovesBaseIndex] == move)
             {
                 return EvaluationConstants.FirstKillerMoveValue;
             }
 
             // 2nd killer move
-            if (thisPlyKillerMoves[1] == move)
+            if (_killerMoves[thisPlyKillerMovesBaseIndex + 1] == move)
             {
                 return EvaluationConstants.SecondKillerMoveValue;
             }
 
             // 3rd killer move
-            if (thisPlyKillerMoves[2] == move)
+            if (_killerMoves[thisPlyKillerMovesBaseIndex + 2] == move)
             {
                 return EvaluationConstants.ThirdKillerMoveValue;
             }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -74,20 +74,22 @@ public sealed partial class Engine
 
         if (isNotQSearch)
         {
+            var thisPlyKillerMoves = _killerMoves[ply];
+
             // 1st killer move
-            if (_killerMoves[0][ply] == move)
+            if (thisPlyKillerMoves[0] == move)
             {
                 return EvaluationConstants.FirstKillerMoveValue;
             }
 
             // 2nd killer move
-            if (_killerMoves[1][ply] == move)
+            if (thisPlyKillerMoves[1] == move)
             {
                 return EvaluationConstants.SecondKillerMoveValue;
             }
 
             // 3rd killer move
-            if (_killerMoves[2][ply] == move)
+            if (thisPlyKillerMoves[2] == move)
             {
                 return EvaluationConstants.ThirdKillerMoveValue;
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -12,14 +12,9 @@ public sealed partial class Engine
     private readonly Move[] _pVTable = new Move[Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2];
 
     /// <summary>
-    /// 3x<see cref="Configuration.EngineSettings.MaxDepth"/>
+    /// (<see cref="Configuration.EngineSettings.MaxDepth"/> + <see cref="Constants.ArrayDepthMargin"/> x 3
     /// </summary>
-    private readonly int[][] _killerMoves =
-    [
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin]
-    ];
+    private readonly int[][] _killerMoves;
 
     /// <summary>
     /// 12x64
@@ -90,10 +85,10 @@ public sealed partial class Engine
                 return onlyOneLegalMoveSearchResult;
             }
 
-            Debug.Assert(_killerMoves.Length == 3);
-            Array.Clear(_killerMoves[0]);
-            Array.Clear(_killerMoves[1]);
-            Array.Clear(_killerMoves[2]);
+            for (int i = 0; i < _killerMoves.Length; ++i)
+            {
+                Array.Clear(_killerMoves[i]);
+            }
             // Not clearing _quietHistory on purpose
             // Not clearing _captureHistory on purpose
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -14,7 +14,7 @@ public sealed partial class Engine
     /// <summary>
     /// (<see cref="Configuration.EngineSettings.MaxDepth"/> + <see cref="Constants.ArrayDepthMargin"/> x 3
     /// </summary>
-    private readonly int[][] _killerMoves;
+    private readonly int[] _killerMoves;
 
     /// <summary>
     /// 12x64
@@ -85,10 +85,7 @@ public sealed partial class Engine
                 return onlyOneLegalMoveSearchResult;
             }
 
-            for (int i = 0; i < _killerMoves.Length; ++i)
-            {
-                Array.Clear(_killerMoves[i]);
-            }
+            Array.Clear(_killerMoves);
             // Not clearing _quietHistory on purpose
             // Not clearing _captureHistory on purpose
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -447,16 +447,17 @@ public sealed partial class Engine
                     }
 
                     // 🔍 Killer moves
-                    var thisPlyKillerMoves = _killerMoves[ply];
-                    if (move.PromotedPiece() == default && move != thisPlyKillerMoves[0])
+                    var thisPlyKillerMovesBaseIndex = ply * 3;
+                    var firstKillerMove = _killerMoves[thisPlyKillerMovesBaseIndex];
+                    if (move.PromotedPiece() == default && move != firstKillerMove)
                     {
-                        if (move != thisPlyKillerMoves[1])
+                        if (move != _killerMoves[thisPlyKillerMovesBaseIndex + 1])
                         {
-                            thisPlyKillerMoves[2] = thisPlyKillerMoves[1];
+                            _killerMoves[thisPlyKillerMovesBaseIndex + 2] = _killerMoves[thisPlyKillerMovesBaseIndex + 1];
                         }
 
-                        thisPlyKillerMoves[1] = thisPlyKillerMoves[0];
-                        thisPlyKillerMoves[0] = move;
+                        _killerMoves[thisPlyKillerMovesBaseIndex + 1] = firstKillerMove;
+                        _killerMoves[thisPlyKillerMovesBaseIndex + 0] = move;
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -447,15 +447,16 @@ public sealed partial class Engine
                     }
 
                     // 🔍 Killer moves
-                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
+                    var thisPlyKillerMoves = _killerMoves[ply];
+                    if (move.PromotedPiece() == default && move != thisPlyKillerMoves[0])
                     {
-                        if (move != _killerMoves[1][ply])
+                        if (move != thisPlyKillerMoves[1])
                         {
-                            _killerMoves[2][ply] = _killerMoves[1][ply];
+                            thisPlyKillerMoves[2] = thisPlyKillerMoves[1];
                         }
 
-                        _killerMoves[1][ply] = _killerMoves[0][ply];
-                        _killerMoves[0][ply] = move;
+                        thisPlyKillerMoves[1] = thisPlyKillerMoves[0];
+                        thisPlyKillerMoves[0] = move;
                     }
                 }
 


### PR DESCRIPTION
```
Test  | perf/killer-moves-reverse-arrays-and-flatten
Elo   | -0.52 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 40854: +12942 -13003 =14909
Penta | [1474, 4500, 8523, 4473, 1457]
https://openbench.lynx-chess.com/test/482/
```