### PR TITLE
🐛 Revert avoiding aspiration windows on mate detected

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -107,8 +107,7 @@ public sealed partial class Engine
                 _nodes = 0;
 
                 if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
-                    || lastSearchResult?.Score is null
-                    || lastSearchResult.Mate != 0)
+                    || lastSearchResult?.Score is null)
                 {
                     bestScore = NegaMax(depth: depth, ply: 0, alpha, beta);
                 }


### PR DESCRIPTION
This effectively reverts #1057 

It turns out that without resetting alpha and beta, we also get empty PVs, but this time on winning positions when getting close to 50mr after not having been able to convert

```
Test  | bugfix/revert-aspiration-windows-mate
Elo   | -0.20 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | 32674: +8511 -8530 =15633
Penta | [627, 3797, 7518, 3758, 637]
https://openbench.lynx-chess.com/test/789/
```