### PR TITLE
🔍 FP: skip only the failing move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -290,7 +290,7 @@ public sealed partial class Engine
                         Game.RemoveFromPositionHashHistory();
                         position.UnmakeMove(move, gameState);
 
-                        break;
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
```
Test  | search/fp-skip-only-that-move
Elo   | -3.27 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 14024: +3736 -3868 =6420
Penta | [355, 1691, 3019, 1625, 322]
https://openbench.lynx-chess.com/test/823/
```