### PR TITLE
🔍 Save static eval in TT

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1088,19 +1088,19 @@ static void TranspositionTable()
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(position, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
     var entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 20
 
-    transpositionTable.RecordHash(position, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
     entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
     entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
     entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 30
 }

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -22,6 +22,8 @@ public static class EvaluationConstants
         0, 1, 1, 2, 4, 0
     ];
 
+    public const int MaxPhase = 24;
+
     /// <summary>
     /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
     /// </summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -496,11 +496,9 @@ public class Position : IDisposable
             * ((blackPawnAttacks & OccupancyBitBoards[(int)Side.White] /* & (~whitePawns) */).CountBits()
                 - (whitePawnAttacks & OccupancyBitBoards[(int)Side.Black] /* & (~blackPawns) */).CountBits());
 
-        const int maxPhase = 24;
-
-        if (gamePhase > maxPhase)    // Early promotions
+        if (gamePhase > MaxPhase)    // Early promotions
         {
-            gamePhase = maxPhase;
+            gamePhase = MaxPhase;
         }
 
         int totalPawnsCount = whitePawns.CountBits() + blackPawns.CountBits();
@@ -558,11 +556,11 @@ public class Position : IDisposable
             }
         }
 
-        int endGamePhase = maxPhase - gamePhase;
+        int endGamePhase = MaxPhase - gamePhase;
 
         var middleGameScore = Utils.UnpackMG(packedScore);
         var endGameScore = Utils.UnpackEG(packedScore);
-        var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
+        var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / MaxPhase;
 
         // Endgame scaling with pawn count, formula yoinked from Sirius
         eval = (int)(eval * ((80 + (totalPawnsCount * 7)) / 128.0));
@@ -576,6 +574,23 @@ public class Position : IDisposable
             : -eval;
 
         return (sideEval, gamePhase);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Phase()
+    {
+        int gamePhase =
+             ((PieceBitBoards[(int)Piece.N] | PieceBitBoards[(int)Piece.n]).CountBits() * GamePhaseByPiece[(int)Piece.N])
+            + ((PieceBitBoards[(int)Piece.B] | PieceBitBoards[(int)Piece.b]).CountBits() * GamePhaseByPiece[(int)Piece.B])
+            + ((PieceBitBoards[(int)Piece.R] | PieceBitBoards[(int)Piece.r]).CountBits() * GamePhaseByPiece[(int)Piece.R])
+            + ((PieceBitBoards[(int)Piece.Q] | PieceBitBoards[(int)Piece.q]).CountBits() * GamePhaseByPiece[(int)Piece.Q]);
+
+        if (gamePhase > MaxPhase)    // Early promotions
+        {
+            gamePhase = MaxPhase;
+        }
+
+        return gamePhase;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -433,7 +433,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalEval, depth, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, rawStaticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
@@ -598,7 +598,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, finalEval, 0, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }


### PR DESCRIPTION
We save the static evaluation as part of `TranspositionTableElement` (+2 bytes, 8 -> 10) in exchange for some measurable speedup as a result of not having to calculate static eval for TT hits
![image](https://github.com/user-attachments/assets/44ef9056-3e41-4d0e-9a16-d9df1b86e429)

This specific PR has [Use raw static eval even when TT score is reused](https://github.com/lynx-chess/Lynx/commit/fd7b94f1f4811d818e160608381a7b47d13eedf3) over https://github.com/lynx-chess/Lynx/pull/1084: even if TT scores are used for search, the real/raw static eval is the one saved in the TT, with still the exception of final evals, that are treated as the static evals of a position that we want to re-use later.

Regular testing conditions:

```
Test  | search/tt-save-staticeval-2
Elo   | 7.79 +- 4.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | 11904: +3472 -3205 =5227
Penta | [323, 1357, 2356, 1562, 354]
https://openbench.lynx-chess.com/test/820/
```
```
Test  | search/tt-save-staticeval-2
Elo   | 4.89 +- 3.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 18458: +4909 -4649 =8900
Penta | [312, 2180, 4033, 2344, 360]
https://openbench.lynx-chess.com/test/827/
```

Small TT:
```
Test  | search/tt-save-staticeval-2
Elo   | 0.67 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 20122: +5674 -5635 =8813
Penta | [570, 2421, 4086, 2368, 616]
https://openbench.lynx-chess.com/test/828/
```
```
Test  | search/tt-save-staticeval-2
Elo   | 4.53 +- 5.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | 7290: +1922 -1827 =3541
Penta | [135, 858, 1582, 917, 153]
https://openbench.lynx-chess.com/test/829/
```