### PR TITLE
🔍 Move countermoves after 2nd killer move 

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -354,9 +354,9 @@ internal static readonly short[] EndGameKingTable =
 
     public const int SecondKillerMoveValue = 262_144;
 
-    public const int ThirdKillerMoveValue = 131_072;
+    public const int CounterMoveValue = 131_072;
 
-    public const int CounterMoveValue = 65_536;
+    public const int ThirdKillerMoveValue = 65_536;
 
     // Revisit bad capture pruning in NegaMax.cs if order changes and promos aren't the lowest before bad captures
     public const int PromotionMoveScoreValue = 32_768;


### PR DESCRIPTION
```
Test  | search/countermoves-after-2nd-killer
Elo   | -1.76 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 23428: +7381 -7500 =8547
Penta | [946, 2712, 4523, 2581, 952]
https://openbench.lynx-chess.com/test/493/
```