### PR TITLE
⚡ Disable DATAS 

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
     <!--<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>-->
     <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Extensions.Configuration.Binder.SourceGeneration</InterceptorsPreviewNamespaces>
@@ -15,10 +14,14 @@
     <PublishTrimmed>true</PublishTrimmed>
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+
     <TieredPGO>true</TieredPGO>
     <TieredCompilationQuickJitForLoops>true</TieredCompilationQuickJitForLoops>
     <!--In favour of tiered compilation-->
     <PublishReadyToRun>false</PublishReadyToRun>
+
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <GarbageCollectionAdaptationMode>0</GarbageCollectionAdaptationMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
```
Score of Lynx-net-9-no-datas-4285-win-x64 vs Lynx-net-9-4284-win-x64: 6549 - 6545 - 10616  [0.500] 23710
...      Lynx-net-9-no-datas-4285-win-x64 playing White: 4877 - 1642 - 5336  [0.636] 11855
...      Lynx-net-9-no-datas-4285-win-x64 playing Black: 1672 - 4903 - 5280  [0.364] 11855
...      White vs Black: 9780 - 3314 - 10616  [0.636] 23710
Elo difference: 0.1 +/- 3.3, LOS: 51.4 %, DrawRatio: 44.8 %
SPRT: llr -1.54 (-53.2%), lbound -2.25, ubound 2.89
```