### PR TITLE
🔍 Improving, `FP_Margin_Improving = FP_Margin +32`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,6 +200,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
+    [SPSA<int>(0, 500, 25)]
+    public int FP_Margin_Improving { get; set; } = 250;
+
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -310,7 +310,10 @@ public sealed partial class Engine
                         //&& alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
                         //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && depth <= Configuration.EngineSettings.FP_MaxDepth
-                        && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
+                        && staticEval
+                                + (improving ? Configuration.EngineSettings.FP_Margin_Improving : Configuration.EngineSettings.FP_Margin)
+                                + (Configuration.EngineSettings.FP_DepthScalingFactor * depth)
+                            <= alpha)
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -493,6 +493,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "fp_margin_improving":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.FP_Margin_Improving = value;
+                    }
+                    break;
+                }
             case "historyprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
```
Score of Lynx-search-improving-fp-1-4367-win-x64 vs Lynx 4354 - main: 11783 - 11732 - 20618  [0.501] 44133
...      Lynx-search-improving-fp-1-4367-win-x64 playing White: 9039 - 2711 - 10317  [0.643] 22067
...      Lynx-search-improving-fp-1-4367-win-x64 playing Black: 2744 - 9021 - 10301  [0.358] 22066
...      White vs Black: 18060 - 5455 - 20618  [0.643] 44133
Elo difference: 0.4 +/- 2.4, LOS: 63.0 %, DrawRatio: 46.7 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```