### PR TITLE
🔍 Assign `bestScore` to `MinEval` instead of to `NegativeCheckmateDetectionLimitt`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -178,7 +178,7 @@ public sealed partial class Engine
         }
 
         var nodeType = NodeType.Alpha;
-        int bestScore = EvaluationConstants.NegativeCheckmateDetectionLimit;
+        int bestScore = EvaluationConstants.MinEval;
         Move? bestMove = null;
         bool isAnyMoveValid = false;
 


### PR DESCRIPTION
```
Score of Lynx-search-fail-soft-mineval-4022-win-x64 vs Lynx 4021 - main: 1441 - 1415 - 2414  [0.502] 5270
...      Lynx-search-fail-soft-mineval-4022-win-x64 playing White: 1083 - 347 - 1205  [0.640] 2635
...      Lynx-search-fail-soft-mineval-4022-win-x64 playing Black: 358 - 1068 - 1209  [0.365] 2635
...      White vs Black: 2151 - 705 - 2414  [0.637] 5270
Elo difference: 1.7 +/- 6.9, LOS: 68.7 %, DrawRatio: 45.8 %
SPRT: llr 0.0516 (1.8%), lbound -2.25, ubound 2.89
```