### PR TITLE
🔍SEE: threshold based on fomula

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -52,19 +52,22 @@ public sealed partial class Engine
 
         if (isCapture)
         {
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
-                ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
-                : EvaluationConstants.BadCaptureMoveBaseScoreValue;
-
             var piece = move.Piece();
             var capturedPiece = move.CapturedPiece();
+
+            var captureHistoryValue = _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
+            var threshold = (-captureHistoryValue / 32) + 236; // SF server
+
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move, threshold))
+                ? EvaluationConstants.GoodCaptureMoveBaseScoreValue
+                : EvaluationConstants.BadCaptureMoveBaseScoreValue;
 
             Debug.Assert(capturedPiece != (int)Piece.K && capturedPiece != (int)Piece.k, $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN()}");
 
             return baseCaptureScore
                 + EvaluationConstants.MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
+                + captureHistoryValue;
         }
 
         if (isPromotion)


### PR DESCRIPTION
Attempted with the wrong value in #988 

I must have understood it wrong, cause
```
Test  | search/see-threshold-formula-fixed
Elo   | -66.68 +- 15.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 1018: +197 -390 =431
Penta | [58, 176, 193, 65, 17]
https://openbench.lynx-chess.com/test/706/
```