### PR TITLE
🔍 Improving: NMP, `((depth + NMP_DepthIncrement) / NMP_DepthDivisor) + (improving ? 1 : 0)`

### DIFF
--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -1,0 +1,13 @@
+﻿namespace Lynx.Model;
+
+public struct PlyStackEntry
+{
+    public int StaticEval { get; set; }
+
+    public Move Move { get; set; }
+
+    public PlyStackEntry()
+    {
+        StaticEval = int.MaxValue;
+    }
+}

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -82,7 +82,7 @@ public sealed partial class Engine
 
             if (ply >= 1)
             {
-                var previousMove = Game.PopFromMoveStack(ply - 1);
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
                 Debug.Assert(previousMove != 0);
                 var previousMovePiece = previousMove.Piece();
                 var previousMoveTargetSquare = previousMove.TargetSquare();
@@ -130,7 +130,7 @@ public sealed partial class Engine
         {
             // 🔍 Continuation history
             // - Counter move history (continuation history, ply - 1)
-            var previousMove = Game.PopFromMoveStack(ply - 1);
+            var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
             previousMovePiece = previousMove.Piece();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -339,9 +339,9 @@ public sealed partial class Engine
                         --reduction;
                     }
 
-                    if (improving)
+                    if (!improving)
                     {
-                        --reduction;
+                        ++reduction;
                     }
 
                     if (ttBestMove != default && isCapture)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,9 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement + (improving ? 1 : 0)) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
+                    + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
+                    + (improving ? 1 : 0);
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -126,6 +126,7 @@ public sealed partial class Engine
                 staticEval = ttRawScore;
             }
 
+            // Fail-high pruning (moves with high scores) - prune more when improving
             if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
@@ -279,6 +280,7 @@ public sealed partial class Engine
                 // If we prune while getting checmated, we risk not finding any move and having an empty PV
                 bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
+                // Fail-low pruning (moves with low scores) - prune less when improving
                 if (!pvNode && !isInCheck && isNotGettingCheckmated
                     && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
                 {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -131,7 +131,7 @@ public sealed partial class Engine
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                 // Return formula by Ciekce, instead of just returning static eval
-                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
+                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * (depth - (improving ? 1 : 0))) >= beta)
                 {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                     return (staticEval + beta) / 2;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,7 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement + (improving ? 1 : 0)) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -70,7 +70,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
-        // the previous evaluation from the same side (pñy - 2).
+        // the previous evaluation from the same side (ply - 2).
         // When true, we can:
         // - Prune more aggressively when evaluation is too high: current position is even getter
         // - Prune less aggressively when evaluation is low low: uncertainty on how bad the position really is
@@ -285,7 +285,7 @@ public sealed partial class Engine
                     // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                     // after searching the first few given by the move ordering algorithm
                     if (depth <= Configuration.EngineSettings.LMP_MaxDepth
-                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth)) // Based on formula suggested by Antares
+                        && moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth / (improving ? 1 : 2))) // Based on formula suggested by Antares
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -333,7 +333,13 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+
                     if (position.IsInCheck())   // i.e. move gives check
+                    {
+                        --reduction;
+                    }
+
+                    if (improving)
                     {
                         --reduction;
                     }


### PR DESCRIPTION
```
Score of Lynx-search-improving-nmp-2-4345-win-x64 vs Lynx-search-improving-lmr-2-4341-win-x64: 3226 - 3314 - 5628  [0.496] 12168
...      Lynx-search-improving-nmp-2-4345-win-x64 playing White: 2486 - 780 - 2818  [0.640] 6084
...      Lynx-search-improving-nmp-2-4345-win-x64 playing Black: 740 - 2534 - 2810  [0.353] 6084
...      White vs Black: 5020 - 1520 - 5628  [0.644] 12168
Elo difference: -2.5 +/- 4.5, LOS: 13.8 %, DrawRatio: 46.3 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```