### PR TITLE
🔍 FP: history factor

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -4,7 +4,8 @@
     // Only warnings and errors are logged to a file by default.
     // "NLog.rules" below can be removed/tweaked to change that benavior.
     // Setting this to false disables both file and console logging (not recommended)
-    "EnableLogging": true
+    "EnableLogging": true,
+    "EnableTuning": true
   },
 
   // Settings that affect the engine behavior - some of them available via UCI as well

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -194,6 +194,9 @@ public sealed class EngineSettings
     [SPSA<int>(1, 200, 10)]
     public int FP_DepthScalingFactor { get; set; } = 73;
 
+    [SPSA<int>(50, 1000, 50)]
+    public int FP_HistoryDepthFactor { get; set; } = 100;
+
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -55,7 +55,7 @@ public sealed class GeneralSettings
 {
     public bool EnableLogging { get; set; } = false;
 
-    public bool EnableTuning { get; set; } = false;
+    public bool EnableTuning { get; set; } = true;
 }
 
 public sealed class EngineSettings

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -276,12 +276,14 @@ public sealed partial class Engine
                         break;
                     }
 
+                    var moveHistory = _quietHistory[move.Piece()][move.TargetSquare()];
+
                     // 🔍 History pruning -  all quiet moves can be pruned
                     // once we find one with a history score too low
                     if (!isCapture
                         && moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
                         && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth // TODO use LMR depth
-                        && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
+                        && moveHistory < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
@@ -294,10 +296,12 @@ public sealed partial class Engine
                     // 🔍 Futility Pruning (FP) - all quiet moves can be pruned
                     // once it's considered that they don't have potential to raise alpha
                     if (visitedMovesCounter > 0
-                        //&& alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
-                        //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && depth <= Configuration.EngineSettings.FP_MaxDepth
-                        && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
+                        && staticEval
+                            + Configuration.EngineSettings.FP_Margin
+                            + (Configuration.EngineSettings.FP_DepthScalingFactor * depth)
+                            + (moveHistory * depth / Configuration.EngineSettings.FP_HistoryDepthFactor)
+                        <= alpha)
                     {
                         // After making a move
                         Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -469,6 +469,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "fp_historydepthfactor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.FP_HistoryDepthFactor = value;
+                    }
+                    break;
+                }
             case "historyprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
`+ (moveHistory * depth / FP_HistoryDepthFactor)`, FP_HistoryDepthFactor = 100

```
Score of Lynx-search-history-fp-4244-win-x64 vs Lynx 4243 - main: 1635 - 1652 - 2923  [0.499] 6210
...      Lynx-search-history-fp-4244-win-x64 playing White: 1262 - 393 - 1450  [0.640] 3105
...      Lynx-search-history-fp-4244-win-x64 playing Black: 373 - 1259 - 1473  [0.357] 3105
...      White vs Black: 2521 - 766 - 2923  [0.641] 6210
Elo difference: -1.0 +/- 6.3, LOS: 38.3 %, DrawRatio: 47.1 %
SPRT: llr -0.715 (-24.7%), lbound -2.25, ubound 2.89
```

Tune attempt: #1097 (wf, despite the branch name), #1109 (ob)
```
Test  | search/history-fp-ob-tune-660
Elo   | -1.51 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 24804: +7091 -7199 =10514
Penta | [798, 2962, 4925, 2984, 733]
https://openbench.lynx-chess.com/test/841/
```

```
Test  | search/history-fp-ob-tune-5000
Elo   | -0.09 +- 2.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.57 (-2.25, 2.89) [0.00, 3.00]
Games | 38448: +10075 -10085 =18288
Penta | [724, 4745, 8296, 4735, 724]
https://openbench.lynx-chess.com/test/847/
```