### PR TITLE
🧹 Refactor & simplify `Game` constructors

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -53,7 +53,7 @@ public sealed partial class Engine
     public Engine(ChannelWriter<string> engineWriter)
     {
         AverageDepth = 0;
-        Game = new Game();
+        Game = new Game(Constants.InitialPositionFEN);
         _isNewGameComing = true;
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
@@ -134,7 +134,7 @@ public sealed partial class Engine
     public void NewGame()
     {
         AverageDepth = 0;
-        Game = new Game();
+        Game = new Game(Constants.InitialPositionFEN);
         _isNewGameComing = true;
         _isNewGameCommandSupported = true;
         _stopRequested = false;

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -24,15 +24,14 @@ public sealed class Game
 
     public Position PositionBeforeLastSearch { get; private set; }
 
-    public Game() : this(Constants.InitialPositionFEN)
+    public Game(ReadOnlySpan<char> fen) : this(fen, [], [], [])
     {
     }
 
-    public Game(ReadOnlySpan<char> fen)
+    public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool)
     {
         var parsedFen = FENParser.ParseFEN(fen);
         CurrentPosition = new Position(parsedFen);
-        PositionBeforeLastSearch = new Position(CurrentPosition);
 
         if (!CurrentPosition.IsValid())
         {
@@ -46,10 +45,7 @@ public sealed class Game
 #if DEBUG
         MoveHistory = new(Constants.MaxNumberMovesInAGame);
 #endif
-    }
 
-    public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool) : this(fen)
-    {
         for (int i = 0; i < rangeSpan.Length; ++i)
         {
             if (rangeSpan[i].Start.Equals(rangeSpan[i].End))

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -55,7 +55,7 @@ public sealed class PositionCommand : GUIBaseCommand
         catch (Exception e)
         {
             _logger.Error(e, "Error parsing position command '{0}'", positionCommandSpan.ToString());
-            return new Game();
+            return new Game(Constants.InitialPositionFEN);
         }
     }
 


### PR DESCRIPTION
Refactor & simplify `Game` constructors, avoiding an unneeded `Position` allocation when moves are provided