### PR TITLE
⚡  Use `StructureOfArraysGenerator` for killer moves

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -60,6 +60,15 @@ public sealed partial class Engine
         _engineWriter = engineWriter;
 
         // Update ResetEngine() after any changes here
+
+        var killerMovesLength = Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin;
+        var byteSize = KillerMoves.GetByteSize(length: killerMovesLength);
+
+        var rentArray = GC.AllocateArray<byte>(byteSize, pinned: true);
+
+        // Create ArrayPool byte[] backed MultiArray
+        _killerMoves = new KillerMoves(killerMovesLength, rentArray);
+
         _quietHistory = new int[12][];
         _captureHistory = new int[12][][];
         _continuationHistory = new int[12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount];

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
     <PackageReference Include="NLog" Version="5.3.3" />
+    <PackageReference Include="StructureOfArraysGenerator" Version="1.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -74,20 +74,22 @@ public sealed partial class Engine
 
         if (isNotQSearch)
         {
+            var killerMove = _killerMoves[ply];
+
             // 1st killer move
-            if (_killerMoves[0][ply] == move)
+            if (killerMove.Zero == move)
             {
                 return EvaluationConstants.FirstKillerMoveValue;
             }
 
             // 2nd killer move
-            if (_killerMoves[1][ply] == move)
+            if (killerMove.One == move)
             {
                 return EvaluationConstants.SecondKillerMoveValue;
             }
 
             // 3rd killer move
-            if (_killerMoves[2][ply] == move)
+            if (killerMove.Two == move)
             {
                 return EvaluationConstants.ThirdKillerMoveValue;
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -14,12 +14,7 @@ public sealed partial class Engine
     /// <summary>
     /// 3x<see cref="Configuration.EngineSettings.MaxDepth"/>
     /// </summary>
-    private readonly int[][] _killerMoves =
-    [
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin],
-        new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin]
-    ];
+    private readonly KillerMoves _killerMoves;
 
     /// <summary>
     /// 12x64
@@ -96,10 +91,9 @@ public sealed partial class Engine
                 return onlyOneLegalMoveSearchResult;
             }
 
-            Debug.Assert(_killerMoves.Length == 3);
-            Array.Clear(_killerMoves[0]);
-            Array.Clear(_killerMoves[1]);
-            Array.Clear(_killerMoves[2]);
+            _killerMoves.Zero.Clear();
+            _killerMoves.One.Clear();
+            _killerMoves.Two.Clear();
             // Not clearing _quietHistory on purpose
             // Not clearing _captureHistory on purpose
 

--- a/src/Lynx/Search/KillerMoves.cs
+++ b/src/Lynx/Search/KillerMoves.cs
@@ -1,0 +1,15 @@
+﻿using StructureOfArraysGenerator;
+
+namespace Lynx;
+
+public struct KillerMove
+{
+    public int Zero;
+    public int One;
+    public int Two;
+}
+
+[MultiArray(typeof(KillerMove))]
+public readonly partial struct KillerMoves
+{
+}

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -448,20 +448,23 @@ public sealed partial class Engine
                         }
                     }
 
-                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
+                    var killerMove = _killerMoves[ply];
+                    if (move.PromotedPiece() == default && move != killerMove.Zero)
                     {
                         // 🔍 Killer moves
-                        if (move != _killerMoves[1][ply])
+                        if (move != killerMove.One)
                         {
-                            _killerMoves[2][ply] = _killerMoves[1][ply];
+                            killerMove.Two = killerMove.One;
                         }
 
-                        _killerMoves[1][ply] = _killerMoves[0][ply];
-                        _killerMoves[0][ply] = move;
+                        killerMove.One = killerMove.Zero;
+                        killerMove.Zero = move;
 
                         // 🔍 Countermoves
                         _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
                     }
+
+                    _killerMoves[ply] = killerMove;
                 }
 
                 _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);


### PR DESCRIPTION
Testing https://github.com/Cysharp/StructureOfArraysGenerator
Killers are a good use case, since they're always retrieved together for the same ply

Buuut
```
Test  | killers-StructureOfArraysGenerator
Elo   | -3.31 +- 3.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 13940: +3846 -3979 =6115
Penta | [356, 1709, 2965, 1592, 348]
https://openbench.lynx-chess.com/test/653/
```