### PR TITLE
🔍 NMP: dynamic `staticEval` and `beta` condition, depth-based

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,6 +142,12 @@ public sealed class EngineSettings
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_DepthDivisor { get; set; } = 3;
 
+    [SPSA<int>(50, 250, 10)]
+    public int NMP_BetaBase { get; set; } = 150;
+
+    [SPSA<int>(10, 50, 2)]
+    public int NMP_BetaDepthScalingFactor { get; set; } = 25;
+
     [SPSA<int>(5, 30, 1)]
     public int AspirationWindow_Base { get; set; } = 13;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -156,6 +156,7 @@ public sealed partial class Engine
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
                 && staticEval >= beta
+                && staticEval >= beta + Configuration.EngineSettings.NMP_BetaBase - (Configuration.EngineSettings.NMP_BetaDepthScalingFactor * depth)
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -336,6 +336,22 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "nmp_betabase":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NMP_BetaBase = value;
+                    }
+                    break;
+                }
+            case "nmp_betadepthscalingfactor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NMP_BetaDepthScalingFactor = value;
+                    }
+                    break;
+                }
 
             //case "aspirationwindow_delta":
             //    {


### PR DESCRIPTION
```
Score of Lynx-search-nmp-staticeval-beta-4319-win-x64 vs Lynx 4316 - main: 652 - 781 - 1221  [0.476] 2654
...      Lynx-search-nmp-staticeval-beta-4319-win-x64 playing White: 515 - 197 - 614  [0.620] 1326
...      Lynx-search-nmp-staticeval-beta-4319-win-x64 playing Black: 137 - 584 - 607  [0.332] 1328
...      White vs Black: 1099 - 334 - 1221  [0.644] 2654
Elo difference: -16.9 +/- 9.7, LOS: 0.0 %, DrawRatio: 46.0 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```