### PR TITLE
Use position's static eval when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -74,6 +74,7 @@ public sealed partial class Engine
         if (isInCheck)
         {
             ++depth;
+            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         }
         else if (depth <= 0)
         {
@@ -177,6 +178,8 @@ public sealed partial class Engine
                 }
             }
         }
+
+        Debug.Assert(staticEval != int.MaxValue);
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);


### PR DESCRIPTION
```
Test  | bugfix/static-eval-in-check
Elo   | -8.46 +- 6.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-5.00, 0.00]
Games | 5504: +1496 -1630 =2378
Penta | [159, 719, 1113, 619, 142]
https://openbench.lynx-chess.com/test/871/
```