### PR TITLE
🔍 Fail soft TT cutoffs

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -94,13 +94,13 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Evaluation, ShortMove BestMove, NodeType NodeType, int score) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
+    public static (int Evaluation, ShortMove BestMove, NodeType NodeType) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         if ((position.UniqueIdentifier >> 48) != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default, default, default);
+            return (EvaluationConstants.NoHashEntry, default, default);
         }
 
         var eval = EvaluationConstants.NoHashEntry;
@@ -114,13 +114,13 @@ public static class TranspositionTableExtensions
             eval = entry.Type switch
             {
                 NodeType.Exact => score,
-                NodeType.Alpha when score <= alpha => alpha,
-                NodeType.Beta when score >= beta => beta,
+                NodeType.Alpha when score <= alpha => score,
+                NodeType.Beta when score >= beta => score,
                 _ => EvaluationConstants.NoHashEntry
             };
         }
 
-        return (eval, entry.Move, entry.Type, entry.Score);
+        return (eval, entry.Move, entry.Type);
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -94,13 +94,13 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Evaluation, ShortMove BestMove, NodeType NodeType) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
+    public static (int Evaluation, ShortMove BestMove, NodeType NodeType, int RawScore) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
         if ((position.UniqueIdentifier >> 48) != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default, default);
+            return (EvaluationConstants.NoHashEntry, default, default, default);
         }
 
         var eval = EvaluationConstants.NoHashEntry;
@@ -120,7 +120,7 @@ public static class TranspositionTableExtensions
             };
         }
 
-        return (eval, entry.Move, entry.Type);
+        return (eval, entry.Move, entry.Type, entry.Score);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -42,12 +42,11 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         ShortMove ttBestMove = default;
         NodeType ttElementType = default;
-        int ttEvaluation = default;
-        int ttScore = default;
+        int ttEvaluation = default;             // TODO rename ttScore
 
         if (!isRoot)
         {
-            (ttEvaluation, ttBestMove, ttElementType, ttScore) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
+            (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
             if (!pvNode && ttEvaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttEvaluation;
@@ -94,9 +93,9 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttElementType != default && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttElementType != default && ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
-                staticEval = ttScore;
+                staticEval = ttEvaluation;
             }
 
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -530,9 +530,9 @@ public sealed partial class Engine
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
         var ttProbeResult = _tt.ProbeHash(_ttMask, position, 0, ply, alpha, beta);
-        if (ttProbeResult.Evaluation != EvaluationConstants.NoHashEntry)
+        if (ttProbeResult.Score != EvaluationConstants.NoHashEntry)
         {
-            return ttProbeResult.Evaluation;
+            return ttProbeResult.Score;
         }
         ShortMove ttBestMove = ttProbeResult.BestMove;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -43,10 +43,11 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
         NodeType ttElementType = default;
         int ttEvaluation = default;             // TODO rename ttScore
+        int ttScore = default;                  // TODO rename ttRawScore
 
         if (!isRoot)
         {
-            (ttEvaluation, ttBestMove, ttElementType) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
+            (ttEvaluation, ttBestMove, ttElementType, ttScore) = _tt.ProbeHash(_ttMask, position, depth, ply, alpha, beta);
             if (!pvNode && ttEvaluation != EvaluationConstants.NoHashEntry)
             {
                 return ttEvaluation;
@@ -93,9 +94,9 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttElementType != default && ttElementType != (ttEvaluation > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttElementType != default && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
-                staticEval = ttEvaluation;
+                staticEval = ttScore;
             }
 
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -74,10 +74,10 @@ public class TranspositionTableTests
         Assert.AreEqual(expectedEvaluation, TranspositionTableExtensions.RecalculateMateScores(evaluation, depth));
     }
 
-    [TestCase(+19, NodeType.Alpha, +20, +30, 20)]
+    [TestCase(+19, NodeType.Alpha, +20, +30, +19)]
     [TestCase(+21, NodeType.Alpha, +20, +30, NoHashEntry)]
     [TestCase(+29, NodeType.Beta, +20, +30, NoHashEntry)]
-    [TestCase(+31, NodeType.Beta, +20, +30, 30)]
+    [TestCase(+31, NodeType.Beta, +20, +30, +31)]
     public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -86,7 +86,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, eval: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta).Score);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor)]
@@ -100,7 +100,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: sharedDepth, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(recordedEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100).Score);
     }
 
     [TestCase(CheckMateBaseEvaluation - 8 * CheckmateDepthFactor, 5, 4, CheckMateBaseEvaluation - 7 * CheckmateDepthFactor)]
@@ -115,6 +115,6 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: recordedDeph, eval: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100).Evaluation);
+        Assert.AreEqual(expectedProbeEval, transpositionTable.ProbeHash(mask, position, depth: 7, ply: probeDepth, alpha: 50, beta: 100).Score);
     }
 }


### PR DESCRIPTION
```
Test  | search/fail-soft-TT
Elo   | -179.79 +- 23.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 536: +51 -306 =179
Penta | [80, 108, 67, 13, 0]
https://openbench.lynx-chess.com/test/758/
```

Depends on https://github.com/lynx-chess/Lynx/pull/1041 maybe?

Nope
```
Score of Lynx-search-fail-soft-tt-4032-win-x64 vs Lynx 4031 - main: 36 - 193 - 94  [0.257] 323
...      Lynx-search-fail-soft-tt-4032-win-x64 playing White: 31 - 75 - 55  [0.363] 161
...      Lynx-search-fail-soft-tt-4032-win-x64 playing Black: 5 - 118 - 39  [0.151] 162
...      White vs Black: 149 - 80 - 94  [0.607] 323
Elo difference: -184.5 +/- 34.2, LOS: 0.0 %, DrawRatio: 29.1 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Maybe https://github.com/lynx-chess/Lynx/pull/1046?

Nope
```
Test  | search/fail-soft-TT-test-with-qsearch-failsoft
Elo   | -279.59 +- 920.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.06 (-2.25, 2.89) [0.00, 3.00]
Games | 12: +0 -8 =4
Penta | [4, 0, 2, 0, 0]
https://openbench.lynx-chess.com/test/765/
```

Reverting TT raw score usage:

8+0.08
```
Score of Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 vs Lynx 4045 - main: 1294 - 1099 - 2180  [0.521] 4573
...      Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 playing White: 998 - 233 - 1056  [0.667] 2287
...      Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 playing Black: 296 - 866 - 1124  [0.375] 2286
...      White vs Black: 1864 - 529 - 2180  [0.646] 4573
Elo difference: 14.8 +/- 7.3, LOS: 100.0 %, DrawRatio: 47.7 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 vs Lynx 4045 - main: 245 - 238 - 467  [0.504] 950
...      Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 playing White: 211 - 45 - 220  [0.674] 476
...      Lynx-search-fail-soft-tt-revert-rawscore-4049-win-x64 playing Black: 34 - 193 - 247  [0.332] 474
...      White vs Black: 404 - 79 - 467  [0.671] 950
Elo difference: 2.6 +/- 15.7, LOS: 62.5 %, DrawRatio: 49.2 %
SPRT: llr 0.0491 (1.7%), lbound -2.25, ubound 2.89
```