### PR TITLE
🔍 Improving: RFP, `depth * (RFP_DepthScalingFactor - (improving ? RFP_ImprovingFactor : 0))`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -157,6 +157,9 @@ public sealed class EngineSettings
     [SPSA<int>(1, 300, 15)]
     public int RFP_DepthScalingFactor { get; set; } = 52;
 
+    [SPSA<int>(1, 100, 5)]
+    public int RFP_ImprovingFactor { get; set; } = 30;
+
     [SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -130,8 +130,9 @@ public sealed partial class Engine
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
+                // Imroving margin idea inspired by Sirius
                 // Return formula by Ciekce, instead of just returning static eval
-                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
+                if (staticEval - (depth * (Configuration.EngineSettings.RFP_DepthScalingFactor - (improving ? Configuration.EngineSettings.RFP_ImprovingFactor : 0))) >= beta)
                 {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                     return (staticEval + beta) / 2;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -378,6 +378,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "rfp_improvingfactor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.RFP_ImprovingFactor = value;
+                    }
+                    break;
+                }
 
             case "razoring_maxdepth":
                 {


### PR DESCRIPTION
```
Test  | search/improving-rfp-4
Elo   | -18.60 +- 8.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 3346: +882 -1061 =1403
Penta | [131, 451, 647, 354, 90]
https://openbench.lynx-chess.com/test/878/
```