### PR TITLE
🔍 Add history bonus for TT move when a TT cutoff fails high

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -57,7 +57,7 @@ public sealed partial class Engine
                     Move fullMove = default;
 
                     // TODO could generate only the quiet ones here
-                    var psuedoLegalMoves = MoveGenerator.GenerateAllMoves(position, stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
+                    var psuedoLegalMoves = MoveGenerator.GenerateAllQuietMoves(position, stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition]);
 
                     for (int i = 1; i < psuedoLegalMoves.Length; ++i)
                     {
@@ -69,7 +69,7 @@ public sealed partial class Engine
                         }
                     }
 
-                    if (fullMove != default && !(fullMove.IsCapture() || fullMove.IsPromotion()))
+                    if (fullMove != default)
                     {
                         var piece = fullMove.Piece();
                         var targetSquare = fullMove.TargetSquare();


### PR DESCRIPTION
Add history bonus for TT move when a TT cutoff fails high (or whatever Ciekce says)

This will fail likely due to how expensive is to get the full move to be able to see whether it's pseudolegal (I could try to omit that), but especially to get the piece needed for the history table.

With the optimization of generating only quiets:
```
Test  | history-bonus-tt-cutoff
Elo   | -1.93 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 21206: +6011 -6129 =9066
Penta | [643, 2596, 4214, 2536, 614]
https://openbench.lynx-chess.com/test/635/
```