### PR TITLE
⚡  Clear TT with `Array.Clear()` and make it readonly

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -76,7 +76,8 @@ public sealed partial class Engine
             _killerMoves[i] = new Move[3];
         }
 
-        InitializeTT();
+        (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
 
 #if !DEBUG
         // Temporary channel so that no output is generated
@@ -114,7 +115,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        InitializeTT(); // TODO SPRT clearing instead
+        Array.Clear(_tt);
 
         // Clear histories
         for (int i = 0; i < 12; ++i)
@@ -358,12 +359,6 @@ public sealed partial class Engine
     {
         _stopRequested = true;
         _absoluteSearchCancellationTokenSource.Cancel();
-    }
-
-    private void InitializeTT()
-    {
-        (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
     private static void InitializeStaticClasses()

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,7 +42,7 @@ public sealed partial class Engine
     private readonly int[] _continuationHistory;
 
     private readonly int[] _maxDepthReached = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
-    private TranspositionTable _tt = [];
+    private readonly TranspositionTable _tt;
     private int _ttMask;
 
     private long _nodes;


### PR DESCRIPTION
```
Test  | refactor/clear-tt-and-make-readonly
Elo   | -9.84 +- 6.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 5300: +1460 -1610 =2230
Penta | [215, 607, 1087, 595, 146]
https://openbench.lynx-chess.com/test/673/
```