### PR TITLE
🔍 History: increase bonus when best score is over beta by some margin

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -397,7 +397,7 @@ public sealed partial class Engine
 
                     var historyDepth = depth;
 
-                    if (staticEval <= alpha)
+                    if (bestScore >= beta + 80)
                     {
                         ++historyDepth;
                     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -395,13 +395,20 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough");
 
+                    var historyDepth = depth;
+
+                    if (staticEval <= alpha)
+                    {
+                        ++historyDepth;
+                    }
+
                     if (isCapture)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(depth, visitedMoves, visitedMovesCounter, move);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(historyDepth, visitedMoves, visitedMovesCounter, move);
                     }
                     else
                     {
-                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(depth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
+                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
                     }
 
                     _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);


### PR DESCRIPTION
```
Test  | search/history-bonus-bestScore-condition
Elo   | 4.59 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 22574: +6609 -6311 =9654
Penta | [626, 2638, 4526, 2806, 691]
https://openbench.lynx-chess.com/test/855/
```