### PR TITLE
⏳ Decrease `DefaultMovesToGo`: 45 -> 35

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -20,7 +20,7 @@
 
     "HardTimeBoundMultiplier": 0.52,
     "SoftTimeBoundMultiplier": 1,
-    "DefaultMovesToGo": 45,
+    "DefaultMovesToGo": 35,
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
     "LMR_MinDepth": 3,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -99,7 +99,7 @@ public sealed class EngineSettings
 
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
-    public int DefaultMovesToGo { get; set; } = 45;
+    public int DefaultMovesToGo { get; set; } = 35;
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 


### PR DESCRIPTION
Not looking very promising (40+0.4), cancelled
![image](https://github.com/user-attachments/assets/6b7f57e2-9018-41e8-b001-439c8c8731e8)
