### PR TITLE
🔍 Continuation history: follow-up history

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -438,7 +438,7 @@ public sealed partial class Engine
                     }
                     else
                     {
-                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
+                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move);
                     }
 
                     _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);


### PR DESCRIPTION
New attempt after https://github.com/lynx-chess/Lynx/pull/862

Not winning, with dev stalling a lot anyway
```
Test  | search/counter-move-history
Elo   | 0.03 +- 1.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 63068: +17326 -17321 =28421
Penta | [1654, 7638, 12938, 7657, 1647]
https://openbench.lynx-chess.com/test/900/
```