### PR TITLE
🔍 SEE pruning capture history

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -180,6 +180,15 @@ public sealed class EngineSettings
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
+    public int SEE_Pruning_CaptureHistory_MaxDepth { get; set; } = 5;
+
+    [SPSA<int>(1, 100, 5)]
+    public int SEE_Pruning_CaptureHistory_Divisor { get; set; } = 32;
+
+    [SPSA<int>(50, 200, 8)]
+    public int SEE_Pruning_CaptureHistory_Limit { get; set; } = 128;
+
+    [SPSA<int>(1, 10, 0.5)]
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]


### PR DESCRIPTION
```
Test  | search/see-pruning-capture-hist
Elo   | -15.81 +- 8.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.90 (-2.25, 2.89) [0.00, 3.00]
Games | 3122: +805 -947 =1370
Penta | [104, 419, 627, 337, 74]
https://openbench.lynx-chess.com/test/815/
```