### PR TITLE
🔍 Save static eval in TT (IV)

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -22,6 +22,8 @@ public static class EvaluationConstants
         0, 1, 1, 2, 4, 0
     ];
 
+    public const int MaxPhase = 24;
+
     /// <summary>
     /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
     /// </summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -496,11 +496,9 @@ public class Position : IDisposable
             * ((blackPawnAttacks & OccupancyBitBoards[(int)Side.White] /* & (~whitePawns) */).CountBits()
                 - (whitePawnAttacks & OccupancyBitBoards[(int)Side.Black] /* & (~blackPawns) */).CountBits());
 
-        const int maxPhase = 24;
-
-        if (gamePhase > maxPhase)    // Early promotions
+        if (gamePhase > MaxPhase)    // Early promotions
         {
-            gamePhase = maxPhase;
+            gamePhase = MaxPhase;
         }
 
         int totalPawnsCount = whitePawns.CountBits() + blackPawns.CountBits();
@@ -558,11 +556,11 @@ public class Position : IDisposable
             }
         }
 
-        int endGamePhase = maxPhase - gamePhase;
+        int endGamePhase = MaxPhase - gamePhase;
 
         var middleGameScore = Utils.UnpackMG(packedScore);
         var endGameScore = Utils.UnpackEG(packedScore);
-        var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / maxPhase;
+        var eval = ((middleGameScore * gamePhase) + (endGameScore * endGamePhase)) / MaxPhase;
 
         // Endgame scaling with pawn count, formula yoinked from Sirius
         eval = (int)(eval * ((80 + (totalPawnsCount * 7)) / 128.0));
@@ -576,6 +574,23 @@ public class Position : IDisposable
             : -eval;
 
         return (sideEval, gamePhase);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int Phase()
+    {
+        int gamePhase =
+             ((PieceBitBoards[(int)Piece.N] | PieceBitBoards[(int)Piece.n]).CountBits() * GamePhaseByPiece[(int)Piece.N])
+            + ((PieceBitBoards[(int)Piece.B] | PieceBitBoards[(int)Piece.b]).CountBits() * GamePhaseByPiece[(int)Piece.B])
+            + ((PieceBitBoards[(int)Piece.R] | PieceBitBoards[(int)Piece.r]).CountBits() * GamePhaseByPiece[(int)Piece.R])
+            + ((PieceBitBoards[(int)Piece.Q] | PieceBitBoards[(int)Piece.q]).CountBits() * GamePhaseByPiece[(int)Piece.Q]);
+
+        if (gamePhase > MaxPhase)    // Early promotions
+        {
+            gamePhase = MaxPhase;
+        }
+
+        return gamePhase;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -165,9 +165,10 @@ public static class TranspositionTableExtensions
         // We want to store the distance to the checkmate position relative to the current node, independently from the root
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
+        var recalculatedStaticEval = RecalculateMateScores(staticEval, -ply);
 
         entry.Key = (ushort)position.UniqueIdentifier;
-        entry.StaticEval = (short)staticEval;
+        entry.StaticEval = (short)recalculatedStaticEval;
         entry.Score = recalculatedScore;
         entry.Depth = depth;
         entry.Type = nodeType;

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -127,7 +127,7 @@ public static class TranspositionTableExtensions
             }
         }
 
-        return (score, entry.Move, entry.Type, rawScore, entry.StaticEval);
+        return (score, entry.Move, entry.Type, rawScore, RecalculateMateScores(entry.StaticEval, ply));
     }
 
     /// <summary>


### PR DESCRIPTION
[Adjust static eval scores when they reflect checkmates](https://github.com/lynx-chess/Lynx/commit/5a459181e7e8008cddc4ecd19e4426f9c44b2d37) + [Also recalculate scores when probing](https://github.com/lynx-chess/Lynx/commit/2c9e6ef4d08d4c6fb71484e5e3594d9da3614a52) over #1085: this also adapts static evals reflecting mates to the ply

vs #1085 
```
Test  | search/tt-save-staticeval-2.2
Elo   | -3.74 +- 4.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 13014: +3520 -3660 =5834
Penta | [381, 1623, 2589, 1583, 331]
https://openbench.lynx-chess.com/test/826/
```