### PR TITLE
🐛 TT resize

### DIFF
--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -2,6 +2,9 @@
   "GeneralSettings": {
     "EnableTuning": true
   },
+  "EngineSettings": {
+    "TranspositionTableSize": 8
+  },
   "NLog": {
     "internalLogLevel": "Warn",
     "throwExceptions": true,

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -9,7 +9,7 @@
   "EngineSettings": {
     "MaxDepth": 128,
     "BenchDepth": 10,
-    "TranspositionTableSize": "256",
+    "TranspositionTableSize": 256,
     "UseOnlineTablebaseInRootPositions": false,
     "UseOnlineTablebaseInSearch": false,
     "OnlineTablebaseMaxSupportedPieces": 7,

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
         }
         else
         {
-            _logger.Warn("Resizing TT {CurrentSize} -> {NewSize}", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
+            _logger.Warn("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
             AllocateTT();
         }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -73,8 +73,7 @@ public sealed partial class Engine
             _killerMoves[i] = new Move[3];
         }
 
-        (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
+        AllocateTT();
 
 #if !DEBUG
         // Temporary channel so that no output is generated
@@ -90,6 +89,14 @@ public sealed partial class Engine
         GC.Collect();
         GC.WaitForPendingFinalizers();
 #pragma warning restore S1215 // "GC.Collect" should not be called
+    }
+
+    private void AllocateTT()
+    {
+        _currentTranspositionTableSize = Configuration.EngineSettings.TranspositionTableSize;
+
+        (var ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(_currentTranspositionTableSize);
+        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
 #pragma warning disable S1144 // Unused private types or members should be removed - used in Release mode
@@ -113,14 +120,14 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        if (Configuration.EngineSettings.TranspositionTableSize == _tt.Length)
+        if (_currentTranspositionTableSize == Configuration.EngineSettings.TranspositionTableSize)
         {
             Array.Clear(_tt);
         }
         else
         {
-            (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-            _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
+            _logger.Warn("Resizing TT {CurrentSize} -> {NewSize}", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
+            AllocateTT();
         }
 
         // Clear histories

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -113,7 +113,15 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        Array.Clear(_tt);
+        if (Configuration.EngineSettings.TranspositionTableSize == _tt.Length)
+        {
+            Array.Clear(_tt);
+        }
+        else
+        {
+            (int ttLength, _ttMask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+            _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
+        }
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
         }
         else
         {
-            _logger.Warn("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
+            _logger.Info("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
             AllocateTT();
         }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -64,7 +64,7 @@ public static class TranspositionTableExtensions
         {
             ttLength = BitOperations.RoundUpToPowerOf2(ttLength) >> 1;    // / 2
         }
-        var ttLengthMb = ttLength / 1024 / 1024;
+        var ttLengthMb = (double)ttLength / 1024 / 1024;
 
         if (ttLength > int.MaxValue)
         {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,8 +42,9 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
+    private int _currentTranspositionTableSize;
     private int _ttMask;
-    private TranspositionTable _tt;
+    private TranspositionTable _tt = null!;
 
     private long _nodes;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,8 +42,8 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
-    private readonly int _ttMask;
-    private readonly TranspositionTable _tt;
+    private int _ttMask;
+    private TranspositionTable _tt;
 
     private long _nodes;
 


### PR DESCRIPTION
- Resize TT on `ucinewgame` after Hash is changed
- Report TT memory size correctly when <8 MB (debug mode/logs)
- Fix `TranspositionTableSize` value in `appsettings.json` (it was a string)

