### PR TITLE
🔍 LMR: reduce less when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -315,7 +315,12 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
-                    if (position.IsInCheck())   // i.e. move gives check
+                    if (position.IsInCheck())   // Move gives check
+                    {
+                        --reduction;
+                    }
+
+                    if (isInCheck)  // Position before move is in check
                     {
                         --reduction;
                     }


### PR DESCRIPTION
8 0.08
```
Score of Lynx-search-lmr-in-check-4342-win-x64 vs Lynx 4325 - main: 2896 - 2946 - 4958  [0.498] 10800
...      Lynx-search-lmr-in-check-4342-win-x64 playing White: 2197 - 731 - 2472  [0.636] 5400
...      Lynx-search-lmr-in-check-4342-win-x64 playing Black: 699 - 2215 - 2486  [0.360] 5400
...      White vs Black: 4412 - 1430 - 4958  [0.638] 10800
Elo difference: -1.6 +/- 4.8, LOS: 25.7 %, DrawRatio: 45.9 %
SPRT: llr -1.54 (-53.4%), lbound -2.25, ubound 2.89
```