### PR TITLE
🧹 Change `SearchResult`'s `Nodes`, `Time` and `NPS` types from `long` to `ulong`

### DIFF
--- a/src/Lynx.Benchmark/UCI_Benchmark.cs
+++ b/src/Lynx.Benchmark/UCI_Benchmark.cs
@@ -42,7 +42,7 @@ public class UCI_Benchmark : BaseBenchmark
     private readonly Channel<object> _channel = Channel.CreateBounded<object>(new BoundedChannelOptions(100_000) { SingleReader = true, SingleWriter = false });
 
     [Benchmark]
-    public (long, long) Bench_DefaultDepth()
+    public (ulong, ulong) Bench_DefaultDepth()
     {
         var engine = new Engine(_channel.Writer);
         return engine.Bench(Configuration.EngineSettings.BenchDepth);

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -102,11 +102,11 @@ public partial class Engine
     /// (https://github.com/JacquesRW/akimbo/blob/main/resources/fens.txt)
     /// plus random some endgame positions to ensure promotions with/without captures are well covered
     /// </summary>
-    public (long TotalNodes, long Nps) Bench(int depth)
+    public (ulong TotalNodes, ulong Nps) Bench(int depth)
     {
         var stopwatch = new Stopwatch();
 
-        long totalNodes = 0;
+        ulong totalNodes = 0;
         double totalSeconds = 0;
 
         foreach (var fen in _benchmarkFens)
@@ -132,7 +132,7 @@ public partial class Engine
         return (totalNodes, Utils.CalculateNps(totalNodes, totalSeconds));
     }
 
-    public async ValueTask PrintBenchResults((long TotalNodes, long Nps) benchResult) => await _engineWriter.WriteAsync($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
-    public static void PrintBenchResults((long TotalNodes, long Nps) benchResult, Action<string> write) => write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
-    public static async ValueTask PrintBenchResults((long TotalNodes, long Nps) benchResult, Func<string, ValueTask> write) => await write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public async ValueTask PrintBenchResults((ulong TotalNodes, ulong Nps) benchResult) => await _engineWriter.WriteAsync($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public static void PrintBenchResults((ulong TotalNodes, ulong Nps) benchResult, Action<string> write) => write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
+    public static async ValueTask PrintBenchResults((ulong TotalNodes, ulong Nps) benchResult, Func<string, ValueTask> write) => await write($"{benchResult.TotalNodes} nodes {benchResult.Nps} nps");
 }

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -8,11 +8,11 @@ public sealed class SearchResult
 
     public (int WDLWin, int WDLDraw, int WDLLoss)? WDL { get; set; } = null;
 
-    public long Nodes { get; set; }
+    public ulong Nodes { get; set; }
 
-    public long Time { get; set; }
+    public ulong Time { get; set; }
 
-    public long NodesPerSecond { get; set; }
+    public ulong NodesPerSecond { get; set; }
 
     public int Score { get; init; }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -46,7 +46,7 @@ public sealed partial class Engine
     private ulong _ttMask;
     private TranspositionTable _tt = null!;
 
-    private long _nodes;
+    private ulong _nodes;
 
     private SearchResult? _previousSearchResult;
 

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -14,11 +14,13 @@ public sealed partial class Engine
 
             if (tablebaseResult.BestMove != 0)
             {
+                var elapsedSeconds = Utils.CalculateElapsedSeconds(stopWatch);
+
                 var searchResult = new SearchResult(tablebaseResult.BestMove, score: 0, targetDepth: 0, [tablebaseResult.BestMove], mate: tablebaseResult.MateScore)
                 {
                     DepthReached = 0,
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
-                    Time = stopWatch.ElapsedMilliseconds,
+                    Time = Utils.CalculateUCITime(elapsedSeconds),
                     NodesPerSecond = 0,
                     HashfullPermill = _tt.HashfullPermillApprox(),
                     WDL = WDL.WDLModel(

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -175,9 +175,9 @@ public static class Utils
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static long CalculateNps(long nodes, double elapsedSeconds)
+    public static ulong CalculateNps(ulong nodes, double elapsedSeconds)
     {
-        return Convert.ToInt64(Math.Clamp(nodes / elapsedSeconds, 1, long.MaxValue));
+        return Convert.ToUInt64(Math.Clamp(nodes / elapsedSeconds, 1, ulong.MaxValue));
     }
 
     /// <summary>
@@ -194,9 +194,9 @@ public static class Utils
     /// <summary>
     /// Transforms the high precision elapsed time in seconds into the time format UCI expects: ms
     /// </summary>
-    public static long CalculateUCITime(double elapsedSeconds)
+    public static ulong CalculateUCITime(double elapsedSeconds)
     {
-        return Math.Clamp(Convert.ToInt64(elapsedSeconds * 1_000), 1, long.MaxValue);
+        return Math.Clamp(Convert.ToUInt64(elapsedSeconds * 1_000), 1, ulong.MaxValue);
     }
 
     /// <summary>


### PR DESCRIPTION
* Change `SearchResult`'s `Nodes`, `Time` and `NPS` type from `long` to `ulong`
* Use high time resolution for `OnlineTablebase`

```
Test  | refactor/nodes-time-nps-ulong
Elo   | 3.43 +- 4.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 9226: +2702 -2611 =3913
Penta | [230, 1039, 2001, 1096, 247]
https://openbench.lynx-chess.com/test/814/
```