### PR TITLE
🔍 History pruning: quiet + continuation history

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -57,7 +57,10 @@
 
     "FP_MaxDepth": 5,
     "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129
+    "FP_Margin": 129,
+
+    "HistoryPrunning_MaxDepth": 7,
+    "HistoryPrunning_Margin": -2500
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -189,6 +189,12 @@ public sealed class EngineSettings
 
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 129;
+
+    [SPSA<int>(0, 10, 0.5)]
+    public int HistoryPrunning_MaxDepth { get; set; } = 129;
+
+    [SPSA<int>(0, -8192, 512)]
+    public int HistoryPrunning_Margin { get; set; } = 2500;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -191,10 +191,10 @@ public sealed class EngineSettings
     public int FP_Margin { get; set; } = 129;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 129;
+    public int HistoryPrunning_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(0, -8192, 512)]
-    public int HistoryPrunning_Margin { get; set; } = 2500;
+    public int HistoryPrunning_Margin { get; set; } = -2500;
 }
 
 [JsonSourceGenerationOptions(


### PR DESCRIPTION
```
Test  | search/history-pruning-quiet-cont
Elo   | 0.89 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.33 (-2.25, 2.89) [0.00, 3.00]
Games | 63726: +18081 -17918 =27727
Penta | [1863, 7597, 12792, 7736, 1875]
https://openbench.lynx-chess.com/test/696/
```