### PR TITLE
🔍 Remove `pvNode` condition for first move full search

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -231,7 +231,7 @@ public sealed partial class Engine
                 // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
                 Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
             }
-            else if (pvNode && visitedMovesCounter == 0)
+            else if (visitedMovesCounter == 0)
             {
                 PrefetchTTEntry();
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters


### PR DESCRIPTION
```
Test  | search/full-firstmove-nonpv
Elo   | 1.04 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.21 (-2.25, 2.89) [-3.00, 1.00]
Games | 26506: +7431 -7352 =11723
Penta | [769, 3103, 5402, 3238, 741]
https://openbench.lynx-chess.com/test/757/
```

```
> python .\sprt.py -w 7423 -l 7348 -d 11713 -e0 -5 -e1 0
ELO: 0.984 +- 3.12 [-2.14, 4.1]
LLR: 4.74 [-5.0, 0.0] (-2.94, 2.94)
H1 Accepted
```