### PR TITLE
⚖️ Custom buckets PSQT V (9 buckets) 

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -18,18 +18,18 @@ public static partial class EvaluationConstants
 
 #pragma warning disable IDE0055 // Discard formatting in this region
 
-    public const int PSQTBucketCount = 16;
+    public const int PSQTBucketCount = 9;
 
     public static readonly int[] PSQTBucketLayout =
     [
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         8,   9,  10,  11,  12,  13,  14,  15,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
-         0,   1,   2,   3,   4,   5,   6,   7,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        3,   3,   4,   5,   6,   7,   8,   8,
+        0,   0,   1,   1,   1,   2,   2,   2,
+        0,   0,   1,   1,   1,   2,   2,   2,
     ];
 
     public static readonly int[] GamePhaseByPiece =


### PR DESCRIPTION
```csharp
    public static readonly int[] PSQTBucketLayout =
    [
        3,   3,   4,   5,   6,   7,   8,   8,
        3,   3,   4,   5,   6,   7,   8,   8,
        3,   3,   4,   5,   6,   7,   8,   8,
        3,   3,   4,   5,   6,   7,   8,   8,
        3,   3,   4,   5,   6,   7,   8,   8,
        3,   3,   4,   5,   6,   7,   8,   8,
        0,   0,   1,   1,   1,   2,   2,   2,
        0,   0,   1,   1,   1,   2,   2,   2,
    ];
```

<details>

<Summary> Old, mistuned version</Summary>

After seeing that IV might improve main by a bit:
```
Score of Lynx-eval-psqt-custom-bucket-scheme-5-9-buckets-3430-win-x64 vs Lynx-eval-psqt-custom-bucket-scheme-4-11-buckets-3427-win-x64: 189 - 214 - 267  [0.481] 670
...      Lynx-eval-psqt-custom-bucket-scheme-5-9-buckets-3430-win-x64 playing White: 135 - 71 - 129  [0.596] 335
...      Lynx-eval-psqt-custom-bucket-scheme-5-9-buckets-3430-win-x64 playing Black: 54 - 143 - 138  [0.367] 335
...      White vs Black: 278 - 125 - 267  [0.614] 670
Elo difference: -13.0 +/- 20.4, LOS: 10.7 %, DrawRatio: 39.9 %
SPRT: llr -0.401 (-13.9%), lbound -2.25, ubound 2.89
```

</details>