### PR TITLE
⚡ Use fixed pointer trick in pinned arrays II

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -214,10 +214,8 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CaptureHistory(int piece, int targetSquare, int capturedPiece)
+    private int CaptureHistory(int arrayIndex)
     {
-        var arrayIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
-
         unsafe
         {
             fixed (int* ptr = &_captureHistory[0])
@@ -226,6 +224,10 @@ public sealed partial class Engine
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int CaptureHistory(int piece, int targetSquare, int capturedPiece)
+        => CaptureHistory(CaptureHistoryIndex(piece, targetSquare, capturedPiece));
 
     /// <summary>
     /// [12][64][12][64][ContinuationHistoryPlyCount]
@@ -252,10 +254,8 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int ContinuationHistory(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
+    private int ContinuationHistory(int arrayIndex)
     {
-        var arrayIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousMoveTargetSquare, ply);
-
         unsafe
         {
             fixed (int* ptr = &_continuationHistory[0])
@@ -264,6 +264,10 @@ public sealed partial class Engine
             }
         }
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int ContinuationHistory(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
+        => ContinuationHistory(ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousMoveTargetSquare, ply));
 
     /// <summary>
     /// [64][64]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -64,7 +64,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + EvaluationConstants.MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
+                + CaptureHistory(piece, move.TargetSquare(), capturedPiece);
         }
 
         if (isPromotion)
@@ -102,7 +102,7 @@ public sealed partial class Engine
                 var previousMoveTargetSquare = previousMove.TargetSquare();
 
                 // Countermove
-                if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
+                if (CounterMove(previousMovePiece, previousMoveTargetSquare) == move)
                 {
                     return EvaluationConstants.CounterMoveValue;
                 }
@@ -110,7 +110,7 @@ public sealed partial class Engine
                 // Counter move history
                 return EvaluationConstants.BaseMoveScore
                     + _quietHistory[move.Piece()][move.TargetSquare()]
-                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
+                    + ContinuationHistory(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0);
             }
 
             // History move or 0 if not found
@@ -213,6 +213,20 @@ public sealed partial class Engine
             + capturedPiece;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int CaptureHistory(int piece, int targetSquare, int capturedPiece)
+    {
+        var arrayIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
+
+        unsafe
+        {
+            fixed (int* ptr = &_captureHistory[0])
+            {
+                return ptr[arrayIndex];
+            }
+        }
+    }
+
     /// <summary>
     /// [12][64][12][64][ContinuationHistoryPlyCount]
     /// </summary>
@@ -237,6 +251,20 @@ public sealed partial class Engine
             + ply;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int ContinuationHistory(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
+    {
+        var arrayIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousMoveTargetSquare, ply);
+
+        unsafe
+        {
+            fixed (int* ptr = &_continuationHistory[0])
+            {
+                return ptr[arrayIndex];
+            }
+        }
+    }
+
     /// <summary>
     /// [64][64]
     /// </summary>
@@ -250,6 +278,20 @@ public sealed partial class Engine
 
         return (previousMoveSourceSquare * sourceSquareOffset)
             + previousMoveTargetSquare;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private int CounterMove(int previousMoveSourceSquare, int previousMoveTargetSquare)
+    {
+        var arrayIndex = CounterMoveIndex(previousMoveSourceSquare, previousMoveTargetSquare);
+
+        unsafe
+        {
+            fixed (int* ptr = &_counterMoves[0])
+            {
+                return ptr[arrayIndex];
+            }
+        }
     }
 
     #region Debugging

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -373,7 +373,7 @@ public sealed partial class Engine
 
                     var captureHistoryIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
                     _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
-                        _captureHistory[captureHistoryIndex],
+                        CaptureHistory(captureHistoryIndex),
                         EvaluationConstants.HistoryBonus[depth]);
 
                     // 🔍 Capture history penalty/malus
@@ -391,7 +391,7 @@ public sealed partial class Engine
                             captureHistoryIndex = CaptureHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, visitedMoveCapturedPiece);
 
                             _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
-                                _captureHistory[captureHistoryIndex],
+                                CaptureHistory(captureHistoryIndex),
                                 -EvaluationConstants.HistoryBonus[depth]);
                         }
                     }
@@ -416,7 +416,7 @@ public sealed partial class Engine
                     var continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
 
                     _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                        _continuationHistory[continuationHistoryIndex],
+                        ContinuationHistory(continuationHistoryIndex),
                         EvaluationConstants.HistoryBonus[depth]);
 
                     //    var previousPreviousMove = Game.MoveStack[ply - 2];
@@ -446,7 +446,7 @@ public sealed partial class Engine
                             continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
 
                             _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                                _continuationHistory[continuationHistoryIndex],
+                                ContinuationHistory(continuationHistoryIndex),
                                 -EvaluationConstants.HistoryBonus[depth]);
                         }
                     }


### PR DESCRIPTION
 Use `fixed (int* ptr = &_array[0])` for accessing history arrays in helpers (https://github.com/lynx-chess/Lynx/pull/966)
+
Use it also to read when updating the same entry that was just read

```
Test  | perf/fixed-trick-pinned-2
Elo   | -5.01 +- 4.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 10130: +2788 -2934 =4408
Penta | [314, 1168, 2171, 1174, 238]
https://openbench.lynx-chess.com/test/680/
```