### PR TITLE
🔍 Save static eval in TT - use always static eval and no final eval

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -433,7 +433,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalEval, depth, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, rawStaticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
@@ -598,7 +598,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, finalEval, 0, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }


### PR DESCRIPTION
```
Score of Lynx-search-tt-save-staticeval-2.3-4222-win-x64 vs Lynx-search-tt-save-staticeval-2-4216-win-x64: 8595 - 8307 - 14348  [0.505] 31250
...      Lynx-search-tt-save-staticeval-2.3-4222-win-x64 playing White: 6573 - 1983 - 7069  [0.647] 15625
...      Lynx-search-tt-save-staticeval-2.3-4222-win-x64 playing Black: 2022 - 6324 - 7279  [0.362] 15625
...      White vs Black: 12897 - 4005 - 14348  [0.642] 31250
Elo difference: 3.2 +/- 2.8, LOS: 98.7 %, DrawRatio: 45.9 %
SPRT: llr 2.44 (84.6%), lbound -2.25, ubound 2.89
```