### PR TITLE
🔍 NMP: fail hard

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -162,7 +162,7 @@ public sealed partial class Engine
 
                 if (evaluation >= beta)
                 {
-                    return evaluation;
+                    return beta;
                 }
             }
         }


### PR DESCRIPTION
```
Test  | search/nmp-fail-hard
Elo   | -4.73 +- 4.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 10656: +2810 -2955 =4891
Penta | [286, 1325, 2217, 1248, 252]
https://openbench.lynx-chess.com/test/767/
```