### PR TITLE
🔍 SEE threshold: arbitrary negative value (-109)

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -41,7 +41,7 @@ public sealed partial class Engine
         // Queen promotion
         if ((promotedPiece + 2) % 6 == 0)
         {
-            var baseScore = SEE.HasPositiveScore(Game.CurrentPosition, move)
+            var baseScore = SEE.HasPositiveScore(Game.CurrentPosition, move, -109)
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 


### PR DESCRIPTION
```
Test  | search/see-threshold-109
Elo   | -11.01 +- 6.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.22 (-2.25, 2.89) [0.00, 3.00]
Games | 5018: +1327 -1486 =2205
Penta | [159, 626, 1055, 553, 116]
https://openbench.lynx-chess.com/test/700/
```