### PR TITLE
🧹 Simplify `appsettings.json`

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -1,65 +1,18 @@
 ﻿{
   // Settings that affect the executable behavior
   "GeneralSettings": {
-    "EnableLogging": true, // logging can be completely disablesd, both console and file, setting this to false. Alternatively, one or more "NLog.rules" can be removed/tweaked
-    "EnableTuning": false // Exposes search tunable values via UCI. Intended to be used for developer only purposes
+    // Only warnings and errors are logged to a file by default.
+    // "NLog.rules" below can be removed/tweaked to change that benavior.
+    // Setting this to false disables both file and console logging (not recommended)
+    "EnableLogging": true
   },
 
-  // Settings that affect the engine behavior
+  // Settings that affect the engine behavior - some of them available via UCI as well
   "EngineSettings": {
-    "MaxDepth": 128,
-    "BenchDepth": 10,
     "TranspositionTableSize": 256,
-    "UseOnlineTablebaseInRootPositions": false,
-    "UseOnlineTablebaseInSearch": false,
-    "OnlineTablebaseMaxSupportedPieces": 7,
+    "UseOnlineTablebaseInRootPositions": false, // Experimental, requires network connection
     "ShowWDL": false,
-    "IsPonder": false,
-    "SPSA_OB_R_end": 0.02,
-
-    "HardTimeBoundMultiplier": 0.52,
-    "SoftTimeBoundMultiplier": 1,
-    "DefaultMovesToGo": 45,
-    "SoftTimeBaseIncrementMultiplier": 0.8,
-
-    "LMR_MinDepth": 3,
-    "LMR_MinFullDepthSearchedMoves": 4,
-    "LMR_Base": 0.91,
-    "LMR_Divisor": 3.42,
-
-    "NMP_MinDepth": 2,
-    "NMP_BaseDepthReduction": 2,
-    "NMP_DepthIncrement": 1,
-    "NMP_DepthDivisor": 4,
-
-    "AspirationWindow_Base": 13,
-    //"AspirationWindow_Delta": 13,
-    "AspirationWindow_MinDepth": 8,
-
-    "RFP_MaxDepth": 6,
-    "RFP_DepthScalingFactor": 82,
-
-    "Razoring_MaxDepth": 1,
-    "Razoring_Depth1Bonus": 129,
-    "Razoring_NotDepth1Bonus": 178,
-
-    "IIR_MinDepth": 3,
-
-    "LMP_MaxDepth": 7,
-    "LMP_BaseMovesToTry": 0,
-    "LMP_MovesDepthMultiplier": 4,
-
-    "History_MaxMoveValue": 8192,
-    "History_MaxMoveRawBonus": 1896,
-
-    "SEE_BadCaptureReduction": 2,
-
-    "FP_MaxDepth": 5,
-    "FP_DepthScalingFactor": 78,
-    "FP_Margin": 129,
-
-    "HistoryPrunning_MaxDepth": 7,
-    "HistoryPrunning_Margin": -2500
+    "IsPonder": false
   },
 
   // Logging settings


### PR DESCRIPTION
Remove most `EngineSettings` from `appsettings.json`, since they have the default values. This includes search settings.

Only those settings that makes sense for a tester to change are left