### PR TITLE
⚖ Tweak 50 moves rule scaling, SF formula I

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1047,7 +1047,7 @@ public class Position
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
-        eval * (200 - movesWithoutCaptureOrPawnMove) / 200;
+        eval * (288 - movesWithoutCaptureOrPawnMove) / 256; // Formula from Halogen
 
     #endregion
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -670,7 +670,7 @@ public class Position
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public (int Score, int Phase) StaticEvaluation()
+    public (int Score, int Phase) StaticEvaluation(int movesWithoutCaptureOrPawnMove = 0)
     {
         //var result = OnlineTablebaseProber.EvaluationSearch(this, movesWithoutCaptureOrPawnMove, cancellationToken);
         //Debug.Assert(result < CheckMateBaseEvaluation, $"position {FEN()} returned tb eval out of bounds: {result}");
@@ -828,6 +828,8 @@ public class Position
 
         // Endgame scaling with pawn count, formula yoinked from Sirius
         eval = (int)(eval * ((80 + (totalPawnsCount * 7)) / 128.0));
+
+        eval = ScaleEvalWith50MovesDrawDistance(eval, movesWithoutCaptureOrPawnMove);
 
         eval = Math.Clamp(eval, MinEval, MaxEval);
 
@@ -1035,6 +1037,17 @@ public class Position
 
         return packedBonus + (ownPiecesAroundCount * KingShieldBonus);
     }
+
+    /// <summary>
+    /// Scales <paramref name="eval"/> with <paramref name="movesWithoutCaptureOrPawnMove"/>, so that
+    /// an eval with 100 halfmove counter is half of the value of one with 0 halfmove counter
+    /// </summary>
+    /// <param name="eval"></param>
+    /// <param name="movesWithoutCaptureOrPawnMove"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
+        eval * (200 - movesWithoutCaptureOrPawnMove) / 200;
 
     #endregion
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1047,7 +1047,7 @@ public class Position
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
-        eval * (288 - movesWithoutCaptureOrPawnMove) / 256; // Formula from Halogen
+        eval * (200 - movesWithoutCaptureOrPawnMove) / 214; // Formula from an old SF version
 
     #endregion
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -28,7 +28,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation().Score;
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         }
 
         _maxDepthReached[ply] = ply;
@@ -87,7 +87,7 @@ public sealed partial class Engine
         }
         else if (!pvNode)
         {
-            (staticEval, phase) = position.StaticEvaluation();
+            (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
 
             // From smol.cs
             // ttEvaluation can be used as a better positional evaluation:
@@ -525,7 +525,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation().Score;
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -541,7 +541,7 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEvaluation = position.StaticEvaluation().Score;
+        var staticEvaluation = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
 
         // Fail-hard beta-cutoff (updating alpha after this check)
         if (staticEvaluation >= beta)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1013,6 +1013,18 @@ public class PositionTest
         Assert.AreEqual(eg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 0));
     }
 
+    [Test]
+    public void ScaleEvalWith50MovesDrawDistance()
+    {
+        const string queenVsRookPosition = "8/4k3/4r3/3Q4/3K4/8/8/8 w - - 0 1";
+
+        var position = new Position(queenVsRookPosition);
+
+        Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
+        Assert.AreEqual(0.5 * position.StaticEvaluation(0).Score, position.StaticEvaluation(100));
+        Assert.AreEqual(0.75 * position.StaticEvaluation(0).Score, position.StaticEvaluation(50));
+    }
+
     private static int AdditionalPieceEvaluation(Position position, Piece piece)
     {
         var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1013,18 +1013,6 @@ public class PositionTest
         Assert.AreEqual(eg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 0));
     }
 
-    [Test]
-    public void ScaleEvalWith50MovesDrawDistance()
-    {
-        const string queenVsRookPosition = "8/4k3/4r3/3Q4/3K4/8/8/8 w - - 0 1";
-
-        var position = new Position(queenVsRookPosition);
-
-        Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
-        Assert.AreEqual((int)(0.5 * position.StaticEvaluation(0).Score), position.StaticEvaluation(100).Score);
-        Assert.AreEqual((int)(0.75 * position.StaticEvaluation(0).Score), position.StaticEvaluation(50).Score);
-    }
-
     private static int AdditionalPieceEvaluation(Position position, Piece piece)
     {
         var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -1021,8 +1021,8 @@ public class PositionTest
         var position = new Position(queenVsRookPosition);
 
         Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
-        Assert.AreEqual(0.5 * position.StaticEvaluation(0).Score, position.StaticEvaluation(100));
-        Assert.AreEqual(0.75 * position.StaticEvaluation(0).Score, position.StaticEvaluation(50));
+        Assert.AreEqual((int)(0.5 * position.StaticEvaluation(0).Score), position.StaticEvaluation(100).Score);
+        Assert.AreEqual((int)(0.75 * position.StaticEvaluation(0).Score), position.StaticEvaluation(50).Score);
     }
 
     private static int AdditionalPieceEvaluation(Position position, Piece piece)


### PR DESCRIPTION
```
Test  | eval/50mr-scaling-sf-1
Elo   | -6.68 +- 5.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.83 (-2.25, 2.89) [0.00, 3.00]
Games | 6610: +1793 -1920 =2897
Penta | [211, 823, 1337, 750, 184]
https://openbench.lynx-chess.com/test/683/
```