### PR TITLE
Initialize static eval to `EvaluationConstants.MaxEval`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -68,7 +68,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         bool isInCheck = position.IsInCheck();
-        int staticEval = int.MaxValue;
+        int staticEval = EvaluationConstants.MaxStaticEval;
         int phase = int.MaxValue;
 
         if (isInCheck)


### PR DESCRIPTION
```
Score of Lynx-search-static-eval-init-max-static-4329-win-x64 vs Lynx 4325 - main: 240 - 376 - 510  [0.440] 1126
...      Lynx-search-static-eval-init-max-static-4329-win-x64 playing White: 185 - 91 - 286  [0.584] 562
...      Lynx-search-static-eval-init-max-static-4329-win-x64 playing Black: 55 - 285 - 224  [0.296] 564
...      White vs Black: 470 - 146 - 510  [0.644] 1126
Elo difference: -42.2 +/- 15.0, LOS: 0.0 %, DrawRatio: 45.3 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```