### PR TITLE
🐛 Killers interfering with Countermoves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -448,16 +448,19 @@ public sealed partial class Engine
                         }
                     }
 
-                    if (move.PromotedPiece() == default && move != _killerMoves[0][ply])
+                    if (move.PromotedPiece() == default)
                     {
                         // 🔍 Killer moves
-                        if (move != _killerMoves[1][ply])
+                        if (move != _killerMoves[0][ply])
                         {
-                            _killerMoves[2][ply] = _killerMoves[1][ply];
-                        }
+                            if (move != _killerMoves[1][ply])
+                            {
+                                _killerMoves[2][ply] = _killerMoves[1][ply];
+                            }
 
-                        _killerMoves[1][ply] = _killerMoves[0][ply];
-                        _killerMoves[0][ply] = move;
+                            _killerMoves[1][ply] = _killerMoves[0][ply];
+                            _killerMoves[0][ply] = move;
+                        }
 
                         // 🔍 Countermoves
                         _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;


### PR DESCRIPTION
Stop preventing countermoves from being populated when the move is the first killer.

😢
```
Test  | bugfix/countermoves-killers
Elo   | -3.07 +- 3.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 15412: +4349 -4485 =6578
Penta | [504, 1877, 3034, 1833, 458]
https://openbench.lynx-chess.com/test/657/
```