### PR TITLE
🐛 Avoid aspiration windows after a checkmate has been detected in the search

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -106,7 +106,9 @@ public sealed partial class Engine
                 _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                 _nodes = 0;
 
-                if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth || lastSearchResult?.Evaluation is null)
+                if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
+                    || lastSearchResult?.Evaluation is null
+                    || lastSearchResult.Mate != 0)
                 {
                     bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
                 }
@@ -117,6 +119,9 @@ public sealed partial class Engine
 
                     alpha = Math.Max(EvaluationConstants.MinEval, lastSearchResult.Evaluation - window);
                     beta = Math.Min(EvaluationConstants.MaxEval, lastSearchResult.Evaluation + window);
+
+                    Debug.Assert(lastSearchResult.Mate == 0 && lastSearchResult.Evaluation > EvaluationConstants.NegativeCheckmateDetectionLimit && lastSearchResult.Evaluation < EvaluationConstants.PositiveCheckmateDetectionLimit);
+                    _logger.Debug("[{{alpha}}, {{beta}}], {{last search eval}} -> [{Alpha}, {Beta}], {Eval}", alpha, beta, lastSearchResult.Evaluation);
 
                     while (true)
                     {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -126,6 +126,9 @@ public sealed partial class Engine
 
                     while (true)
                     {
+                        _logger.Debug("Aspiration windows: [{Alpha}, {Beta}] for eval {Eval}, nodes {Nodes}, depth {Depth}",
+                            alpha, beta, bestEvaluation, _nodes, depth);
+
                         bestEvaluation = NegaMax(depth: depth, ply: 0, alpha, beta);
 
                         window += window >> 1;   // window / 2

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -114,14 +114,15 @@ public sealed partial class Engine
                 }
                 else
                 {
-                    // 🔍 Aspiration Windows
+                    // 🔍 Aspiration windows
                     var window = Configuration.EngineSettings.AspirationWindow_Base;
 
                     alpha = Math.Max(EvaluationConstants.MinEval, lastSearchResult.Evaluation - window);
                     beta = Math.Min(EvaluationConstants.MaxEval, lastSearchResult.Evaluation + window);
 
+                    _logger.Debug("Aspiration windows: [{Alpha}, {Beta}] for eval {Eval}, nodes {Nodes}, depth {Depth}",
+                        alpha, beta, lastSearchResult.Evaluation, _nodes, depth);
                     Debug.Assert(lastSearchResult.Mate == 0 && lastSearchResult.Evaluation > EvaluationConstants.NegativeCheckmateDetectionLimit && lastSearchResult.Evaluation < EvaluationConstants.PositiveCheckmateDetectionLimit);
-                    _logger.Debug("[{{alpha}}, {{beta}}], {{last search eval}} -> [{Alpha}, {Beta}], {Eval}", alpha, beta, lastSearchResult.Evaluation);
 
                     while (true)
                     {
@@ -144,8 +145,7 @@ public sealed partial class Engine
                             break;
                         }
 
-                        _logger.Debug("Eval ({0}) (depth {1}, nodes {2}) outside of aspiration window, new window [{3}, {4}]",
-                            bestEvaluation, depth, _nodes, alpha, beta);
+                        _logger.Debug("Aspiration windows: eval {Eval} outside of aspiration window", bestEvaluation);
                     }
                 }
 


### PR DESCRIPTION
Problem to tackle: infinite aspirations windows search reaching a state as ridiculous as the followig;

```
Lynx.Cli.Writer|[Lynx]	info depth 1 seldepth 1 multipv 1 score cp -1319 nodes 5 nps 5 time 0 pv g2h3 
Lynx.Engine|Depth 2: mate in -5 detected (50 moves until draw by repetition) 
Lynx.Engine|Stopping search: mate is short enough 
Lynx.Cli.Writer|[Lynx]	info depth 2 seldepth 3 multipv 1 score mate -5 nodes 48 nps 48 time 0 hashfull 104 pv g2h3 e3e2 
Lynx.Cli.Writer|[Lynx]	info depth 2 seldepth 3 multipv 1 score mate -5 nodes 48 nps 48 time 0 hashfull 104 pv g2h3 e3e2 
Lynx.Cli.Writer|[Lynx]	bestmove g2h3 ponder e3e2 
Lynx.Cli.Program|[GUI]	position fen rnbqk1nr/pp3p2/3pp1p1/1N2b2p/4PB2/3B4/PPP2PPP/RN1Q1RK1 w kq - 0 1 moves f4e5 d6e5 a2a4 a7a6 b5a3 b8c6 a3c4 e8f8 d1d2 h5h4 h2h3 f8g7 d2c3 f7f6 a4a5 c6d4 b1d2 a8b8 d2b3 g6g5 f1d1 g8e7 c4b6 d4b3 c3b3 d8c7 d3c4 e7c6 c2c3 h8e8 d1d3 e8d8 d3d8 c6d8 a1d1 d8c6 b3a3 g7f7 c4e2 f7g7 e2h5 g5g4 h3g4 f6f5 e4f5 c7e7 a3e7 c6e7 d1d8 e6f5 g4f5 e5e4 d8e8 e7f5 b6c8 e4e3 f2e3 f5e3 c8d6 b8e8 d6e8 g7h6 h5e2 h6g5 e8d6 h4h3 g2h3 g5h4 g1f2 e3d5 d6b7 h4h3 b7c5 h3h2 e2a6 d5f4 a6b7 f4h3 f2e3 h2g1 c5e4 g1g2 a5a6 h3g5 e4g5 g2g3 g5e4 g3h3 a6a7 h3g2 a7a8q g2h3 a8g8 
Lynx.Cli.Program|Position parsing took 0ms 
Lynx.Cli.Program|[GUI]	isready 
Lynx.Cli.Writer|[Lynx]	readyok 
Lynx.Cli.Program|[GUI]	go wtime 2421 btime 1439 winc 80 binc 80 
Lynx.Engine|Soft time bound: 0.10200000000000001s 
Lynx.Engine|Hard time bound: 0.722s 
Lynx.Cli.Writer|[Lynx]	info depth 1 seldepth 1 multipv 1 score cp -1296 nodes 2 nps 2 time 0 pv h3h2 
Lynx.Cli.Writer|[Lynx]	info depth 2 seldepth 3 multipv 1 score cp -1346 nodes 49 nps 49 time 0 pv h3h2 g8g4 
Lynx.Cli.Writer|[Lynx]	info depth 3 seldepth 5 multipv 1 score cp -1377 nodes 147 nps 147 time 0 pv h3h2 g8g4 h2h1 
Lynx.Cli.Writer|[Lynx]	info depth 4 seldepth 5 multipv 1 score cp -30001 nodes 11 nps 11 time 0 pv  
Lynx.Cli.Writer|[Lynx]	info depth 5 seldepth 7 multipv 1 score cp -30001 nodes 50 nps 50 time 0 pv  
Lynx.Cli.Writer|[Lynx]	info depth 6 seldepth 8 multipv 1 score cp -30001 nodes 87 nps 87 time 0 pv  
Lynx.Cli.Writer|[Lynx]	info depth 7 seldepth 8 multipv 1 score cp -30001 nodes 91 nps 91 time 0 pv  
Lynx.Engine|Eval (-30001) (depth 8, nodes 84) outside of aspiration window, new window [-30001, -29995] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 168) outside of aspiration window, new window [-30001, -29998] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 252) outside of aspiration window, new window [-30001, -30000] 
Lynx.Engine|Eval (-29980) (depth 8, nodes 309) outside of aspiration window, new window [-30001, -29917] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 399) outside of aspiration window, new window [-30001, -29959] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 483) outside of aspiration window, new window [-30001, -29980] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 567) outside of aspiration window, new window [-30001, -29991] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 651) outside of aspiration window, new window [-30001, -29996] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 735) outside of aspiration window, new window [-30001, -29999] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 819) outside of aspiration window, new window [-30001, -30000] 
Lynx.Engine|Eval (-29980) (depth 8, nodes 854) outside of aspiration window, new window [-30001, -28914] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 940) outside of aspiration window, new window [-30001, -29458] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1026) outside of aspiration window, new window [-30001, -29730] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1112) outside of aspiration window, new window [-30001, -29866] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1198) outside of aspiration window, new window [-30001, -29934] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1282) outside of aspiration window, new window [-30001, -29968] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1366) outside of aspiration window, new window [-30001, -29985] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1450) outside of aspiration window, new window [-30001, -29993] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1534) outside of aspiration window, new window [-30001, -29997] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1618) outside of aspiration window, new window [-30001, -29999]
....
Lynx.Engine|Eval (-29980) (depth 8, nodes 3052) outside of aspiration window, new window [-30001, 30001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3138) outside of aspiration window, new window [-30001, 0] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3224) outside of aspiration window, new window [-30001, -15001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3310) outside of aspiration window, new window [-30001, -22501] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3396) outside of aspiration window, new window [-30001, -26251] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3482) outside of aspiration window, new window [-30001, -28126] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3568) outside of aspiration window, new window [-30001, -29064] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3654) outside of aspiration window, new window [-30001, -29533] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3740) outside of aspiration window, new window [-30001, -29767] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3826) outside of aspiration window, new window [1967549553, 983759893] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 3828) outside of aspiration window, new window [-30001, 491864946] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3914) outside of aspiration window, new window [-30001, 245917472] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4000) outside of aspiration window, new window [1271841875, 758879673] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4002) outside of aspiration window, new window [1907777854, -814154885] 
Lynx.Engine|Eval (-29920) (depth 8, nodes 4010) outside of aspiration window, new window [-30001, -407092443] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4018) outside of aspiration window, new window [-30001, -2145113894] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4026) outside of aspiration window, new window [-30001, 30001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4112) outside of aspiration window, new window [-30001, 0] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4198) outside of aspiration window, new window [1870919157, 935459578] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4200) outside of aspiration window, new window [-30001, 467714788]
....
```

Having search results with cp -30001 may or may not be consequence of this, will see later

(spoiler, it of course didn't, see [crash](https://openbench.lynx-chess.com/event/288814/) in https://openbench.lynx-chess.com/test/771/ )