### PR TITLE
🧠 Use `StringBuilder` object pool for `info` command

### DIFF
--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="8.0.8" />
     <PackageReference Include="NLog" Version="5.3.3" />
   </ItemGroup>
 

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.UCI.Commands.Engine;
-using System.Text;
 
 namespace Lynx.Model;
 
@@ -46,7 +45,7 @@ public sealed class SearchResult
 
     public override string ToString()
     {
-        var sb = new StringBuilder(256);
+        var sb = ObjectPools.StringBuilderPool.Get();
 
         sb.Append(InfoCommand.Id)
           .Append(" depth ").Append(Depth)
@@ -82,6 +81,10 @@ public sealed class SearchResult
             sb.Length--;
         }
 
-        return sb.ToString();
+        var result = sb.ToString();
+
+        ObjectPools.StringBuilderPool.Return(sb);
+
+        return result;
     }
 }

--- a/src/Lynx/ObjectPools.cs
+++ b/src/Lynx/ObjectPools.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Extensions.ObjectPool;
+using System.Text;
+
+namespace Lynx;
+public static class ObjectPools
+{
+    public static readonly ObjectPool<StringBuilder> StringBuilderPool =
+        new DefaultObjectPoolProvider().CreateStringBuilderPool(
+            initialCapacity: 256,
+            maximumRetainedCapacity: 4 * 1024); //Default value in StringBuilderPooledObjectPolicy.MaximumRetainedCapacity)
+}


### PR DESCRIPTION
`bench 14` comparison: 25 times less SB allocations

Before:
![main-no-pool](https://github.com/user-attachments/assets/37db04fd-649a-4a6c-8d5e-8061e9364366)

After:
![sb-pool](https://github.com/user-attachments/assets/951a3f77-d6d8-4791-9579-10ed4055c87c)

Together with #1001

```
Test  | perf/stringbuilder-pool
Elo   | 1.30 +- 3.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [-5.00, 0.00]
Games | 16004: +4511 -4451 =7042
Penta | [425, 1828, 3428, 1904, 417]
https://openbench.lynx-chess.com/test/711/ 
```