### PR TITLE
🐛 Prevent negative checkmate scores from being lower than `EvaluationConstants.MinEval`

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -89,17 +89,17 @@ public static partial class EvaluationConstants
     /// <summary>
     /// Base absolute checkmate evaluation value. Actual absolute evaluations are lower than this one by a number of <see cref="Position.DepthCheckmateFactor"/>
     /// </summary>
-    public const int CheckMateBaseEvaluation = 30_000;
+    public const int CheckMateBaseEvaluation = 29_000;
 
     /// <summary>
     /// Max eval, including checkmate values
     /// </summary>
-    public const int MaxEval = CheckMateBaseEvaluation + 1;
+    public const int MaxEval = 32_000;  // CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     /// <summary>
     /// Min eval, including checkmate values
     /// </summary>
-    public const int MinEval = -CheckMateBaseEvaluation - 1;
+    public const int MinEval = -32_000;    // -CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     /// <summary>
     /// This value combined with <see cref="PositiveCheckmateDetectionLimit"/> and <see cref="NegativeCheckmateDetectionLimit"/> should allows mates up to in <see cref="Constants.AbsoluteMaxDepth"/> moves.
@@ -109,12 +109,12 @@ public static partial class EvaluationConstants
     /// <summary>
     /// Minimum evaluation for a position to be White checkmate
     /// </summary>
-    public const int PositiveCheckmateDetectionLimit = 27_000; // CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
+    public const int PositiveCheckmateDetectionLimit = 26_000; // CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     /// <summary>
     /// Minimum evaluation for a position to be Black checkmate
     /// </summary>
-    public const int NegativeCheckmateDetectionLimit = -27_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
+    public const int NegativeCheckmateDetectionLimit = -26_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     /// <summary>
     /// Max static eval. It doesn't include checkmate values and it's below <see cref="PositiveCheckmateDetectionLimit"/>
@@ -125,6 +125,16 @@ public static partial class EvaluationConstants
     /// Min static eval. It doesn't include checkmate values and it's above <see cref="NegativeCheckmateDetectionLimit"/>
     /// </summary>
     public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1;
+
+    /// <summary>
+    /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
+    /// </summary>
+    public const int NoHashEntry = 25_000;
+
+    /// <summary>
+    /// Evaluation to be returned when there's one single legal move
+    /// </summary>
+    public const int SingleMoveScore = 200;
 
     #region Move ordering
 
@@ -155,16 +165,6 @@ public static partial class EvaluationConstants
     public const int BaseMoveScore = int.MinValue / 2;
 
     #endregion
-
-    /// <summary>
-    /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
-    /// </summary>
-    public const int NoHashEntry = 25_000;
-
-    /// <summary>
-    /// Evaluation to be returned when there's one single legal move
-    /// </summary>
-    public const int SingleMoveScore = 200;
 
     public const int ContinuationHistoryPlyCount = 1;
 }

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -47,12 +47,14 @@ public class EvaluationConstantsTest
     public void MaxEvalTest()
     {
         Assert.Greater(MaxEval, PositiveCheckmateDetectionLimit + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
+        Assert.Less(MaxEval, short.MaxValue);
     }
 
     [Test]
     public void MinEvalTest()
     {
         Assert.Less(MinEval, NegativeCheckmateDetectionLimit - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
+        Assert.Greater(MinEval, short.MinValue);
     }
 
     [Test]


### PR DESCRIPTION
Distance `MinEval` from `-CheckMateBaseEvaluation` enough so that there's no possible interference between them at TT level.
Now I reaaaally want to change `EvaluationConstants.CheckmateDepthFactor` to 1, but now it's not the time.

Logs seen when saving an item to a TT.
```
RecordHash: for position "6k1/4b1p1/8/4P3/8/q7/6r1/2K5 w - - 0 1", with raw score -29865, saving -30085 from TT
RecordHash: for position "6k1/4b1p1/8/4P3/6r1/1q6/8/1K6 w - - 0 1", with raw score -29865, saving -30085 from TT
```

Logs seen when retrieving that item from TT, ending up with a score < `EvaluationConstants.MinEval` (-30001).
```
ProbeHash: for position "6k1/4b1p1/8/4P3/8/q7/6r1/2K5 w - - 0 1", with raw score -30085, returning -30005 from TT. Alpha -29921^, Beta -29920, Type "Alpha", Recalculated score -30005
Returning -30005 from TT at depth 0, ply 8
Full search in first visited move returned -30005
```

This which eventually causes some NegaMax calls to use that value and return it, which ends up in the situation where other shallower NegaMax instances have a bestScore that never bets beaten in the fail-soft version of alphabeta, eventually causing an empty PV and a crash due to `a8a8` move

Logs produced using https://github.com/lynx-chess/Lynx/commit/b8f23b98e9cf868a24c83498161c979804baaf37, from [bugfix/no-pruning-negative-checkmate-score-debugging](https://github.com/lynx-chess/Lynx/tree/bugfix/no-pruning-negative-checkmate-score-debugging) (#1062)

-----

Code-flow explanation, dumbed for future me:
- The negative checkmate scores issue was already there since.. forever
  If `bestScore` is `EvaluationContants.MinEval`, the double invocations to `TranspositionTableExtensions.RecalculateMateScores` on saving an entry and on retrieving it lead the resulting score to be lower than `EvaluationContants.MinEval`.
- While adopting fail soft, I directly jumped into the nested implementation: 
  ```csharp
            if (score > bestScore)
            {
                bestScore = score;

                if (score >= beta) { /* ... */} }
                if (score > alpha) { /* ... */} }
            }
  ```
  vs the option of checking `alpha` and `beta` outside of the `if (score  > bestScore` conditional.
  This implies that if the returned `score` is ever lower than `bestScore`, which gets initialized to `EvaluationContants.MinEval`, there's never a fail low node that beats alpha, that is there's no move beating the 'no move', so there's no PV populated.
- This leads to the issue in Aspiration windows implementation of the IDDFS:`
  ```csharp
                    while (true)
                    {
                        bestScore = NegaMax(depth: depth, ply: 0, alpha, beta);
                        window += window >> 1;   // window / 2

                        if (alpha >= bestScore)     // Fail low
                        {
                            alpha = Math.Max(bestScore - window, EvaluationConstants.MinEval);
                            beta = (alpha + beta) >> 1;  // (alpha + beta) / 2
                        }
                        else if (beta <= bestScore)     // Fail high
                            beta = Math.Min(bestScore + window, EvaluationConstants.MaxEval);
                        else
                            break;
                    }
  ```
  In our case, `bestScore` is lower than `EvaluationConstants.MinEval` but `alpha` is restricted to [minEval, ...), so alpha always beats `bestScore`. Given that, we end up in the situation described in https://github.com/lynx-chess/Lynx/pull/1057 (but not fixed): an infinite Aspiration windows loop where stuff overflows due to the window variable growing indefinitely, variables start to overflow and a cancellation with still no PV ends up happening
```log
Lynx.Engine|Eval (-30001) (depth 8, nodes 84) outside of aspiration window, new window [-30001, -29995] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 168) outside of aspiration window, new window [-30001, -29998] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 252) outside of aspiration window, new window [-30001, -30000] 
Lynx.Engine|Eval (-29980) (depth 8, nodes 309) outside of aspiration window, new window [-30001, -29917] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 399) outside of aspiration window, new window [-30001, -29959] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 483) outside of aspiration window, new window [-30001, -29980] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 567) outside of aspiration window, new window [-30001, -29991] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 651) outside of aspiration window, new window [-30001, -29996] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 735) outside of aspiration window, new window [-30001, -29999] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 819) outside of aspiration window, new window [-30001, -30000] 
Lynx.Engine|Eval (-29980) (depth 8, nodes 854) outside of aspiration window, new window [-30001, -28914] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 940) outside of aspiration window, new window [-30001, -29458] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1026) outside of aspiration window, new window [-30001, -29730] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1112) outside of aspiration window, new window [-30001, -29866] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1198) outside of aspiration window, new window [-30001, -29934] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1282) outside of aspiration window, new window [-30001, -29968] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1366) outside of aspiration window, new window [-30001, -29985] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1450) outside of aspiration window, new window [-30001, -29993] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1534) outside of aspiration window, new window [-30001, -29997] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 1618) outside of aspiration window, new window [-30001, -29999]
....
Lynx.Engine|Eval (-29980) (depth 8, nodes 3052) outside of aspiration window, new window [-30001, 30001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3138) outside of aspiration window, new window [-30001, 0] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3224) outside of aspiration window, new window [-30001, -15001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3310) outside of aspiration window, new window [-30001, -22501] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3396) outside of aspiration window, new window [-30001, -26251] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3482) outside of aspiration window, new window [-30001, -28126] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3568) outside of aspiration window, new window [-30001, -29064] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3654) outside of aspiration window, new window [-30001, -29533] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3740) outside of aspiration window, new window [-30001, -29767] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3826) outside of aspiration window, new window [1967549553, 983759893] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 3828) outside of aspiration window, new window [-30001, 491864946] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 3914) outside of aspiration window, new window [-30001, 245917472] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4000) outside of aspiration window, new window [1271841875, 758879673] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4002) outside of aspiration window, new window [1907777854, -814154885] 
Lynx.Engine|Eval (-29920) (depth 8, nodes 4010) outside of aspiration window, new window [-30001, -407092443] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4018) outside of aspiration window, new window [-30001, -2145113894] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4026) outside of aspiration window, new window [-30001, 30001] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4112) outside of aspiration window, new window [-30001, 0] 
Lynx.Engine|Eval (-30001) (depth 8, nodes 4198) outside of aspiration window, new window [1870919157, 935459578] 
Lynx.Engine|Eval (-29960) (depth 8, nodes 4200) outside of aspiration window, new window [-30001, 467714788]
...
Search cancellation requested after 625ms (depth 8, nodes 963346), best move will be returned
[Lynx]	info depth 7 seldepth 13 multipv 1 score cp -30001 nodes 963346 nps 592828 time 625 hashfull 78 pv 
[Lynx]	bestmove a8a8
```

----
```
Test  | bugfix/tt-min-eval-vs-checkmated-scores
Elo   | -0.67 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 49608: +13007 -13102 =23499
Penta | [964, 5769, 11415, 5710, 946]
https://openbench.lynx-chess.com/test/788/
```