### PR TITLE
🔍 History pruning: apply to (bad) captures as well

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -275,12 +275,15 @@ public sealed partial class Engine
                         break;
                     }
 
+                    var moveHistory = isCapture
+                        ? _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())]
+                        : _quietHistory[move.Piece()][move.TargetSquare()];
+
                     // 🔍 History pruning -  all quiet moves can be pruned
                     // once we find one with a history score too low
-                    if (!isCapture
-                        && moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
+                    if (moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
                         && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
-                        && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
+                        && moveHistory < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                     {
                         RevertMove();
                         break;


### PR DESCRIPTION
```
Test  | search/history-pruning-capture
Elo   | -7.23 +- 5.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.19 (-2.25, 2.89) [0.00, 3.00]
Games | 7212: +1994 -2144 =3074
Penta | [226, 866, 1519, 822, 173]
https://openbench.lynx-chess.com/test/839/
```