### PR TITLE
🔍 NMP: relax beta at higher depths

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,6 +142,11 @@ public sealed class EngineSettings
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_DepthDivisor { get; set; } = 3;
 
+    [SPSA<int>(10, 30, 1)]
+    public int NMP_DepthBeta { get; set; } = 23;
+
+    public int NMP_MarginBeta { get; set; } = 400;
+
     [SPSA<int>(5, 30, 1)]
     public int AspirationWindow_Base { get; set; } = 13;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,7 +155,7 @@ public sealed partial class Engine
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                && staticEval >= beta
+                && staticEval >= beta - (Configuration.EngineSettings.NMP_DepthBeta * depth) + Configuration.EngineSettings.NMP_MarginBeta  // Viz
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal


### PR DESCRIPTION
```
Score of Lynx-search-nmp-relax-beta-with-depth-4278-win-x64 vs Lynx 4272 - main: 114 - 257 - 264  [0.387] 635
...      Lynx-search-nmp-relax-beta-with-depth-4278-win-x64 playing White: 85 - 82 - 150  [0.505] 317
...      Lynx-search-nmp-relax-beta-with-depth-4278-win-x64 playing Black: 29 - 175 - 114  [0.270] 318
...      White vs Black: 260 - 111 - 264  [0.617] 635
Elo difference: -79.6 +/- 20.8, LOS: 0.0 %, DrawRatio: 41.6 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted```