### PR TITLE
⚖️ Full king bucketed PSQTs (64 buckets)

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -20,18 +20,6 @@ public static partial class EvaluationConstants
 
     public const int PSQTBucketCount = 16;
 
-    public static readonly int[] PSQTBucketLayout =
-    [
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
-    ];
-
     public static readonly int[] GamePhaseByPiece =
     [
         0, 1, 1, 2, 4, 0,

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -688,8 +688,8 @@ public class Position
         var whiteKing = PieceBitBoards[(int)Piece.K].GetLS1BIndex();
         var blackKing = PieceBitBoards[(int)Piece.k].GetLS1BIndex();
 
-        var whiteBucket = EvaluationConstants.PSQTBucketLayout[whiteKing];
-        var blackBucket = EvaluationConstants.PSQTBucketLayout[blackKing ^ 56];
+        var whiteBucket = whiteKing;
+        var blackBucket = blackKing ^ 56;
 
         for (int pieceIndex = (int)Piece.P; pieceIndex < (int)Piece.K; ++pieceIndex)
         {


### PR DESCRIPTION
8_555_554 positions (7M + 777 + 777)
❌
```
Test  | eval/psqt-64-buckets
Elo   | -619.51 +- 122.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 382: +5 -366 =11
Penta | [175, 11, 5, 0, 0]
https://openbench.lynx-chess.com/test/507/
```