### PR TITLE
🔍 SPSA WF tuning

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -25,38 +25,38 @@
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.91,
-    "LMR_Divisor": 3.42,
+    "LMR_Base": 0.67,
+    "LMR_Divisor": 3.16,
 
     "NMP_MinDepth": 2,
     "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
+    "NMP_DepthIncrement": 2,
+    "NMP_DepthDivisor": 3,
 
-    "AspirationWindow_Delta": 13,
-    "AspirationWindow_MinDepth": 8,
+    "AspirationWindow_Delta": 15,
+    "AspirationWindow_MinDepth": 7,
 
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 82,
+    "RFP_MaxDepth": 9,
+    "RFP_DepthScalingFactor": 60,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 129,
-    "Razoring_NotDepth1Bonus": 178,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 164,
+    "Razoring_NotDepth1Bonus": 183,
 
-    "IIR_MinDepth": 3,
+    "IIR_MinDepth": 4,
 
     "LMP_MaxDepth": 7,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 4,
+    "LMP_BaseMovesToTry": 1,
+    "LMP_MovesDepthMultiplier": 3,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 2,
+    "SEE_BadCaptureReduction": 3,
 
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129
+    "FP_MaxDepth": 7,
+    "FP_DepthScalingFactor": 68,
+    "FP_Margin": 103
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -23,25 +23,25 @@
     "DefaultMovesToGo": 45,
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
-    "LMR_MinDepth": 3,
+    "LMR_MinDepth": 4,
     "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.67,
-    "LMR_Divisor": 3.16,
+    "LMR_Base": 0.60,
+    "LMR_Divisor": 3.18,
 
     "NMP_MinDepth": 2,
-    "NMP_BaseDepthReduction": 2,
+    "NMP_BaseDepthReduction": 1,
     "NMP_DepthIncrement": 2,
     "NMP_DepthDivisor": 3,
 
     "AspirationWindow_Delta": 15,
-    "AspirationWindow_MinDepth": 7,
+    "AspirationWindow_MinDepth": 8,
 
     "RFP_MaxDepth": 9,
-    "RFP_DepthScalingFactor": 60,
+    "RFP_DepthScalingFactor": 51,
 
     "Razoring_MaxDepth": 2,
-    "Razoring_Depth1Bonus": 164,
-    "Razoring_NotDepth1Bonus": 183,
+    "Razoring_Depth1Bonus": 165,
+    "Razoring_NotDepth1Bonus": 189,
 
     "IIR_MinDepth": 4,
 
@@ -55,8 +55,8 @@
     "SEE_BadCaptureReduction": 3,
 
     "FP_MaxDepth": 7,
-    "FP_DepthScalingFactor": 68,
-    "FP_Margin": 103
+    "FP_DepthScalingFactor": 73,
+    "FP_Margin": 93
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -106,7 +106,7 @@ public sealed class EngineSettings
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public int LMR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
     public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
@@ -115,19 +115,19 @@ public sealed class EngineSettings
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.67;
+    public double LMR_Base { get; set; } = 0.60;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.16;
+    public double LMR_Divisor { get; set; } = 3.18;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
 
     [SPSA<int>(1, 5, 0.5)]
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
     public int NMP_DepthIncrement { get; set; } = 2;
@@ -139,22 +139,22 @@ public sealed class EngineSettings
     public int AspirationWindow_Delta { get; set; } = 15;
 
     [SPSA<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 7;
+    public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(1, 10, 0.5)]
     public int RFP_MaxDepth { get; set; } = 9;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 60;
+    public int RFP_DepthScalingFactor { get; set; } = 51;
 
     [SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 164;
+    public int Razoring_Depth1Bonus { get; set; } = 165;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 183;
+    public int Razoring_NotDepth1Bonus { get; set; } = 189;
 
     [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -182,10 +182,10 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 68;
+    public int FP_DepthScalingFactor { get; set; } = 73;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 103;
+    public int FP_Margin { get; set; } = 93;
 }
 
 public sealed class TaperedEvaluationTerm

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -115,13 +115,13 @@ public sealed class EngineSettings
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.91;
+    public double LMR_Base { get; set; } = 0.67;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.42;
+    public double LMR_Divisor { get; set; } = 3.16;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
@@ -130,43 +130,43 @@ public sealed class EngineSettings
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public int NMP_DepthIncrement { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(1, 100, 5)]
-    public int AspirationWindow_Delta { get; set; } = 13;
+    public int AspirationWindow_Delta { get; set; } = 15;
 
     [SPSA<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 8;
+    public int AspirationWindow_MinDepth { get; set; } = 7;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public int RFP_MaxDepth { get; set; } = 9;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 82;
+    public int RFP_DepthScalingFactor { get; set; } = 60;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 129;
+    public int Razoring_Depth1Bonus { get; set; } = 164;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 178;
+    public int Razoring_NotDepth1Bonus { get; set; } = 183;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 3;
+    public int IIR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public int LMP_BaseMovesToTry { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 4;
+    public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -176,16 +176,16 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 78;
+    public int FP_DepthScalingFactor { get; set; } = 68;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 129;
+    public int FP_Margin { get; set; } = 103;
 }
 
 public sealed class TaperedEvaluationTerm


### PR DESCRIPTION
Note step 1 used instead of 0.5 that engine produces

<details>

<Summary>21680 games (2598 iter)</Summary>

![image](https://github.com/user-attachments/assets/d2bc3ab6-8f6f-4dc5-bdbf-348bc9f620b0)

```json
{
   "t":21680,
   "spsa_params":{
      "a":1.0,
      "c":1.0,
      "A":200,
      "alpha":0.601,
      "gamma":0.102
   },
   "uci_params":[
      {
         "name":"LMR_MinDepth",
         "value":3.19609860088911,
         "min_value":3,
         "max_value":10,
         "step":1
      },
      {
         "name":"LMR_MinFullDepthSearchedMoves",
         "value":3.8135231070622746,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"LMR_Base",
         "value":67.31267591814883,
         "min_value":10,
         "max_value":200,
         "step":10
      },
      {
         "name":"LMR_Divisor",
         "value":316.01552142764535,
         "min_value":100,
         "max_value":500,
         "step":10
      },
      {
         "name":"NMP_MinDepth",
         "value":2.1603830754523274,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"NMP_BaseDepthReduction",
         "value":1.500176720946674,
         "min_value":1,
         "max_value":5,
         "step":1
      },
      {
         "name":"NMP_DepthIncrement",
         "value":1.809088992948925,
         "min_value":0,
         "max_value":10,
         "step":1
      },
      {
         "name":"NMP_DepthDivisor",
         "value":3.2026696120441907,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"AspirationWindow_Delta",
         "value":15.261907794308968,
         "min_value":1,
         "max_value":100,
         "step":5
      },
      {
         "name":"AspirationWindow_MinDepth",
         "value":7.32619440565353,
         "min_value":1,
         "max_value":20,
         "step":1
      },
      {
         "name":"RFP_MaxDepth",
         "value":9.250923707919595,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"RFP_DepthScalingFactor",
         "value":60.24695484684181,
         "min_value":1,
         "max_value":300,
         "step":15
      },
      {
         "name":"Razoring_MaxDepth",
         "value":1.527061163348777,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"Razoring_Depth1Bonus",
         "value":163.6798145412359,
         "min_value":1,
         "max_value":300,
         "step":15
      },
      {
         "name":"Razoring_NotDepth1Bonus",
         "value":183.1270627849615,
         "min_value":1,
         "max_value":300,
         "step":15
      },
      {
         "name":"IIR_MinDepth",
         "value":4.12584541544784,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"LMP_MaxDepth",
         "value":7.2545319657989085,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"LMP_BaseMovesToTry",
         "value":1.16937654369405,
         "min_value":0,
         "max_value":10,
         "step":1
      },
      {
         "name":"LMP_MovesDepthMultiplier",
         "value":3.0213788689460817,
         "min_value":0,
         "max_value":10,
         "step":1
      },
      {
         "name":"SEE_BadCaptureReduction",
         "value":3.3462999372192987,
         "min_value":0,
         "max_value":6,
         "step":1
      },
      {
         "name":"FP_MaxDepth",
         "value":6.884316406211213,
         "min_value":1,
         "max_value":10,
         "step":1
      },
      {
         "name":"FP_DepthScalingFactor",
         "value":68.46489727415093,
         "min_value":1,
         "max_value":200,
         "step":10
      },
      {
         "name":"FP_Margin",
         "value":102.53465891238218,
         "min_value":0,
         "max_value":500,
         "step":25
      }
   ]
}
```

</details>

```
Test  | search/re-tune
Elo   | -3.97 +- 6.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.92 (-2.25, 2.89) [0.00, 3.00]
Games | 4992: +1358 -1415 =2219
Penta | [141, 597, 1063, 568, 127]
https://openbench.lynx-chess.com/test/586/
```

-----

<details>

<Summary>~29464 games (~3683 iter)</Summary>

![image](https://github.com/user-attachments/assets/99341e0a-fdf7-437e-92fa-85b4513168df)


```json
![image](https://github.com/user-attachments/assets/310af1e5-e9b1-47d7-ae79-ba66c8c5c893)

```

</details>

```
Test  | search/re-tune
Elo   | -12.76 +- 7.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 4848: +1418 -1596 =1834
Penta | [216, 600, 922, 518, 168]
https://openbench.lynx-chess.com/test/597/
```

```
Test  | search/re-tune
Elo   | -12.89 +- 6.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 4394: +1156 -1319 =1919
Penta | [136, 566, 915, 485, 95]
https://openbench.lynx-chess.com/test/598/
```