### PR TITLE
🔍 QSearch fail hard: alpha before beta

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -615,16 +615,6 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, evaluation);
 
-            // Fail-hard beta-cutoff
-            if (evaluation >= beta)
-            {
-                PrintMessage($"Pruning: {move} is enough to discard this line");
-
-                _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
-
-                return evaluation; // The refutation doesn't matter, since it'll be pruned
-            }
-
             if (evaluation > alpha)
             {
                 alpha = evaluation;
@@ -634,6 +624,16 @@ public sealed partial class Engine
                 CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                 nodeType = NodeType.Exact;
+            }
+
+            // Fail-hard beta-cutoff
+            if (evaluation >= beta)
+            {
+                PrintMessage($"Pruning: {move} is enough to discard this line");
+
+                _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
+
+                return evaluation; // The refutation doesn't matter, since it'll be pruned
             }
         }
 


### PR DESCRIPTION
```
Test  | qsearch/alpha-before-beta
Elo   | -17.02 +- 10.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.32 (-2.25, 2.89) [0.00, 3.00]
Games | 1982: +479 -576 =927
Penta | [54, 285, 399, 210, 43]
https://openbench.lynx-chess.com/test/764/
```