### PR TITLE
🔍 LMR: use continuation history and clamp it all to [-1,1]

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -27,6 +27,7 @@
     "LMR_MinFullDepthSearchedMoves": 4,
     "LMR_Base": 0.91,
     "LMR_Divisor": 3.42,
+    "LMR_MaxHistoryReduction": 1,
 
     "NMP_MinDepth": 2,
     "NMP_BaseDepthReduction": 2,

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -123,6 +123,8 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.42;
 
+    public int LMR_MaxHistoryReduction { get; set; } = 1;
+
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -314,7 +314,18 @@ public sealed partial class Engine
                     }
 
                     // -= history/(maxHistory/2)
-                    reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
+                    var pìece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+
+                    var previousMove = Game.PopFromMoveStack(ply - 1);
+                    var previousMovePiece = previousMove.Piece();
+                    var previousTargetSquare = previousMove.TargetSquare();
+
+                    var continuationHistoryIndex = ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousTargetSquare, 0);
+
+                    reduction -= 2
+                        * (_quietHistory[pìece][targetSquare] + _continuationHistory[ContinuationHistoryIndex(pìece, targetSquare, previousMovePiece, previousTargetSquare, ply)])
+                        / Configuration.EngineSettings.History_MaxMoveValue;
 
                     // Don't allow LMR to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -321,8 +321,6 @@ public sealed partial class Engine
                     var previousMovePiece = previousMove.Piece();
                     var previousTargetSquare = previousMove.TargetSquare();
 
-                    var continuationHistoryIndex = ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousTargetSquare, 0);
-
                     reduction -= 2
                         * (_quietHistory[pìece][targetSquare] + _continuationHistory[ContinuationHistoryIndex(pìece, targetSquare, previousMovePiece, previousTargetSquare, ply)])
                         / Configuration.EngineSettings.History_MaxMoveValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -321,9 +321,14 @@ public sealed partial class Engine
                     var previousMovePiece = previousMove.Piece();
                     var previousTargetSquare = previousMove.TargetSquare();
 
-                    reduction -= 2
+                    var historyReduction = 2
                         * (_quietHistory[pìece][targetSquare] + _continuationHistory[ContinuationHistoryIndex(pìece, targetSquare, previousMovePiece, previousTargetSquare, ply)])
                         / Configuration.EngineSettings.History_MaxMoveValue;
+
+                    reduction -= Math.Clamp(
+                        historyReduction,
+                        -Configuration.EngineSettings.LMR_MaxHistoryReduction,
+                        +Configuration.EngineSettings.LMR_MaxHistoryReduction);
 
                     // Don't allow LMR to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want


### PR DESCRIPTION
```
Test  | search/continuation-history-lmr-clamped
Elo   | -0.17 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 51814: +14564 -14590 =22660
Penta | [1519, 6277, 10311, 6311, 1489]
https://openbench.lynx-chess.com/test/691/
```