### PR TITLE
🔍 SPSA 2024-10-1 (1233 iter)

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -24,8 +24,8 @@
 
     "LMR_MinDepth": 3,
     "LMR_MinFullDepthSearchedMoves": 3,
-    "LMR_Base": 0.77,
-    "LMR_Divisor": 3.51,
+    "LMR_Base": 0.75,
+    "LMR_Divisor": 3.49,
 
     "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 2,
@@ -37,29 +37,29 @@
     "AspirationWindow_MinDepth": 8,
 
     "RFP_MaxDepth": 7,
-    "RFP_DepthScalingFactor": 50,
+    "RFP_DepthScalingFactor": 52,
 
     "Razoring_MaxDepth": 2,
-    "Razoring_Depth1Bonus": 72,
-    "Razoring_NotDepth1Bonus": 213,
+    "Razoring_Depth1Bonus": 68,
+    "Razoring_NotDepth1Bonus": 208,
 
     "IIR_MinDepth": 4,
 
-    "LMP_MaxDepth": 7,
+    "LMP_MaxDepth": 8,
     "LMP_BaseMovesToTry": 1,
     "LMP_MovesDepthMultiplier": 3,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 1,
+    "SEE_BadCaptureReduction": 2,
 
-    "FP_MaxDepth": 8,
-    "FP_DepthScalingFactor": 70,
-    "FP_Margin": 211,
+    "FP_MaxDepth": 7,
+    "FP_DepthScalingFactor": 73,
+    "FP_Margin": 218,
 
-    "HistoryPrunning_MaxDepth": 4,
-    "HistoryPrunning_Margin": -1926
+    "HistoryPrunning_MaxDepth": 5,
+    "HistoryPrunning_Margin": -1940
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -23,43 +23,43 @@
     "SoftTimeBaseIncrementMultiplier": 0.8,
 
     "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.91,
-    "LMR_Divisor": 3.42,
+    "LMR_MinFullDepthSearchedMoves": 3,
+    "LMR_Base": 0.77,
+    "LMR_Divisor": 3.51,
 
-    "NMP_MinDepth": 2,
+    "NMP_MinDepth": 3,
     "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
+    "NMP_DepthIncrement": 0,
+    "NMP_DepthDivisor": 3,
 
     "AspirationWindow_Base": 13,
     //"AspirationWindow_Delta": 13,
     "AspirationWindow_MinDepth": 8,
 
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 82,
+    "RFP_MaxDepth": 7,
+    "RFP_DepthScalingFactor": 50,
 
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 129,
-    "Razoring_NotDepth1Bonus": 178,
+    "Razoring_MaxDepth": 2,
+    "Razoring_Depth1Bonus": 72,
+    "Razoring_NotDepth1Bonus": 213,
 
-    "IIR_MinDepth": 3,
+    "IIR_MinDepth": 4,
 
     "LMP_MaxDepth": 7,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 4,
+    "LMP_BaseMovesToTry": 1,
+    "LMP_MovesDepthMultiplier": 3,
 
     "History_MaxMoveValue": 8192,
     "History_MaxMoveRawBonus": 1896,
 
-    "SEE_BadCaptureReduction": 2,
+    "SEE_BadCaptureReduction": 1,
 
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129,
+    "FP_MaxDepth": 8,
+    "FP_DepthScalingFactor": 70,
+    "FP_Margin": 211,
 
-    "HistoryPrunning_MaxDepth": 7,
-    "HistoryPrunning_Margin": -2500
+    "HistoryPrunning_MaxDepth": 4,
+    "HistoryPrunning_Margin": -1926
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -192,7 +192,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 4;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1929;
+    public int HistoryPrunning_Margin { get; set; } = -1926;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -107,31 +107,31 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.91;
+    public double LMR_Base { get; set; } = 0.77;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.42;
+    public double LMR_Divisor { get; set; } = 3.51;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_MinDepth { get; set; } = 2;
+    public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 5, 0.5)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 1;
+    public int NMP_DepthIncrement { get; set; } = 0;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 4;
+    public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
     public int AspirationWindow_Base { get; set; } = 13;
@@ -143,31 +143,31 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 6;
+    public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 82;
+    public int RFP_DepthScalingFactor { get; set; } = 50;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 1;
+    public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 129;
+    public int Razoring_Depth1Bonus { get; set; } = 72;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 178;
+    public int Razoring_NotDepth1Bonus { get; set; } = 213;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 3;
+    public int IIR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 0;
+    public int LMP_BaseMovesToTry { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 4;
+    public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -177,22 +177,22 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 1;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 5;
+    public int FP_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 78;
+    public int FP_DepthScalingFactor { get; set; } = 70;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 129;
+    public int FP_Margin { get; set; } = 211;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 7;
+    public int HistoryPrunning_MaxDepth { get; set; } = 4;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -2500;
+    public int HistoryPrunning_Margin { get; set; } = -1929;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,13 +113,13 @@ public sealed class EngineSettings
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.77;
+    public double LMR_Base { get; set; } = 0.75;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.51;
+    public double LMR_Divisor { get; set; } = 3.49;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
@@ -146,22 +146,22 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 50;
+    public int RFP_DepthScalingFactor { get; set; } = 52;
 
     [SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 72;
+    public int Razoring_Depth1Bonus { get; set; } = 68;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 213;
+    public int Razoring_NotDepth1Bonus { get; set; } = 208;
 
     [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 7;
+    public int LMP_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(0, 10, 0.5)]
     public int LMP_BaseMovesToTry { get; set; } = 1;
@@ -177,22 +177,22 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 1;
+    public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 8;
+    public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 70;
+    public int FP_DepthScalingFactor { get; set; } = 73;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 211;
+    public int FP_Margin { get; set; } = 218;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 4;
+    public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1926;
+    public int HistoryPrunning_Margin { get; set; } = -1940;
 }
 
 [JsonSourceGenerationOptions(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/68b1adf7-f4a8-4e10-a9a0-83da42e5cfeb)

```
Final results:
iterations: 1233 (290.29s per iter)
games: 39456 (9.07s per game)
Final parameters:
LMR_MinDepth = 3(+0.11) in [3, 10]
LMR_MinFullDepthSearchedMoves = 3(-0.809753) in [1, 10] LMR_Base = 75(-16.335787) in [10, 200]
LMR_Divisor = 349(+6.60) in [100, 500]
NMP_MinDepth = 3(+1.12) in [1, 10]
NMP_BaseDepthReduction = 2(-0.052816) in [1, 5]
NMP_DepthIncrement = 0(-0.599883) in [0, 10]
NMP_DepthDivisor = 3(-0.597590) in [1, 10]
AspirationWindow_Base = 13(+0.19) in [5, 30]
AspirationWindow_MinDepth = 8(-0.122278) in [1, 20] RFP_MaxDepth = 7(+1.24) in [1, 10]
RFP_DepthScalingFactor = 52(-30.398700) in [1, 300] Razoring_MaxDepth = 2(+1.08) in [1, 10]
Razoring_Depth1Bonus = 68(-61.302254) in [1, 300]
Razoring_NotDepth1Bonus = 208(+29.93) in [1, 300]
IIR_MinDepth = 4(+0.84) in [1, 10]
LMP_MaxDepth = 8(+0.98) in [1, 10]
LMP_BaseMovesToTry = 1(+1.33) in [0, 10]
LMP_MovesDepthMultiplier = 3(-0.865120) in [0, 10] SEE_BadCaptureReduction = 2(-0.494244) in [0, 6]
FP_MaxDepth = 7(+2.37) in [1, 10]
FP_DepthScalingFactor = 73(-4.621732) in [1, 200]
FP_Margin = 218(+88.53) in [0, 500]
HistoryPrunning_MaxDepth = 5(-2.357467) in [0, 10] HistoryPrunning_Margin = -1940(+559.99) in [-8192, 0]
```

```
Test  | spsa/1-10-wf-1233-iter
Elo   | 9.01 +- 4.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.53 (-2.25, 2.89) [0.00, 3.00]
Games | 7944: +2137 -1931 =3876
Penta | [140, 889, 1729, 1053, 161]
https://openbench.lynx-chess.com/test/807/
```