### PR TITLE
🙄 Properly test fail-soft

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -349,9 +349,9 @@ public sealed partial class Engine
             PrintMove(position, ply, move, evaluation);
 
             // Improving alpha
-            if (score > alpha)
+            if (evaluation > alpha)
             {
-                alpha = score;
+                alpha = evaluation;
 
                 if (pvNode)
                 {
@@ -474,7 +474,6 @@ public sealed partial class Engine
 
                 return beta;    // TODO return evaluation?
             }
-
 
             ++visitedMovesCounter;
         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -352,135 +352,136 @@ public sealed partial class Engine
             if (score > bestScore)
             {
                 bestScore = score;
-
-                // Improving alpha
-                if (score > alpha)
-                {
-                    alpha = score;
-                    bestMove = move;
-
-                    if (pvNode)
-                    {
-                        _pVTable[pvIndex] = move;
-                        CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
-                    }
-
-                    nodeType = NodeType.Exact;
-                }
-
-                // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
-                if (score >= beta)
-                {
-                    PrintMessage($"Pruning: {move} is enough");
-
-                    if (isCapture)
-                    {
-                        var piece = move.Piece();
-                        var targetSquare = move.TargetSquare();
-                        var capturedPiece = move.CapturedPiece();
-
-                        var captureHistoryIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
-                        _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
-                            _captureHistory[captureHistoryIndex],
-                            EvaluationConstants.HistoryBonus[depth]);
-
-                        // 🔍 Capture history penalty/malus
-                        // When a capture fails high, penalize previous visited captures
-                        for (int i = 0; i < visitedMovesCounter; ++i)
-                        {
-                            var visitedMove = visitedMoves[i];
-
-                            if (visitedMove.IsCapture())
-                            {
-                                var visitedMovePiece = visitedMove.Piece();
-                                var visitedMoveTargetSquare = visitedMove.TargetSquare();
-                                var visitedMoveCapturedPiece = visitedMove.CapturedPiece();
-
-                                captureHistoryIndex = CaptureHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, visitedMoveCapturedPiece);
-
-                                _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
-                                    _captureHistory[captureHistoryIndex],
-                                    -EvaluationConstants.HistoryBonus[depth]);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        // 🔍 Quiet history moves
-                        // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
-                        var piece = move.Piece();
-                        var targetSquare = move.TargetSquare();
-
-                        _quietHistory[piece][targetSquare] = ScoreHistoryMove(
-                            _quietHistory[piece][targetSquare],
-                            EvaluationConstants.HistoryBonus[depth]);
-
-                        // 🔍 Continuation history
-                        // - Counter move history (continuation history, ply - 1)
-                        var previousMove = Game.PopFromMoveStack(ply - 1);
-                        var previousMovePiece = previousMove.Piece();
-                        var previousTargetSquare = previousMove.TargetSquare();
-
-                        var continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
-
-                        _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                            _continuationHistory[continuationHistoryIndex],
-                            EvaluationConstants.HistoryBonus[depth]);
-
-                        //    var previousPreviousMove = Game.MoveStack[ply - 2];
-                        //    var previousPreviousMovePiece = previousPreviousMove.Piece();
-                        //    var previousPreviousMoveTargetSquare = previousPreviousMove.TargetSquare();
-
-                        //    _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare] = ScoreHistoryMove(
-                        //        _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare],
-                        //        EvaluationConstants.HistoryBonus[depth]);
-
-                        for (int i = 0; i < visitedMovesCounter - 1; ++i)
-                        {
-                            var visitedMove = visitedMoves[i];
-
-                            if (!visitedMove.IsCapture())
-                            {
-                                var visitedMovePiece = visitedMove.Piece();
-                                var visitedMoveTargetSquare = visitedMove.TargetSquare();
-
-                                // 🔍 Quiet history penalty / malus
-                                // When a quiet move fails high, penalize previous visited quiet moves
-                                _quietHistory[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
-                                    _quietHistory[visitedMovePiece][visitedMoveTargetSquare],
-                                    -EvaluationConstants.HistoryBonus[depth]);
-
-                                // 🔍 Continuation history penalty / malus
-                                continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
-
-                                _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                                    _continuationHistory[continuationHistoryIndex],
-                                    -EvaluationConstants.HistoryBonus[depth]);
-                            }
-                        }
-
-                        var thisPlyKillerMoves = _killerMoves[ply];
-                        if (move.PromotedPiece() == default && move != thisPlyKillerMoves[0])
-                        {
-                            // 🔍 Killer moves
-                            if (move != thisPlyKillerMoves[1])
-                            {
-                                thisPlyKillerMoves[2] = thisPlyKillerMoves[1];
-                            }
-
-                            thisPlyKillerMoves[1] = thisPlyKillerMoves[0];
-                            thisPlyKillerMoves[0] = move;
-
-                            // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
-                            _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
-                        }
-                    }
-
-                    _tt.RecordHash(_ttMask, position, depth, ply, bestScore, NodeType.Beta, bestMove);
-
-                    return bestScore;
-                }
             }
+
+            // Improving alpha
+            if (score > alpha)
+            {
+                alpha = score;
+                bestMove = move;
+
+                if (pvNode)
+                {
+                    _pVTable[pvIndex] = move;
+                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                }
+
+                nodeType = NodeType.Exact;
+            }
+
+            // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
+            if (score >= beta)
+            {
+                PrintMessage($"Pruning: {move} is enough");
+
+                if (isCapture)
+                {
+                    var piece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+                    var capturedPiece = move.CapturedPiece();
+
+                    var captureHistoryIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
+                    _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
+                        _captureHistory[captureHistoryIndex],
+                        EvaluationConstants.HistoryBonus[depth]);
+
+                    // 🔍 Capture history penalty/malus
+                    // When a capture fails high, penalize previous visited captures
+                    for (int i = 0; i < visitedMovesCounter; ++i)
+                    {
+                        var visitedMove = visitedMoves[i];
+
+                        if (visitedMove.IsCapture())
+                        {
+                            var visitedMovePiece = visitedMove.Piece();
+                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
+                            var visitedMoveCapturedPiece = visitedMove.CapturedPiece();
+
+                            captureHistoryIndex = CaptureHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, visitedMoveCapturedPiece);
+
+                            _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
+                                _captureHistory[captureHistoryIndex],
+                                -EvaluationConstants.HistoryBonus[depth]);
+                        }
+                    }
+                }
+                else
+                {
+                    // 🔍 Quiet history moves
+                    // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
+                    var piece = move.Piece();
+                    var targetSquare = move.TargetSquare();
+
+                    _quietHistory[piece][targetSquare] = ScoreHistoryMove(
+                        _quietHistory[piece][targetSquare],
+                        EvaluationConstants.HistoryBonus[depth]);
+
+                    // 🔍 Continuation history
+                    // - Counter move history (continuation history, ply - 1)
+                    var previousMove = Game.PopFromMoveStack(ply - 1);
+                    var previousMovePiece = previousMove.Piece();
+                    var previousTargetSquare = previousMove.TargetSquare();
+
+                    var continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
+
+                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
+                        _continuationHistory[continuationHistoryIndex],
+                        EvaluationConstants.HistoryBonus[depth]);
+
+                    //    var previousPreviousMove = Game.MoveStack[ply - 2];
+                    //    var previousPreviousMovePiece = previousPreviousMove.Piece();
+                    //    var previousPreviousMoveTargetSquare = previousPreviousMove.TargetSquare();
+
+                    //    _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare] = ScoreHistoryMove(
+                    //        _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare],
+                    //        EvaluationConstants.HistoryBonus[depth]);
+
+                    for (int i = 0; i < visitedMovesCounter - 1; ++i)
+                    {
+                        var visitedMove = visitedMoves[i];
+
+                        if (!visitedMove.IsCapture())
+                        {
+                            var visitedMovePiece = visitedMove.Piece();
+                            var visitedMoveTargetSquare = visitedMove.TargetSquare();
+
+                            // 🔍 Quiet history penalty / malus
+                            // When a quiet move fails high, penalize previous visited quiet moves
+                            _quietHistory[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
+                                _quietHistory[visitedMovePiece][visitedMoveTargetSquare],
+                                -EvaluationConstants.HistoryBonus[depth]);
+
+                            // 🔍 Continuation history penalty / malus
+                            continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
+
+                            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
+                                _continuationHistory[continuationHistoryIndex],
+                                -EvaluationConstants.HistoryBonus[depth]);
+                        }
+                    }
+
+                    var thisPlyKillerMoves = _killerMoves[ply];
+                    if (move.PromotedPiece() == default && move != thisPlyKillerMoves[0])
+                    {
+                        // 🔍 Killer moves
+                        if (move != thisPlyKillerMoves[1])
+                        {
+                            thisPlyKillerMoves[2] = thisPlyKillerMoves[1];
+                        }
+
+                        thisPlyKillerMoves[1] = thisPlyKillerMoves[0];
+                        thisPlyKillerMoves[0] = move;
+
+                        // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
+                        _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
+                    }
+                }
+
+                _tt.RecordHash(_ttMask, position, depth, ply, bestScore, NodeType.Beta, bestMove);
+
+                return bestScore;
+            }
+
             ++visitedMovesCounter;
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -221,10 +221,10 @@ public sealed partial class Engine
             Game.AddToPositionHashHistory(position.UniqueIdentifier);
             Game.PushToMoveStack(ply, move);
 
-            int evaluation;
+            int score;
             if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
             {
-                evaluation = 0;
+                score = 0;
 
                 // We don't need to evaluate further down to know it's a draw.
                 // Since we won't be evaluating further down, we need to clear the PV table because those moves there
@@ -235,7 +235,7 @@ public sealed partial class Engine
             {
                 PrefetchTTEntry();
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-                evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                score = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
             }
             else
@@ -318,24 +318,24 @@ public sealed partial class Engine
                 }
 
                 // Search with reduced depth
-                evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
+                score = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
 
                 // 🔍 Principal Variation Search (PVS)
-                if (evaluation > alpha && reduction > 0)
+                if (score > alpha && reduction > 0)
                 {
                     // Optimistic search, validating that the rest of the moves are worse than bestmove.
                     // It should produce more cutoffs and therefore be faster.
                     // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                     // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha);
+                    score = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha);
                 }
 
-                if (evaluation > alpha && evaluation < beta)
+                if (score > alpha && score < beta)
                 {
                     // PVS Hypothesis invalidated -> search with full depth and full score bandwidth
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-                    evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                    score = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
                 }
             }
@@ -346,12 +346,12 @@ public sealed partial class Engine
             Game.RemoveFromPositionHashHistory();
             position.UnmakeMove(move, gameState);
 
-            PrintMove(position, ply, move, evaluation);
+            PrintMove(position, ply, move, score);
 
             // Improving alpha
-            if (evaluation > alpha)
+            if (score > alpha)
             {
-                alpha = evaluation;
+                alpha = score;
 
                 if (pvNode)
                 {
@@ -363,7 +363,7 @@ public sealed partial class Engine
             }
 
             // Fail-hard beta-cutoff - refutation found, no need to keep searching this line
-            if (evaluation >= beta)
+            if (score >= beta)
             {
                 PrintMessage($"Pruning: {move} is enough");
 


### PR DESCRIPTION
See [diff without whitespaces](https://github.com/lynx-chess/Lynx/pull/1049/files?diff=split&w=1): this reverts to fail hard, but keeping alpha and beta checks order.

```
Test  | test/fuck
Elo   | -59.10 +- 14.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 1098: +209 -394 =495
Penta | [55, 187, 209, 84, 14]
https://openbench.lynx-chess.com/test/763/
```