### PR TITLE
🔍 Aspiration windows: limit failHighReduction

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -128,7 +128,7 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        var aspWindowDepth = depth - Math.Min(2, failHighReduction);
+                        var aspWindowDepth = depth - Math.Min(3, failHighReduction);
 
                         _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
                             aspWindowDepth, alpha, beta, bestScore, _nodes);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -128,10 +128,12 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                            depth, alpha, beta, bestScore, _nodes);
+                        var aspWindowDepth = depth - Math.Min(2, failHighReduction);
 
-                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta);
+                        _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
+                            aspWindowDepth, alpha, beta, bestScore, _nodes);
+
+                        bestScore = NegaMax(depth: aspWindowDepth, ply: 0, alpha, beta);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, 40965, 61447, 92170
                         window += window >> 1;   // window / 2


### PR DESCRIPTION
2
```
Test  | search/asp-windows-limit-failhighcount
Elo   | -1.08 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 29252: +8251 -8342 =12659
Penta | [769, 3451, 6265, 3384, 757]
https://openbench.lynx-chess.com/test/844/
```

3
```
Test  | search/asp-windows-limit-failhighcount
Elo   | -2.35 +- 5.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.89 (-2.25, 2.89) [0.00, 3.00]
Games | 7102: +1989 -2037 =3076
Penta | [202, 806, 1562, 800, 181]
https://openbench.lynx-chess.com/test/842/
```