### PR TITLE
Initialize static eval to `int.MinEval`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -68,7 +68,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         bool isInCheck = position.IsInCheck();
-        int staticEval = int.MaxValue;
+        int staticEval = int.MinValue;
         int phase = int.MaxValue;
 
         if (isInCheck)


### PR DESCRIPTION
```
Score of Lynx-search-static-eval-init-min-4328-win-x64 vs Lynx 4325 - main: 4952 - 5017 - 8214  [0.498] 18183
...      Lynx-search-static-eval-init-min-4328-win-x64 playing White: 3744 - 1266 - 4082  [0.636] 9092
...      Lynx-search-static-eval-init-min-4328-win-x64 playing Black: 1208 - 3751 - 4132  [0.360] 9091
...      White vs Black: 7495 - 2474 - 8214  [0.638] 18183
Elo difference: -1.2 +/- 3.7, LOS: 25.8 %, DrawRatio: 45.2 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```