### PR TITLE
🔍 SPSA 2024-10-2

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -22,44 +22,44 @@
     "DefaultMovesToGo": 45,
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
-    "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.91,
-    "LMR_Divisor": 3.42,
+    "LMR_MinDepth": 4,
+    "LMR_MinFullDepthSearchedMoves": 1,
+    "LMR_Base": 1.16,
+    "LMR_Divisor": 3.96,
 
     "NMP_MinDepth": 2,
-    "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
+    "NMP_BaseDepthReduction": 3,
+    "NMP_DepthIncrement": 8,
+    "NMP_DepthDivisor": 6,
 
-    "AspirationWindow_Base": 13,
+    "AspirationWindow_Base": 14,
     //"AspirationWindow_Delta": 13,
-    "AspirationWindow_MinDepth": 8,
+    "AspirationWindow_MinDepth": 4,
 
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 82,
+    "RFP_MaxDepth": 7,
+    "RFP_DepthScalingFactor": 51,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 129,
-    "Razoring_NotDepth1Bonus": 178,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 187,
+    "Razoring_NotDepth1Bonus": 139,
 
     "IIR_MinDepth": 3,
 
-    "LMP_MaxDepth": 7,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 4,
+    "LMP_MaxDepth": 8,
+    "LMP_BaseMovesToTry": 1,
+    "LMP_MovesDepthMultiplier": 2,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 2,
+    "SEE_BadCaptureReduction": 1,
 
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129,
+    "FP_MaxDepth": 4,
+    "FP_DepthScalingFactor": 101,
+    "FP_Margin": 55,
 
-    "HistoryPrunning_MaxDepth": 7,
-    "HistoryPrunning_Margin": -2500
+    "HistoryPrunning_MaxDepth": 8,
+    "HistoryPrunning_Margin": -2024
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -104,70 +104,70 @@ public sealed class EngineSettings
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public int LMR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 1;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.91;
+    public double LMR_Base { get; set; } = 1.16;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.42;
+    public double LMR_Divisor { get; set; } = 3.96;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 2;
 
     [SPSA<int>(1, 5, 0.5)]
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 3;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public int NMP_DepthIncrement { get; set; } = 8;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public int NMP_DepthDivisor { get; set; } = 6;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 13;
+    public int AspirationWindow_Base { get; set; } = 14;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
 
     [SPSA<int>(1, 20, 1)]
-    public int AspirationWindow_MinDepth { get; set; } = 8;
+    public int AspirationWindow_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 82;
+    public int RFP_DepthScalingFactor { get; set; } = 51;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 129;
+    public int Razoring_Depth1Bonus { get; set; } = 187;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 178;
+    public int Razoring_NotDepth1Bonus { get; set; } = 139;
 
     [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 7;
+    public int LMP_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public int LMP_BaseMovesToTry { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 4;
+    public int LMP_MovesDepthMultiplier { get; set; } = 2;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -177,22 +177,22 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 1;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public int FP_MaxDepth { get; set; } = 4;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 78;
+    public int FP_DepthScalingFactor { get; set; } = 101;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 129;
+    public int FP_Margin { get; set; } = 55;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 7;
+    public int HistoryPrunning_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -2500;
+    public int HistoryPrunning_Margin { get; set; } = -2024;
 }
 
 [JsonSourceGenerationOptions(


### PR DESCRIPTION
https://openbench.lynx-chess.com/tune/794/

7090 iter:
```
LMR_MinDepth, 4
LMR_MinFullDepthSearchedMoves, 1
LMR_Base, 116
LMR_Divisor, 396
NMP_MinDepth, 2
NMP_BaseDepthReduction, 3
NMP_DepthIncrement, 8
NMP_DepthDivisor, 6
AspirationWindow_Base, 14
AspirationWindow_MinDepth, 4
RFP_MaxDepth, 7
RFP_DepthScalingFactor, 51
Razoring_MaxDepth, 2
Razoring_Depth1Bonus, 187
Razoring_NotDepth1Bonus, 139
IIR_MinDepth, 3
LMP_MaxDepth, 8
LMP_BaseMovesToTry, 1
LMP_MovesDepthMultiplier, 2
SEE_BadCaptureReduction, 1
FP_MaxDepth, 4
FP_DepthScalingFactor, 101
FP_Margin, 55
HistoryPrunning_MaxDepth, 8
HistoryPrunning_Margin, -2024
```

```
Test  | spsa/2-10-ob-7090-iter
Elo   | -1.24 +- 7.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.30 (-2.25, 2.89) [0.00, 3.00]
Games | 3372: +839 -851 =1682
Penta | [51, 423, 752, 407, 53]
https://openbench.lynx-chess.com/test/806/
```