### PR TITLE
⚡ Merge static eval loops III

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -693,41 +693,38 @@ public class Position
         var whiteBucket = PSQTBucketLayout[whiteKing];
         var blackBucket = PSQTBucketLayout[blackKing ^ 56];
 
-        for (int pieceIndex = (int)Piece.P; pieceIndex < (int)Piece.K; ++pieceIndex)
+        for (int pieceIndexWhite = (int)Piece.P; pieceIndexWhite < (int)Piece.K; ++pieceIndexWhite)
         {
-            // Bitboard copy that we 'empty'
-            var bitboard = PieceBitBoards[pieceIndex];
+            var pieceIndexBlack = pieceIndexWhite + 6;
 
-            while (bitboard != default)
+            // Bitboard copies that we 'empty'
+            var bitboardWhite = PieceBitBoards[pieceIndexWhite];
+            var bitboardBlack = PieceBitBoards[pieceIndexBlack];
+
+            while (bitboardWhite != default)
             {
-                var pieceSquareIndex = bitboard.GetLS1BIndex();
-                bitboard.ResetLS1B();
+                var pieceSquareIndex = bitboardWhite.GetLS1BIndex();
+                bitboardWhite.ResetLS1B();
 
-                packedScore += PSQT(0, whiteBucket, pieceIndex, pieceSquareIndex)
-                             + PSQT(1, blackBucket, pieceIndex, pieceSquareIndex);
+                packedScore += PSQT(0, whiteBucket, pieceIndexWhite, pieceSquareIndex)
+                             + PSQT(1, blackBucket, pieceIndexWhite, pieceSquareIndex);
 
-                gamePhase += GamePhaseByPiece[pieceIndex];
+                gamePhase += GamePhaseByPiece[pieceIndexWhite];
 
-                packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndex);
+                packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndexWhite);
             }
-        }
 
-        for (int pieceIndex = (int)Piece.p; pieceIndex < (int)Piece.k; ++pieceIndex)
-        {
-            // Bitboard copy that we 'empty'
-            var bitboard = PieceBitBoards[pieceIndex];
-
-            while (bitboard != default)
+            while (bitboardBlack != default)
             {
-                var pieceSquareIndex = bitboard.GetLS1BIndex();
-                bitboard.ResetLS1B();
+                var pieceSquareIndex = bitboardBlack.GetLS1BIndex();
+                bitboardBlack.ResetLS1B();
 
-                packedScore += PSQT(0, blackBucket, pieceIndex, pieceSquareIndex)
-                             + PSQT(1, whiteBucket, pieceIndex, pieceSquareIndex);
+                packedScore += PSQT(0, blackBucket, pieceIndexBlack, pieceSquareIndex)
+                             + PSQT(1, whiteBucket, pieceIndexBlack, pieceSquareIndex);
 
-                gamePhase += GamePhaseByPiece[pieceIndex];
+                gamePhase += GamePhaseByPiece[pieceIndexBlack];
 
-                packedScore -= AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndex);
+                packedScore -= AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndexBlack);
             }
         }
 
@@ -883,6 +880,44 @@ public class Position
             (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.N or (int)Piece.n => KnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
             (int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex),
+            _ => 0
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int AdditionalPieceEvaluationWhiteIndex(int bucket, int pieceSquareIndex, int pieceIndex)
+    {
+        return pieceIndex switch
+        {
+            (int)Piece.P => PawnAdditionalEvaluation(bucket, pieceSquareIndex, pieceIndex),
+            (int)Piece.R => RookAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.B => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.N => KnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.Q => QueenAdditionalEvaluation(pieceSquareIndex),
+            _ => throw new ArgumentException($"Only white indexes expected, but {pieceIndex} was used")
+        };
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int AdditionalPieceEvaluation2(int bucket, int pieceSquareIndex, int pieceIndex)
+    {
+        return pieceIndex switch
+        {
+            (int)Piece.P => PawnAdditionalEvaluation(bucket, pieceSquareIndex, pieceIndex),
+            (int)Piece.p => -PawnAdditionalEvaluation(bucket, pieceSquareIndex, pieceIndex),
+
+            (int)Piece.R => RookAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.r => -RookAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+
+            (int)Piece.B => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.b => -BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+
+            (int)Piece.N => KnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+            (int)Piece.n => -KnightAdditionalEvaluation(pieceSquareIndex, pieceIndex),
+
+            (int)Piece.Q => QueenAdditionalEvaluation(pieceSquareIndex),
+            (int)Piece.q => -QueenAdditionalEvaluation(pieceSquareIndex),
+
             _ => 0
         };
     }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1030,8 +1030,8 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
         return UnpackEG(piece == Piece.K
-            ? position.KingAdditionalEvaluation(bitBoard, Side.White)
-            : position.KingAdditionalEvaluation(bitBoard, Side.Black));
+            ? position.KingAdditionalEvaluation(bitBoard, 0)
+            : position.KingAdditionalEvaluation(bitBoard, 6));
     }
 
     private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)


### PR DESCRIPTION
Continuation of #947, which passed [-3, 1], but increasing the simplification by including kings in the loop

```
Score of Lynx-perf-eval-one-loop-1-2-3674-win-x64 vs Lynx 3671 - main: 1121 - 1213 - 1846  [0.489] 4180
...      Lynx-perf-eval-one-loop-1-2-3674-win-x64 playing White: 838 - 293 - 959  [0.630] 2090
...      Lynx-perf-eval-one-loop-1-2-3674-win-x64 playing Black: 283 - 920 - 887  [0.348] 2090
...      White vs Black: 1758 - 576 - 1846  [0.641] 4180
Elo difference: -7.6 +/- 7.9, LOS: 2.8 %, DrawRatio: 44.2 %
SPRT: llr -1.65 (-57.1%), lbound -2.25, ubound 2.89
```