### PR TITLE
🔍 Aspiration windows: limit `failHighReduction` && alpha condition for `failHighReduction`

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -146,7 +146,11 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Min(bestScore + window, EvaluationConstants.MaxEval);
-                            ++failHighReduction;
+
+                            if (alpha <= 2000 && failHighReduction <= 2)
+                            {
+                                ++failHighReduction;
+                            }
                         }
                         else
                         {


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1102  and https://github.com/lynx-chess/Lynx/pull/1103 together

```
Test  | search/asp-windows-limit-failhighcount-and-alpha-condition
Elo   | -0.63 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 37784: +10777 -10846 =16161
Penta | [996, 4484, 8015, 4387, 1010]
https://openbench.lynx-chess.com/test/885/
```