### PR TITLE
⚡ Refactor `Game.PositionHashHistory` into a private array

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -253,7 +253,7 @@ public sealed partial class Engine
             Game.UpdateInitialPosition();
         }
 
-        AverageDepth += (resultToReturn.Depth - AverageDepth) / Math.Ceiling(0.5 * Game.PositionHashHistory.Count);
+        AverageDepth += (resultToReturn.Depth - AverageDepth) / Math.Ceiling(0.5 * Game.PositionHashHistoryLength());
 
         return resultToReturn;
     }
@@ -270,7 +270,7 @@ public sealed partial class Engine
 
         var tasks = new Task<SearchResult?>[] {
                 // Other copies of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove (same reason)
-                ProbeOnlineTablebase(Game.CurrentPosition, new(Game.PositionHashHistory),  Game.HalfMovesWithoutCaptureOrPawnMove),
+                ProbeOnlineTablebase(Game.CurrentPosition, Game.CopyPositionHashHistory(),  Game.HalfMovesWithoutCaptureOrPawnMove),
                 Task.Run(()=>(SearchResult?)IDDFS(maxDepth, softLimitTimeBound))
             };
 

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -234,4 +234,5 @@ public sealed class Game
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public long[] CopyPositionHashHistory() => _positionHashHistory[.._positionHashHistoryPointer];
 
+    internal void ClearPositionHashHistory() => _positionHashHistoryPointer = 0;
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -11,7 +11,8 @@ public sealed class Game
     public List<Move> MoveHistory { get; }
 #endif
 
-    public List<long> PositionHashHistory { get; }
+    private int _positionHashHistoryPointer;
+    private readonly long[] _positionHashHistory;
 
     /// <summary>
     /// Indexed by ply
@@ -38,7 +39,8 @@ public sealed class Game
             _logger.Warn($"Invalid position detected: {fen.ToString()}");
         }
 
-        PositionHashHistory = new(Constants.MaxNumberMovesInAGame) { CurrentPosition.UniqueIdentifier };
+        _positionHashHistory = new long[Constants.MaxNumberMovesInAGame];
+        AddToPositionHashHistory(CurrentPosition.UniqueIdentifier);
         HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
         _moveStack = new Move[1024];
 
@@ -128,10 +130,10 @@ public sealed class Game
         var currentHash = CurrentPosition.UniqueIdentifier;
 
         // [Count - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
-        var limit = Math.Max(0, PositionHashHistory.Count - 1 - HalfMovesWithoutCaptureOrPawnMove);
-        for (int i = PositionHashHistory.Count - 3; i >= limit; i -= 2)
+        var limit = Math.Max(0, _positionHashHistoryPointer - HalfMovesWithoutCaptureOrPawnMove);
+        for (int i = _positionHashHistoryPointer - 2; i >= limit; i -= 2)
         {
-            if (currentHash == PositionHashHistory[i])
+            if (currentHash == _positionHashHistory[i])
             {
                 return true;
             }
@@ -152,19 +154,19 @@ public sealed class Game
     }
 
     /// <summary>
-    /// To be used in online tb proving only, with a copy of <see cref="PositionHashHistory"/> that hasn't been updated with <paramref name="position"/>
+    /// To be used in online tb proving only, with a copy of <see cref="_positionHashHistory"/> that hasn't been updated with <paramref name="position"/>
     /// </summary>
     /// <param name="positionHashHistory"></param>
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsThreefoldRepetition(List<long> positionHashHistory, Position position, int halfMovesWithoutCaptureOrPawnMove = Constants.MaxNumberMovesInAGame)
+    public static bool IsThreefoldRepetition(ReadOnlySpan<long> positionHashHistory, Position position, int halfMovesWithoutCaptureOrPawnMove = Constants.MaxNumberMovesInAGame)
     {
         var currentHash = position.UniqueIdentifier;
 
         // Since positionHashHistory hasn't been updated with position, [Count] would be the last one, so we want to start searching 2 ealier
-        var limit = Math.Max(0, positionHashHistory.Count - halfMovesWithoutCaptureOrPawnMove);
-        for (int i = positionHashHistory.Count - 2; i >= limit; i -= 2)
+        var limit = Math.Max(0, positionHashHistory.Length - halfMovesWithoutCaptureOrPawnMove);
+        for (int i = positionHashHistory.Length - 2; i >= limit; i -= 2)
         {
             if (currentHash == positionHashHistory[i])
             {
@@ -193,7 +195,7 @@ public sealed class Game
 #if DEBUG
             MoveHistory.Add(moveToPlay);
 #endif
-            PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
+            AddToPositionHashHistory(CurrentPosition.UniqueIdentifier);
             Update50movesRule(moveToPlay, moveToPlay.IsCapture());
         }
         else
@@ -219,4 +221,17 @@ public sealed class Game
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Move PopFromMoveStack(int n) => _moveStack[n + EvaluationConstants.ContinuationHistoryPlyCount];
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int PositionHashHistoryLength() => _positionHashHistoryPointer;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void AddToPositionHashHistory(long hash) => _positionHashHistory[++_positionHashHistoryPointer] = hash;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void RemoveFromPositionHashHistory() => --_positionHashHistoryPointer;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public long[] CopyPositionHashHistory() => _positionHashHistory[.._positionHashHistoryPointer];
+
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -129,7 +129,7 @@ public sealed class Game
     {
         var currentHash = CurrentPosition.UniqueIdentifier;
 
-        // [Count - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
+        // We want to start searching 2 half-moves ealier thaan the last one and finish HalfMovesWithoutCaptureOrPawnMove earlier
         var limit = Math.Max(0, _positionHashHistoryPointer - HalfMovesWithoutCaptureOrPawnMove);
         for (int i = _positionHashHistoryPointer - 2; i >= limit; i -= 2)
         {

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -129,9 +129,9 @@ public sealed class Game
     {
         var currentHash = CurrentPosition.UniqueIdentifier;
 
-        // We want to start searching 2 half-moves ealier thaan the last one and finish HalfMovesWithoutCaptureOrPawnMove earlier
-        var limit = Math.Max(0, _positionHashHistoryPointer - HalfMovesWithoutCaptureOrPawnMove);
-        for (int i = _positionHashHistoryPointer - 2; i >= limit; i -= 2)
+        // [_positionHashHistoryPointer - 1] would be the last one, we want to start searching 2 ealier and finish HalfMovesWithoutCaptureOrPawnMove earlier
+        var limit = Math.Max(0, _positionHashHistoryPointer - 1 - HalfMovesWithoutCaptureOrPawnMove);
+        for (int i = _positionHashHistoryPointer - 3; i >= limit; i -= 2)
         {
             if (currentHash == _positionHashHistory[i])
             {
@@ -154,7 +154,7 @@ public sealed class Game
     }
 
     /// <summary>
-    /// To be used in online tb proving only, with a copy of <see cref="_positionHashHistory"/> that hasn't been updated with <paramref name="position"/>
+    /// To be used in online tb proving only, in combination with the result of <see cref="CopyPositionHashHistory"/>
     /// </summary>
     /// <param name="positionHashHistory"></param>
     /// <param name="position"></param>
@@ -226,7 +226,7 @@ public sealed class Game
     public int PositionHashHistoryLength() => _positionHashHistoryPointer;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AddToPositionHashHistory(long hash) => _positionHashHistory[++_positionHashHistoryPointer] = hash;
+    public void AddToPositionHashHistory(long hash) => _positionHashHistory[_positionHashHistoryPointer++] = hash;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RemoveFromPositionHashHistory() => --_positionHashHistoryPointer;

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -43,7 +43,7 @@ public static class OnlineTablebaseProber
         TypeInfoResolver = SourceGenerationContext.Default
     };
 
-    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, List<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
+    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, long[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
         var fen = position.FEN(halfMovesWithoutCaptureOrPawnMove);
         _logger.Info("[{0}] Querying online tb for position {1}", nameof(RootSearch), fen);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -234,7 +234,7 @@ public sealed partial class Engine
             // Before making a move
             var oldHalfMovesWithoutCaptureOrPawnMove = Game.HalfMovesWithoutCaptureOrPawnMove;
             var canBeRepetition = Game.Update50movesRule(move, isCapture);
-            Game.PositionHashHistory.Add(position.UniqueIdentifier);
+            Game.AddToPositionHashHistory(position.UniqueIdentifier);
             Game.PushToMoveStack(ply, move);
 
             int evaluation;
@@ -264,7 +264,7 @@ public sealed partial class Engine
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
+                        Game.RemoveFromPositionHashHistory();
                         position.UnmakeMove(move, gameState);
 
                         break;
@@ -280,7 +280,7 @@ public sealed partial class Engine
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
+                        Game.RemoveFromPositionHashHistory();
                         position.UnmakeMove(move, gameState);
 
                         break;
@@ -355,7 +355,7 @@ public sealed partial class Engine
             // After making a move
             // Game.PositionHashHistory is update above
             Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-            Game.PositionHashHistory.RemoveAt(Game.PositionHashHistory.Count - 1);
+            Game.RemoveFromPositionHashHistory();
             position.UnmakeMove(move, gameState);
 
             PrintMove(position, ply, move, evaluation);

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 namespace Lynx;
 public sealed partial class Engine
 {
-    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, List<long> positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
+    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, long[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
     {
         var stopWatch = Stopwatch.StartNew();
 
@@ -24,7 +24,7 @@ public sealed partial class Engine
                     HashfullPermill = _tt.HashfullPermillApprox(),
                     WDL = WDL.WDLModel(
                         (int)Math.CopySign(
-                            EvaluationConstants.PositiveCheckmateDetectionLimit + EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore,
+                            EvaluationConstants.PositiveCheckmateDetectionLimit + (EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore),
                             tablebaseResult.MateScore),
                         0)
                 };

--- a/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
+++ b/tests/Lynx.Test/BestMove/ForceOrAvoidDrawTest.cs
@@ -164,7 +164,7 @@ public class ForceOrAvoidDrawTest : BaseTest
         Assert.AreEqual(98, engine.Game.MoveHistory.Count);
 #endif
 
-        engine.Game.PositionHashHistory.Clear(); // Make sure we don't take account threefold repetition
+        engine.Game.ClearPositionHashHistory(); // Make sure we don't take account threefold repetition
 
         // Act
         var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
@@ -215,7 +215,7 @@ public class ForceOrAvoidDrawTest : BaseTest
         Assert.AreEqual(99, engine.Game.MoveHistory.Count);
 #endif
 
-        engine.Game.PositionHashHistory.Clear(); // Make sure we don't take account threefold repetition
+        engine.Game.ClearPositionHashHistory(); // Make sure we don't take account threefold repetition
 
         // Act
         var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
@@ -236,7 +236,7 @@ public class ForceOrAvoidDrawTest : BaseTest
         // Source: https://github.com/PGG106/Alexandria/issues/213
         const string mateIn1Fen = "4Q3/8/1p4pk/1PbB1p1p/7P/p3P1PK/P3qP2/8 w - - 99 88";
 
-        var result = TestBestMove(mateIn1Fen, new[] { "e8h8" }, Array.Empty<string>(), depth: 1);
+        var result = TestBestMove(mateIn1Fen, ["e8h8"], [], depth: 1);
         Assert.AreEqual(1, result.Mate);
     }
 }

--- a/tests/Lynx.Test/Commands/PositionCommandTest.cs
+++ b/tests/Lynx.Test/Commands/PositionCommandTest.cs
@@ -58,7 +58,7 @@ public class PositionCommandTest
         Assert.AreEqual("e2e3", parsedGame.MoveHistory[8].UCIString());
         Assert.AreEqual("rnbqkb1r/pp3ppp/4pn2/2pp4/3P4/2N1PNP1/PPP2P1P/R1BQKB1R b KQkq - 0 5", parsedGame.CurrentPosition.FEN(parsedGame.HalfMovesWithoutCaptureOrPawnMove, (parsedGame.MoveHistory.Count / 2) + (parsedGame.MoveHistory.Count % 2)));
 #endif
-        Assert.AreEqual("rnbqkb1r/pp3ppp/4pn2/2pp4/3P4/2N1PNP1/PPP2P1P/R1BQKB1R b KQkq - 0 5", parsedGame.CurrentPosition.FEN(parsedGame.HalfMovesWithoutCaptureOrPawnMove, (parsedGame.PositionHashHistory.Count / 2) + (parsedGame.PositionHashHistory.Count % 2)));
+        Assert.AreEqual("rnbqkb1r/pp3ppp/4pn2/2pp4/3P4/2N1PNP1/PPP2P1P/R1BQKB1R b KQkq - 0 5", parsedGame.CurrentPosition.FEN(parsedGame.HalfMovesWithoutCaptureOrPawnMove, (parsedGame.PositionHashHistoryLength() / 2) + (parsedGame.PositionHashHistoryLength() % 2)));
 
         Assert.Pass();
     }
@@ -73,7 +73,7 @@ public class PositionCommandTest
         var parsedGame = PositionCommand.ParseGame(Constants.LongPositionCommand, movePool);
 
         Assert.AreNotEqual(Constants.InitialPositionFEN, parsedGame.CurrentPosition);
-        Assert.Greater(parsedGame.PositionHashHistory.Count, 500);
+        Assert.Greater(parsedGame.PositionHashHistoryLength(), 500);
 
 #if DEBUG
         Assert.Greater(parsedGame.MoveHistory.Count, 590);

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -124,17 +124,17 @@ public class GameTest : BaseTest
         winningPosition = new Position("1n2k2r/8/8/8/8/8/4PPPP/1N2K2R w Kk - 0 1");
 
         game = new Game(winningPosition.FEN());
-        repeatedMoves = new List<Move>
-            {
-                MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
-                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.Encode((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
-                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),  // Repetition detected, but that's not what we want to test
-                MoveExtensions.Encode((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
-                MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
-                MoveExtensions.Encode((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
-                MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)   // Not repetition, due to castling rights removal
-            };
+        repeatedMoves =
+        [
+            MoveExtensions.Encode((int)BoardSquare.b1, (int)BoardSquare.c3, (int)Piece.N),
+            MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+            MoveExtensions.Encode((int)BoardSquare.c3, (int)BoardSquare.b1, (int)Piece.N),
+            MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n),  // Repetition detected, but that's not what we want to test
+            MoveExtensions.Encode((int)BoardSquare.e1, (int)BoardSquare.d1, (int)Piece.K),
+            MoveExtensions.Encode((int)BoardSquare.b8, (int)BoardSquare.c6, (int)Piece.n),
+            MoveExtensions.Encode((int)BoardSquare.d1, (int)BoardSquare.e1, (int)Piece.K),
+            MoveExtensions.Encode((int)BoardSquare.c6, (int)BoardSquare.b8, (int)Piece.n)   // Not repetition, due to castling rights removal
+        ];
 
         // Act
         foreach (var move in repeatedMoves.Take(7))
@@ -148,7 +148,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
 #endif
-        Assert.AreEqual(repeatedMoves.Count + 1, game.PositionHashHistory.Count);
+        Assert.AreEqual(repeatedMoves.Count + 1, game.PositionHashHistoryLength());
 
         var eval = winningPosition.StaticEvaluation().Score;
         Assert.AreNotEqual(0, eval);
@@ -185,7 +185,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(101, game.MoveHistory.Count);
 #endif
-        Assert.AreEqual(101 + 1, game.PositionHashHistory.Count);
+        Assert.AreEqual(101 + 1, game.PositionHashHistoryLength());
 
         // If the checkmate is in the move when it's claimed, checkmate remains
         Assert.False(game.Is50MovesRepetition());
@@ -214,7 +214,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(100, game.MoveHistory.Count);
 #endif
-        Assert.AreEqual(100 + 1, game.PositionHashHistory.Count);
+        Assert.AreEqual(100 + 1, game.PositionHashHistoryLength());
 
         Assert.True(game.Is50MovesRepetition());
     }
@@ -246,7 +246,7 @@ public class GameTest : BaseTest
 #if DEBUG
         Assert.AreEqual(51, game.MoveHistory.Count);
 #endif
-        Assert.AreEqual(51 + 1, game.PositionHashHistory.Count);
+        Assert.AreEqual(51 + 1, game.PositionHashHistoryLength());
 
         Assert.False(game.Is50MovesRepetition());
     }

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -380,7 +380,7 @@ public class OnlineTablebaseProberTest
         var position = game.CurrentPosition;
 
         // Act
-        var result = await OnlineTablebaseProber.RootSearch(position, game.PositionHashHistory, game.HalfMovesWithoutCaptureOrPawnMove, default);
+        var result = await OnlineTablebaseProber.RootSearch(position, game.CopyPositionHashHistory(), game.HalfMovesWithoutCaptureOrPawnMove, default);
 
         // Assert
         Assert.AreEqual(0, result.MateScore);
@@ -406,7 +406,7 @@ public class OnlineTablebaseProberTest
         var position = game.CurrentPosition;
 
         // Act
-        var result = await OnlineTablebaseProber.RootSearch(position, game.PositionHashHistory, game.HalfMovesWithoutCaptureOrPawnMove, default);
+        var result = await OnlineTablebaseProber.RootSearch(position, game.CopyPositionHashHistory(), game.HalfMovesWithoutCaptureOrPawnMove, default);
 
         // Assert
         Assert.AreEqual(0, result.MateScore);


### PR DESCRIPTION
Transform `Game.PositionHashHistory` into an internal array instead of a public List and treat it as a stack

With a pointer the tip of the stack is tracked.
- On add, the next item is modified and the pointer increases
- On remove, the pointer simply decreases, leaving the 'garbage' there

```
Test  | perf/game-positionhashHistory-manual-stack
Elo   | 4.26 +- 5.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 7752: +2236 -2141 =3375
Penta | [181, 861, 1709, 932, 193]
https://openbench.lynx-chess.com/test/704/
```