### PR TITLE
🔍 Improving: NMP, `NMP_BaseDepthReduction + (improving ? 1 : 0)`, reduced base

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -134,7 +134,7 @@ public sealed class EngineSettings
     public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 5, 0.5)]
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 1;
 
     [SPSA<int>(0, 10, 0.5)]
     public int NMP_DepthIncrement { get; set; } = 0;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,10 @@ public sealed partial class Engine
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                 && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
-                var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
+                var nmpReduction =
+                    Configuration.EngineSettings.NMP_BaseDepthReduction
+                    + (improving ? 1 : 0)
+                    + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor);   // Clarity
 
                 // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
                 //var nmpReduction = Math.Min(


### PR DESCRIPTION
Same as #1136 but with reduced base

```
Score of Lynx-search-improving-nmp-3-4356-win-x64 vs Lynx 4354 - main: 1246 - 1317 - 2247  [0.493] 4810
...      Lynx-search-improving-nmp-3-4356-win-x64 playing White: 956 - 304 - 1145  [0.636] 2405
...      Lynx-search-improving-nmp-3-4356-win-x64 playing Black: 290 - 1013 - 1102  [0.350] 2405
...      White vs Black: 1969 - 594 - 2247  [0.643] 4810
Elo difference: -5.1 +/- 7.2, LOS: 8.0 %, DrawRatio: 46.7 %
SPRT: llr -1.49 (-51.5%), lbound -2.25, ubound 2.89
```