### PR TITLE
🔍 QSearch: Fail hard -> fail soft, beta before a,pha

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -564,6 +564,8 @@ public sealed partial class Engine
 
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
+        int bestScore = staticEvaluation;
+
         bool isThereAnyValidCapture = false;
 
         Span<int> scores = stackalloc int[pseudoLegalMoves.Length];
@@ -610,31 +612,37 @@ public sealed partial class Engine
             Game.PushToMoveStack(ply, move);
 
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-            int evaluation = -QuiescenceSearch(ply + 1, -beta, -alpha);
+            int score = -QuiescenceSearch(ply + 1, -beta, -alpha);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
             position.UnmakeMove(move, gameState);
 
-            PrintMove(position, ply, move, evaluation);
+            PrintMove(position, ply, move, score);
 
-            // Fail-hard beta-cutoff
-            if (evaluation >= beta)
+            if(score > bestScore)
             {
-                PrintMessage($"Pruning: {move} is enough to discard this line");
-
-                _tt.RecordHash(_ttMask, position, 0, ply, beta, NodeType.Beta, bestMove);
-
-                return evaluation; // The refutation doesn't matter, since it'll be pruned
+                bestScore = score;
             }
 
-            if (evaluation > alpha)
+            // Improving alpha
+            if (score > alpha)
             {
-                alpha = evaluation;
+                alpha = score;
                 bestMove = move;
 
                 _pVTable[pvIndex] = move;
                 CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                 nodeType = NodeType.Exact;
+            }
+
+            // Fail-hard beta-cutoff
+            if (score >= beta)
+            {
+                PrintMessage($"Pruning: {move} is enough to discard this line");
+
+                _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
+
+                return bestScore; // The refutation doesn't matter, since it'll be pruned
             }
         }
 
@@ -648,8 +656,8 @@ public sealed partial class Engine
             return finalEval;
         }
 
-        _tt.RecordHash(_ttMask, position, 0, ply, alpha, nodeType, bestMove);
+        _tt.RecordHash(_ttMask, position, 0, ply, bestScore, nodeType, bestMove);
 
-        return alpha;
+        return bestScore;
     }
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -617,31 +617,31 @@ public sealed partial class Engine
 
             PrintMove(position, ply, move, score);
 
-            if(score > bestScore)
+            if (score > bestScore)
             {
                 bestScore = score;
-            }
 
-            // Improving alpha
-            if (score > alpha)
-            {
-                alpha = score;
-                bestMove = move;
+                // Improving alpha
+                if (score > alpha)
+                {
+                    alpha = score;
+                    bestMove = move;
 
-                _pVTable[pvIndex] = move;
-                CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                    _pVTable[pvIndex] = move;
+                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
-                nodeType = NodeType.Exact;
-            }
+                    nodeType = NodeType.Exact;
+                }
 
-            // Fail-hard beta-cutoff
-            if (score >= beta)
-            {
-                PrintMessage($"Pruning: {move} is enough to discard this line");
+                // Fail-hard beta-cutoff
+                if (score >= beta)
+                {
+                    PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
 
-                return bestScore; // The refutation doesn't matter, since it'll be pruned
+                    return bestScore; // The refutation doesn't matter, since it'll be pruned
+                }
             }
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -621,6 +621,16 @@ public sealed partial class Engine
             {
                 bestScore = score;
 
+                // Fail-hard beta-cutoff
+                if (score >= beta)
+                {
+                    PrintMessage($"Pruning: {move} is enough to discard this line");
+
+                    _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
+
+                    return bestScore; // The refutation doesn't matter, since it'll be pruned
+                }
+
                 // Improving alpha
                 if (score > alpha)
                 {
@@ -631,16 +641,6 @@ public sealed partial class Engine
                     CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                     nodeType = NodeType.Exact;
-                }
-
-                // Fail-hard beta-cutoff
-                if (score >= beta)
-                {
-                    PrintMessage($"Pruning: {move} is enough to discard this line");
-
-                    _tt.RecordHash(_ttMask, position, 0, ply, bestScore, NodeType.Beta, bestMove);
-
-                    return bestScore; // The refutation doesn't matter, since it'll be pruned
                 }
             }
         }


### PR DESCRIPTION
See https://github.com/lynx-chess/Lynx/pull/1046

```
Score of Lynx-search-fail-soft-qsearch-beta-before-alpha-4042-win-x64 vs Lynx 4035 - main: 1169 - 971 - 1820  [0.525] 3960
...      Lynx-search-fail-soft-qsearch-beta-before-alpha-4042-win-x64 playing White: 874 - 217 - 889  [0.666] 1980
...      Lynx-search-fail-soft-qsearch-beta-before-alpha-4042-win-x64 playing Black: 295 - 754 - 931  [0.384] 1980
...      White vs Black: 1628 - 512 - 1820  [0.641] 3960
Elo difference: 17.4 +/- 7.9, LOS: 100.0 %, DrawRatio: 46.0 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```