### PR TITLE
🧹 Prevent `TranspositionTableElement` struct fields from being modified from outside

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -28,22 +28,22 @@ public struct TranspositionTableElement
     private NodeType _type;
 
     /// <summary>
-    /// 16 MSB of Zobrist key
+    /// 16 MSB of Position's Zobrist key
     /// </summary>
     public readonly ushort Key => _key;
 
     /// <summary>
-    /// Best move found in a position. 0 if the position failed low (score <= alpha)
+    /// Best move found in the position. 0 if the search failed low (score <= alpha)
     /// </summary>
     public readonly ShortMove Move => _move;
 
     /// <summary>
-    /// Position evaluation
+    /// Position's score
     /// </summary>
     public readonly int Score => _score;
 
     /// <summary>
-    /// Position evaluation
+    /// Position's static evaluation
     /// </summary>
     public readonly int StaticEval => _staticEval;
 
@@ -69,7 +69,7 @@ public struct TranspositionTableElement
     {
         _key = (ushort)key;
         _score = (short)score;
-        _score = (short)staticEval;
+        _staticEval = (short)staticEval;
         _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
         _type = nodeType;
         _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -15,19 +15,35 @@ public enum NodeType : byte
 
 public struct TranspositionTableElement
 {
-    /// <summary>
-    /// 16 MSB of Zobrist key
-    /// </summary>
-    public ushort Key { get; set; }
+    private ushort _key;
 
-    /// <summary>
-    /// Best move found in a position. 0 if the position failed low (score <= alpha)
-    /// </summary>
-    public ShortMove Move { get; set; }
+    private ShortMove _move;
 
     private short _score;
 
     private byte _depth;
+
+    private NodeType _type;
+
+    /// <summary>
+    /// 16 MSB of Zobrist key
+    /// </summary>
+    public readonly ushort Key => _key;
+
+    /// <summary>
+    /// Best move found in a position. 0 if the position failed low (score <= alpha)
+    /// </summary>
+    public readonly ShortMove Move => _move;
+
+    /// <summary>
+    /// Position evaluation
+    /// </summary>
+    public readonly int Score => _score;
+
+    /// <summary>
+    /// How deep the recorded search went. For us this numberis targetDepth - ply
+    /// </summary>
+    public readonly int Depth => _depth;
 
     /// <summary>
     /// Node (position) type:
@@ -35,19 +51,21 @@ public struct TranspositionTableElement
     /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
     /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
     /// </summary>
-    public NodeType Type { get; set; }
+    public readonly NodeType Type => _type;
 
     /// <summary>
-    /// How deep the recorded search went. For us this numberis targetDepth - ply
+    /// Struct size in bytes
     /// </summary>
-    public int Depth { readonly get => _depth; set => _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref value, 1))[0]; }
-
-    /// <summary>
-    /// Position evaluation
-    /// </summary>
-    public int Score { readonly get => _score; set => _score = (short)value; }
-
     public static ulong Size => (ulong)Marshal.SizeOf(typeof(TranspositionTableElement));
+
+    public void Update(ulong key, int score, int depth, NodeType nodeType, Move? move)
+    {
+        _key = (ushort)key;
+        _score = (short)score;
+        _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
+        _type = nodeType;
+        _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
+    }
 }
 
 public static class TranspositionTableExtensions
@@ -108,6 +126,7 @@ public static class TranspositionTableExtensions
             return (EvaluationConstants.NoHashEntry, default, default, default);
         }
 
+        var type = entry.Type;
         var rawScore = entry.Score;
         var score = EvaluationConstants.NoHashEntry;
 
@@ -115,9 +134,9 @@ public static class TranspositionTableExtensions
         {
             var recalculatedScore = RecalculateMateScores(rawScore, ply);
 
-            if (entry.Type == NodeType.Exact
-                || (entry.Type == NodeType.Alpha && recalculatedScore <= alpha)
-                || (entry.Type == NodeType.Beta && recalculatedScore >= beta))
+            if (type == NodeType.Exact
+                || (type == NodeType.Alpha && recalculatedScore <= alpha)
+                || (type == NodeType.Beta && recalculatedScore >= beta))
             {
                 // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
                 // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
@@ -125,7 +144,7 @@ public static class TranspositionTableExtensions
             }
         }
 
-        return (score, entry.Move, entry.Type, rawScore);
+        return (score, entry.Move, type, rawScore);
     }
 
     /// <summary>
@@ -164,11 +183,7 @@ public static class TranspositionTableExtensions
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
-        entry.Key = (ushort)position.UniqueIdentifier;
-        entry.Score = recalculatedScore;
-        entry.Depth = depth;
-        entry.Type = nodeType;
-        entry.Move = move != null ? (ShortMove)move : entry.Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
+        entry.Update(position.UniqueIdentifier, recalculatedScore, depth, nodeType, move);
     }
 
     /// <summary>


### PR DESCRIPTION
- Replace `TranspositionTableElement` auto-properties with the private field + getters-only
- Add a method to update those fields

```
Test  | refactor/expose-tt-getters-only
Elo   | 0.29 +- 3.01 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | 23868: +7033 -7013 =9822
Penta | [687, 2773, 5022, 2737, 715]
https://openbench.lynx-chess.com/test/832/
```