### PR TITLE
🔍 Don't allow LMR to drop depth to 0, keeping 1 as min

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -317,8 +317,9 @@ public sealed partial class Engine
                     reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
 
                     // Don't allow LMR to drop into qsearch or increase the depth
-                    // depth - 1 - depth +2 = 1, min depth we want
-                    reduction = Math.Clamp(reduction, 0, depth - 2);
+                    // Lower limit 1: Idea from Stormphrax
+                    // Upper limit depth - 2: depth - 1 - depth +2 = 1, min depth we want
+                    reduction = Math.Clamp(reduction, 1, depth - 2);
                 }
 
                 // 🔍 Static Exchange Evaluation (SEE) reduction


### PR DESCRIPTION
```
Test  | lmr-no-d0
Elo   | -0.79 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 34934: +10041 -10120 =14773
Penta | [1103, 4138, 7056, 4075, 1095]
https://openbench.lynx-chess.com/test/632/
```