### PR TITLE
🧹 Move TT outside `Engine`: static class

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,6 @@
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount8" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount14" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount27" />
-    <Using Include="Lynx.Model.TranspositionTableElement[]" Alias="TranspositionTable" />
   </ItemGroup >
 
   <PropertyGroup>

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -38,7 +38,7 @@ var uciHandler = new UCIHandler(uciChannel, engineChannel, engine);
 var tasks = new List<Task>
 {
     Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
-    Task.Run(() => new Searcher(uciChannel, engine).Run(cancellationToken)),
+    Task.Run(() => new Searcher(uciChannel, engineChannel, engine).Run(cancellationToken)),
     Task.Run(() => new Listener(uciHandler).Run(cancellationToken, args)),
     uciChannel.Reader.Completion,
     engineChannel.Reader.Completion

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading.Channels;
 using static Lynx.EvaluationConstants;
 using static Lynx.TunableEvalParameters;
+using static Lynx.Model.TranspositionTable;
 
 //_2_GettingStarted();
 //_3_PawnAttacks();
@@ -1050,7 +1051,7 @@ static void TranspositionTable()
     static void TesSize(int size)
     {
         Console.WriteLine("Hash: {0} MB", size);
-        var length = TranspositionTableExtensions.CalculateLength(size);
+        var length = CalculateLength(size);
 
         var lengthMb = length / 1024 / 1024;
 
@@ -1071,7 +1072,7 @@ static void TranspositionTable()
     TesSize(512);
     TesSize(1024);
 
-    var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+    var ttLength = CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
     var transpositionTable = new TranspositionTableElement[ttLength];
     var position = new Position(Constants.InitialPositionFEN);
     position.Print();
@@ -1080,28 +1081,28 @@ static void TranspositionTable()
     var hashKey = position.UniqueIdentifier % 0x400000;
     Console.WriteLine(hashKey);
 
-    var hashKey2 = TranspositionTableExtensions.CalculateTTIndex(position.UniqueIdentifier, ttLength);
+    var hashKey2 = CalculateTTIndex(position.UniqueIdentifier);
     Console.WriteLine(hashKey2);
 
     Array.Clear(transpositionTable);
 
-    //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
-    //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
+    //RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
+    //var entry = ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
-    var entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
+    var entry = ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 20
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
+    entry = ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
+    entry = ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
+    entry = ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
     Console.WriteLine(entry); // Expected 30
 }
 

--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Lynx.UCI.Commands.GUI;
+using System.Diagnostics;
 
 namespace Lynx;
 
@@ -116,7 +117,11 @@ public partial class Engine
             AdjustPosition($"position fen {fen}");
             stopwatch.Restart();
 
-            var result = BestMove(new($"go depth {depth}"));
+            var goCommand = new GoCommand($"go depth {depth}");
+            var searchConstraints = TimeManager.CalculateTimeManagement(Game, goCommand);
+
+            var result = BestMove(goCommand, in searchConstraints);
+
             var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
             totalSeconds += elapsedSeconds;
             totalNodes += result.Nodes;

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -37,8 +37,6 @@ public sealed partial class Engine
     private bool _isNewGameComing;
 #pragma warning restore IDE0052, CS0414 // Remove unread private members
 
-    private Move? _moveToPonder;
-
     public double AverageDepth { get; private set; }
 
     public RegisterCommand? Registration { get; set; }
@@ -106,10 +104,14 @@ public sealed partial class Engine
         var sw = Stopwatch.StartNew();
 
         InitializeStaticClasses();
+
         const string goWarmupCommand = "go depth 10";   // ~300 ms
+        var command = new GoCommand(goWarmupCommand);
 
         AdjustPosition(Constants.SuperLongPositionCommand);
-        BestMove(new(goWarmupCommand));
+
+        var searchConstrains = TimeManager.CalculateTimeManagement(Game, command);
+        BestMove(command, searchConstrains);
 
         Bench(2);
 
@@ -182,89 +184,33 @@ public sealed partial class Engine
         StopSearching();
     }
 
+    /// <summary>
+    /// Uses <see cref="TimeManager.CalculateTimeManagement(Game, GoCommand)"/> internally
+    /// </summary>
+    /// <param name="goCommand"></param>
+    /// <returns></returns>
     public SearchResult BestMove(GoCommand goCommand)
     {
-        bool isPondering = goCommand.Ponder;
+        var searchConstraints = TimeManager.CalculateTimeManagement(Game, goCommand);
 
+        return BestMove(goCommand, in searchConstraints);
+    }
+
+    public SearchResult BestMove(GoCommand goCommand, in SearchConstraints searchConstrains)
+    {
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
 
-        int maxDepth = -1;
-        int hardLimitTimeBound;
-        int softLimitTimeBound = int.MaxValue;
-
-        double millisecondsLeft;
-        int millisecondsIncrement;
-        if (Game.CurrentPosition.Side == Side.White)
+        if (searchConstrains.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
         {
-            millisecondsLeft = goCommand.WhiteTime;
-            millisecondsIncrement = goCommand.WhiteIncrement;
-        }
-        else
-        {
-            millisecondsLeft = goCommand.BlackTime;
-            millisecondsIncrement = goCommand.BlackIncrement;
+            _searchCancellationTokenSource.CancelAfter(searchConstrains.HardLimitTimeBound);
         }
 
-        // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
-        const int engineGuiCommunicationTimeOverhead = 50;
-
-        if (!isPondering)
-        {
-            if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
-            {
-                const int minSearchTime = 50;
-
-                var movesDivisor = goCommand.MovesToGo == 0
-                    ? ExpectedMovesLeft(Game.PositionHashHistoryLength()) * 3 / 2
-                    : goCommand.MovesToGo;
-
-                millisecondsLeft -= engineGuiCommunicationTimeOverhead;
-                millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
-
-                hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
-
-                var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * Configuration.EngineSettings.SoftTimeBaseIncrementMultiplier);
-                softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * Configuration.EngineSettings.SoftTimeBoundMultiplier));
-
-                _logger.Info("Soft time bound: {0}s", 0.001 * softLimitTimeBound);
-                _logger.Info("Hard time bound: {0}s", 0.001 * hardLimitTimeBound);
-
-                _searchCancellationTokenSource.CancelAfter(hardLimitTimeBound);
-            }
-            else if (goCommand.MoveTime > 0)
-            {
-                softLimitTimeBound = hardLimitTimeBound = goCommand.MoveTime - engineGuiCommunicationTimeOverhead;
-                _logger.Info("Time to move: {0}s", 0.001 * hardLimitTimeBound);
-
-                _searchCancellationTokenSource.CancelAfter(hardLimitTimeBound);
-            }
-            else if (goCommand.Depth > 0)
-            {
-                maxDepth = goCommand.Depth > Constants.AbsoluteMaxDepth ? Constants.AbsoluteMaxDepth : goCommand.Depth;
-            }
-            else if (goCommand.Infinite)
-            {
-                maxDepth = Configuration.EngineSettings.MaxDepth;
-                _logger.Info("Infinite search (depth {0})", maxDepth);
-            }
-            else
-            {
-                maxDepth = DefaultMaxDepth;
-                _logger.Warn("Unexpected or unsupported go command");
-            }
-        }
-        else
-        {
-            maxDepth = Configuration.EngineSettings.MaxDepth;
-            _logger.Info("Pondering search (depth {0})", maxDepth);
-        }
-
-        SearchResult resultToReturn = IDDFS(maxDepth, softLimitTimeBound);
+        SearchResult resultToReturn = IDDFS(searchConstrains.MaxDepth, searchConstrains.SoftLimitTimeBound);
         //SearchResult resultToReturn = await SearchBestMove(maxDepth, decisionTime);
 
         Game.ResetCurrentPositionToBeforeSearchState();
-        if (!isPondering
+        if (!goCommand.Ponder
             && resultToReturn.BestMove != default
             && !_absoluteSearchCancellationTokenSource.IsCancellationRequested)
         {
@@ -275,21 +221,6 @@ public sealed partial class Engine
         AverageDepth += (resultToReturn.Depth - AverageDepth) / Math.Ceiling(0.5 * Game.PositionHashHistoryLength());
 
         return resultToReturn;
-    }
-
-    /// <summary>
-    /// Straight from expositor's author paper, https://expositor.dev/pdf/movetime.pdf
-    /// </summary>
-    /// <param name="plies_played"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ExpectedMovesLeft(int plies_played)
-    {
-        double p = (double)(plies_played);
-
-        return (int)Math.Round(
-            (59.3 + ((72830.0 - (p * 2330.0)) / ((p * p) + (p * 10.0) + 2644.0)))   // Plies remaining
-            / 2.0); // Full moves remaining
     }
 
 #pragma warning disable S1144 // Unused private types or members should be removed - wanna keep this around
@@ -336,7 +267,7 @@ public sealed partial class Engine
         return tbResult ?? searchResult!;
     }
 
-    public void Search(GoCommand goCommand)
+    public SearchResult? Search(GoCommand goCommand, in SearchConstraints searchConstraints)
     {
         if (_isSearching)
         {
@@ -349,7 +280,7 @@ public sealed partial class Engine
         try
         {
             _isPondering = goCommand.Ponder;
-            var searchResult = BestMove(goCommand);
+            var searchResult = BestMove(goCommand, in searchConstraints);
 
             if (_isPondering)
             {
@@ -367,17 +298,16 @@ public sealed partial class Engine
                     _isPondering = false;
                     goCommand.DisablePonder();
 
-                    searchResult = BestMove(goCommand);
+                    searchResult = BestMove(goCommand, in searchConstraints);
                 }
             }
 
-            // We print best move even in case of go ponder + stop, and IDEs are expected to ignore it
-            _moveToPonder = searchResult.Moves.Length >= 2 ? searchResult.Moves[1] : null;
-            _engineWriter.TryWrite(new BestMoveCommand(searchResult.BestMove, _moveToPonder));
+            return searchResult;
         }
         catch (Exception e)
         {
             _logger.Fatal(e, "Error in {0} while calculating BestMove", nameof(Search));
+            return null;
         }
         finally
         {

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -111,7 +111,7 @@ public sealed partial class Engine
         AdjustPosition(Constants.SuperLongPositionCommand);
 
         var searchConstrains = TimeManager.CalculateTimeManagement(Game, command);
-        BestMove(command, searchConstrains);
+        BestMove(command, in searchConstrains);
 
         Bench(2);
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -71,7 +71,7 @@ public sealed partial class Engine
             _killerMoves[i] = new Move[3];
         }
 
-        AllocateTT();
+        TranspositionTable.InitializeTT();
 
 #if !DEBUG
         // Temporary channel so that no output is generated
@@ -87,14 +87,6 @@ public sealed partial class Engine
         GC.Collect();
         GC.WaitForPendingFinalizers();
 #pragma warning restore S1215 // "GC.Collect" should not be called
-    }
-
-    private void AllocateTT()
-    {
-        _currentTranspositionTableSize = Configuration.EngineSettings.TranspositionTableSize;
-
-        var ttLength = TranspositionTableExtensions.CalculateLength(_currentTranspositionTableSize);
-        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
 #pragma warning disable S1144 // Unused private types or members should be removed - used in Release mode
@@ -122,15 +114,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        if (_currentTranspositionTableSize == Configuration.EngineSettings.TranspositionTableSize)
-        {
-            Array.Clear(_tt);
-        }
-        else
-        {
-            _logger.Info("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
-            AllocateTT();
-        }
+        TranspositionTable.ResetTT();
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Model/SearchConstraints.cs
+++ b/src/Lynx/Model/SearchConstraints.cs
@@ -1,0 +1,19 @@
+﻿namespace Lynx.Model;
+
+public readonly struct SearchConstraints
+{
+    public const int DefaultHardLimitTimeBound  = int.MaxValue;
+
+    public readonly int HardLimitTimeBound;
+
+    public readonly int SoftLimitTimeBound;
+
+    public readonly int MaxDepth;
+
+    public SearchConstraints(int hardLimitTimeBound, int softLimitTimeBound, int maxDepth)
+    {
+        HardLimitTimeBound = hardLimitTimeBound;
+        SoftLimitTimeBound = softLimitTimeBound;
+        MaxDepth = maxDepth;
+    }
+}

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -4,6 +4,8 @@ using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics.X86;
 using System.Text;
 
+using static Lynx.Model.TranspositionTable;
+
 namespace Lynx;
 
 public sealed partial class Engine
@@ -13,14 +15,14 @@ public sealed partial class Engine
     {
         if (Sse.IsSupported)
         {
-            var index = TranspositionTableExtensions.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier, _tt.Length);
+            var index = CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier);
 
             unsafe
             {
                 // Since _tt is a pinned array
                 // This is no-op pinning as it does not influence the GC compaction
                 // https://tooslowexception.com/pinned-object-heap-in-net-5/
-                fixed (TranspositionTableElement* ttPtr = _tt)
+                fixed (TranspositionTableElement* ttPtr = TT)
                 {
                     Sse.Prefetch0(ttPtr + index);
                 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
+using static Lynx.Model.TranspositionTable;
+
 namespace Lynx;
 
 public sealed partial class Engine
@@ -41,9 +43,6 @@ public sealed partial class Engine
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
-
-    private int _currentTranspositionTableSize;
-    private TranspositionTable _tt = null!;
 
     private ulong _nodes;
 
@@ -355,7 +354,7 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = Utils.CalculateUCITime(elapsedSeconds);
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds);
-        finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
+        finalSearchResult.HashfullPermill = HashfullPermillApprox();
         if (Configuration.EngineSettings.ShowWDL)
         {
             finalSearchResult.WDL = WDL.WDLModel(bestScore, depth);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -333,9 +333,15 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+
                     if (position.IsInCheck())   // i.e. move gives check
                     {
                         --reduction;
+                    }
+
+                    if (!improving)
+                    {
+                        ++reduction;
                     }
 
                     if (ttBestMove != default && isCapture)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -2,6 +2,8 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
+using static Lynx.Model.TranspositionTable;
+
 namespace Lynx;
 
 public sealed partial class Engine
@@ -47,7 +49,7 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
+            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = ProbeHash(position, depth, ply, alpha, beta);
 
             // TT cutoffs
             if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
@@ -92,7 +94,7 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
+            RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
         else if (!pvNode)
@@ -441,7 +443,7 @@ public sealed partial class Engine
                         UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
                     }
 
-                    _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
+                    RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore;
                 }
@@ -455,12 +457,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
+            RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
+        RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
 
         // Node fails low
         return bestScore;
@@ -497,7 +499,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, 0, ply, alpha, beta);
+        var ttProbeResult = ProbeHash(position, 0, ply, alpha, beta);
         if (ttProbeResult.Score != EvaluationConstants.NoHashEntry)
         {
             return ttProbeResult.Score;
@@ -597,7 +599,7 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore; // The refutation doesn't matter, since it'll be pruned
                 }
@@ -622,12 +624,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
+            RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
+        RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
 
         return bestScore;
     }

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -1,6 +1,8 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 
+using static Lynx.Model.TranspositionTable;
+
 namespace Lynx;
 public sealed partial class Engine
 {
@@ -22,7 +24,7 @@ public sealed partial class Engine
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = Utils.CalculateUCITime(elapsedSeconds),
                     NodesPerSecond = 0,
-                    HashfullPermill = _tt.HashfullPermillApprox(),
+                    HashfullPermill = HashfullPermillApprox(),
                     WDL = WDL.WDLModel(
                         (int)Math.CopySign(
                             EvaluationConstants.PositiveCheckmateDetectionLimit + (EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore),

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -1,0 +1,99 @@
+﻿using Lynx.Model;
+using Lynx.UCI.Commands.GUI;
+using NLog;
+using System.Runtime.CompilerServices;
+
+namespace Lynx;
+public static class TimeManager
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public static SearchConstraints CalculateTimeManagement(Game game, GoCommand goCommand)
+    {
+        bool isPondering = goCommand.Ponder;
+
+        int maxDepth = -1;
+        int hardLimitTimeBound = SearchConstraints.DefaultHardLimitTimeBound;
+        int softLimitTimeBound = int.MaxValue;
+
+        double millisecondsLeft;
+        int millisecondsIncrement;
+        if (game.CurrentPosition.Side == Side.White)
+        {
+            millisecondsLeft = goCommand.WhiteTime;
+            millisecondsIncrement = goCommand.WhiteIncrement;
+        }
+        else
+        {
+            millisecondsLeft = goCommand.BlackTime;
+            millisecondsIncrement = goCommand.BlackIncrement;
+        }
+
+        // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
+        const int engineGuiCommunicationTimeOverhead = 50;
+
+        if (!isPondering)
+        {
+            if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
+            {
+                const int minSearchTime = 50;
+
+                var movesDivisor = goCommand.MovesToGo == 0
+                    ? ExpectedMovesLeft(game.PositionHashHistoryLength()) * 3 / 2
+                    : goCommand.MovesToGo;
+
+                millisecondsLeft -= engineGuiCommunicationTimeOverhead;
+                millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
+
+                hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
+
+                var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * Configuration.EngineSettings.SoftTimeBaseIncrementMultiplier);
+                softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * Configuration.EngineSettings.SoftTimeBoundMultiplier));
+
+                _logger.Info("Soft time bound: {0}s", 0.001 * softLimitTimeBound);
+                _logger.Info("Hard time bound: {0}s", 0.001 * hardLimitTimeBound);
+            }
+            else if (goCommand.MoveTime > 0)
+            {
+                softLimitTimeBound = hardLimitTimeBound = goCommand.MoveTime - engineGuiCommunicationTimeOverhead;
+                _logger.Info("Time to move: {0}s", 0.001 * hardLimitTimeBound);
+            }
+            else if (goCommand.Depth > 0)
+            {
+                maxDepth = goCommand.Depth > Constants.AbsoluteMaxDepth ? Constants.AbsoluteMaxDepth : goCommand.Depth;
+            }
+            else if (goCommand.Infinite)
+            {
+                maxDepth = Configuration.EngineSettings.MaxDepth;
+                _logger.Info("Infinite search (depth {0})", maxDepth);
+            }
+            else
+            {
+                maxDepth = Engine.DefaultMaxDepth;
+                _logger.Warn("Unexpected or unsupported go command");
+            }
+        }
+        else
+        {
+            maxDepth = Configuration.EngineSettings.MaxDepth;
+            _logger.Info("Pondering search (depth {0})", maxDepth);
+        }
+
+        return new(hardLimitTimeBound, softLimitTimeBound, maxDepth);
+    }
+
+    /// <summary>
+    /// Straight from expositor's author paper, https://expositor.dev/pdf/movetime.pdf
+    /// </summary>
+    /// <param name="plies_played"></param>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ExpectedMovesLeft(int plies_played)
+    {
+        double p = (double)(plies_played);
+
+        return (int)Math.Round(
+            (59.3 + ((72830.0 - (p * 2330.0)) / ((p * p) + (p * 10.0) + 2644.0)))   // Plies remaining
+            / 2.0); // Full moves remaining
+    }
+}

--- a/src/Lynx/UCI/Commands/Engine/BestMoveCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/BestMoveCommand.cs
@@ -18,10 +18,12 @@ public sealed class BestMoveCommand : IEngineBaseCommand
     private readonly Move _move;
     private readonly Move? _moveToPonder;
 
-    public BestMoveCommand(Move move, Move? moveToPonder = null)
+    public BestMoveCommand(SearchResult searchResult)
     {
-        _move = move;
-        _moveToPonder = moveToPonder;
+        _move = searchResult.BestMove;
+
+        // We alwaus try to print ponder move, regardless of ponder on/off
+        _moveToPonder = searchResult.Moves.Length >= 2 ? searchResult.Moves[1] : null;
     }
 
     public override string ToString()

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -48,8 +48,8 @@ public class EvaluationConstantsTest
     {
         Assert.Greater(MaxEval, PositiveCheckmateDetectionLimit + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
         Assert.Greater(MaxEval, CheckMateBaseEvaluation + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
-        Assert.Greater(MaxEval, TranspositionTableExtensions.RecalculateMateScores(CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
-        Assert.Greater(MaxEval, TranspositionTableExtensions.RecalculateMateScores(CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
+        Assert.Greater(MaxEval, Lynx.Model.TranspositionTable.RecalculateMateScores(CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
+        Assert.Greater(MaxEval, Lynx.Model.TranspositionTable.RecalculateMateScores(CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
         Assert.Less(MaxEval, short.MaxValue);
     }
 
@@ -58,8 +58,8 @@ public class EvaluationConstantsTest
     {
         Assert.Less(MinEval, NegativeCheckmateDetectionLimit - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
         Assert.Less(MinEval, -CheckMateBaseEvaluation - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
-        Assert.Less(MinEval, TranspositionTableExtensions.RecalculateMateScores(-CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
-        Assert.Less(MinEval, TranspositionTableExtensions.RecalculateMateScores(-CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
+        Assert.Less(MinEval, Lynx.Model.TranspositionTable.RecalculateMateScores(-CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
+        Assert.Less(MinEval, Lynx.Model.TranspositionTable.RecalculateMateScores(-CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
         Assert.Greater(MinEval, short.MinValue);
     }
 

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
 using static Lynx.EvaluationConstants;
+using static Lynx.Model.TranspositionTable;
 
 namespace Lynx.Test.Model;
 public class TranspositionTableTests
@@ -21,7 +22,7 @@ public class TranspositionTableTests
     [TestCase(-CheckMateBaseEvaluation + (2 * CheckmateDepthFactor), 4, -CheckMateBaseEvaluation + (6 * CheckmateDepthFactor))]
     public void RecalculateMateScores(int evaluation, int depth, int expectedEvaluation)
     {
-        Assert.AreEqual(expectedEvaluation, TranspositionTableExtensions.RecalculateMateScores(evaluation, depth));
+        Assert.AreEqual(expectedEvaluation, TranspositionTable.RecalculateMateScores(evaluation, depth));
     }
 
     [TestCase(+19, NodeType.Alpha, +20, +30, +19)]
@@ -31,13 +32,12 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        InitializeTT();
         var staticEval = position.StaticEvaluation().Score;
 
-        transpositionTable.RecordHash(position, staticEval, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, move: 1234);
+        RecordHash(position, staticEval, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta);
+        var ttEntry = ProbeHash(position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta);
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(staticEval, ttEntry.StaticEval);
     }
@@ -48,12 +48,11 @@ public class TranspositionTableTests
     {
         const int sharedDepth = 5;
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        InitializeTT();
 
-        transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        RecordHash(position, recordedEval, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100);
+        var ttEntry = ProbeHash(position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100);
         Assert.AreEqual(recordedEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }
@@ -65,12 +64,11 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash_CheckmateDifferentDepth(int recordedEval, int recordedDeph, int probeDepth, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        InitializeTT();
 
-        transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
+        RecordHash(position, recordedEval, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 7, ply: probeDepth, alpha: 50, beta: 100);
+        var ttEntry = ProbeHash(position, depth: 7, ply: probeDepth, alpha: 50, beta: 100);
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }


### PR DESCRIPTION
Big con: fucks up the tests

```
Test  | refactor/tt-outside-of-engine-1-static
Elo   | 2.48 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | 11198: +3199 -3119 =4880
Penta | [272, 1257, 2471, 1317, 282]
https://openbench.lynx-chess.com/test/906/
```