### PR TITLE
🔍 Improving: LMR, `if (improving) --reduction;`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -333,7 +333,13 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+
                     if (position.IsInCheck())   // i.e. move gives check
+                    {
+                        --reduction;
+                    }
+
+                    if (improving)
                     {
                         --reduction;
                     }


### PR DESCRIPTION
```
Score of Lynx-search-improving-lmr-1-4340-win-x64 vs Lynx-search-improving-rfp-1-4335-win-x64: 980 - 1103 - 1823  [0.484] 3906
...      Lynx-search-improving-lmr-1-4340-win-x64 playing White: 743 - 256 - 954  [0.625] 1953
...      Lynx-search-improving-lmr-1-4340-win-x64 playing Black: 237 - 847 - 869  [0.344] 1953
...      White vs Black: 1590 - 493 - 1823  [0.640] 3906
Elo difference: -10.9 +/- 7.9, LOS: 0.4 %, DrawRatio: 46.7 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```