### PR TITLE
🔍  FP: history factor, OB tuned values

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -189,16 +189,16 @@ public sealed class EngineSettings
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 8;
+    public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 95;
+    public int FP_DepthScalingFactor { get; set; } = 90;
 
     [SPSA<int>(50, 1000, 50)]
-    public int FP_HistoryDepthFactor { get; set; } = 218;
+    public int FP_HistoryDepthFactor { get; set; } = 241;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 182;
+    public int FP_Margin { get; set; } = 185;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -189,16 +189,16 @@ public sealed class EngineSettings
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int FP_MaxDepth { get; set; } = 7;
+    public int FP_MaxDepth { get; set; } = 8;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 73;
+    public int FP_DepthScalingFactor { get; set; } = 95;
 
     [SPSA<int>(50, 1000, 50)]
-    public int FP_HistoryDepthFactor { get; set; } = 100;
+    public int FP_HistoryDepthFactor { get; set; } = 218;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 218;
+    public int FP_Margin { get; set; } = 182;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -224,12 +224,6 @@ public class Position : IDisposable
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
 
         return new GameState(uniqueIdentifierCopy, enpassantCopy, castleCopy);
-        //var clone = new Position(this);
-        //clone.UnmakeMove(move, gameState);
-        //if (uniqueIdentifierCopy != clone.UniqueIdentifier)
-        //{
-        //    throw new($"{FEN()}: {uniqueIdentifierCopy} expected, got {clone.UniqueIdentifier} got after Make/Unmake move {move.ToEPDString()}");
-        //}
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -233,6 +233,14 @@ public sealed partial class Engine
             Game.AddToPositionHashHistory(position.UniqueIdentifier);
             Game.PushToMoveStack(ply, move);
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            void RevertMove()
+            {
+                Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+                Game.RemoveFromPositionHashHistory();
+                position.UnmakeMove(move, gameState);
+            }
+
             int score;
             if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
             {
@@ -263,11 +271,7 @@ public sealed partial class Engine
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
                         && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
                     {
-                        // After making a move
-                        Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.RemoveFromPositionHashHistory();
-                        position.UnmakeMove(move, gameState);
-
+                        RevertMove();
                         break;
                     }
 
@@ -280,11 +284,7 @@ public sealed partial class Engine
                         && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth // TODO use LMR depth
                         && moveHistory < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                     {
-                        // After making a move
-                        Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.RemoveFromPositionHashHistory();
-                        position.UnmakeMove(move, gameState);
-
+                        RevertMove();
                         break;
                     }
 
@@ -298,11 +298,7 @@ public sealed partial class Engine
                             + (moveHistory * depth / Configuration.EngineSettings.FP_HistoryDepthFactor)
                         <= alpha)
                     {
-                        // After making a move
-                        Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                        Game.RemoveFromPositionHashHistory();
-                        position.UnmakeMove(move, gameState);
-
+                        RevertMove();
                         break;
                     }
                 }
@@ -375,10 +371,7 @@ public sealed partial class Engine
             }
 
             // After making a move
-            // Game.PositionHashHistory is update above
-            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-            Game.RemoveFromPositionHashHistory();
-            position.UnmakeMove(move, gameState);
+            RevertMove();
 
             PrintMove(position, ply, move, score);
 


### PR DESCRIPTION
```
Test  | search/history-fp-ob-tune-5000
Elo   | -0.09 +- 2.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.57 (-2.25, 2.89) [0.00, 3.00]
Games | 38448: +10075 -10085 =18288
Penta | [724, 4745, 8296, 4735, 724]
https://openbench.lynx-chess.com/test/847/
```