### PR TITLE
🧠 Cache `Move.UCIString` results in a `Dictionary`

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -338,7 +338,7 @@ public sealed partial class Engine
 
             // We print best move even in case of go ponder + stop, and IDEs are expected to ignore it
             _moveToPonder = searchResult.Moves.Length >= 2 ? searchResult.Moves[1] : null;
-            _engineWriter.TryWrite(BestMoveCommand.BestMove(searchResult.BestMove, _moveToPonder));
+            _engineWriter.TryWrite(new BestMoveCommand(searchResult.BestMove, _moveToPonder));
         }
         catch (Exception e)
         {

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
     <PackageReference Include="NLog" Version="5.3.3" />
   </ItemGroup>
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -406,6 +406,28 @@ public static class MoveExtensions
         return span[..^1].ToString();
     }
 
+    private static readonly Dictionary<int, string> _uCIStringCache = new(1024);
+
+    /// <summary>
+    /// NOT thread-safe
+    /// </summary>
+    /// <param name="move"></param>
+    /// <returns></returns>
+    [SkipLocalsInit]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string UCIStringMemoized(this Move move)
+    {
+        if (_uCIStringCache.TryGetValue(move, out var uciString))
+        {
+            return uciString;
+        }
+
+        var str = move.UCIString();
+        _uCIStringCache[move] = str;
+
+        return str;
+    }
+
     /// <summary>
     /// First file letter, then rank number and finally the whole square.
     /// At least according to https://chess.stackexchange.com/a/1819

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.UCI.Commands.Engine;
-using System.Text;
 
 namespace Lynx.Model;
 
@@ -46,7 +45,7 @@ public sealed class SearchResult
 
     public override string ToString()
     {
-        var sb = new StringBuilder(256);
+        var sb = ObjectPools.StringBuilderPool.Get();
 
         sb.Append(InfoCommand.Id)
           .Append(" depth ").Append(Depth)
@@ -82,6 +81,10 @@ public sealed class SearchResult
             sb.Length--;
         }
 
-        return sb.ToString();
+        var result = sb.ToString();
+
+        ObjectPools.StringBuilderPool.Return(sb);
+
+        return result;
     }
 }

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -73,7 +73,7 @@ public sealed class SearchResult
         sb.Append(" pv ");
         foreach (var move in Moves)
         {
-            sb.Append(move.UCIString()).Append(' ');
+            sb.Append(move.UCIStringMemoized()).Append(' ');
         }
 
         // Remove the trailing space

--- a/src/Lynx/ObjectPools.cs
+++ b/src/Lynx/ObjectPools.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.ObjectPool;
+using System.Text;
+
+namespace Lynx;
+public static class ObjectPools
+{
+    public static readonly ObjectPool<StringBuilder> StringBuilderPool =
+        new DefaultObjectPoolProvider().CreateStringBuilderPool(
+            initialCapacity: 256,
+            maximumRetainedCapacity: 4 * 1024); //Default value in StringBuilderPooledObjectPolicy.MaximumRetainedCapacity)
+}

--- a/src/Lynx/UCI/Commands/Engine/BestMoveCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/BestMoveCommand.cs
@@ -15,11 +15,20 @@ public sealed class BestMoveCommand : EngineBaseCommand
 {
     public const string Id = "bestmove";
 
-    public static string BestMove(Move move, Move? moveToPonder = null)
+    private readonly Move _move;
+    private readonly Move? _moveToPonder;
+
+    public BestMoveCommand(Move move, Move? moveToPonder = null)
     {
-        return $"bestmove {move.UCIString()}" +
-            (moveToPonder.HasValue
-                ? $" ponder {moveToPonder!.Value.UCIString()}"
+        _move = move;
+        _moveToPonder = moveToPonder;
+    }
+
+    public override string ToString()
+    {
+        return $"bestmove {_move.UCIStringMemoized()}" +
+            (_moveToPonder.HasValue
+                ? $" ponder {_moveToPonder!.Value.UCIStringMemoized()}"
                 : string.Empty);
     }
 }


### PR DESCRIPTION
Frist attempted in https://github.com/lynx-chess/Lynx/pull/997 with a concurrent dictionary,
After #999, we can guarantee the `Move.UCIString()` calls related to `info` commands to happen in a single thread, so we can re-try with a regular dictionary.
We also move here the serialization of `bestmove` command to the Writer thread to be able to do the same with `UCIString()` invocations there.

`bench 14` comparisons (it should be more drastic in real games, where all positions are related to each other) show 50% less string allocations

Before:

![main-precache](https://github.com/user-attachments/assets/c389d4bd-1721-4f5b-95f5-7772d568a43a)

This branch:

![cache](https://github.com/user-attachments/assets/d2877dc3-5003-4780-9be6-77c571a84c51)

Together with #1002

```
Test  | perf/stringbuilder-pool
Elo   | 1.30 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [-5.00, 0.00]
Games | 16004: +4511 -4451 =7042
Penta | [425, 1828, 3428, 1904, 417]
https://openbench.lynx-chess.com/test/711/ 
```