### PR TITLE
⚡ Only invoke`CancellationTokenSource.Token.ThrowIfCancellationRequested()` every 1024 nodes

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -22,6 +22,7 @@
     "SoftTimeBoundMultiplier": 1,
     "DefaultMovesToGo": 45,
     "SoftTimeBaseIncrementMultiplier": 0.8,
+    "DivisibleNodesToCheckTimeLimit": 1024,
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 4,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -103,6 +103,8 @@ public sealed class EngineSettings
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
+    public int DivisibleNodesToCheckTimeLimit { get; set; } = 1024;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -32,7 +32,11 @@ public sealed partial class Engine
         }
 
         _maxDepthReached[ply] = ply;
-        _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+        if (_nodes % Configuration.EngineSettings.DivisibleNodesToCheckTimeLimit == 0)
+        {
+            _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+            _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+        }
 
         var pvIndex = PVTable.Indexes[ply];
         var nextPvIndex = PVTable.Indexes[ply + 1];
@@ -63,9 +67,6 @@ public sealed partial class Engine
                 --depth;
             }
         }
-
-        // Before any time-consuming operations
-        _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         bool isInCheck = position.IsInCheck();
         int staticEval = int.MaxValue, phase = int.MaxValue;
@@ -515,8 +516,11 @@ public sealed partial class Engine
     {
         var position = Game.CurrentPosition;
 
-        _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
-        _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+        if (_nodes % Configuration.EngineSettings.DivisibleNodesToCheckTimeLimit == 0)
+        {
+            _absoluteSearchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+            _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
+        }
 
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {


### PR DESCRIPTION
```
Test  | perf/time-checking
Elo   | -2.77 +- 3.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 16540: +4908 -5040 =6592
Penta | [550, 1838, 3575, 1808, 499]
https://openbench.lynx-chess.com/test/590/
```