### PR TITLE
🔍 Move countermoves after 1st killer move

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -352,11 +352,11 @@ internal static readonly short[] EndGameKingTable =
 
     public const int FirstKillerMoveValue = 524_288;
 
-    public const int SecondKillerMoveValue = 262_144;
+    public const int CounterMoveValue = 262_144;
 
-    public const int ThirdKillerMoveValue = 131_072;
+    public const int SecondKillerMoveValue = 131_072;
 
-    public const int CounterMoveValue = 65_536;
+    public const int ThirdKillerMoveValue = 65_536;
 
     // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
     public const int PromotionMoveScoreValue = 32_768;


### PR DESCRIPTION
```
Test  | search/countermoves-after-1st-killer
Elo   | -1.36 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 27118: +8443 -8549 =10126
Penta | [1064, 3133, 5220, 3129, 1013]
https://openbench.lynx-chess.com/test/492/
```