### PR TITLE
🔍 Improving: LMP with `depth * depth` formula

### DIFF
--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -1,0 +1,13 @@
+﻿namespace Lynx.Model;
+
+public struct PlyStackEntry
+{
+    public int StaticEval { get; set; }
+
+    public Move Move { get; set; }
+
+    public PlyStackEntry()
+    {
+        StaticEval = int.MaxValue;
+    }
+}

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
 
             if (ply >= 1)
             {
-                var previousMove = Game.PopFromMoveStack(ply - 1);
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
                 Debug.Assert(previousMove != 0);
                 var previousMovePiece = previousMove.Piece();
                 var previousMoveTargetSquare = previousMove.TargetSquare();
@@ -130,7 +130,7 @@ public sealed partial class Engine
         {
             // 🔍 Continuation history
             // - Counter move history (continuation history, ply - 1)
-            var previousMove = Game.PopFromMoveStack(ply - 1);
+            var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
             previousMovePiece = previousMove.Piece();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
-        // the previous evaluation from the same side (pñy - 2).
+        // the previous evaluation from the same side (ply - 2).
         // When true, we can:
         // - Prune more aggressively when evaluation is too high: current position is even getter
         // - Prune less aggressively when evaluation is low low: uncertainty on how bad the position really is
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;


### PR DESCRIPTION
```
Test  | search/improving-lmp-depth
Elo   | -16.46 +- 8.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.99 (-2.25, 2.89) [0.00, 3.00]
Games | 3296: +893 -1049 =1354
Penta | [119, 468, 612, 348, 101]
https://openbench.lynx-chess.com/test/872/
```