### PR TITLE
⚖️ Tempo V

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -204,6 +204,8 @@ public sealed class EngineSettings
 
     [SPSA<int>(-8192, 0, 512)]
     public int HistoryPrunning_Margin { get; set; } = -1940;
+
+    public const int Tempo = 10;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -563,9 +563,9 @@ public class Position : IDisposable
 
         eval = Math.Clamp(eval, MinStaticEval, MaxStaticEval);
 
-        var sideEval = Side == Side.White
-            ? eval + EngineSettings.Tempo
-            : -eval - EngineSettings.Tempo;
+        var sideEval = EngineSettings.Tempo + (Side == Side.White
+            ? eval
+            : -eval);
 
         return (sideEval, gamePhase);
     }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -564,8 +564,8 @@ public class Position : IDisposable
         eval = Math.Clamp(eval, MinStaticEval, MaxStaticEval);
 
         var sideEval = Side == Side.White
-            ? eval
-            : -eval;
+            ? eval + EngineSettings.Tempo
+            : -eval - EngineSettings.Tempo;
 
         return (sideEval, gamePhase);
     }


### PR DESCRIPTION
```
Test  | tempo-2
Elo   | -1.13 +- 2.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 28836: +8211 -8305 =12320
Penta | [846, 3481, 5855, 3393, 843]
https://openbench.lynx-chess.com/test/862/
```