### PR TITLE
🔍 History: `History_BestScoreBetaMargin` 80 -> 100

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -185,7 +185,8 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int History_BestScoreBetaMargin { get; set; } = 80;
+    //[SPSA<int>(0, 200, 10)]
+    public int History_BestScoreBetaMargin { get; set; } = 60;
 
     [SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -186,7 +186,7 @@ public sealed class EngineSettings
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
     //[SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 60;
+    public int History_BestScoreBetaMargin { get; set; } = 100;
 
     [SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;


### PR DESCRIPTION
```
Test  | search/History_BestScoreBetaMargin-100
Elo   | -1.18 +- 2.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 27026: +7031 -7123 =12872
Penta | [532, 3343, 5840, 3281, 517]
https://openbench.lynx-chess.com/test/859/
```
