### PR TITLE
🔍 `parentWasNullMove` -> `ancestorWasNullMove`

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -113,7 +113,7 @@ public sealed partial class Engine
 
                 if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth || lastSearchResult?.Evaluation is null)
                 {
-                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
+                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, parentWasNullMove: false);
                 }
                 else
                 {
@@ -126,7 +126,7 @@ public sealed partial class Engine
                     while (true)
                     {
                         _isFollowingPV = true;
-                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
+                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, parentWasNullMove: false);
 
                         window += window >> 1;   // window / 2
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -113,7 +113,7 @@ public sealed partial class Engine
 
                 if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth || lastSearchResult?.Evaluation is null)
                 {
-                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, parentWasNullMove: false);
+                    bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, ancestorWasNullMove: false);
                 }
                 else
                 {
@@ -126,7 +126,7 @@ public sealed partial class Engine
                     while (true)
                     {
                         _isFollowingPV = true;
-                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, parentWasNullMove: false);
+                        bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta, ancestorWasNullMove: false);
 
                         window += window >> 1;   // window / 2
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -20,7 +20,7 @@ public sealed partial class Engine
     /// </param>
     /// <returns></returns>
     [SkipLocalsInit]
-    private int NegaMax(int depth, int ply, int alpha, int beta, bool parentWasNullMove = false)
+    private int NegaMax(int depth, int ply, int alpha, int beta, bool parentWasNullMove)
     {
         var position = Game.CurrentPosition;
 
@@ -250,7 +250,7 @@ public sealed partial class Engine
             else if (pvNode && visitedMovesCounter == 0)
             {
                 PrefetchTTEntry();
-                evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha, parentWasNullMove);
             }
             else
             {
@@ -332,7 +332,7 @@ public sealed partial class Engine
                 }
 
                 // Search with reduced depth
-                evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
+                evaluation = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha, parentWasNullMove);
 
                 // 🔍 Principal Variation Search (PVS)
                 if (evaluation > alpha && reduction > 0)
@@ -342,13 +342,13 @@ public sealed partial class Engine
                     // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                     // Search with full depth but narrowed score bandwidth
-                    evaluation = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha);
+                    evaluation = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha, parentWasNullMove);
                 }
 
                 if (evaluation > alpha && evaluation < beta)
                 {
                     // PVS Hypothesis invalidated -> search with full depth and full score bandwidth
-                    evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                    evaluation = -NegaMax(depth - 1, ply + 1, -beta, -alpha, parentWasNullMove);
                 }
             }
 


### PR DESCRIPTION
```
Test  | bugfix/propagate-parentWasNullMove
Elo   | -0.67 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 36516: +10090 -10160 =16266
Penta | [981, 4417, 7540, 4331, 989]
https://openbench.lynx-chess.com/test/743/
```