### PR TITLE
🔍 Futility Pruning in QSearch II

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,8 +200,8 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
-    [SPSAAttribute<int>(0, 200, 10)]
-    public int FP_QS_Margin { get; set; } = 75;
+    [SPSA<int>(50, 250, 10)]
+    public int FP_QS_Margin { get; set; } = 150;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,6 +200,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
+    [SPSAAttribute<int>(0, 200, 10)]
+    public int FP_QS_Margin { get; set; } = 75;
+
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -201,7 +201,7 @@ public sealed class EngineSettings
     public int FP_Margin { get; set; } = 218;
 
     [SPSA<int>(50, 250, 10)]
-    public int FP_QS_Margin { get; set; } = 150;
+    public int FP_QS_Margin { get; set; } = 75;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,7 +571,7 @@ public sealed partial class Engine
 
             // QSearch Futility Pruning (FP)
             // Moves without potential to raise alpha are discarded
-            if (!position.IsInCheck() && futilityScore < alpha && !SEE.HasPositiveScore(position, move))
+            if (!position.IsInCheck() && futilityScore < alpha) // TODO SEE score
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -573,6 +573,9 @@ public sealed partial class Engine
             // Moves without potential to raise alpha are discarded
             if (!position.IsInCheck() && futilityScore < alpha && moveScores[i] < EvaluationConstants.PromotionMoveScoreValue) // TODO SEE score
             {
+                if (futilityScore > bestScore)
+                    bestScore = futilityScore;
+
                 continue;
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -535,7 +535,10 @@ public sealed partial class Engine
 
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
-        int bestScore = staticEval;
+        var bestScore = staticEval;
+        var futilityScore = position.IsInCheck()
+            ? EvaluationConstants.MinEval
+            : staticEval + Configuration.EngineSettings.FP_QS_Margin;
 
         bool isAnyCaptureValid = false;
 
@@ -562,6 +565,13 @@ public sealed partial class Engine
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScores[i] < EvaluationConstants.PromotionMoveScoreValue && moveScores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            {
+                continue;
+            }
+
+            // QSearch Futility Pruning (FP)
+            // Moves without potential to raise alpha are discarded
+            if (!position.IsInCheck() && futilityScore < alpha && !SEE.HasPositiveScore(position, move))
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,7 +571,7 @@ public sealed partial class Engine
 
             // QSearch Futility Pruning (FP)
             // Moves without potential to raise alpha are discarded
-            if (!position.IsInCheck() && futilityScore < alpha) // TODO SEE score
+            if (!position.IsInCheck() && futilityScore < alpha && moveScores[i] < EvaluationConstants.PromotionMoveScoreValue) // TODO SEE score
             {
                 continue;
             }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -493,6 +493,15 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "fp_qs_margin":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.FP_QS_Margin = value;
+                    }
+                    break;
+                }
+
             case "historyprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
Previously attempted in https://github.com/lynx-chess/Lynx/pull/752

```
Score of Lynx-search-futility-pruning-qs-2-4359-win-x64 vs Lynx 4354 - main: 6621 - 6616 - 11413  [0.500] 24650
...      Lynx-search-futility-pruning-qs-2-4359-win-x64 playing White: 5027 - 1631 - 5667  [0.638] 12325
...      Lynx-search-futility-pruning-qs-2-4359-win-x64 playing Black: 1594 - 4985 - 5746  [0.362] 12325
...      White vs Black: 10012 - 3225 - 11413  [0.638] 24650
Elo difference: 0.1 +/- 3.2, LOS: 51.7 %, DrawRatio: 46.3 %
SPRT: llr -1.63 (-56.4%), lbound -2.25, ubound 2.89
```

 No SEE
```
Score of Lynx-search-futility-pruning-qs-2-4364-win-x64 vs Lynx 4354 - main: 3 - 129 - 25  [0.099] 157
...      Lynx-search-futility-pruning-qs-2-4364-win-x64 playing White: 3 - 57 - 18  [0.154] 78
...      Lynx-search-futility-pruning-qs-2-4364-win-x64 playing Black: 0 - 72 - 7  [0.044] 79
...      White vs Black: 75 - 57 - 25  [0.557] 157
Elo difference: -384.2 +/- 70.3, LOS: 0.0 %, DrawRatio: 15.9 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```

Reusing SEE Score
```
Score of Lynx-search-futility-pruning-qs-2-4366-win-x64 vs Lynx 4354 - main: 3477 - 3562 - 6015  [0.497] 13054
...      Lynx-search-futility-pruning-qs-2-4366-win-x64 playing White: 2663 - 863 - 3002  [0.638] 6528
...      Lynx-search-futility-pruning-qs-2-4366-win-x64 playing Black: 814 - 2699 - 3013  [0.356] 6526
...      White vs Black: 5362 - 1677 - 6015  [0.641] 13054
Elo difference: -2.3 +/- 4.4, LOS: 15.6 %, DrawRatio: 46.1 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted

```
Updating bestScore, margin 150
```
Test  | search/futility-pruning-qs-2
Elo   | -6.42 +- 4.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 8064: +2118 -2267 =3679
Penta | [191, 1062, 1672, 919, 188]
https://openbench.lynx-chess.com/test/898/
```

Updating bestScore, margin 75
```
Test  | search/futility-pruning-qs-2
Elo   | -1.37 +- 2.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 25648: +6997 -7098 =11553
Penta | [643, 3210, 5210, 3127, 634]
https://openbench.lynx-chess.com/test/899/
```