### PR TITLE
🔍 SEE pruning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -180,6 +180,15 @@ public sealed class EngineSettings
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
+    public int SEE_Pruning_MaxDepth { get; set; } = 5;
+
+    [SPSA<int>(-150, -50, 5)]
+    public int SEE_Pruning_Noisy_DepthScalingFactor { get; set; } = -99;
+
+    [SPSA<int>(-100, 0, 5)]
+    public int SEE_Pruning_Quiet_DepthScalingFactor { get; set; } = -50;
+
+    [SPSA<int>(1, 10, 0.5)]
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,7 +294,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 SEE pruning
-                    if (depth <= 5 && !SEE.HasPositiveScore(position, move, threshold: -100 * depth))
+                    if (depth <= 5 && !SEE.HasPositiveScore(position, move, threshold: -99 * depth))
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,7 +294,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 SEE pruning
-                    if (!SEE.HasPositiveScore(position, move, threshold: -1_000))
+                    if (!SEE.HasPositiveScore(position, move, threshold: -100 * depth))
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,7 +294,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 SEE pruning
-                    if (!SEE.HasPositiveScore(position, move))
+                    if (!SEE.HasPositiveScore(position, move, threshold: -1_000))
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,14 +294,21 @@ public sealed partial class Engine
                     }
 
                     // 🔍 SEE pruning
-                    if (depth <= 5 && !SEE.HasPositiveScore(position, move, threshold: -99 * depth))
+                    if (depth <= Configuration.EngineSettings.SEE_Pruning_MaxDepth)
                     {
-                        // After making a move
-                        Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.RemoveFromPositionHashHistory();
-                        position.UnmakeMove(move, gameState);
+                        var threshold = isCapture
+                            ? Configuration.EngineSettings.SEE_Pruning_Noisy_DepthScalingFactor * depth
+                            : Configuration.EngineSettings.SEE_Pruning_Quiet_DepthScalingFactor * depth;
 
-                        continue;
+                        if (!SEE.HasPositiveScore(position, move, threshold))
+                        {
+                            // After making a move
+                            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+                            Game.RemoveFromPositionHashHistory();
+                            position.UnmakeMove(move, gameState);
+
+                            continue;
+                        }
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,7 +294,7 @@ public sealed partial class Engine
                     }
 
                     // 🔍 SEE pruning
-                    if (!SEE.HasPositiveScore(position, move, threshold: -100 * depth))
+                    if (depth <= 5 && !SEE.HasPositiveScore(position, move, threshold: -100 * depth))
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -292,6 +292,17 @@ public sealed partial class Engine
 
                         break;
                     }
+
+                    // 🔍 SEE pruning
+                    if (!SEE.HasPositiveScore(position, move))
+                    {
+                        // After making a move
+                        Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+                        Game.RemoveFromPositionHashHistory();
+                        position.UnmakeMove(move, gameState);
+
+                        continue;
+                    }
                 }
 
                 PrefetchTTEntry();


### PR DESCRIPTION
Preconditions in outer conditional:
```csharp
!pvNode && !isInCheck && isNotGettingCheckmated
    && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue   // bad captures and quiets
```

Simplest version: `if (!SEE.HasPositiveScore(position, move))`
```
Test  | search/see-pruning
Elo   | -219.81 +- 37.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.52 (-2.25, 2.89) [0.00, 3.00]
Games | 334: +29 -216 =89
Penta | [70, 56, 33, 7, 1]
https://openbench.lynx-chess.com/test/816/
```

High negative threshold: -1000
```
Test  | search/see-pruning
Elo   | -85.87 +- 18.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.03 (-2.25, 2.89) [0.00, 3.00]
Games | 710: +122 -294 =294
Penta | [50, 129, 122, 51, 3]
https://openbench.lynx-chess.com/test/817/
```

Threshold: -100 * depth
```
Test  | search/see-pruning
Elo   | -68.20 +- 18.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.47 (-2.25, 2.89) [0.00, 3.00]
Games | 614: +113 -232 =269
Penta | [39, 92, 130, 41, 5]
https://openbench.lynx-chess.com/test/818/
```

Depth: <= 5 && Threshold: -100 * depth
```
Test  | search/see-pruning
Elo   | -23.58 +- 12.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.21 (-2.25, 2.89) [0.00, 3.00]
Games | 1284: +323 -410 =551
Penta | [39, 180, 270, 135, 18]
https://openbench.lynx-chess.com/test/819/
```

Depth: <= 5 && Threshold: -99 * depth
```
Test  | search/see-pruning
Elo   | -37.78 +- 17.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.07 (-2.25, 2.89) [0.00, 3.00]
Games | 794: +175 -261 =358
Penta | [32, 131, 141, 77, 16]
https://openbench.lynx-chess.com/test/820/
```

Depth: <= 5 && Threshold: -99 * depth for noisy, -50 * depth for quiet

```
Test  | search/see-pruning
Elo   | -53.50 +- 19.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.20 (-2.25, 2.89) [0.00, 3.00]
Games | 648: +135 -234 =279
Penta | [38, 102, 113, 63, 8]
https://openbench.lynx-chess.com/test/822/
```