### PR TITLE
⚡  Flatten MVVLVA array

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -1,4 +1,6 @@
 ﻿using Lynx.Model;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable IDE1006 // Naming Styles
 
@@ -293,7 +295,7 @@ internal static readonly short[] EndGameKingTable =
     ///      Queen              101    201    301    401    501    0
     ///       King              100    200    300    400    500    0
     /// </summary>
-    public static readonly int[][] MostValueableVictimLeastValuableAttacker =
+    private static readonly int[][] MostValueableVictimLeastValuableAttackerJagged =
     [         //    P     N     B     R      Q  K    p    n      b    r      q          k
         /* P */ [   0,    0,    0,    0,     0, 0,  1500, 4000, 4500, 5500, 11500 ], // 0],
         /* N */ [   0,    0,    0,    0,     0, 0,  1400, 3900, 4400, 5400, 11400 ], // 0],
@@ -308,6 +310,16 @@ internal static readonly short[] EndGameKingTable =
         /* q */ [1100, 3600, 4100, 5100, 11100, 0,     0,    0,    0,    0,     0 ], // 0],
         /* k */ [1000, 3500, 4001, 5000, 11000, 0,     0,    0,    0,    0,     0 ], // 0]
     ];
+
+    public static readonly ImmutableArray<int> MVVLVA =
+        MostValueableVictimLeastValuableAttackerJagged.SelectMany(victim => victim).ToImmutableArray();
+
+    /// <summary>
+    /// [12][11]
+    /// </summary>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int MVVLVAIndex(int piece, int capturedPiece) => (piece * 11) + capturedPiece;
 
     public static readonly int[] MVV_PieceValues =
     [

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -62,7 +62,7 @@ public sealed partial class Engine
             Debug.Assert(capturedPiece != (int)Piece.K && capturedPiece != (int)Piece.k, $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN()}");
 
             return baseCaptureScore
-                + EvaluationConstants.MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
+                + EvaluationConstants.MVVLVA[EvaluationConstants.MVVLVAIndex(piece, capturedPiece)]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
                 + _captureHistory[piece][move.TargetSquare()][capturedPiece];
         }
@@ -192,7 +192,6 @@ public sealed partial class Engine
         Array.Copy(_pVTable, source, _pVTable, target, moveCountToCopy);
         //PrintPvTable();
     }
-
 
     /// <summary>
     /// [12][64][12][64][ContinuationHistoryPlyCount]


### PR DESCRIPTION
```
Test  | perf/mvvlva-flatten
Elo   | -1.20 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 28606: +8987 -9086 =10533
Penta | [1091, 3059, 6007, 3150, 996]
https://openbench.lynx-chess.com/test/491/
```