### PR TITLE
🔍 SPSA 2024-10-1 (848 iter)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -23,43 +23,43 @@
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
     "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.91,
-    "LMR_Divisor": 3.42,
+    "LMR_MinFullDepthSearchedMoves": 3,
+    "LMR_Base": 0.77,
+    "LMR_Divisor": 3.51,
 
-    "NMP_MinDepth": 2,
+    "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
+    "NMP_DepthIncrement": 0,
+    "NMP_DepthDivisor": 3,
 
     "AspirationWindow_Base": 13,
     //"AspirationWindow_Delta": 13,
     "AspirationWindow_MinDepth": 8,
 
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 82,
+    "RFP_MaxDepth": 7,
+    "RFP_DepthScalingFactor": 50,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 129,
-    "Razoring_NotDepth1Bonus": 178,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 72,
+    "Razoring_NotDepth1Bonus": 213,
 
-    "IIR_MinDepth": 3,
+    "IIR_MinDepth": 4,
 
     "LMP_MaxDepth": 7,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 4,
+    "LMP_BaseMovesToTry": 1,
+    "LMP_MovesDepthMultiplier": 3,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 2,
+    "SEE_BadCaptureReduction": 1,
 
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129,
+    "FP_MaxDepth": 8,
+    "FP_DepthScalingFactor": 70,
+    "FP_Margin": 211,
 
-    "HistoryPrunning_MaxDepth": 7,
-    "HistoryPrunning_Margin": -2500
+    "HistoryPrunning_MaxDepth": 4,
+    "HistoryPrunning_Margin": -1926
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -192,7 +192,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 4;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1929;
+    public int HistoryPrunning_Margin { get; set; } = -1926;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -107,31 +107,31 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.91;
+    public double LMR_Base { get; set; } = 0.77;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.42;
+    public double LMR_Divisor { get; set; } = 3.51;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_MinDepth { get; set; } = 2;
+    public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 5, 0.5)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public int NMP_DepthIncrement { get; set; } = 0;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
     public int AspirationWindow_Base { get; set; } = 13;
@@ -143,31 +143,31 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 82;
+    public int RFP_DepthScalingFactor { get; set; } = 50;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 129;
+    public int Razoring_Depth1Bonus { get; set; } = 72;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 178;
+    public int Razoring_NotDepth1Bonus { get; set; } = 213;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 3;
+    public int IIR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public int LMP_BaseMovesToTry { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 4;
+    public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -177,22 +177,22 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 1;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public int FP_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 78;
+    public int FP_DepthScalingFactor { get; set; } = 70;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 129;
+    public int FP_Margin { get; set; } = 211;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 7;
+    public int HistoryPrunning_MaxDepth { get; set; } = 4;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -2500;
+    public int HistoryPrunning_Margin { get; set; } = -1929;
 }
 
 [JsonSourceGenerationOptions(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0b86ab56-0582-42c0-a5a7-9e834eb8990e)

```bash
iterations: 848 (290.38s per iter)
games: 27136 (9.07s per game)
LMR_MinDepth = 3(+0.12) in [3, 10]
LMR_MinFullDepthSearchedMoves = 3(-1.120162) in [1, 10]
LMR_Base = 77(-13.851942) in [10, 200]
LMR_Divisor = 351(+9.04) in [100, 500]
NMP_MinDepth = 3(+1.07) in [1, 10]
NMP_BaseDepthReduction = 2(+0.21) in [1, 5]
NMP_DepthIncrement = 0(-0.735638) in [0, 10]
NMP_DepthDivisor = 3(-0.817994) in [1, 10]
AspirationWindow_Base = 13(+0.06) in [5, 30]
AspirationWindow_MinDepth = 8(+0.32) in [1, 20]
RFP_MaxDepth = 7(+0.91) in [1, 10]
RFP_DepthScalingFactor = 50(-31.751627) in [1, 300]
Razoring_MaxDepth = 2(+0.93) in [1, 10]
Razoring_Depth1Bonus = 72(-57.403233) in [1, 300]
Razoring_NotDepth1Bonus = 213(+35.18) in [1, 300]
IIR_MinDepth = 4(+0.60) in [1, 10]
LMP_MaxDepth = 7(-0.141530) in [1, 10]
LMP_BaseMovesToTry = 1(+0.91) in [0, 10]
LMP_MovesDepthMultiplier = 3(-0.850589) in [0, 10]
SEE_BadCaptureReduction = 1(-0.554494) in [0, 6]
FP_MaxDepth = 8(+2.73) in [1, 10]
FP_DepthScalingFactor = 70(-7.830901) in [1, 200]
FP_Margin = 211(+82.24) in [0, 500]
HistoryPrunning_MaxDepth = 4(-2.541227) in [0, 10]
HistoryPrunning_Margin = -1926(+573.69) in [-8192, 0]
```

40+0.4 (cancelled, superseded by #1074)
```
Score of Lynx-spsa-1-10-wf-848-iter-4146-win-x64 vs Lynx 4144 - main: 2849 - 2710 - 5271  [0.506] 10830
...      Lynx-spsa-1-10-wf-848-iter-4146-win-x64 playing White: 2370 - 465 - 2580  [0.676] 5415
...      Lynx-spsa-1-10-wf-848-iter-4146-win-x64 playing Black: 479 - 2245 - 2691  [0.337] 5415
...      White vs Black: 4615 - 944 - 5271  [0.669] 10830
Elo difference: 4.5 +/- 4.7, LOS: 96.9 %, DrawRatio: 48.7 %
SPRT: llr 1.55 (53.7%), lbound -2.25, ubound 2.89

Score of Lynx-spsa-1-10-wf-848-iter-4161-win-x64 vs Lynx 4160 - main: 652 - 623 - 1285  [0.506] 2560
...      Lynx-spsa-1-10-wf-848-iter-4161-win-x64 playing White: 539 - 110 - 632  [0.667] 1281
...      Lynx-spsa-1-10-wf-848-iter-4161-win-x64 playing Black: 113 - 513 - 653  [0.344] 1279
...      White vs Black: 1052 - 223 - 1285  [0.662] 2560
Elo difference: 3.9 +/- 9.5, LOS: 79.2 %, DrawRatio: 50.2 %
SPRT: llr 0.311 (10.8%), lbound -2.25, ubound 2.89
```