### PR TITLE
🔍 Improving, `FP_Margin 100, FP_Margin_Improving 300`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,6 +200,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
+    [SPSA<int>(0, 500, 25)]
+    public int FP_Margin_Improving { get; set; } = 250;
+
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -198,10 +198,10 @@ public sealed class EngineSettings
     public int FP_DepthScalingFactor { get; set; } = 73;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 218;
+    public int FP_Margin { get; set; } = 100;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin_Improving { get; set; } = 250;
+    public int FP_Margin_Improving { get; set; } = 300;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -310,7 +310,10 @@ public sealed partial class Engine
                         //&& alpha < EvaluationConstants.PositiveCheckmateDetectionLimit
                         //&& beta > EvaluationConstants.NegativeCheckmateDetectionLimit
                         && depth <= Configuration.EngineSettings.FP_MaxDepth
-                        && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
+                        && staticEval
+                                + (improving ? Configuration.EngineSettings.FP_Margin_Improving : Configuration.EngineSettings.FP_Margin)
+                                + (Configuration.EngineSettings.FP_DepthScalingFactor * depth)
+                            <= alpha)
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -493,6 +493,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "fp_margin_improving":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.FP_Margin_Improving = value;
+                    }
+                    break;
+                }
             case "historyprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
```
Test  | search/improving-fp-2
Elo   | -0.26 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 48618: +13403 -13440 =21775
Penta | [1217, 5952, 10045, 5841, 1254]
https://openbench.lynx-chess.com/test/896/
```