### PR TITLE
Split move ordering between regular search and QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -176,7 +176,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -189,7 +189,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
             }
         }
 
@@ -564,7 +564,7 @@ public sealed partial class Engine
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            scores[i] = ScoreMoveQuiescence(pseudoLegalMoves[i], ply, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)


### PR DESCRIPTION
Also attempted in https://github.com/lynx-chess/Lynx/pull/707 and https://github.com/lynx-chess/Lynx/pull/635.
I was hoping that continuation history could benefit from this, but.. not really

```
Test  | move-ordering/split-negamax-qsearch-3
Elo   | -0.07 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 57382: +18252 -18263 =20867
Penta | [2038, 6311, 12061, 6186, 2095]
https://openbench.lynx-chess.com/test/488/
```