### PR TITLE
🧹 Cleanup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,18 +31,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <NoWarn>$(NoWarn),1591,S101,RCS1090,S3903,S1133</NoWarn>
+    <NoWarn>$(NoWarn),1591,S101,RCS1090,S3903,S1133,IDE0290</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
-
-  <!--<ItemGroup Condition="!$(AssemblyName.EndsWith('Test')) AND !$(AssemblyName.EndsWith('Benchmark')) AND !$(AssemblyName.EndsWith('Dev'))">
-    <PackageReference Include="ClrHeapAllocationAnalyzer" Version="3.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>-->
 
 </Project>

--- a/src/Lynx.Benchmark/CheckmateDetectionLimits_Benchmark.cs
+++ b/src/Lynx.Benchmark/CheckmateDetectionLimits_Benchmark.cs
@@ -75,7 +75,6 @@
  */
 
 using BenchmarkDotNet.Attributes;
-using Lynx.Model;
 
 namespace Lynx.Benchmark;
 

--- a/src/Lynx.Benchmark/FENGeneration_Benchmark.cs
+++ b/src/Lynx.Benchmark/FENGeneration_Benchmark.cs
@@ -201,7 +201,6 @@
 
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
-using NLog;
 using System.Text;
 
 namespace Lynx.Benchmark;

--- a/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
@@ -140,7 +140,6 @@
 
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
-using NLog;
 using System.Runtime.CompilerServices;
 
 namespace Lynx.Benchmark;

--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
@@ -145,7 +145,6 @@
 #pragma warning disable S101, S1854 // Types should be named in PascalCase
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
-using NLog;
 using System.Runtime.CompilerServices;
 
 namespace Lynx.Benchmark;

--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
@@ -150,14 +150,15 @@ using System.Runtime.CompilerServices;
 namespace Lynx.Benchmark;
 public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
 {
-    public static IEnumerable<(string, int)> Data => new[] {
-            (Constants.InitialPositionFEN, 4),
-            (Constants.TrickyTestPositionFEN, 4),
-            ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 4),
-            ("3K4/8/8/8/8/8/4p3/2k2R2 b - - 0 1", 6),
-            ("2K2r2/4P3/8/8/8/8/8/3k4 w - - 0 1", 6),
-            ("8/p7/8/1P6/K1k3p1/6P1/7P/8 w - -", 6)
-        };
+    public static IEnumerable<(string, int)> Data =>
+    [
+        (Constants.InitialPositionFEN, 4),
+        (Constants.TrickyTestPositionFEN, 4),
+        ("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10", 4),
+        ("3K4/8/8/8/8/8/4p3/2k2R2 b - - 0 1", 6),
+        ("2K2r2/4P3/8/8/8/8/8/3k4 w - - 0 1", 6),
+        ("8/p7/8/1P6/K1k3p1/6P1/7P/8 w - -", 6)
+    ];
 
     [Benchmark(Baseline = true)]
     [ArgumentsSource(nameof(Data))]
@@ -1376,8 +1377,6 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
 #endif
 
-        private const int TRUE = 1;
-
         /// <summary>
         /// Indexed by <see cref="Piece"/>.
         /// Checks are not considered
@@ -1411,7 +1410,7 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
 #if DEBUG
             if (position.Side == Side.Both)
             {
-                return new List<Move>();
+                return [];
             }
 #endif
 

--- a/src/Lynx.Benchmark/Program.cs
+++ b/src/Lynx.Benchmark/Program.cs
@@ -1,11 +1,13 @@
-﻿using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Running;
+﻿using BenchmarkDotNet.Running;
 using System.Reflection;
+#if DEBUG
+using BenchmarkDotNet.Configs;
+#endif
 
 //Lynx.Benchmark.BitBoard_Struct_ReadonlyStruct_Class_Record.SizeTest();
 
 #if DEBUG
 BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args, new DebugInProcessConfig());
 #else
-            BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
+BenchmarkSwitcher.FromAssembly(Assembly.GetExecutingAssembly()).Run(args);
 #endif

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -1,5 +1,4 @@
 ﻿using System.Diagnostics;
-using System.Threading.Channels;
 
 namespace Lynx;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -4,7 +4,6 @@ using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 using System.Threading.Channels;
 
 namespace Lynx;

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -216,7 +216,7 @@ public static class MoveExtensions
                 var actualPromotedPiece = m.PromotedPiece();
 
                 return actualPromotedPiece == promotedPiece
-                || actualPromotedPiece == promotedPiece - 6;
+                    || actualPromotedPiece == promotedPiece - 6;
             }
 
             move = candidateMoves.FirstOrDefault(predicate);

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,11 +1,8 @@
 ﻿using NLog;
-using NLog.Targets;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Intrinsics.X86;
-using System.Threading.Tasks;
 
 namespace Lynx.Model;
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -435,7 +435,7 @@ public static class MoveGenerator
     internal static void GeneratePieceCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position, int offset)
     {
         var bitboard = position.PieceBitBoards[piece];
-        var oppositeSide = (int)Utils.OppositeSide(position.Side);
+        var oppositeSide = Utils.OppositeSide(position.Side);
         int sourceSquare, targetSquare;
 
         while (bitboard != default)

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -193,7 +193,6 @@ public sealed partial class Engine
         //PrintPvTable();
     }
 
-
     /// <summary>
     /// [12][64][12][64][ContinuationHistoryPlyCount]
     /// </summary>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -172,7 +172,9 @@ public sealed partial class Engine
         catch (OperationCanceledException)
         {
             isCancelled = true;
+#pragma warning disable S6667 // Logging in a catch clause should pass the caught exception as a parameter - expected exception we want to ignore
             _logger.Info("Search cancellation requested after {0}ms (depth {1}, nodes {2}), best move will be returned", _stopWatch.ElapsedMilliseconds, depth, _nodes);
+#pragma warning restore S6667 // Logging in a catch clause should pass the caught exception as a parameter.
 
             for (int i = 0; i < lastSearchResult?.Moves.Count; ++i)
             {

--- a/src/Lynx/UCI/Commands/GUI/GoCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/GoCommand.cs
@@ -1,5 +1,4 @@
-﻿using NLog.LayoutRenderers.Wrappers;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 
 namespace Lynx.UCI.Commands.GUI;
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -610,7 +610,7 @@ public sealed class UCIHandler
     {
         const string fullMoveCounterString = " 1";
 
-        var fen = _engine.Game.CurrentPosition.FEN()[..^3] + _engine.Game.HalfMovesWithoutCaptureOrPawnMove + fullMoveCounterString;
+        var fen = _engine.Game.CurrentPosition.FEN()[..^3] + _engine.Game.HalfMovesWithoutCaptureOrPawnMove.ToString() + fullMoveCounterString;
 
         await _engineToUci.Writer.WriteAsync(fen, cancellationToken);
     }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Runtime.Intrinsics.X86;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using System.Threading;
 using System.Threading.Channels;
 
 namespace Lynx;

--- a/tests/Lynx.Test/BestMove/WACSilver200.cs
+++ b/tests/Lynx.Test/BestMove/WACSilver200.cs
@@ -64,8 +64,8 @@ public class WACSilver200 : BaseTest
 
     private static class WACData
     {
-        public static object[] Data = new object[]
-        {
+        public static object[] Data =
+        [
             new object[] {"5rk1/1ppb3p/p1pb4/6q1/3P1p1r/2P1R2P/PP1BQ1P1/5RKN w - -              ", "Rg3", "WAC.003"},
             new object[] {"r1bq2rk/pp3pbp/2p1p1pQ/7P/3P4/2PB1N2/PP3PPR/2KR4 w - -               ", "Qxh7+", "WAC.004"},
             new object[] {"5k2/6pp/p1qN4/1p1p4/3P4/2PKP2Q/PP3r2/3R4 b - -                       ", "Qc4+", "WAC.005"},
@@ -266,6 +266,6 @@ public class WACSilver200 : BaseTest
             new object[] {"3Q4/p3b1k1/2p2rPp/2q5/4B3/P2P4/7P/6RK w - -                          ", "Qh8+", "WAC.298"},
             new object[] {"b2b1r1k/3R1ppp/4qP2/4p1PQ/4P3/5B2/4N1K1/8 w - -                      ", "g6", "WAC.300"},
             new object[] {"r2q1rk1/2p2ppp/p1n2n2/Pp2p3/1P2P3/1BPPQR2/6PP/RN4K1 b - -            ", "Nd4", "WAC.301" }
-        };
+        ];
     }
 }

--- a/tests/Lynx.Test/Commands/PositionCommandTest.cs
+++ b/tests/Lynx.Test/Commands/PositionCommandTest.cs
@@ -1,8 +1,10 @@
-﻿using Lynx.Model;
-using Lynx.UCI.Commands.GUI;
+﻿using Lynx.UCI.Commands.GUI;
 using Moq;
 using NUnit.Framework;
 using System.Threading.Channels;
+#if DEBUG
+using Lynx.Model;
+#endif
 
 namespace Lynx.Test.Commands;
 

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -20,7 +20,7 @@ public class EvaluationConstantsTest
     [TestCase(-NegativeCheckmateDetectionLimit)]
     public void CheckmateDetectionLimitConstants(int checkmateDetectionLimit)
     {
-        Assert.Greater(CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth * CheckmateDepthFactor,
+        Assert.Greater(CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth * CheckmateDepthFactor),
             checkmateDetectionLimit);
 
         Assert.Greater(checkmateDetectionLimit, _sensibleEvaluation);

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -20,7 +20,7 @@ public class MoveToEPDStringTest
         int isCapture = default, int isDoublePawnPush = default, int isEnPassant = default,
         int isShortCastle = default, int isLongCastle = default)
     {
-        int move = 0;
+        int move;
 
         if (isShortCastle != default)
         {

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -525,7 +525,7 @@ public class PositionTest
             evaluation = -evaluation;
         }
 
-        Assert.AreEqual(2 * Configuration.EngineSettings.SemiOpenFileRookBonus.MG
+        Assert.AreEqual((2 * Configuration.EngineSettings.SemiOpenFileRookBonus.MG)
             + Configuration.EngineSettings.RookMobilityBonus[rookMobilitySideToMove].MG - Configuration.EngineSettings.RookMobilityBonus[rookMobilitySideNotToMove].MG,
         evaluation);
     }


### PR DESCRIPTION
- [Avoid boxing in string concatenation](https://github.com/lynx-chess/Lynx/commit/8da7b176e54398d705f8a07b3eb8cc19799c2a96), probs unnecessary because of https://github.com/dotnet/roslyn/issues/44168
- [Remove unnecessary casting](https://github.com/lynx-chess/Lynx/commit/15414fc3e578714ce15d831d2b1ddcea3c791f40)
- General cleanup + removal of `ClrHeapAllocationAnalyzer`, since it's archived and most of their analyzers were integrated into roslyn