### PR TITLE
🔍 Make `TranspositionTableElement.Key` an `ushort` instead of a `short`

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -19,7 +19,7 @@ public struct TranspositionTableElement
     /// <summary>
     /// 16 MSB of Zobrist key
     /// </summary>
-    private short _key;
+    private ushort _key;
 
     /// <summary>
     /// Best move found in a position. 0 if the position failed low (score <= alpha)
@@ -48,7 +48,7 @@ public struct TranspositionTableElement
     /// </summary>
     public int Score { readonly get => _score; set => _score = (short)value; }
 
-    public long Key { readonly get => _key; set => _key = (ShortMove)(value >> 48); }
+    public long Key { readonly get => _key; set => _key = (ushort)(value >> 48); }
 }
 
 public static class TranspositionTableExtensions


### PR DESCRIPTION
This might prevent information loss or the attempt to use the wrong TT entries, given how `(short)n` can be -1 instead of the intended value it'd have with `(ushort)n`.

```
Test  | tt-key-ushort
Elo   | 4.68 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 7130: +2036 -1940 =3154
Penta | [144, 772, 1662, 818, 169]
https://openbench.lynx-chess.com/test/799/
```