### PR TITLE
🔍 Improving: LMP, dividing by 2

### DIFF
--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -1,0 +1,13 @@
+﻿namespace Lynx.Model;
+
+public struct PlyStackEntry
+{
+    public int StaticEval { get; set; }
+
+    public Move Move { get; set; }
+
+    public PlyStackEntry()
+    {
+        StaticEval = int.MaxValue;
+    }
+}

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
 
             if (ply >= 1)
             {
-                var previousMove = Game.PopFromMoveStack(ply - 1);
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
                 Debug.Assert(previousMove != 0);
                 var previousMovePiece = previousMove.Piece();
                 var previousMoveTargetSquare = previousMove.TargetSquare();
@@ -130,7 +130,7 @@ public sealed partial class Engine
         {
             // 🔍 Continuation history
             // - Counter move history (continuation history, ply - 1)
-            var previousMove = Game.PopFromMoveStack(ply - 1);
+            var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
             previousMovePiece = previousMove.Piece();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
-        // the previous evaluation from the same side (pñy - 2).
+        // the previous evaluation from the same side (ply - 2).
         // When true, we can:
         // - Prune more aggressively when evaluation is too high: current position is even getter
         // - Prune less aggressively when evaluation is low low: uncertainty on how bad the position really is
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;


### PR DESCRIPTION
See https://github.com/lynx-chess/Lynx/pull/1129 as alternative.
#1127 failed quickly.

```
Score of Lynx-search-improving-lmp-4331-win-x64 vs Lynx 4325 - main: 2102 - 2213 - 3484  [0.493] 7799
...      Lynx-search-improving-lmp-4331-win-x64 playing White: 1613 - 535 - 1751  [0.638] 3899
...      Lynx-search-improving-lmp-4331-win-x64 playing Black: 489 - 1678 - 1733  [0.348] 3900
...      White vs Black: 3291 - 1024 - 3484  [0.645] 7799
Elo difference: -4.9 +/- 5.7, LOS: 4.6 %, DrawRatio: 44.7 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```