### PR TITLE
⚡ Disable CET

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -22,6 +22,9 @@
 
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <GarbageCollectionAdaptationMode>0</GarbageCollectionAdaptationMode>
+
+    <!--https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support-->
+    <CETCompat>false</CETCompat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
```
Score of Lynx-net-9-no-cet-4299-win-x64 vs Lynx 4292 - main: 2745 - 2635 - 4416  [0.506] 9796
...      Lynx-net-9-no-cet-4299-win-x64 playing White: 2109 - 624 - 2165  [0.652] 4898
...      Lynx-net-9-no-cet-4299-win-x64 playing Black: 636 - 2011 - 2251  [0.360] 4898
...      White vs Black: 4120 - 1260 - 4416  [0.646] 9796
Elo difference: 3.9 +/- 5.1, LOS: 93.3 %, DrawRatio: 45.1 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```