### PR TITLE
🔍 NMP: conditional fail hard to avoid false mates

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -157,12 +157,18 @@ public sealed partial class Engine
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                 var gameState = position.MakeNullMove();
-                var evaluation = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
+                var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
                 position.UnMakeNullMove(gameState);
 
-                if (evaluation >= beta)
+                if (nmpScore >= beta)
                 {
-                    return evaluation;
+                    // Avoid false mates in NMP fail soft - idea by cj5716
+                    if (nmpScore > EvaluationConstants.PositiveCheckmateDetectionLimit)
+                    {
+                        nmpScore = beta;
+                    }
+
+                    return nmpScore;
                 }
             }
         }
@@ -349,7 +355,7 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, score);
 
-            if(score > bestScore)
+            if (score > bestScore)
             {
                 bestScore = score;
             }


### PR DESCRIPTION
Idea by cj5716 (Alex).

No bench change though, so I don't have many hopes.

```
Test  | search/fail-soft-nmp
Elo   | 1.34 +- 1.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.72 (-2.25, 2.89) [0.00, 3.00]
Games | 48988: +13615 -13426 =21947
Penta | [1117, 5488, 11098, 5671, 1120]
https://openbench.lynx-chess.com/test/759/
```

![image](https://github.com/user-attachments/assets/d1594a9a-c06d-42df-9764-f43b73418102)
