### PR TITLE
🔍 Regular search fail soft: beta before alpha

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -353,21 +353,6 @@ public sealed partial class Engine
             {
                 bestScore = score;
 
-                // Improving alpha
-                if (score > alpha)
-                {
-                    alpha = score;
-                    bestMove = move;
-
-                    if (pvNode)
-                    {
-                        _pVTable[pvIndex] = move;
-                        CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
-                    }
-
-                    nodeType = NodeType.Exact;
-                }
-
                 // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
                 if (score >= beta)
                 {
@@ -479,6 +464,21 @@ public sealed partial class Engine
                     _tt.RecordHash(_ttMask, position, depth, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore;
+                }
+
+                // Improving alpha
+                if (score > alpha)
+                {
+                    alpha = score;
+                    bestMove = move;
+
+                    if (pvNode)
+                    {
+                        _pVTable[pvIndex] = move;
+                        CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                    }
+
+                    nodeType = NodeType.Exact;
                 }
             }
             ++visitedMovesCounter;


### PR DESCRIPTION
```
Score of Lynx-search-beta-before-alpha-4036-win-x64 vs Lynx 4035 - main: 188 - 242 - 330  [0.464] 760
...      Lynx-search-beta-before-alpha-4036-win-x64 playing White: 148 - 60 - 172  [0.616] 380
...      Lynx-search-beta-before-alpha-4036-win-x64 playing Black: 40 - 182 - 158  [0.313] 380
...      White vs Black: 330 - 100 - 330  [0.651] 760
Elo difference: -24.7 +/- 18.6, LOS: 0.5 %, DrawRatio: 43.4 %
SPRT: llr -0.878 (-30.4%), lbound -2.25, ubound 2.89
```