### PR TITLE
⚡ Simplify and potentially fix conditions for end of the game detection

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lynx;
@@ -391,9 +392,11 @@ public sealed partial class Engine
 
         if (!isAnyMoveValid)
         {
-            var eval = Position.EvaluateFinalPosition(ply, isInCheck);
+            Debug.Assert(bestMove is null);
 
+            var eval = Position.EvaluateFinalPosition(ply, isInCheck);
             _tt.RecordHash(_ttMask, position, depth, ply, eval, NodeType.Exact);
+
             return eval;
         }
 
@@ -552,6 +555,8 @@ public sealed partial class Engine
         if (!isAnyCaptureValid
             && !MoveGenerator.CanGenerateAtLeastAValidMove(position)) // Bad captures can be pruned, so all moves need to be generated for now
         {
+            Debug.Assert(bestMove is null);
+
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
             _tt.RecordHash(_ttMask, position, 0, ply, finalEval, NodeType.Exact);
 


### PR DESCRIPTION
I have some hope this change fixes the non-pv, min score bug
```
[GUI]	position fen rn1qk2r/1b1pnpbp/pp2p1p1/2pP4/P1P1PP2/2N5/1P4PP/R1BQKBNR w KQkq - 0 1 moves g1f3 d7d6 f1d3 e8g8 e1g1 b8d7 d5e6 f7e6 f3g5 f8f6 d1g4 d7f8 g5f3 e7c6 c1e3 d8e7 a1d1 f6f7 f3g5 f7f6 h2h3 c6d4 g1h2 f8d7 g4h4 h7h6 g5f3 a8f8 f3d4 g6g5 f4g5 f6f1 d4f5 f8f5 e4f5 g7e5 g2g3 f1f3 f5f6 e7f7 c3e2 f3e3 h4h6 b7e4 g5g6 e3e2 d3e2 f7g6 h6g6 e4g6 a4a5 b6a5 d1a1 d7f6 a1a5 f6e4 e2d3 e5g3 h2g2 g3e5 b2b3 g6f5 a5a6 e4d2 d3f5 e6f5 a6b6 f5f4 g2f2 f4f3 f2e3 e5f4 e3f4 f3f2 f4e3 d2c4 e3f2 c4b6 f2e3 g8g7 e3e4 g7g6 e4d3 g6g5 b3b4 c5b4 d3c2 b6d5 c2b3 g5h5 b3c4 h5h4 c4b3 h4h3 b3a4 h3g4 a4b3 g4f4 b3c2 f4e3 c2b1 e3d3 b1b2 d3c4 b2c1 c4c3 c1d1 d5b6 d1e2 d6d5 e2f3 d5d4 f3g4 d4d3 g4f5 d3d2 f5e5 b4b3 e5f5 b3b2 f5g5 b2b1q g5f4 d2d1q f4g5 d1d4
Position parsing took 0ms
[GUI]	isready
[Lynx]	readyok
[GUI]	go wtime 582 btime 1968 winc 80 binc 80
Soft time bound: 0.078s
Hard time bound: 0.276s
[Lynx]	info depth 1 seldepth 1 multipv 1 score cp -1108 nodes 2 nps 2 time 0 pv g5h6
[Lynx]	info depth 2 seldepth 3 multipv 1 score cp -1143 nodes 63 nps 63 time 0 pv g5h6 b1d1
[Lynx]	info depth 3 seldepth 5 multipv 1 score cp -1304 nodes 121 nps 121 time 0 pv g5h5 d4f6 h5g4
[Lynx]	info depth 4 seldepth 5 multipv 1 score cp -30001 nodes 22 nps 22 time 0 pv 
Depth 5: mate in -2 detected (49 moves until draw by repetition)
Stopping search: mate is short enough
[Lynx]	info depth 5 seldepth 9 multipv 1 score mate -2 nodes 365 nps 365 time 0 hashfull 108 pv g5h6 d4f6 h6h5 b1f5
[Lynx]	info depth 5 seldepth 9 multipv 1 score mate -2 nodes 365 nps 365 time 0 hashfull 108 pv g5h6 d4f6 h6h5 b1f5
[Lynx]	bestmove g5h6 ponder d4f6
```