### PR TITLE
⚡ Only update PV table on PV nodes

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -349,7 +349,7 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, score);
 
-            if(score > bestScore)
+            if (score > bestScore)
             {
                 bestScore = score;
             }
@@ -360,8 +360,11 @@ public sealed partial class Engine
                 alpha = score;
                 bestMove = move;
 
-                _pVTable[pvIndex] = move;
-                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                if (pvNode)
+                {
+                    _pVTable[pvIndex] = move;
+                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                }
 
                 nodeType = NodeType.Exact;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -466,8 +466,11 @@ public sealed partial class Engine
                 alpha = evaluation;
                 bestMove = move;
 
-                _pVTable[pvIndex] = move;
-                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                if (pvNode)
+                {
+                    _pVTable[pvIndex] = move;
+                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                }
 
                 nodeType = NodeType.Exact;
             }


### PR DESCRIPTION
```
Score of Lynx-perf-update-pvtable-pvnode-only-4016-win-x64 vs Lynx 4008 - main: 3497 - 3425 - 5208  [0.503] 12130
...      Lynx-perf-update-pvtable-pvnode-only-4016-win-x64 playing White: 2509 - 956 - 2600  [0.628] 6065
...      Lynx-perf-update-pvtable-pvnode-only-4016-win-x64 playing Black: 988 - 2469 - 2608  [0.378] 6065
...      White vs Black: 4978 - 1944 - 5208  [0.625] 12130
Elo difference: 2.1 +/- 4.7, LOS: 80.7 %, DrawRatio: 42.9 %
SPRT: llr 0.297 (10.3%), lbound -2.25, ubound 2.89
```

```bash
> python .\sprt.py -w 3497 -l 3425 -d 5208 -e0 -5 -e1 0
ELO: 2.06 +- 4.66 [-2.6, 6.73]
LLR: 2.95 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```