### PR TITLE
🔍 SPSA 2024-10-9 (40+0.4, 2211 iter)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -116,34 +116,34 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
+    public int LMR_MinFullDepthSearchedMoves { get; set; } = 4;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.10)]
-    public double LMR_Base { get; set; } = 0.75;
+    public double LMR_Base { get; set; } = 0.86;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.49;
+    public double LMR_Divisor { get; set; } = 3.35;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_MinDepth { get; set; } = 3;
+    public int NMP_MinDepth { get; set; } = 2;
 
     [SPSA<int>(1, 5, 0.5)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int NMP_DepthIncrement { get; set; } = 0;
+    public int NMP_DepthIncrement { get; set; } = 1;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int NMP_DepthDivisor { get; set; } = 3;
+    public int NMP_DepthDivisor { get; set; } = 4;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 13;
+    public int AspirationWindow_Base { get; set; } = 12;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -155,28 +155,28 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 52;
+    public int RFP_DepthScalingFactor { get; set; } = 80;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 2;
+    public int Razoring_MaxDepth { get; set; } = 1;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 68;
+    public int Razoring_Depth1Bonus { get; set; } = 121;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 208;
+    public int Razoring_NotDepth1Bonus { get; set; } = 194;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int IIR_MinDepth { get; set; } = 4;
+    public int IIR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMP_MaxDepth { get; set; } = 8;
+    public int LMP_MaxDepth { get; set; } = 6;
 
     [SPSA<int>(0, 10, 0.5)]
     public int LMP_BaseMovesToTry { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 3;
+    public int LMP_MovesDepthMultiplier { get; set; } = 4;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 
@@ -186,16 +186,16 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     [SPSA<int>(0, 6, 0.5)]
-    public int SEE_BadCaptureReduction { get; set; } = 2;
+    public int SEE_BadCaptureReduction { get; set; } = 1;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 7;
+    public int FP_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 73;
+    public int FP_DepthScalingFactor { get; set; } = 75;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 218;
+    public int FP_Margin { get; set; } = 153;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9191b6eb-baa7-4ebb-8137-313708722a0c)

```
iterations: 2211 (173.99s per iter)
games: 17688 (21.75s per game)
LMR_MinDepth = 3(+0.15) in [3, 10]
LMR_MinFullDepthSearchedMoves = 4(+0.15) in [1, 10]
LMR_Base = 86(-5.248402) in [10, 200]
LMR_Divisor = 335(-7.348750) in [100, 500]
NMP_MinDepth = 2(+0.02) in [1, 10]
NMP_BaseDepthReduction = 2(+0.10) in [1, 5]
NMP_DepthIncrement = 1(-0.472779) in [0, 10]
NMP_DepthDivisor = 4(+0.14) in [1, 10]
AspirationWindow_Base = 12(-0.629595) in [5, 30]
AspirationWindow_Delta = 11(-1.549011) in [5, 30]
AspirationWindow_MinDepth = 8(-0.357291) in [1, 20]
RFP_MaxDepth = 7(+0.90) in [1, 10]
RFP_DepthScalingFactor = 80(-1.709453) in [1, 300]
Razoring_MaxDepth = 1(+0.39) in [1, 10]
Razoring_Depth1Bonus = 121(-8.183799) in [1, 300]
Razoring_NotDepth1Bonus = 194(+15.92) in [1, 300]
IIR_MinDepth = 3(-0.060159) in [1, 10]
LMP_MaxDepth = 6(-0.843513) in [1, 10]
LMP_BaseMovesToTry = 1(+0.76) in [0, 10]
LMP_MovesDepthMultiplier = 4(-0.021790) in [0, 10]
SEE_BadCaptureReduction = 1(-0.781106) in [0, 6]
FP_MaxDepth = 5(+0.20) in [1, 10]
FP_DepthScalingFactor = 75(-3.219324) in [1, 200]
FP_Margin = 153(+23.68) in [0, 500]
```

```
Test  | spsa/9-10-2211-iter
Elo   | -4.21 +- 5.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.14 (-2.25, 2.89) [0.00, 5.00]
Games | 5694: +1462 -1531 =2701
Penta | [124, 723, 1202, 694, 104]
https://openbench.lynx-chess.com/test/838/
```