### PR TITLE
🧹 Move eval params to its own class and make all of them `static readonly`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 
 using static Lynx.EvaluationConstants;
+using static Lynx.EvaluationParams;
 
 namespace Lynx.Model;
 

--- a/src/Lynx/TunableEvalParameters.cs
+++ b/src/Lynx/TunableEvalParameters.cs
@@ -1,7 +1,5 @@
 ﻿// 2024-8-9 2:23:22  51
 
-using System.Runtime.CompilerServices;
-
 namespace Lynx;
 
 #pragma warning disable IDE0055, IDE1006 // Discard formatting and naming styles
@@ -3007,7 +3005,10 @@ public static partial class EvaluationConstants
 			   0,	   0,	   0,	   0,	   0,	   0,	   0,	   0,
 		],
 	];
+}
 
+public static class EvaluationParams
+{
 	public static readonly TaperedEvaluationTerm IsolatedPawnPenalty = new(-19, -15);
 
 	public static readonly TaperedEvaluationTerm OpenFileRookBonus = new(42, 7);
@@ -3028,7 +3029,7 @@ public static partial class EvaluationConstants
 
 	public static readonly TaperedEvaluationTerm PieceAttackedByPawnPenalty = new(-43, -27);
 
-	public static TaperedEvaluationTermByRank PassedPawnBonus { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; } = new(
+	public static readonly TaperedEvaluationTermByRank PassedPawnBonus = new(
 		new(0, 0),
 		new(7, 15),
 		new(-0, 21),
@@ -3038,7 +3039,7 @@ public static partial class EvaluationConstants
 		new(228, 273),
 		new(0, 0));
 
-	public static TaperedEvaluationTermByCount27 VirtualKingMobilityBonus { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; } = new(
+	public static readonly TaperedEvaluationTermByCount27 VirtualKingMobilityBonus = new(
 		new(0, 0),
 		new(0, 0),
 		new(0, 0),
@@ -3068,7 +3069,7 @@ public static partial class EvaluationConstants
 		new(-16, -75),
 		new(-2, -87));
 
-	public static TaperedEvaluationTermByCount8 KnightMobilityBonus { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; } = new(
+	public static readonly TaperedEvaluationTermByCount8 KnightMobilityBonus = new(
 		new(0, 0),
 		new(20, -7),
 		new(27, 4),
@@ -3079,7 +3080,7 @@ public static partial class EvaluationConstants
 		new(29, 11),
 		new(30, 5));
 
-	public static TaperedEvaluationTermByCount14 BishopMobilityBonus { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; } = new(
+	public static readonly TaperedEvaluationTermByCount14 BishopMobilityBonus= new(
 		new(-277, -301),
 		new(0, 0),
 		new(10, -20),
@@ -3096,7 +3097,7 @@ public static partial class EvaluationConstants
 		new(86, 110),
 		new(0, 0));
 
-	public static TaperedEvaluationTermByCount14 RookMobilityBonus { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; } = new(
+	public static readonly TaperedEvaluationTermByCount14 RookMobilityBonus = new(
 		new(0, 0),
 		new(9, 24),
 		new(14, 25),

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -1,6 +1,8 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+
 using static Lynx.EvaluationConstants;
+using static Lynx.EvaluationParams;
 
 namespace Lynx.Test;
 public class EvaluationConstantsTest

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
 using static Lynx.EvaluationConstants;
+using static Lynx.EvaluationParams;
 
 namespace Lynx.Test.Model;
 


### PR DESCRIPTION
This supersedes #907 
```
Test  | eval/params-separated-class-2
Elo   | 2.35 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 11848: +3550 -3470 =4828
Penta | [317, 1332, 2599, 1306, 370]
https://openbench.lynx-chess.com/test/588/
```