### PR TITLE
⚖️ Improve endgame scaling with pawn count

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -762,63 +762,58 @@ public class Position
             gamePhase = maxPhase;
         }
 
-        int totalPawnsCount = int.MinValue;
+        int totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
 
         // Pawnless endgames with few pieces
-        if (gamePhase <= 3)
+        if (gamePhase <= 3 && totalPawnsCount == 0)
         {
-            totalPawnsCount = PieceBitBoards[(int)Piece.P].CountBits() + PieceBitBoards[(int)Piece.p].CountBits();
-
-            if (totalPawnsCount == 0)
+            switch (gamePhase)
             {
-                switch (gamePhase)
-                {
-                    //case 5:
-                    //    {
-                    //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
-                    //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
-                    //        {
-                    //            packedScore >>= 1; // /2
-                    //        }
+                //case 5:
+                //    {
+                //        // RB vs R, RN vs R - scale it down due to the chances of it being a draw
+                //        if (pieceCount[(int)Piece.R] == 1 && pieceCount[(int)Piece.r] == 1)
+                //        {
+                //            packedScore >>= 1; // /2
+                //        }
 
-                    //        break;
-                    //    }
-                    case 3:
-                        {
-                            var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
+                //        break;
+                //    }
+                case 3:
+                    {
+                        var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                            if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            // Without rooks, only BB vs N is a win and BN vs N can have some chances
-                            // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
-                            //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
-                            //{
-                            //    packedScore >>= 1; // /2
-                            //}
-
-                            break;
-                        }
-                    case 2:
-                        {
-                            var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
-
-                            if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
-                                    || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
-                            {
-                                return (0, gamePhase);
-                            }
-
-                            break;
-                        }
-                    case 1:
-                    case 0:
+                        if (PieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
                         {
                             return (0, gamePhase);
                         }
-                }
+
+                        // Without rooks, only BB vs N is a win and BN vs N can have some chances
+                        // Not taking that into account here though, we would need this to rule them out: `pieceCount[(int)Piece.b - winningSideOffset] == 1 || pieceCount[(int)Piece.B + winningSideOffset] <= 1`
+                        //if (pieceCount[(int)Piece.R + winningSideOffset] == 0)  // BN vs B, NN vs B, BB vs B, BN vs N, NN vs N
+                        //{
+                        //    packedScore >>= 1; // /2
+                        //}
+
+                        break;
+                    }
+                case 2:
+                    {
+                        var whiteKnightsCount = PieceBitBoards[(int)Piece.N].CountBits();
+
+                        if (whiteKnightsCount + PieceBitBoards[(int)Piece.n].CountBits() == 2            // NN vs -, N vs N
+                                || whiteKnightsCount + PieceBitBoards[(int)Piece.B].CountBits() == 1)    // B vs N, B vs B
+                        {
+                            return (0, gamePhase);
+                        }
+
+                        break;
+                    }
+                case 1:
+                case 0:
+                    {
+                        return (0, gamePhase);
+                    }
             }
         }
 
@@ -828,21 +823,8 @@ public class Position
         var endGameScore = Utils.UnpackEG(packedScore);
         var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
-        if (gamePhase <= 3)
-        {
-            var pawnScalingPenalty = 16 - totalPawnsCount;
-
-            if (eval > 1)
-            {
-                pawnScalingPenalty = Math.Min(eval - 1, pawnScalingPenalty);
-                eval -= pawnScalingPenalty;
-            }
-            else if (eval < -1)
-            {
-                pawnScalingPenalty = Math.Min(-eval - 1, pawnScalingPenalty);
-                eval += pawnScalingPenalty;
-            }
-        }
+        // Formula yoinked from Sirius
+        eval *= ((80 + (totalPawnsCount * 7)) / 128);
 
         eval = Math.Clamp(eval, MinEval, MaxEval);
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -824,7 +824,7 @@ public class Position
         var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
 
         // Formula yoinked from Sirius
-        eval *= ((80 + (totalPawnsCount * 7)) / 128);
+        eval = (int)(eval * ((80 + (totalPawnsCount * 7)) / 128.0));
 
         eval = Math.Clamp(eval, MinEval, MaxEval);
 


### PR DESCRIPTION
Previously scaling added in https://github.com/lynx-chess/Lynx/pull/821
This improves it a bit
```
Test  | eval/improve-eg-scaling
Elo   | 6.48 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 15020: +4392 -4112 =6516
Penta | [433, 1742, 2945, 1892, 498]
https://openbench.lynx-chess.com/test/622/
```

Doing it when phase < 3 makes it surprisingly inefective:

```
Test  | eval/improve-eg-scaling-2
Elo   | -10.07 +- 6.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 5796: +1543 -1711 =2542
Penta | [178, 777, 1147, 627, 169]
https://openbench.lynx-chess.com/test/624/
```

Applying my own method/formula, regardless the phase:
```
Test  | eval/improve-eg-scaling-3
Elo   | 0.00 +- 0.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.00 (-2.25, 2.89) [0.00, 3.00]
Games | 0: +0 -0 =0
Penta | [0, 0, 0, 0, 0]
https://openbench.lynx-chess.com/test/625/
```