### PR TITLE
🔍 SEE threshold: arbitrary positive value (+10) 

### DIFF
--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -36,14 +36,14 @@ public sealed partial class Engine
             }
 
             return PromotionMoveScoreValue
-                + (SEE.HasPositiveScore(Game.CurrentPosition, move)
+                + (SEE.HasPositiveScore(Game.CurrentPosition, move, threshold: 10)
                     ? GoodCaptureMoveBaseScoreValue
                     : BadCaptureMoveBaseScoreValue);
         }
 
         if (isCapture)
         {
-            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move, threshold: 10))
                 ? GoodCaptureMoveBaseScoreValue
                 : BadCaptureMoveBaseScoreValue;
 


### PR DESCRIPTION
Negative value in #987 

```
Test  | search/see-threshold-10
Elo   | -28.74 +- 10.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 2108: +496 -670 =942
Penta | [74, 311, 425, 203, 41]
https://openbench.lynx-chess.com/test/798/
```