### PR TITLE
🔍 Improve queen promotion with capture move ordering

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -130,6 +130,8 @@ public static partial class EvaluationConstants
 
     public const int TTMoveScoreValue = 2_097_152;
 
+    public const int QueenPromotionWithCaptureBaseValue = GoodCaptureMoveBaseScoreValue + PromotionMoveScoreValue;
+
     public const int GoodCaptureMoveBaseScoreValue = 1_048_576;
 
     public const int FirstKillerMoveValue = 524_288;

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -30,13 +30,15 @@ public sealed partial class Engine
         // Queen promotion
         if ((promotedPiece + 2) % 6 == 0)
         {
-            var baseScore = SEE.HasPositiveScore(Game.CurrentPosition, move)
-                ? GoodCaptureMoveBaseScoreValue
-                : BadCaptureMoveBaseScoreValue;
+            if (isCapture)
+            {
+                return QueenPromotionWithCaptureBaseValue + move.CapturedPiece();
+            }
 
-            var captureBonus = isCapture ? 1 : 0;
-
-            return baseScore + PromotionMoveScoreValue + captureBonus;
+            return PromotionMoveScoreValue
+                + (SEE.HasPositiveScore(Game.CurrentPosition, move)
+                    ? GoodCaptureMoveBaseScoreValue
+                    : BadCaptureMoveBaseScoreValue);
         }
 
         if (isCapture)


### PR DESCRIPTION
Improve queen promotion with capture move ordering by taking into account the captured pieces, but more importantly avoid SEE call there, since it'll always be a good capture

```
Test  | perf/move-ordering-queen-capture
Elo   | 0.12 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [-5.00, 0.00]
Games | 26532: +6967 -6958 =12607
Penta | [507, 3145, 6014, 3032, 568]
https://openbench.lynx-chess.com/test/786/
```