### PR TITLE
🔍 Aspiration windows: alpha condition for `failHighReduction`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -152,7 +152,7 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(500, 3000, 150)]
-    public int AspirationWindow_MaxAlpha { get; set; } = 2000;
+    public int AspirationWindow_MaxAlpha { get; set; } = 1000;
 
     [SPSA<int>(1, 10, 0.5)]
     public int RFP_MaxDepth { get; set; } = 7;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -151,6 +151,9 @@ public sealed class EngineSettings
     [SPSA<int>(1, 20, 1)]
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
+    [SPSA<int>(500, 3000, 150)]
+    public int AspirationWindow_MaxAlpha { get; set; } = 2000;
+
     [SPSA<int>(1, 10, 0.5)]
     public int RFP_MaxDepth { get; set; } = 7;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -146,7 +146,11 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Min(bestScore + window, EvaluationConstants.MaxEval);
-                            ++failHighReduction;
+
+                            if (alpha <= Configuration.EngineSettings.AspirationWindow_MaxAlpha)
+                            {
+                                ++failHighReduction;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
2000
```
Test  | search/asp-windows-failhigh-reduction-alpha-condition
Elo   | -2.35 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 18174: +5139 -5262 =7773
Penta | [502, 2147, 3882, 2084, 472]
https://openbench.lynx-chess.com/test/850/
```

1000
```
Score of Lynx-search-asp-windows-failhigh-reduction-alpha-condition-4274-win-x64 vs Lynx 4272 - main: 4002 - 3952 - 6406  [0.502] 14360
...      Lynx-search-asp-windows-failhigh-reduction-alpha-condition-4274-win-x64 playing White: 3023 - 943 - 3214  [0.645] 7180
...      Lynx-search-asp-windows-failhigh-reduction-alpha-condition-4274-win-x64 playing Black: 979 - 3009 - 3192  [0.359] 7180
...      White vs Black: 6032 - 1922 - 6406  [0.643] 14360
Elo difference: 1.2 +/- 4.2, LOS: 71.2 %, DrawRatio: 44.6 %
SPRT: llr -0.187 (-6.5%), lbound -2.25, ubound 2.89
```

```
Test  | search/asp-windows-failhigh-reduction-alpha-condition
Elo   | -0.58 +- 2.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.76 (-2.25, 2.89) [0.00, 3.00]
Games | 28266: +7274 -7321 =13671
Penta | [391, 3159, 7102, 3068, 413]
https://openbench.lynx-chess.com/test/853/
```