### PR TITLE
🧹 Differentiate `MinEval`/`MaxEval` and `MinStaticEval`/`MaxStaticEval`

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -92,6 +92,16 @@ public static partial class EvaluationConstants
     public const int CheckMateBaseEvaluation = 30_000;
 
     /// <summary>
+    /// Max eval, including checkmate values
+    /// </summary>
+    public const int MaxEval = CheckMateBaseEvaluation + 1;
+
+    /// <summary>
+    /// Min eval, including checkmate values
+    /// </summary>
+    public const int MinEval = -CheckMateBaseEvaluation - 1;
+
+    /// <summary>
     /// This value combined with <see cref="PositiveCheckmateDetectionLimit"/> and <see cref="NegativeCheckmateDetectionLimit"/> should allows mates up to in <see cref="Constants.AbsoluteMaxDepth"/> moves.
     /// </summary>
     public const int CheckmateDepthFactor = 10;
@@ -106,9 +116,16 @@ public static partial class EvaluationConstants
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
-    public const int MinEval = NegativeCheckmateDetectionLimit + 1;
+    /// <summary>
+    /// Max static eval. It doesn't include checkmate values and it's below <see cref="PositiveCheckmateDetectionLimit"/>
+    /// </summary>
+    public const int MaxStaticEval = PositiveCheckmateDetectionLimit - 1;
 
-    public const int MaxEval = PositiveCheckmateDetectionLimit - 1;
+    /// <summary>
+    /// Min static eval. It doesn't include checkmate values and it's above <see cref="NegativeCheckmateDetectionLimit"/>
+    /// </summary>
+    public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1;
+
 
     public const int PVMoveScoreValue = 4_194_304;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -569,7 +569,7 @@ public class Position : IDisposable
 
         eval = ScaleEvalWith50MovesDrawDistance(eval, movesWithoutCaptureOrPawnMove);
 
-        eval = Math.Clamp(eval, MinEval, MaxEval);
+        eval = Math.Clamp(eval, MinStaticEval, MaxStaticEval);
 
         var sideEval = Side == Side.White
             ? eval

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -8,9 +8,6 @@ namespace Lynx;
 
 public sealed partial class Engine
 {
-    private const int MinValue = short.MinValue;
-    private const int MaxValue = short.MaxValue;
-
     /// <summary>
     /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
     /// </summary>
@@ -409,7 +406,7 @@ $" {484,-3}                                                         {_pVTable[48
     [Conditional("DEBUG")]
     internal void PrintHistoryMoves()
     {
-        int max = int.MinValue;
+        int max = EvaluationConstants.MinEval;
 
         for (int i = 0; i < 12; ++i)
         {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -68,8 +68,8 @@ public sealed partial class Engine
         Array.Clear(_maxDepthReached);
 
         int bestEvaluation = 0;
-        int alpha = MinValue;
-        int beta = MaxValue;
+        int alpha = EvaluationConstants.MinEval;
+        int beta = EvaluationConstants.MaxEval;
         SearchResult? lastSearchResult = null;
         int depth = 1;
         bool isMateDetected = false;
@@ -115,8 +115,8 @@ public sealed partial class Engine
                     // 🔍 Aspiration Windows
                     var window = Configuration.EngineSettings.AspirationWindow_Base;
 
-                    alpha = Math.Max(MinValue, lastSearchResult.Evaluation - window);
-                    beta = Math.Min(MaxValue, lastSearchResult.Evaluation + window);
+                    alpha = Math.Max(EvaluationConstants.MinEval, lastSearchResult.Evaluation - window);
+                    beta = Math.Min(EvaluationConstants.MaxEval, lastSearchResult.Evaluation + window);
 
                     while (true)
                     {
@@ -127,12 +127,12 @@ public sealed partial class Engine
                         // Depth change: https://github.com/lynx-chess/Lynx/pull/440
                         if (alpha >= bestEvaluation)     // Fail low
                         {
-                            alpha = Math.Max(bestEvaluation - window, MinValue);
+                            alpha = Math.Max(bestEvaluation - window, EvaluationConstants.MinEval);
                             beta = (alpha + beta) >> 1;  // (alpha + beta) / 2
                         }
                         else if (beta <= bestEvaluation)     // Fail high
                         {
-                            beta = Math.Min(bestEvaluation + window, MaxValue);
+                            beta = Math.Min(bestEvaluation + window, EvaluationConstants.MaxEval);
                         }
                         else
                         {

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -21,16 +21,50 @@ public class EvaluationConstantsTest
         (1 * (Math.Max(MiddleGameKingTable[0].Max(), EndGameKingTable[0].Max()) + (UnpackMG(KingShieldBonus) * 8))) +
         MiddleGameQueenTable[0].Max(); // just in case
 
-    [TestCase(PositiveCheckmateDetectionLimit)]
-    [TestCase(-NegativeCheckmateDetectionLimit)]
-    public void CheckmateDetectionLimitConstants(int checkmateDetectionLimit)
+    [Test]
+    public void PositiveCheckmateDetectionLimitTest()
     {
-        Assert.Greater(CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth * CheckmateDepthFactor),
-            checkmateDetectionLimit);
+        Assert.Greater(CheckMateBaseEvaluation - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor),
+            PositiveCheckmateDetectionLimit);
 
-        Assert.Greater(checkmateDetectionLimit, _sensibleEvaluation);
+        Assert.Greater(PositiveCheckmateDetectionLimit, _sensibleEvaluation);
 
-        Assert.Greater(short.MaxValue, checkmateDetectionLimit);
+        Assert.Greater(short.MaxValue, PositiveCheckmateDetectionLimit);
+    }
+
+    [Test]
+    public void NegativeCheckmateDetectionLimitTest()
+    {
+        Assert.Less(-(CheckMateBaseEvaluation - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor)),
+            NegativeCheckmateDetectionLimit);
+
+        Assert.Less(NegativeCheckmateDetectionLimit, -_sensibleEvaluation);
+
+        Assert.Less(short.MinValue, NegativeCheckmateDetectionLimit);
+    }
+
+    [Test]
+    public void MaxEvalTest()
+    {
+        Assert.Greater(MaxEval, PositiveCheckmateDetectionLimit + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
+    }
+
+    [Test]
+    public void MinEvalTest()
+    {
+        Assert.Less(MinEval, NegativeCheckmateDetectionLimit - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
+    }
+
+    [Test]
+    public void MaxStaticEvalTest()
+    {
+        Assert.Less(MaxStaticEval, PositiveCheckmateDetectionLimit);
+    }
+
+    [Test]
+    public void MinStaticEvalTest()
+    {
+        Assert.Greater(MinStaticEval, NegativeCheckmateDetectionLimit);
     }
 
     [Test]

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -957,10 +957,10 @@ public class PositionTest
     /// </summary>
     /// <param name="fen"></param>
     /// <param name="expectedStaticEvaluation"></param>
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", MinEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", MaxEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
-    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K6k b - - 0 1", MinEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
-    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K5k1 w - - 0 1", MaxEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
+    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", MinStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K6k b - - 0 1", MinStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
+    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
     public void StaticEvaluation_Clamp(string fen, int expectedStaticEvaluation)
     {
         var position = new Position(fen);


### PR DESCRIPTION
Former one used to alpha/beta, latter one used for static eval clamp.

No bench change