### PR TITLE
🔍 NMP, tweak reduction using eval - beta

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,6 +142,12 @@ public sealed class EngineSettings
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_DepthDivisor { get; set; } = 3;
 
+    [SPSA<int>(150, 350, 10)]
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 200;
+
+    [SPSA<int>(1, 10, 0.5)]
+    public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
+
     [SPSA<int>(5, 30, 1)]
     public int AspirationWindow_Base { get; set; } = 13;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -143,7 +143,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(150, 350, 10)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 200;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 100;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Security.Authentication;
 
 namespace Lynx;
 
@@ -170,14 +171,20 @@ public sealed partial class Engine
                 }
             }
 
+            var staticEvalBetaDiff = staticEval - beta;
+
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
             if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                && staticEval >= beta
+                && staticEvalBetaDiff >= 0
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
+                    + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
+                    + Math.Min(
+                        Configuration.EngineSettings.NMP_StaticEvalBetaMaxReduction,
+                        staticEvalBetaDiff / Configuration.EngineSettings.NMP_StaticEvalBetaDivisor);
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -336,6 +336,22 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "nmp_staticevalbetadivisor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NMP_StaticEvalBetaDivisor = value;
+                    }
+                    break;
+                }
+            case "nmp_staticevalbetamaxreduction":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NMP_StaticEvalBetaMaxReduction = value;
+                    }
+                    break;
+                }
 
             //case "aspirationwindow_delta":
             //    {


### PR DESCRIPTION
`+ Math.Min(NMP_StaticEvalBetaMaxReduction, staticEvalBetaDiff / NMP_StaticEvalBetaDivisor)`.

Continuation of efforts in https://github.com/lynx-chess/Lynx/pull/837/files

```
Test  | nmp/tweak-reduction-staticeval-2
Elo   | -0.90 +- 2.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 32014: +8832 -8915 =14267
Penta | [874, 3877, 6526, 3918, 812]
https://openbench.lynx-chess.com/test/886/
```

```
Test  | nmp/tweak-reduction-staticeval-2
Elo   | 0.50 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 120212: +33182 -33009 =54021
Penta | [3121, 14545, 24530, 14860, 3050]
https://openbench.lynx-chess.com/test/894/
```

```
Test  | nmp/tweak-reduction-staticeval-2
Elo   | 3.81 +- 2.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | 24974: +6443 -6169 =12362
Penta | [424, 2898, 5552, 3206, 407]
https://openbench.lynx-chess.com/test/914/
```