### PR TITLE
🔍 QSearch: Fail hard -> fail soft, alpha before beta

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -564,6 +564,8 @@ public sealed partial class Engine
 
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
+        int bestScore = staticEvaluation;
+
         bool isThereAnyValidCapture = false;
 
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
@@ -610,31 +612,37 @@ public sealed partial class Engine
             Game.PushToMoveStack(ply, move);
 
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-            int evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
+            int score = -QuiescenceSearch(ply + 1, -beta, -alpha);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
             position.UnmakeMove(move, gameState);
 
-            PrintMove(position, ply, move, evaluation);
+            PrintMove(position, ply, move, score);
 
-            // Fail-hard beta-cutoff
-            if (evaluation >= beta)
+            if(score > bestScore)
             {
-                PrintMessage($"Pruning: {move} is enough to discard this line");
-
-                _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
-
-                return evaluation; // The refutation doesn't matter, since it'll be pruned
+                bestScore = score;
             }
 
-            if (evaluation > alpha)
+            // Improving alpha
+            if (score > alpha)
             {
-                alpha = evaluation;
+                alpha = score;
                 bestMove = move;
 
                 _pVTable[pvIndex] = move;
                 CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                 nodeType = NodeType.Exact;
+            }
+
+            // Fail-hard beta-cutoff
+            if (score >= beta)
+            {
+                PrintMessage($"Pruning: {move} is enough to discard this line");
+
+                _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
+
+                return bestScore; // The refutation doesn't matter, since it'll be pruned
             }
         }
 
@@ -648,8 +656,8 @@ public sealed partial class Engine
             return finalEval;
         }
 
-        _tt.RecordHash(_ttMask, position, 0, ply, alpha, nodeType, bestMove);
+        _tt.RecordHash(_ttMask, position, 0, ply, bestScore, nodeType, bestMove);
 
-        return alpha;
+        return bestScore;
     }
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -617,31 +617,31 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, score);
 
-            if(score > bestScore)
+            if (score > bestScore)
             {
                 bestScore = score;
-            }
 
-            // Improving alpha
-            if (score > alpha)
-            {
-                alpha = score;
-                bestMove = move;
+                // Improving alpha
+                if (score > alpha)
+                {
+                    alpha = score;
+                    bestMove = move;
 
-                _pVTable[pvIndex] = move;
-                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                    _pVTable[pvIndex] = move;
+                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
-                nodeType = NodeType.Exact;
-            }
+                    nodeType = NodeType.Exact;
+                }
 
-            // Fail-hard beta-cutoff
-            if (score >= beta)
-            {
-                PrintMessage($"Pruning: {move} is enough to discard this line");
+                // Fail-hard beta-cutoff
+                if (score >= beta)
+                {
+                    PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
 
-                return bestScore; // The refutation doesn't matter, since it'll be pruned
+                    return bestScore; // The refutation doesn't matter, since it'll be pruned
+                }
             }
         }
 


### PR DESCRIPTION
See https://github.com/lynx-chess/Lynx/pull/1052

Fail soft with alpha before beta vs fail hard
```
Score of Lynx-search-fail-soft-qsearch-4034-win-x64 vs Lynx 4031 - main: 3798 - 3557 - 6180  [0.509] 13535
...      Lynx-search-fail-soft-qsearch-4034-win-x64 playing White: 2885 - 823 - 3060  [0.652] 6768
...      Lynx-search-fail-soft-qsearch-4034-win-x64 playing Black: 913 - 2734 - 3120  [0.365] 6767
...      White vs Black: 5619 - 1736 - 6180  [0.643] 13535
Elo difference: 6.2 +/- 4.3, LOS: 99.8 %, DrawRatio: 45.7 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

Fail soft with alpha before beta  vs fail soft beta before alpha
```
Test  | search/fail-soft-qsearch
Elo   | -28.80 +- 20.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.97 (-2.25, 2.89) [0.00, 5.00]
Games | 520: +127 -170 =223
Penta | [23, 70, 100, 61, 6]
https://openbench.lynx-chess.com/test/766/
```