### PR TITLE
🔍 SEE pruning II

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -232,7 +232,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[moveIndex];
 
             // SEE pruning
-            if (depth <= 2 && !pvNode && move != ttBestMove && isNotGettingCheckmated && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue)
+            if (depth == 1 && !pvNode && move != ttBestMove && isNotGettingCheckmated && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue)
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -232,7 +232,7 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[moveIndex];
 
             // SEE pruning
-            if (depth == 1 && !pvNode && move != ttBestMove && isNotGettingCheckmated && !SEE.HasPositiveScore(position, move))
+            if (depth <= 2 && !pvNode && move != ttBestMove && isNotGettingCheckmated && moveScores[moveIndex] < EvaluationConstants.PromotionMoveScoreValue)
             {
                 continue;
             }


### PR DESCRIPTION
Similar but with d  <= 5: https://github.com/lynx-chess/Lynx/pull/1077

[Attempt dubious SEE pruning](https://github.com/lynx-chess/Lynx/pull/1144/commits/f3d905178b0e51c66a14c615f7ba8e399f2a9822)
```
Test  | search/see-pruning-2
Elo   | -1.59 +- 4.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.35 (-2.25, 2.89) [0.00, 5.00]
Games | 11566: +3116 -3169 =5281
Penta | [283, 1436, 2388, 1403, 273]
https://openbench.lynx-chess.com/test/891/
```

[Replace SEE with moveScore check, depth <= 2](https://github.com/lynx-chess/Lynx/pull/1144/commits/b8662ae27f93c1cb2d6afd2f1926da4399756304)
```
Test  | search/see-pruning-2
Elo   | -56.54 +- 13.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 1184: +239 -430 =515
Penta | [55, 215, 207, 96, 19]
https://openbench.lynx-chess.com/test/895/
```

[Back to only depth 1](https://github.com/lynx-chess/Lynx/pull/1144/commits/18223a33f8069c4cb9b31cb754831a543c55f980)
```
Test  | search/see-pruning-2
Elo   | -30.69 +- 10.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 1952: +449 -621 =882
Penta | [67, 282, 413, 184, 30]
https://openbench.lynx-chess.com/test/897/
```
