### PR TITLE
🧹Use `short.MinValue` for `NoHashEntry`

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -131,7 +131,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
     /// </summary>
-    public const int NoHashEntry = 25_000;
+    public const int NoHashEntry = short.MinValue;
 
     /// <summary>
     /// Evaluation to be returned when there's one single legal move


### PR DESCRIPTION
```
Test  | refactor/NoHashEntry-value
Elo   | -4.89 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 10878: +3057 -3210 =4611
Penta | [346, 1363, 2153, 1252, 325]
https://openbench.lynx-chess.com/test/849/
```