### PR TITLE
⚡ GC mode `Server` -> `Workstation`

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>


### PR DESCRIPTION
Jim Ablett released a version of Lynx v1.7.0 with default GC mode set to Workstation.
Here's a comparison with the official version and Jim's one, which serves as an updated test regarding this topic since this should be the only different between both binaries.

8+0.08, Hash 256 (I know🤦🏼‍♂️, forgot to update it), 8moves_v3, no draw or win adjudication
```
Score of Lynx 1.7.0 vs Lynx 1.7.0 JA: 1556 - 1423 - 3781  [0.510] 6760
...      Lynx 1.7.0 playing White: 846 - 631 - 1903  [0.532] 3380
...      Lynx 1.7.0 playing Black: 710 - 792 - 1878  [0.488] 3380
...      White vs Black: 1638 - 1341 - 3781  [0.522] 6760
Elo difference: 6.8 +/- 5.5, LOS: 99.3 %, DrawRatio: 55.9 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
```

Server GC mode was introduced back in May 2021 (https://github.com/lynx-chess/Lynx/commit/be0f621e6e8c3411f377793ebf841153090ebb73) and I recall having done some tests myself that concluded that no relevant strength gain by changing GC mode, but can't find those tests and that commit states that the change wasn't tested.