### PR TITLE
🐛 Don't prune moves in regular search while being checkmated

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -240,7 +240,10 @@ public sealed partial class Engine
             }
             else
             {
-                if (!pvNode && !isInCheck
+                // If we prune while getting checmated, we risk not finding any move and having an empty PV
+                bool isNotGettingCheckmated = bestMove > EvaluationConstants.NegativeCheckmateDetectionLimit;
+
+                if (!pvNode && !isInCheck && isNotGettingCheckmated
                     && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
                 {
                     // Late Move Pruning (LMP) - all quiet moves can be pruned

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -241,7 +241,7 @@ public sealed partial class Engine
             else
             {
                 // If we prune while getting checmated, we risk not finding any move and having an empty PV
-                bool isNotGettingCheckmated = bestMove > EvaluationConstants.NegativeCheckmateDetectionLimit;
+                bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
                 if (!pvNode && !isInCheck && isNotGettingCheckmated
                     && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move


### PR DESCRIPTION
Still didn't solve the illegal moves issue, but..
```
Test  | bugfix/no-pruning-negative-checkmate-score
Elo   | 2.42 +- 4.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 10928: +2867 -2791 =5270
Penta | [208, 1238, 2477, 1352, 189]
https://openbench.lynx-chess.com/test/779/
```