### PR TITLE
🧹 Make `Position.UniqueIdentifier` an `ulong` instead of a `long`

### DIFF
--- a/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
@@ -1519,7 +1519,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         internal static ulong[,] Initialize()
         {
             var zobristTable = new ulong[64, 12];
-            var randomInstance = new Random(int.MaxValue);
+            var randomInstance = new LynxRandom(int.MaxValue);
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {

--- a/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_implementation_Benchmark.cs
@@ -292,7 +292,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
 
     public struct MakeMovePosition
     {
-        public long UniqueIdentifier { get; private set; }
+        public ulong UniqueIdentifier { get; private set; }
 
         public BitBoard[] PieceBitBoards { get; }
 
@@ -715,7 +715,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
             int capturedPiece = -1;
             var castleCopy = Castle;
             BoardSquare enpassantCopy = EnPassant;
-            long uniqueIdentifierCopy = UniqueIdentifier;
+            var uniqueIdentifierCopy = UniqueIdentifier;
 
             var oldSide = Side;
             var offset = Utils.PieceOffset(oldSide);
@@ -837,7 +837,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
             int capturedPiece = -1;
             byte castleCopy = Castle;
             BoardSquare enpassantCopy = EnPassant;
-            long uniqueIdentifierCopy = UniqueIdentifier;
+            var uniqueIdentifierCopy = UniqueIdentifier;
 
             var oldSide = (int)Side;
             var offset = Utils.PieceOffset(oldSide);
@@ -949,7 +949,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
 
             byte castleCopy = Castle;
             BoardSquare enpassantCopy = EnPassant;
-            long uniqueIdentifierCopy = UniqueIdentifier;
+            var uniqueIdentifierCopy = UniqueIdentifier;
 
             var oldSide = (int)Side;
             var offset = Utils.PieceOffset(oldSide);
@@ -1394,7 +1394,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
 
     public readonly struct MakeMoveGameStateWithZobristKey
     {
-        public readonly long ZobristKey;
+        public readonly ulong ZobristKey;
 
         public readonly int CapturedPiece;
 
@@ -1402,7 +1402,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
 
         public readonly byte Castle;
 
-        public MakeMoveGameStateWithZobristKey(int capturedPiece, byte castle, BoardSquare enpassant, long zobristKey)
+        public MakeMoveGameStateWithZobristKey(int capturedPiece, byte castle, BoardSquare enpassant, ulong zobristKey)
         {
             CapturedPiece = capturedPiece;
             Castle = castle;
@@ -1415,10 +1415,10 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
 
     public static class MakeMoveZobristTable
     {
-        private static readonly long[,] _table = Initialize();
+        private static readonly ulong[,] _table = Initialize();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
+        public static ulong PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
         /// <summary>
         /// Uses <see cref="Piece.P"/> and squares <see cref="BoardSquare.a1"/>-<see cref="BoardSquare.h1"/>
@@ -1426,7 +1426,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         /// <param name="enPassantSquare"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long EnPassantHash(int enPassantSquare)
+        public static ulong EnPassantHash(int enPassantSquare)
         {
             if (enPassantSquare == (int)BoardSquare.noSquare)
             {
@@ -1443,7 +1443,7 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long SideHash()
+        public static ulong SideHash()
         {
             return _table[(int)BoardSquare.h8, (int)Piece.p];
         }
@@ -1456,9 +1456,9 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         /// <param name="castle"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long CastleHash(byte castle)
+        public static ulong CastleHash(byte castle)
         {
-            long combinedHash = 0;
+            ulong combinedHash = 0;
 
             if ((castle & (int)CastlingRights.WK) != default)
             {
@@ -1489,9 +1489,9 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         /// <param name="position"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long PositionHash(MakeMovePosition position)
+        public static ulong PositionHash(MakeMovePosition position)
         {
-            long positionHash = 0;
+            ulong positionHash = 0;
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {
@@ -1516,16 +1516,16 @@ public class MakeUnmakeMove_implementation_Benchmark : BaseBenchmark
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static long[,] Initialize()
+        internal static ulong[,] Initialize()
         {
-            var zobristTable = new long[64, 12];
+            var zobristTable = new ulong[64, 12];
             var randomInstance = new Random(int.MaxValue);
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {
                 for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
                 {
-                    zobristTable[squareIndex, pieceIndex] = randomInstance.NextInt64();
+                    zobristTable[squareIndex, pieceIndex] = randomInstance.NextUInt64();
                 }
             }
 

--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
@@ -295,7 +295,7 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
 
     public struct MakeMovePosition
     {
-        public long UniqueIdentifier { get; private set; }
+        public ulong UniqueIdentifier { get; private set; }
 
         public BitBoard[] PieceBitBoards { get; }
 
@@ -1266,10 +1266,10 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
 
     public static class MakeMoveZobristTable
     {
-        private static readonly long[,] _table = Initialize();
+        private static readonly ulong[,] _table = Initialize();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
+        public static ulong PieceHash(int boardSquare, int piece) => _table[boardSquare, piece];
 
         /// <summary>
         /// Uses <see cref="Piece.P"/> and squares <see cref="BoardSquare.a1"/>-<see cref="BoardSquare.h1"/>
@@ -1277,7 +1277,7 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         /// <param name="enPassantSquare"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long EnPassantHash(int enPassantSquare)
+        public static ulong EnPassantHash(int enPassantSquare)
         {
             if (enPassantSquare == (int)BoardSquare.noSquare)
             {
@@ -1294,7 +1294,7 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long SideHash()
+        public static ulong SideHash()
         {
             return _table[(int)BoardSquare.h8, (int)Piece.p];
         }
@@ -1307,9 +1307,9 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         /// <param name="castle"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long CastleHash(int castle)
+        public static ulong CastleHash(int castle)
         {
-            long combinedHash = 0;
+            ulong combinedHash = 0;
 
             if ((castle & (int)CastlingRights.WK) != default)
             {
@@ -1340,9 +1340,9 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         /// <param name="position"></param>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static long PositionHash(MakeMovePosition position)
+        public static ulong PositionHash(MakeMovePosition position)
         {
-            long positionHash = 0;
+            ulong positionHash = 0;
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {
@@ -1367,16 +1367,16 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         /// </summary>
         /// <returns></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static long[,] Initialize()
+        internal static ulong[,] Initialize()
         {
-            var zobristTable = new long[64, 12];
+            var zobristTable = new ulong[64, 12];
             var randomInstance = new Random(int.MaxValue);
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {
                 for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
                 {
-                    zobristTable[squareIndex, pieceIndex] = randomInstance.NextInt64();
+                    zobristTable[squareIndex, pieceIndex] = randomInstance.NextUInt64();
                 }
             }
 

--- a/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
+++ b/src/Lynx.Benchmark/MakeUnmakeMove_integration_Benchmark.cs
@@ -1370,7 +1370,7 @@ public class MakeUnmakeMove_integration_Benchmark : BaseBenchmark
         internal static ulong[,] Initialize()
         {
             var zobristTable = new ulong[64, 12];
-            var randomInstance = new Random(int.MaxValue);
+            var randomInstance = new LynxRandom(int.MaxValue);
 
             for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
             {

--- a/src/Lynx.Benchmark/ParseGame_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseGame_Benchmark.cs
@@ -477,7 +477,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
         public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<long> PositionHashHistory { get; }
+        public HashSet<ulong> PositionHashHistory { get; }
 
         public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 
@@ -552,7 +552,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
         public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<long> PositionHashHistory { get; }
+        public HashSet<ulong> PositionHashHistory { get; }
 
         public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 
@@ -633,7 +633,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
         public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<long> PositionHashHistory { get; }
+        public HashSet<ulong> PositionHashHistory { get; }
 
         public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 

--- a/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
+++ b/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
@@ -173,7 +173,7 @@ public class TryParseFromUCIString_Benchmark : BaseBenchmark
         public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<long> PositionHashHistory { get; }
+        public HashSet<ulong> PositionHashHistory { get; }
 
         public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 

--- a/src/Lynx.Benchmark/ZobristPositionHash_Benchmark.cs
+++ b/src/Lynx.Benchmark/ZobristPositionHash_Benchmark.cs
@@ -85,15 +85,15 @@ public class ZobristPositionHash_Benchmark : BaseBenchmark
 
     [Benchmark(Baseline = true)]
     [ArgumentsSource(nameof(Data))]
-    public long Original(Position position) => PositionHash_Original_DoubleLoop(position);
+    public ulong Original(Position position) => PositionHash_Original_DoubleLoop(position);
 
     [Benchmark]
     [ArgumentsSource(nameof(Data))]
-    public long Improved(Position position) => PositionHash_Improved(position);
+    public ulong Improved(Position position) => PositionHash_Improved(position);
 
-    private static long PositionHash_Original_DoubleLoop(Position position)
+    private static ulong PositionHash_Original_DoubleLoop(Position position)
     {
-        long positionHash = 0;
+        ulong positionHash = 0;
 
         for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
         {
@@ -113,9 +113,9 @@ public class ZobristPositionHash_Benchmark : BaseBenchmark
         return positionHash;
     }
 
-    private static long PositionHash_Improved(Position position)
+    private static ulong PositionHash_Improved(Position position)
     {
-        long positionHash = 0;
+        ulong positionHash = 0;
 
         for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
         {

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1056,7 +1056,7 @@ static void TranspositionTable()
 
         Console.WriteLine("TT memory: {0} MB", lengthMb * Marshal.SizeOf(typeof(TranspositionTableElement)));
         Console.WriteLine("TT array length: {0}MB, (0x{1}, {2} items)", lengthMb, length.ToString("X"), length);
-        Console.WriteLine("TT mask: 0x{0} ({1})\n", mask.ToString("X"), Convert.ToString(mask, 2));
+        Console.WriteLine("TT mask: 0x{0} ({1})\n", mask.ToString("X"), Convert.ToString((long)mask, 2));
     }
 
     Console.WriteLine($"{nameof(TranspositionTableElement)} size: {Marshal.SizeOf(typeof(TranspositionTableElement))} bytes\n");
@@ -1071,7 +1071,7 @@ static void TranspositionTable()
     TesSize(512);
     TesSize(1024);
 
-    var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+    var (length, mask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
     var transpositionTable = new TranspositionTableElement[length];
     var position = new Position(Constants.InitialPositionFEN);
     position.Print();

--- a/src/Lynx/LynxRandom.cs
+++ b/src/Lynx/LynxRandom.cs
@@ -1,0 +1,86 @@
+﻿using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Lynx;
+
+public class LynxRandom : Random
+{
+    private readonly XoshiroImpl _impl;
+
+    public LynxRandom()
+    {
+        _impl = new XoshiroImpl(this);
+    }
+
+    public LynxRandom(int seed) : base(seed)
+    {
+        _impl = new XoshiroImpl(this);
+    }
+
+    /// <summary>
+    /// Based on dotnet/runtime implementation,
+    /// https://github.com/dotnet/runtime/blob/508fef51e841aa16ffed1aae32bf4793a2cea363/src/libraries/System.Private.CoreLib/src/System/Random.Xoshiro256StarStarImpl.cs
+    /// </summary>
+    /// <returns></returns>
+    public ulong NextUInt64() => _impl.NextUInt64();
+
+    /// <summary>
+    /// Based on dotnet/runtime implementation,
+    /// https://github.com/dotnet/runtime/blob/a7f96cb070ffb8adf266b2e09d26759d7f978a60/src/libraries/System.Private.CoreLib/src/System/Random.Xoshiro256StarStarImpl.cs
+    /// <see cref="NextUInt64"/> is subsequently based on the algorithm from http://prng.di.unimi.it/xoshiro256starstar.c
+    /// Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+    /// To the extent possible under law, the author has dedicated all copyright
+    /// and related and neighboring rights to this software to the public domain
+    /// worldwide. This software is distributed without any warranty.
+    /// See <http://creativecommons.org/publicdomain/zero/1.0/>.
+    /// </summary>
+    internal sealed class XoshiroImpl
+    {
+        private ulong _s0, _s1, _s2, _s3;
+
+        public XoshiroImpl(Random random)
+        {
+            do
+            {
+                _s0 = InternalNextUInt64();
+                _s1 = InternalNextUInt64();
+                _s2 = InternalNextUInt64();
+                _s3 = InternalNextUInt64();
+            }
+            while ((_s0 | _s1 | _s2 | _s3) == 0); // at least one value must be non-zero
+
+            // 'Naive' version of what we're trying to achieve
+            ulong InternalNextUInt64()
+            {
+                Span<byte> arr = stackalloc byte[8];
+                random.NextBytes(arr);
+
+                return BitConverter.ToUInt64(arr);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong NextUInt64()
+        {
+            ulong s0 = _s0, s1 = _s1, s2 = _s2, s3 = _s3;
+
+            ulong result = BitOperations.RotateLeft(s1 * 5, 7) * 9;
+            ulong t = s1 << 17;
+
+            s2 ^= s0;
+            s3 ^= s1;
+            s1 ^= s2;
+            s0 ^= s3;
+
+            s2 ^= t;
+            s3 = BitOperations.RotateLeft(s3, 45);
+
+            _s0 = s0;
+            _s1 = s1;
+            _s2 = s2;
+            _s3 = s3;
+
+            return result;
+        }
+    }
+}

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -14,7 +14,7 @@ public sealed class Game : IDisposable
 #endif
 
     private int _positionHashHistoryPointer;
-    private readonly long[] _positionHashHistory;
+    private readonly ulong[] _positionHashHistory;
 
     /// <summary>
     /// Indexed by ply
@@ -35,7 +35,7 @@ public sealed class Game : IDisposable
     public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool)
     {
         Debug.Assert(Constants.MaxNumberMovesInAGame <= 1024, "Need to customized ArrayPool due to desired array size requirements");
-        _positionHashHistory = ArrayPool<long>.Shared.Rent(Constants.MaxNumberMovesInAGame);
+        _positionHashHistory = ArrayPool<ulong>.Shared.Rent(Constants.MaxNumberMovesInAGame);
         _moveStack = ArrayPool<Move>.Shared.Rent(Constants.MaxNumberMovesInAGame);
 
         var parsedFen = FENParser.ParseFEN(fen);
@@ -165,7 +165,7 @@ public sealed class Game : IDisposable
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsThreefoldRepetition(ReadOnlySpan<long> positionHashHistory, Position position, int halfMovesWithoutCaptureOrPawnMove = Constants.MaxNumberMovesInAGame)
+    public static bool IsThreefoldRepetition(ReadOnlySpan<ulong> positionHashHistory, Position position, int halfMovesWithoutCaptureOrPawnMove = Constants.MaxNumberMovesInAGame)
     {
         var currentHash = position.UniqueIdentifier;
 
@@ -239,20 +239,20 @@ public sealed class Game : IDisposable
     public int PositionHashHistoryLength() => _positionHashHistoryPointer;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void AddToPositionHashHistory(long hash) => _positionHashHistory[_positionHashHistoryPointer++] = hash;
+    public void AddToPositionHashHistory(ulong hash) => _positionHashHistory[_positionHashHistoryPointer++] = hash;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void RemoveFromPositionHashHistory() => --_positionHashHistoryPointer;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public long[] CopyPositionHashHistory() => _positionHashHistory[.._positionHashHistoryPointer];
+    public ulong[] CopyPositionHashHistory() => _positionHashHistory[.._positionHashHistoryPointer];
 
     internal void ClearPositionHashHistory() => _positionHashHistoryPointer = 0;
 
     public void FreeResources()
     {
         ArrayPool<Move>.Shared.Return(_moveStack);
-        ArrayPool<long>.Shared.Return(_positionHashHistory);
+        ArrayPool<ulong>.Shared.Return(_positionHashHistory);
 
         CurrentPosition.FreeResources();
         PositionBeforeLastSearch.FreeResources();

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,13 +1,13 @@
 ﻿namespace Lynx.Model;
 public readonly struct GameState
 {
-    public readonly long ZobristKey;
+    public readonly ulong ZobristKey;
 
     public readonly BoardSquare EnPassant;
 
     public readonly byte Castle;
 
-    public GameState(long zobristKey, BoardSquare enpassant, byte castle)
+    public GameState(ulong zobristKey, BoardSquare enpassant, byte castle)
     {
         ZobristKey = zobristKey;
         EnPassant = enpassant;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -13,7 +13,7 @@ public class Position : IDisposable
 {
     private bool _disposedValue;
 
-    public long UniqueIdentifier { get; private set; }
+    public ulong UniqueIdentifier { get; private set; }
 
     /// <summary>
     /// Use <see cref="Piece"/> as index
@@ -96,7 +96,7 @@ public class Position : IDisposable
     {
         byte castleCopy = Castle;
         BoardSquare enpassantCopy = EnPassant;
-        long uniqueIdentifierCopy = UniqueIdentifier;
+        var uniqueIdentifierCopy = UniqueIdentifier;
 
         var oldSide = (int)Side;
         var offset = Utils.PieceOffset(oldSide);

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -48,7 +48,7 @@ public struct TranspositionTableElement
     /// </summary>
     public int Score { readonly get => _score; set => _score = (short)value; }
 
-    public long Key { readonly get => _key; set => _key = (ushort)(value >> 48); }
+    public ulong Key { readonly get => _key; set => _key = (ushort)(value >> 48); }
 }
 
 public static class TranspositionTableExtensions
@@ -56,7 +56,7 @@ public static class TranspositionTableExtensions
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
     private static readonly ulong _ttElementSize = (ulong)Marshal.SizeOf(typeof(TranspositionTableElement));
 
-    public static (int Length, int Mask) CalculateLength(int size)
+    public static (int Length, ulong Mask) CalculateLength(int size)
     {
         ulong sizeBytes = (ulong)size * 1024ul * 1024ul;
         ulong ttLength = sizeBytes / _ttElementSize;
@@ -79,7 +79,7 @@ public static class TranspositionTableExtensions
         _logger.Info("TT entry:\t{0} bytes", _ttElementSize);
         _logger.Info("TT mask:\t{0}", mask.ToString("X"));
 
-        return ((int)ttLength, (int)mask);
+        return ((int)ttLength, mask);
     }
 
     /// <summary>
@@ -94,7 +94,7 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Score, ShortMove BestMove, NodeType NodeType, int RawScore) ProbeHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int alpha, int beta)
+    public static (int Score, ShortMove BestMove, NodeType NodeType, int RawScore) ProbeHash(this TranspositionTable tt, ulong ttMask, Position position, int depth, int ply, int alpha, int beta)
     {
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 
@@ -135,7 +135,7 @@ public static class TranspositionTableExtensions
     /// <param name="nodeType"></param>
     /// <param name="move"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void RecordHash(this TranspositionTable tt, int ttMask, Position position, int depth, int ply, int score, NodeType nodeType, Move? move = null)
+    public static void RecordHash(this TranspositionTable tt, ulong ttMask, Position position, int depth, int ply, int score, NodeType nodeType, Move? move = null)
     {
         ref var entry = ref tt[position.UniqueIdentifier & ttMask];
 

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -43,7 +43,7 @@ public static class OnlineTablebaseProber
         TypeInfoResolver = SourceGenerationContext.Default
     };
 
-    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, long[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
+    public static async Task<(int MateScore, Move BestMove)> RootSearch(Position position, ulong[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
         var fen = position.FEN(halfMovesWithoutCaptureOrPawnMove);
         _logger.Info("[{0}] Querying online tb for position {1}", nameof(RootSearch), fen);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -43,7 +43,7 @@ public sealed partial class Engine
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
     private int _currentTranspositionTableSize;
-    private int _ttMask;
+    private ulong _ttMask;
     private TranspositionTable _tt = null!;
 
     private long _nodes;

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Lynx;
 public sealed partial class Engine
 {
-    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, long[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
+    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, ulong[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
     {
         var stopWatch = Stopwatch.StartNew();
 

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -214,17 +214,6 @@ public static class Utils
         return (short)((packed + 0x8000) >> 16);
     }
 
-    /// <summary>
-    /// Returns a random <see cref="UInt64"/>
-    /// </summary>
-    public static ulong NextUInt64(this Random random)
-    {
-        Span<byte> arr = stackalloc byte[8];
-        random.NextBytes(arr);
-
-        return BitConverter.ToUInt64(arr);
-    }
-
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -214,6 +214,17 @@ public static class Utils
         return (short)((packed + 0x8000) >> 16);
     }
 
+    /// <summary>
+    /// Returns a random <see cref="UInt64"/>
+    /// </summary>
+    public static ulong NextUInt64(this Random random)
+    {
+        Span<byte> arr = stackalloc byte[8];
+        random.NextBytes(arr);
+
+        return BitConverter.ToUInt64(arr);
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -12,15 +12,15 @@ public static class ZobristTable
     /// <summary>
     /// 64x12
     /// </summary>
-    private static readonly long[][] _table = Initialize();
+    private static readonly ulong[][] _table = Initialize();
 
-    private static readonly long WK_Hash = _table[(int)BoardSquare.a8][(int)Piece.p];
-    private static readonly long WQ_Hash = _table[(int)BoardSquare.b8][(int)Piece.p];
-    private static readonly long BK_Hash = _table[(int)BoardSquare.c8][(int)Piece.p];
-    private static readonly long BQ_Hash = _table[(int)BoardSquare.d8][(int)Piece.p];
+    private static readonly ulong WK_Hash = _table[(int)BoardSquare.a8][(int)Piece.p];
+    private static readonly ulong WQ_Hash = _table[(int)BoardSquare.b8][(int)Piece.p];
+    private static readonly ulong BK_Hash = _table[(int)BoardSquare.c8][(int)Piece.p];
+    private static readonly ulong BQ_Hash = _table[(int)BoardSquare.d8][(int)Piece.p];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long PieceHash(int boardSquare, int piece) => _table[boardSquare][piece];
+    public static ulong PieceHash(int boardSquare, int piece) => _table[boardSquare][piece];
 
     /// <summary>
     /// Uses <see cref="Piece.P"/> and squares <see cref="BoardSquare.a1"/>-<see cref="BoardSquare.h1"/>
@@ -28,7 +28,7 @@ public static class ZobristTable
     /// <param name="enPassantSquare"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long EnPassantHash(int enPassantSquare)
+    public static ulong EnPassantHash(int enPassantSquare)
     {
         if (enPassantSquare == (int)BoardSquare.noSquare)
         {
@@ -52,7 +52,7 @@ public static class ZobristTable
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long SideHash()
+    public static ulong SideHash()
     {
         return _table[(int)BoardSquare.h8][(int)Piece.p];
     }
@@ -65,7 +65,7 @@ public static class ZobristTable
     /// <param name="castle"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long CastleHash(byte castle)
+    public static ulong CastleHash(byte castle)
     {
         return castle switch
         {
@@ -101,9 +101,9 @@ public static class ZobristTable
     /// <param name="position"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long PositionHash(Position position)
+    public static ulong PositionHash(Position position)
     {
-        long positionHash = 0;
+        ulong positionHash = 0;
 
         for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
         {
@@ -130,17 +130,17 @@ public static class ZobristTable
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static long[][] Initialize()
+    internal static ulong[][] Initialize()
     {
-        var zobristTable = new long[64][];
+        var zobristTable = new ulong[64][];
         var randomInstance = new Random(int.MaxValue);
 
         for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
         {
-            zobristTable[squareIndex] = new long[12];
+            zobristTable[squareIndex] = new ulong[12];
             for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
             {
-                zobristTable[squareIndex][pieceIndex] = randomInstance.NextInt64();
+                zobristTable[squareIndex][pieceIndex] = randomInstance.NextUInt64();
             }
         }
 

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -133,7 +133,7 @@ public static class ZobristTable
     internal static ulong[][] Initialize()
     {
         var zobristTable = new ulong[64][];
-        var randomInstance = new Random(int.MaxValue);
+        var randomInstance = new LynxRandom(int.MaxValue);
 
         for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
         {

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -32,7 +32,7 @@ public class TranspositionTableTests
         }
 
         // Mask: 111....11
-        Assert.AreEqual(1, Convert.ToString(mask, 2).AsEnumerable().Distinct().Count());
+        Assert.AreEqual(1, Convert.ToString((long)mask, 2).AsEnumerable().Distinct().Count());
 
         if (sizeMb <= 16)
         {
@@ -49,9 +49,9 @@ public class TranspositionTableTests
             }
         }
 
-        static void Verify(int length, int mask, int i)
+        static void Verify(int length, ulong mask, int i)
         {
-            Assert.AreEqual(i % length, i & mask, $"Error in {i}: {i} %{length} should be {i} & 0x{mask:X}");
+            Assert.AreEqual(i % length, (ulong)i & mask, $"Error in {i}: {i} %{length} should be {i} & 0x{mask:X}");
         }
     }
 
@@ -81,7 +81,7 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+        var (length, mask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
         transpositionTable.RecordHash(mask, position, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, move: 1234);
@@ -95,7 +95,7 @@ public class TranspositionTableTests
     {
         const int sharedDepth = 5;
         var position = new Position(Constants.InitialPositionFEN);
-        var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+        var (length, mask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
@@ -110,7 +110,7 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash_CheckmateDifferentDepth(int recordedEval, int recordedDeph, int probeDepth, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var (mask, length) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+        var (length, mask) = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
         var transpositionTable = new TranspositionTableElement[length];
 
         transpositionTable.RecordHash(mask, position, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, move: 1234);

--- a/tests/Lynx.Test/ZobristHashGenerationTest.cs
+++ b/tests/Lynx.Test/ZobristHashGenerationTest.cs
@@ -32,7 +32,7 @@ public class ZobristHashGenerationTest
     {
         var originalPosition = new Position(fen);
 
-        var fenDictionary = new Dictionary<string, (string Move, long Hash)>()
+        var fenDictionary = new Dictionary<string, (string Move, ulong Hash)>()
         {
             [originalPosition.FEN()] = ("", originalPosition.UniqueIdentifier)
         };
@@ -48,7 +48,7 @@ public class ZobristHashGenerationTest
     {
         var originalPosition = new Position(fen);
 
-        var fenDictionary = new Dictionary<string, (string Move, long Hash)>()
+        var fenDictionary = new Dictionary<string, (string Move, ulong Hash)>()
         {
             [originalPosition.FEN()] = ("", originalPosition.UniqueIdentifier)
         };
@@ -58,7 +58,7 @@ public class ZobristHashGenerationTest
 
 #pragma warning restore S4144 // Methods should not have identical implementations
 
-    private static void TransversePosition(Position originalPosition, Dictionary<string, (string Move, long Hash)> fenDictionary, int maxDepth = 10, int depth = 0)
+    private static void TransversePosition(Position originalPosition, Dictionary<string, (string Move, ulong Hash)> fenDictionary, int maxDepth = 10, int depth = 0)
     {
         foreach (var move in MoveGenerator.GenerateAllMoves(originalPosition))
         {

--- a/tests/Lynx.Test/ZobristTableTest.cs
+++ b/tests/Lynx.Test/ZobristTableTest.cs
@@ -5,7 +5,7 @@ namespace Lynx.Test;
 
 public class ZobristTableTest
 {
-    private readonly long[][] _zobristTable = ZobristTable.Initialize();
+    private readonly ulong[][] _zobristTable = ZobristTable.Initialize();
 
     [Test]
     public void XorBehavior()
@@ -16,7 +16,7 @@ public class ZobristTableTest
             {
                 var hash = _zobristTable[i][j];
 
-                var n = Random.Shared.NextInt64();
+                var n = Random.Shared.NextUInt64();
 
                 var xored = n ^ hash;
 
@@ -127,9 +127,9 @@ public class ZobristTableTest
         Assert.AreEqual(originalHash, currentHash);
     }
 
-    private long CalculateCastleHash(byte castle)
+    private ulong CalculateCastleHash(byte castle)
     {
-        long combinedHash = 0;
+        ulong combinedHash = 0;
 
         if ((castle & (int)CastlingRights.WK) != default)
         {
@@ -154,9 +154,9 @@ public class ZobristTableTest
         return combinedHash;
     }
 
-    private static long OriginalPositionHash(Position position)
+    private static ulong OriginalPositionHash(Position position)
     {
-        long positionHash = 0;
+        ulong positionHash = 0;
 
         for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
         {

--- a/tests/Lynx.Test/ZobristTableTest.cs
+++ b/tests/Lynx.Test/ZobristTableTest.cs
@@ -5,6 +5,7 @@ namespace Lynx.Test;
 
 public class ZobristTableTest
 {
+    private readonly LynxRandom _random = new LynxRandom();
     private readonly ulong[][] _zobristTable = ZobristTable.Initialize();
 
     [Test]
@@ -16,7 +17,7 @@ public class ZobristTableTest
             {
                 var hash = _zobristTable[i][j];
 
-                var n = Random.Shared.NextUInt64();
+                var n = _random.NextUInt64();
 
                 var xored = n ^ hash;
 


### PR DESCRIPTION
If the `.NextUInt64()` implementation is replaced with `(ulong).NextInt64()`, no bench changes

```
Test  | refactor/position-hash-ulong
Elo   | 1.82 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 23312: +6311 -6189 =10812
Penta | [552, 2795, 4859, 2879, 571]
https://openbench.lynx-chess.com/test/824/
```