### PR TITLE
🔍 Add `ttScore >= alpha` condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -48,7 +48,9 @@ public sealed partial class Engine
         if (!isRoot)
         {
             (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
-            if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
+            if (!pvNode
+                && ttScore != EvaluationConstants.NoHashEntry
+                && ttScore >= alpha) // TODO || cutnode
             {
                 return ttScore;
             }


### PR DESCRIPTION
```
Score of Lynx-search-tt-alpha-condition-4270-win-x64 vs Lynx 4267 - main: 1372 - 1494 - 2310  [0.488] 5176
...      Lynx-search-tt-alpha-condition-4270-win-x64 playing White: 1058 - 338 - 1192  [0.639] 2588
...      Lynx-search-tt-alpha-condition-4270-win-x64 playing Black: 314 - 1156 - 1118  [0.337] 2588
...      White vs Black: 2214 - 652 - 2310  [0.651] 5176
Elo difference: -8.2 +/- 7.0, LOS: 1.1 %, DrawRatio: 44.6 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```