### PR TITLE
🔍 Fail hard: alpha before beta

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -348,6 +348,17 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, evaluation);
 
+            if (evaluation > alpha)
+            {
+                alpha = evaluation;
+                bestMove = move;
+
+                _pVTable[pvIndex] = move;
+                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+
+                nodeType = NodeType.Exact;
+            }
+
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
             if (evaluation >= beta)
             {
@@ -459,17 +470,6 @@ public sealed partial class Engine
                 _tt.RecordHash(_ttMask, position, depth, ply, beta, NodeType.Beta, bestMove);
 
                 return beta;    // TODO return evaluation?
-            }
-
-            if (evaluation > alpha)
-            {
-                alpha = evaluation;
-                bestMove = move;
-
-                _pVTable[pvIndex] = move;
-                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
-
-                nodeType = NodeType.Exact;
             }
 
             ++visitedMovesCounter;


### PR DESCRIPTION
Just validating #1039 cause I'm a moron that tests multiple things at the same time, and given how bad is having beta before alpha with fail soft (#1047) 

vs 5a3803d24e98b47912ad3dc4bb65396f5fdbd71a (previous main commit)
```
Test  | test/alpha-before-beta
Elo   | -6.32 +- 47.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.03 (-2.25, 2.89) [0.00, 3.00]
Games | 110: +33 -35 =42
Penta | [4, 13, 24, 9, 5]
https://openbench.lynx-chess.com/test/762/
```