### PR TITLE
🔍 Update capture history in QSearch

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -51,6 +51,7 @@
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
+    "CaptureHistory_QSearchBonusDepth": 1,
 
     "SEE_BadCaptureReduction": 2,
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -168,14 +168,20 @@ public sealed class EngineSettings
     [SPSAAttribute<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 4;
 
+    [SPSAAttribute<int>(8_192, 65_536, 8_192)]
     public int History_MaxMoveValue { get; set; } = 8_192;
-
-    public int CaptureHistory_QSearchBonusDepth { get; set; } = 1;
 
     /// <summary>
     /// 1896: constant from depth 12
     /// </summary>
+    [SPSAAttribute<int>(1, 1_896, 100)]
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
+
+    /// <summary>
+    /// See <see cref="EvaluationConstants.HistoryBonus"/> values
+    /// </summary>
+    [SPSAAttribute<int>(1, 12, 0.5)]
+    public int CaptureHistory_QSearchBonusDepth { get; set; } = 1;
 
     [SPSAAttribute<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -170,6 +170,8 @@ public sealed class EngineSettings
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
+    public int CaptureHistory_QSearchBonusDepth { get; set; } = 1;
+
     /// <summary>
     /// 1896: constant from depth 12
     /// </summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -619,6 +619,36 @@ public sealed partial class Engine
 
                 _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
 
+                if (move.IsCapture())
+                {
+                    // 🔍 Capture history
+                    var piece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+                    var capturedPiece = move.CapturedPiece();
+
+                    _captureHistory[piece][targetSquare][capturedPiece] = ScoreHistoryMove(
+                        _captureHistory[piece][targetSquare][capturedPiece],
+                        EvaluationConstants.HistoryBonus[1]);
+
+                    // TODO Capture history penalty/malus
+                    // When a capture fails high, penalize previous visited captures
+                    //for (int i = 0; i < visitedMovesCounter; ++i)
+                    //{
+                    //    var visitedMove = visitedMoves[i];
+
+                    //    if (visitedMove.IsCapture())
+                    //    {
+                    //        var visitedMovePiece = visitedMove.Piece();
+                    //        var visitedMoveTargetSquare = visitedMove.TargetSquare();
+                    //        var visitedMoveCapturedPiece = visitedMove.CapturedPiece();
+
+                    //        _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece] = ScoreHistoryMove(
+                    //            _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece],
+                    //            -EvaluationConstants.HistoryBonus[depth]);
+                    //    }
+                    //}
+                }
+
                 return evaluation; // The refutation doesn't matter, since it'll be pruned
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -628,7 +628,7 @@ public sealed partial class Engine
 
                     _captureHistory[piece][targetSquare][capturedPiece] = ScoreHistoryMove(
                         _captureHistory[piece][targetSquare][capturedPiece],
-                        EvaluationConstants.HistoryBonus[1]);
+                        EvaluationConstants.HistoryBonus[Configuration.EngineSettings.CaptureHistory_QSearchBonusDepth]);
 
                     // TODO Capture history penalty/malus
                     // When a capture fails high, penalize previous visited captures
@@ -644,7 +644,7 @@ public sealed partial class Engine
 
                     //        _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece] = ScoreHistoryMove(
                     //            _captureHistory[visitedMovePiece][visitedMoveTargetSquare][visitedMoveCapturedPiece],
-                    //            -EvaluationConstants.HistoryBonus[depth]);
+                    //            -EvaluationConstants.HistoryBonus[Configuration.EngineSettings.CaptureHistory_QSearchBonusDepth]);
                     //    }
                     //}
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -402,6 +402,31 @@ public sealed class UCIHandler
                     break;
                 }
 
+            case "history_maxmovevalue":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.History_MaxMoveValue = value;
+                    }
+                    break;
+                }
+            case "history_maxmoverawbonus":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.History_MaxMoveRawBonus = value;
+                    }
+                    break;
+                }
+            case "capturehistory_qsearchbonusdepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CaptureHistory_QSearchBonusDepth = value;
+                    }
+                    break;
+                }
+
             case "lmp_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
`=` 8+0.08, index 1
```
Test  | search/capture-history-in-qsearch
Elo   | 0.44 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 101258: +31816 -31687 =37755
Penta | [3958, 11562, 19514, 11583, 4012]
https://openbench.lynx-chess.com/test/495/
```

❌ 8+0.08, index 1 with malus (`search/capture-history-in-qsearch-with-malus`. https://github.com/lynx-chess/Lynx/commit/478fbe788cfa1308e23e71c36581122f4709a50b)
```
Test  | search/capture-history-in-qsearch-with-malus
Elo   | -0.07 +- 2.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 57488: +18301 -18312 =20875
Penta | [2303, 6639, 10914, 6542, 2346]
https://openbench.lynx-chess.com/test/497/
```

`=` 8+0.08, index 3
```
Score of Lynx-search-capture-history-in-qsearch-3377-win-x64 vs Lynx 3371 - main: 16455 - 16311 - 19704  [0.501] 52470
...      Lynx-search-capture-history-in-qsearch-3377-win-x64 playing White: 11602 - 4783 - 9850  [0.630] 26235
...      Lynx-search-capture-history-in-qsearch-3377-win-x64 playing Black: 4853 - 11528 - 9854  [0.373] 26235
...      White vs Black: 23130 - 9636 - 19704  [0.629] 52470
Elo difference: 1.0 +/- 2.3, LOS: 78.7 %, DrawRatio: 37.6 %
SPRT: llr -1.14 (-39.5%), lbound -2.25, ubound 2.89
```