### PR TITLE
🔍SEE: threshold based on fomula but using static eval

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
+using static System.Formats.Asn1.AsnWriter;
 
 namespace Lynx;
 
@@ -20,7 +21,7 @@ public sealed partial class Engine
     /// <param name="bestMoveTTCandidate"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int ply, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int ply, bool isNotQSearch, int staticScore, ShortMove bestMoveTTCandidate = default)
     {
         if (_isScoringPV && move == _pVTable[ply])
         {
@@ -41,7 +42,9 @@ public sealed partial class Engine
         // Queen promotion
         if ((promotedPiece + 2) % 6 == 0)
         {
-            var baseScore = SEE.HasPositiveScore(Game.CurrentPosition, move)
+            var threshold = (-staticScore / 32) + 236;    // SF server
+
+            var baseScore = SEE.HasPositiveScore(Game.CurrentPosition, move, threshold)
                 ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
                 : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -176,7 +176,7 @@ public sealed partial class Engine
             _isFollowingPV = false;
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, staticEval, ttBestMove);
 
                 if (pseudoLegalMoves[i] == _pVTable[depth])
                 {
@@ -189,7 +189,7 @@ public sealed partial class Engine
         {
             for (int i = 0; i < pseudoLegalMoves.Length; ++i)
             {
-                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+                scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, staticEval, ttBestMove);
             }
         }
 
@@ -571,7 +571,7 @@ public sealed partial class Engine
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            scores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, staticEvaluation, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)


### PR DESCRIPTION
Try SEE threshold formula suggested in SF server (-score / 32) + 236) **but using static eval instead of capture history** due to a misunderstanding

```
Test  | search/see-threshold-formula
Elo   | 0.81 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.13 (-2.25, 2.89) [0.00, 3.00]
Games | 19322: +5461 -5416 =8445
Penta | [487, 2259, 4142, 2268, 505]
https://openbench.lynx-chess.com/test/701/
```