### PR TITLE
🧹 Move TT outside of `Engine`: independent class, instantiated at top level

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,6 @@
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount8" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount14" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount27" />
-    <Using Include="Lynx.Model.TranspositionTableElement[]" Alias="TranspositionTable" />
   </ItemGroup >
 
   <PropertyGroup>

--- a/src/Lynx.Benchmark/UCI_Benchmark.cs
+++ b/src/Lynx.Benchmark/UCI_Benchmark.cs
@@ -33,6 +33,7 @@
  */
 
 using BenchmarkDotNet.Attributes;
+using Lynx.Model;
 using System.Threading.Channels;
 
 namespace Lynx.Benchmark;
@@ -44,7 +45,7 @@ public class UCI_Benchmark : BaseBenchmark
     [Benchmark]
     public (ulong, ulong) Bench_DefaultDepth()
     {
-        var engine = new Engine(_channel.Writer);
+        var engine = new Engine(_channel.Writer, new TranspositionTable());
         return engine.Bench(Configuration.EngineSettings.BenchDepth);
     }
 }

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -1,11 +1,8 @@
 ﻿using Lynx;
 using Lynx.Cli;
-using Lynx.Model;
-using Lynx.UCI.Commands.Engine;
 using Microsoft.Extensions.Configuration;
 using NLog;
 using NLog.Extensions.Logging;
-using System.Threading.Channels;
 
 #if DEBUG
 Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
@@ -27,55 +24,6 @@ if (Configuration.GeneralSettings.EnableLogging)
     LogManager.Configuration = new NLogLoggingConfiguration(config.GetSection("NLog"));
 }
 
-var uciChannel = Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
-var engineChannel = Channel.CreateBounded<object>(new BoundedChannelOptions(2 * Configuration.EngineSettings.MaxDepth) { SingleReader = true, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
-
-using CancellationTokenSource source = new();
-CancellationToken cancellationToken = source.Token;
-
-var tt = new TranspositionTable();
-var engine = new Engine(engineChannel, tt);
-var uciHandler = new UCIHandler(uciChannel, engineChannel, engine);
-
-var tasks = new List<Task>
-{
-    Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
-    Task.Run(() => new Searcher(uciChannel, engineChannel, engine, tt).Run(cancellationToken)),
-    Task.Run(() => new Listener(uciHandler).Run(cancellationToken, args)),
-    uciChannel.Reader.Completion,
-    engineChannel.Reader.Completion
-};
-
-try
-{
-    Console.WriteLine($"{IdCommand.EngineName} {IdCommand.GetVersion()} by {IdCommand.EngineAuthor}");
-    await Task.WhenAny(tasks);
-}
-catch (AggregateException ae)
-{
-    foreach (var e in ae.InnerExceptions)
-    {
-        if (e is TaskCanceledException taskCanceledException)
-        {
-            Console.WriteLine("Cancellation requested: {0}", taskCanceledException.Message);
-        }
-        else
-        {
-            Console.WriteLine("Exception: {0}", e.GetType().Name);
-        }
-    }
-}
-catch (Exception e)
-{
-    Console.WriteLine("Unexpected exception");
-    Console.WriteLine(e.Message);
-}
-finally
-{
-    engineChannel.Writer.TryComplete();
-    uciChannel.Writer.TryComplete();
-    //source.Cancel();
-    LogManager.Shutdown(); // Flush and close down internal threads and timers
-}
+await Runner.Run(args);
 
 Thread.Sleep(2_000);

--- a/src/Lynx.Cli/Program.cs
+++ b/src/Lynx.Cli/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx;
 using Lynx.Cli;
+using Lynx.Model;
 using Lynx.UCI.Commands.Engine;
 using Microsoft.Extensions.Configuration;
 using NLog;
@@ -32,13 +33,14 @@ var engineChannel = Channel.CreateBounded<object>(new BoundedChannelOptions(2 * 
 using CancellationTokenSource source = new();
 CancellationToken cancellationToken = source.Token;
 
-var engine = new Engine(engineChannel);
+var tt = new TranspositionTable();
+var engine = new Engine(engineChannel, tt);
 var uciHandler = new UCIHandler(uciChannel, engineChannel, engine);
 
 var tasks = new List<Task>
 {
     Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
-    Task.Run(() => new Searcher(uciChannel, engineChannel, engine).Run(cancellationToken)),
+    Task.Run(() => new Searcher(uciChannel, engineChannel, engine, tt).Run(cancellationToken)),
     Task.Run(() => new Listener(uciHandler).Run(cancellationToken, args)),
     uciChannel.Reader.Completion,
     engineChannel.Reader.Completion

--- a/src/Lynx.Cli/Runner.cs
+++ b/src/Lynx.Cli/Runner.cs
@@ -1,0 +1,69 @@
+﻿using Lynx.Model;
+using Lynx.UCI.Commands.Engine;
+using NLog;
+using System.Threading.Channels;
+
+namespace Lynx.Cli;
+
+public static class Runner
+{
+    private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+    public static async Task Run(params string[] args)
+    {
+        var uciChannel = Channel.CreateBounded<string>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
+        var engineChannel = Channel.CreateBounded<object>(new BoundedChannelOptions(2 * Configuration.EngineSettings.MaxDepth) { SingleReader = true, SingleWriter = false, FullMode = BoundedChannelFullMode.DropOldest });
+
+        using CancellationTokenSource source = new();
+        CancellationToken cancellationToken = source.Token;
+
+        var tt = new TranspositionTable();
+        var engine = new Engine(engineChannel, tt);
+        var uciHandler = new UCIHandler(uciChannel, engineChannel, engine);
+
+        var tasks = new List<Task>
+        {
+            Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
+            Task.Run(() => new Searcher(uciChannel, engineChannel, engine, tt).Run(cancellationToken)),
+            Task.Run(() => new Listener(uciHandler).Run(cancellationToken, args)),
+            uciChannel.Reader.Completion,
+            engineChannel.Reader.Completion
+        };
+
+        try
+        {
+            Console.WriteLine($"{IdCommand.EngineName} {IdCommand.GetVersion()} by {IdCommand.EngineAuthor}");
+            await Task.WhenAny(tasks);
+        }
+        catch (AggregateException ae)
+        {
+            foreach (var e in ae.InnerExceptions)
+            {
+                if (e is TaskCanceledException taskCanceledException)
+                {
+                    Console.WriteLine("Cancellation requested exception: {0}", taskCanceledException.Message);
+                    _logger.Fatal(ae, "Cancellation requested exception: {0}", taskCanceledException.Message);
+                }
+                else
+                {
+                    Console.WriteLine("Exception {0}: {1}", e.GetType().Name, e.Message);
+                    _logger.Fatal(ae, "Exception {0}: {1}", e.GetType().Name, e.Message);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine("Unexpected exception");
+            Console.WriteLine(e.Message);
+
+            _logger.Fatal(e, "Unexpected exception: {Exception}", e.Message);
+        }
+        finally
+        {
+            engineChannel.Writer.TryComplete();
+            uciChannel.Writer.TryComplete();
+            //source.Cancel();
+            LogManager.Shutdown(); // Flush and close down internal threads and timers
+        }
+    }
+}

--- a/src/Lynx.Cli/Runner.cs
+++ b/src/Lynx.Cli/Runner.cs
@@ -1,5 +1,4 @@
-﻿using Lynx.Model;
-using Lynx.UCI.Commands.Engine;
+﻿using Lynx.UCI.Commands.Engine;
 using NLog;
 using System.Threading.Channels;
 
@@ -17,14 +16,13 @@ public static class Runner
         using CancellationTokenSource source = new();
         CancellationToken cancellationToken = source.Token;
 
-        var tt = new TranspositionTable();
-        var engine = new Engine(engineChannel, tt);
-        var uciHandler = new UCIHandler(uciChannel, engineChannel, engine);
+        var searcher = new Searcher(uciChannel, engineChannel);
+        var uciHandler = new UCIHandler(uciChannel, engineChannel, searcher.Engine);
 
         var tasks = new List<Task>
         {
             Task.Run(() => new Writer(engineChannel).Run(cancellationToken)),
-            Task.Run(() => new Searcher(uciChannel, engineChannel, engine, tt).Run(cancellationToken)),
+            Task.Run(() => searcher.Run(cancellationToken)),
             Task.Run(() => new Listener(uciHandler).Run(cancellationToken, args)),
             uciChannel.Reader.Completion,
             engineChannel.Reader.Completion

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -703,7 +703,7 @@ static void _54_ScoreMove()
     var position = new Position(KillerPosition);
     position.Print();
 
-    var engine = new Engine(Channel.CreateBounded<object>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
+    var engine = new Engine(Channel.CreateBounded<object>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }), new TranspositionTable());
     engine.SetGame(new(position.FEN()));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
@@ -1050,13 +1050,13 @@ static void TranspositionTable()
     static void TesSize(int size)
     {
         Console.WriteLine("Hash: {0} MB", size);
-        var length = TranspositionTableExtensions.CalculateLength(size);
+        var length = Lynx.Model.TranspositionTable.CalculateLength(size);
 
         var lengthMb = length / 1024 / 1024;
 
         Console.WriteLine("TT memory: {0} MB", lengthMb * Marshal.SizeOf(typeof(TranspositionTableElement)));
         Console.WriteLine("TT array length: {0}MB, (0x{1}, {2} items)", lengthMb, length.ToString("X"), length);
-        Console.WriteLine("TT mask: 0x{0} ({1})\n", (length - 1).ToString("X"), Convert.ToString((length - 1), 2));
+        Console.WriteLine("TT mask: 0x{0} ({1})\n", (length - 1).ToString("X"), Convert.ToString(length - 1, 2));
     }
 
     Console.WriteLine($"{nameof(TranspositionTableElement)} size: {Marshal.SizeOf(typeof(TranspositionTableElement))} bytes\n");
@@ -1071,8 +1071,9 @@ static void TranspositionTable()
     TesSize(512);
     TesSize(1024);
 
-    var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-    var transpositionTable = new TranspositionTableElement[ttLength];
+    var ttLength = Lynx.Model.TranspositionTable.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+    var transpositionTable = new TranspositionTable();
+
     var position = new Position(Constants.InitialPositionFEN);
     position.Print();
     Console.WriteLine($"Hash: {position.UniqueIdentifier}");
@@ -1080,10 +1081,10 @@ static void TranspositionTable()
     var hashKey = position.UniqueIdentifier % 0x400000;
     Console.WriteLine(hashKey);
 
-    var hashKey2 = TranspositionTableExtensions.CalculateTTIndex(position.UniqueIdentifier, ttLength);
+    var hashKey2 = transpositionTable.CalculateTTIndex(position.UniqueIdentifier);
     Console.WriteLine(hashKey2);
 
-    Array.Clear(transpositionTable);
+    transpositionTable.ResetTT();
 
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1084,7 +1084,7 @@ static void TranspositionTable()
     var hashKey2 = transpositionTable.CalculateTTIndex(position.UniqueIdentifier);
     Console.WriteLine(hashKey2);
 
-    transpositionTable.ResetTT();
+    transpositionTable.Reset();
 
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
 using System.Diagnostics;

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -115,7 +115,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        _tt.ResetTT();
+        _tt.Reset();
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -14,7 +14,7 @@ public sealed partial class Engine
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
     private readonly ChannelWriter<object> _engineWriter;
-    private readonly TranspositionTable _ttWraper;
+    private readonly TranspositionTable _tt;
 
     private bool _isSearching;
 
@@ -59,7 +59,7 @@ public sealed partial class Engine
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
         _engineWriter = engineWriter;
-        _ttWraper = tt;
+        _tt = tt;
         // Update ResetEngine() after any changes here
 
         _quietHistory = new int[12][];
@@ -115,7 +115,7 @@ public sealed partial class Engine
 
     private void ResetEngine()
     {
-        _ttWraper.ResetTT();
+        _tt.ResetTT();
 
         // Clear histories
         for (int i = 0; i < 12; ++i)

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -16,10 +16,10 @@ public class TranspositionTable
 
     public TranspositionTable()
     {
-        InitializeTT();
+        Allocate();
     }
 
-    private void InitializeTT()
+    private void Allocate()
     {
         _currentTranspositionTableSize = Configuration.EngineSettings.TranspositionTableSize;
 
@@ -27,7 +27,7 @@ public class TranspositionTable
         _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
-    public void ResetTT()
+    public void Reset()
     {
         if (_currentTranspositionTableSize == Configuration.EngineSettings.TranspositionTableSize)
         {
@@ -36,7 +36,7 @@ public class TranspositionTable
         else
         {
             _logger.Info("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
-            InitializeTT();
+            Allocate();
         }
     }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -4,119 +4,53 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
-
-public enum NodeType : byte
-{
-    Unknown,    // Making it 0 instead of -1 because of default struct initialization
-    Exact,
-    Alpha,
-    Beta
-}
-
-public struct TranspositionTableElement
-{
-    private ushort _key;
-
-    private ShortMove _move;
-
-    private short _score;
-
-    private short _staticEval;
-
-    private byte _depth;
-
-    private NodeType _type;
-
-    /// <summary>
-    /// 16 MSB of Position's Zobrist key
-    /// </summary>
-    public readonly ushort Key => _key;
-
-    /// <summary>
-    /// Best move found in the position. 0 if the search failed low (score <= alpha)
-    /// </summary>
-    public readonly ShortMove Move => _move;
-
-    /// <summary>
-    /// Position's score
-    /// </summary>
-    public readonly int Score => _score;
-
-    /// <summary>
-    /// Position's static evaluation
-    /// </summary>
-    public readonly int StaticEval => _staticEval;
-
-    /// <summary>
-    /// How deep the recorded search went. For us this numberis targetDepth - ply
-    /// </summary>
-    public readonly int Depth => _depth;
-
-    /// <summary>
-    /// Node (position) type:
-    /// <see cref="NodeType.Exact"/>: == <see cref="Score"/>,
-    /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
-    /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
-    /// </summary>
-    public readonly NodeType Type => _type;
-
-    /// <summary>
-    /// Struct size in bytes
-    /// </summary>
-    public static ulong Size => (ulong)Marshal.SizeOf(typeof(TranspositionTableElement));
-
-    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, Move? move)
-    {
-        _key = (ushort)key;
-        _score = (short)score;
-        _staticEval = (short)staticEval;
-        _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
-        _type = nodeType;
-        _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
-    }
-}
-
-public static class TranspositionTableExtensions
+public class TranspositionTable
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    public static int CalculateLength(int size)
+    private int _currentTranspositionTableSize;
+
+    TranspositionTableElement[] _tt = [];
+
+    public TranspositionTableElement[] TT { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _tt; }
+
+    public TranspositionTable()
     {
-        var ttEntrySize = TranspositionTableElement.Size;
+        InitializeTT();
+    }
 
-        ulong sizeBytes = (ulong)size * 1024ul * 1024ul;
-        ulong ttLength = sizeBytes / ttEntrySize;
-        var ttLengthMb = (double)ttLength / 1024 / 1024;
+    private void InitializeTT()
+    {
+        _currentTranspositionTableSize = Configuration.EngineSettings.TranspositionTableSize;
 
-        if (ttLength > (ulong)Array.MaxLength)
+        var ttLength = CalculateLength(_currentTranspositionTableSize);
+        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
+    }
+
+    public void ResetTT()
+    {
+        if (_currentTranspositionTableSize == Configuration.EngineSettings.TranspositionTableSize)
         {
-            throw new ArgumentException($"Invalid transpositon table (Hash) size: {ttLengthMb}Mb, {ttLength} values (> Array.MaxLength, {Array.MaxLength})");
+            Array.Clear(TT);
         }
-
-        var mask = ttLength - 1;
-
-        _logger.Info("Hash value:\t{0} MB", size);
-        _logger.Info("TT memory:\t{0} MB", (ttLengthMb * ttEntrySize).ToString("F"));
-        _logger.Info("TT length:\t{0} items", ttLength);
-        _logger.Info("TT entry:\t{0} bytes", ttEntrySize);
-        _logger.Info("TT mask:\t{0}", mask.ToString("X"));
-
-        return (int)ttLength;
+        else
+        {
+            _logger.Info("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _currentTranspositionTableSize, Configuration.EngineSettings.TranspositionTableSize);
+            InitializeTT();
+        }
     }
 
     /// <summary>
     /// 'Fixed-point multiplication trick', see https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
     /// </summary>
     /// <param name="positionUniqueIdentifier"></param>
-    /// <param name="ttLength"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong CalculateTTIndex(ulong positionUniqueIdentifier, int ttLength) => (ulong)(((UInt128)positionUniqueIdentifier * (UInt128)ttLength) >> 64);
+    public ulong CalculateTTIndex(ulong positionUniqueIdentifier) => (ulong)(((UInt128)positionUniqueIdentifier * (UInt128)_tt.Length) >> 64);
 
     /// <summary>
     /// Checks the transposition table and, if there's a eval value that can be deducted from it of there's a previously recorded <paramref name="position"/>, it's returned. <see cref="EvaluationConstants.NoHashEntry"/> is returned otherwise
     /// </summary>
-    /// <param name="tt"></param>
     /// <param name="position"></param>
     /// <param name="depth"></param>
     /// <param name="ply">Ply</param>
@@ -124,10 +58,10 @@ public static class TranspositionTableExtensions
     /// <param name="beta"></param>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static (int Score, ShortMove BestMove, NodeType NodeType, int RawScore, int StaticEval) ProbeHash(this TranspositionTable tt, Position position, int depth, int ply, int alpha, int beta)
+    public (int Score, ShortMove BestMove, NodeType NodeType, int RawScore, int StaticEval) ProbeHash(Position position, int depth, int ply, int alpha, int beta)
     {
-        var ttIndex = CalculateTTIndex(position.UniqueIdentifier, tt.Length);
-        ref var entry = ref tt[ttIndex];
+        var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
+        ref var entry = ref _tt[ttIndex];
 
         if ((ushort)position.UniqueIdentifier != entry.Key)
         {
@@ -158,7 +92,6 @@ public static class TranspositionTableExtensions
     /// <summary>
     /// Adds a <see cref="TranspositionTableElement"/> to the transposition tabke
     /// </summary>
-    /// <param name="tt"></param>
     /// <param name="position"></param>
     /// <param name="depth"></param>
     /// <param name="ply">Ply</param>
@@ -166,10 +99,10 @@ public static class TranspositionTableExtensions
     /// <param name="nodeType"></param>
     /// <param name="move"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void RecordHash(this TranspositionTable tt, Position position, int staticEval, int depth, int ply, int score, NodeType nodeType, Move? move = null)
+    public void RecordHash(Position position, int staticEval, int depth, int ply, int score, NodeType nodeType, Move? move = null)
     {
-        var ttIndex = CalculateTTIndex(position.UniqueIdentifier, tt.Length);
-        ref var entry = ref tt[ttIndex];
+        var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
+        ref var entry = ref _tt[ttIndex];
 
         //if (entry.Key != default && entry.Key != position.UniqueIdentifier)
         //{
@@ -192,6 +125,59 @@ public static class TranspositionTableExtensions
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
         entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, move);
+    }
+
+    /// <summary>
+    /// Exact TT occupancy per mill
+    /// </summary>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int HashfullPermill() => _tt.Length > 0
+        ? (int)(1000L * PopulatedItemsCount() / _tt.LongLength)
+        : 0;
+
+    /// <summary>
+    /// Orders of magnitude faster than <see cref="HashfullPermill(TranspositionTableElement[])"/>
+    /// </summary>
+    /// <returns></returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int HashfullPermillApprox()
+    {
+        int items = 0;
+        for (int i = 0; i < 1000; ++i)
+        {
+            if (_tt[i].Key != default)
+            {
+                ++items;
+            }
+        }
+
+        //Console.WriteLine($"Real: {HashfullPermill(transpositionTable)}, estimated: {items}");
+        return items;
+    }
+
+    internal static int CalculateLength(int size)
+    {
+        var ttEntrySize = TranspositionTableElement.Size;
+
+        ulong sizeBytes = (ulong)size * 1024ul * 1024ul;
+        ulong ttLength = sizeBytes / ttEntrySize;
+        var ttLengthMb = (double)ttLength / 1024 / 1024;
+
+        if (ttLength > (ulong)Array.MaxLength)
+        {
+            throw new ArgumentException($"Invalid transpositon table (Hash) size: {ttLengthMb}Mb, {ttLength} values (> Array.MaxLength, {Array.MaxLength})");
+        }
+
+        var mask = ttLength - 1;
+
+        _logger.Info("Hash value:\t{0} MB", size);
+        _logger.Info("TT memory:\t{0} MB", (ttLengthMb * ttEntrySize).ToString("F"));
+        _logger.Info("TT length:\t{0} items", ttLength);
+        _logger.Info("TT entry:\t{0} bytes", ttEntrySize);
+        _logger.Info("TT mask:\t{0}", mask.ToString("X"));
+
+        return (int)ttLength;
     }
 
     /// <summary>
@@ -218,76 +204,45 @@ public static class TranspositionTableExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int PopulatedItemsCount(this TranspositionTable transpositionTable)
+    private int PopulatedItemsCount()
     {
         int items = 0;
-        for (int i = 0; i < transpositionTable.Length; ++i)
+        for (int i = 0; i < _tt.Length; ++i)
         {
-            if (transpositionTable[i].Key != default)
+            if (_tt[i].Key != default)
             {
                 ++items;
             }
         }
 
-        return items;
-    }
-
-    /// <summary>
-    /// Exact TT occupancy per mill
-    /// </summary>
-    /// <param name="transpositionTable"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int HashfullPermill(this TranspositionTable transpositionTable) => transpositionTable.Length > 0
-        ? (int)(1000L * transpositionTable.PopulatedItemsCount() / transpositionTable.LongLength)
-        : 0;
-
-    /// <summary>
-    /// Orders of magnitude faster than <see cref="HashfullPermill(TranspositionTableElement[])"/>
-    /// </summary>
-    /// <param name="transpositionTable"></param>
-    /// <returns></returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int HashfullPermillApprox(this TranspositionTable transpositionTable)
-    {
-        int items = 0;
-        for (int i = 0; i < 1000; ++i)
-        {
-            if (transpositionTable[i].Key != default)
-            {
-                ++items;
-            }
-        }
-
-        //Console.WriteLine($"Real: {HashfullPermill(transpositionTable)}, estimated: {items}");
         return items;
     }
 
     [Conditional("DEBUG")]
-    internal static void Stats(this TranspositionTable transpositionTable)
+    private void Stats()
     {
         int items = 0;
-        for (int i = 0; i < transpositionTable.Length; ++i)
+        for (int i = 0; i < _tt.Length; ++i)
         {
-            if (transpositionTable[i].Key != default)
+            if (_tt[i].Key != default)
             {
                 ++items;
             }
         }
         _logger.Info("TT Occupancy:\t{0}% ({1}MB)",
-            100 * transpositionTable.PopulatedItemsCount() / transpositionTable.Length,
-            transpositionTable.Length * Marshal.SizeOf(typeof(TranspositionTableElement)) / 1024 / 1024);
+            100 * PopulatedItemsCount() / _tt.Length,
+            _tt.Length * Marshal.SizeOf(typeof(TranspositionTableElement)) / 1024 / 1024);
     }
 
     [Conditional("DEBUG")]
-    internal static void Print(this TranspositionTable transpositionTable)
+    private void Print()
     {
         Console.WriteLine("Transposition table content:");
-        for (int i = 0; i < transpositionTable.Length; ++i)
+        for (int i = 0; i < _tt.Length; ++i)
         {
-            if (transpositionTable[i].Key != default)
+            if (_tt[i].Key != default)
             {
-                Console.WriteLine($"{i}: Key = {transpositionTable[i].Key}, Depth: {transpositionTable[i].Depth}, Score: {transpositionTable[i].Score}, Move: {(transpositionTable[i].Move != 0 ? ((Move)transpositionTable[i].Move).UCIString() : "-")} {transpositionTable[i].Type}");
+                Console.WriteLine($"{i}: Key = {_tt[i].Key}, Depth: {_tt[i].Depth}, Score: {_tt[i].Score}, Move: {(_tt[i].Move != 0 ? ((Move)_tt[i].Move).UCIString() : "-")} {_tt[i].Type}");
             }
         }
         Console.WriteLine("");

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -1,0 +1,77 @@
+﻿using NLog;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Lynx.Model;
+
+public enum NodeType : byte
+{
+    Unknown,    // Making it 0 instead of -1 because of default struct initialization
+    Exact,
+    Alpha,
+    Beta
+}
+
+public struct TranspositionTableElement
+{
+    private ushort _key;
+
+    private ShortMove _move;
+
+    private short _score;
+
+    private short _staticEval;
+
+    private byte _depth;
+
+    private NodeType _type;
+
+    /// <summary>
+    /// 16 MSB of Position's Zobrist key
+    /// </summary>
+    public readonly ushort Key => _key;
+
+    /// <summary>
+    /// Best move found in the position. 0 if the search failed low (score <= alpha)
+    /// </summary>
+    public readonly ShortMove Move => _move;
+
+    /// <summary>
+    /// Position's score
+    /// </summary>
+    public readonly int Score => _score;
+
+    /// <summary>
+    /// Position's static evaluation
+    /// </summary>
+    public readonly int StaticEval => _staticEval;
+
+    /// <summary>
+    /// How deep the recorded search went. For us this numberis targetDepth - ply
+    /// </summary>
+    public readonly int Depth => _depth;
+
+    /// <summary>
+    /// Node (position) type:
+    /// <see cref="NodeType.Exact"/>: == <see cref="Score"/>,
+    /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
+    /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
+    /// </summary>
+    public readonly NodeType Type => _type;
+
+    /// <summary>
+    /// Struct size in bytes
+    /// </summary>
+    public static ulong Size => (ulong)Marshal.SizeOf(typeof(TranspositionTableElement));
+
+    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, Move? move)
+    {
+        _key = (ushort)key;
+        _score = (short)score;
+        _staticEval = (short)staticEval;
+        _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
+        _type = nodeType;
+        _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
+    }
+}

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -13,14 +13,14 @@ public sealed partial class Engine
     {
         if (Sse.IsSupported)
         {
-            var index = _ttWraper.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier);
+            var index = _tt.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier);
 
             unsafe
             {
                 // Since _tt is a pinned array
                 // This is no-op pinning as it does not influence the GC compaction
                 // https://tooslowexception.com/pinned-object-heap-in-net-5/
-                fixed (TranspositionTableElement* ttPtr = _ttWraper.TT)
+                fixed (TranspositionTableElement* ttPtr = _tt.TT)
                 {
                     Sse.Prefetch0(ttPtr + index);
                 }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -13,14 +13,14 @@ public sealed partial class Engine
     {
         if (Sse.IsSupported)
         {
-            var index = TranspositionTableExtensions.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier, _tt.Length);
+            var index = _ttWraper.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier);
 
             unsafe
             {
                 // Since _tt is a pinned array
                 // This is no-op pinning as it does not influence the GC compaction
                 // https://tooslowexception.com/pinned-object-heap-in-net-5/
-                fixed (TranspositionTableElement* ttPtr = _tt)
+                fixed (TranspositionTableElement* ttPtr = _ttWraper.TT)
                 {
                     Sse.Prefetch0(ttPtr + index);
                 }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -8,26 +8,6 @@ namespace Lynx;
 
 public sealed partial class Engine
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void PrefetchTTEntry()
-    {
-        if (Sse.IsSupported)
-        {
-            var index = _tt.CalculateTTIndex(Game.CurrentPosition.UniqueIdentifier);
-
-            unsafe
-            {
-                // Since _tt is a pinned array
-                // This is no-op pinning as it does not influence the GC compaction
-                // https://tooslowexception.com/pinned-object-heap-in-net-5/
-                fixed (TranspositionTableElement* ttPtr = _tt.TT)
-                {
-                    Sse.Prefetch0(ttPtr + index);
-                }
-            }
-        }
-    }
-
 #pragma warning disable RCS1226 // Add paragraph to documentation comment
 #pragma warning disable RCS1243 // Duplicate word in a comment
     /// <summary>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,9 +42,6 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
-    private int _currentTranspositionTableSize;
-    private TranspositionTable _tt = null!;
-
     private ulong _nodes;
 
     private SearchResult? _previousSearchResult;
@@ -355,7 +352,7 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = Utils.CalculateUCITime(elapsedSeconds);
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds);
-        finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
+        finalSearchResult.HashfullPermill = _ttWraper.HashfullPermillApprox();
         if (Configuration.EngineSettings.ShowWDL)
         {
             finalSearchResult.WDL = WDL.WDLModel(bestScore, depth);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -352,7 +352,7 @@ public sealed partial class Engine
         finalSearchResult.Nodes = _nodes;
         finalSearchResult.Time = Utils.CalculateUCITime(elapsedSeconds);
         finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds);
-        finalSearchResult.HashfullPermill = _ttWraper.HashfullPermillApprox();
+        finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
         if (Configuration.EngineSettings.ShowWDL)
         {
             finalSearchResult.WDL = WDL.WDLModel(bestScore, depth);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -47,7 +47,7 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
+            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _ttWraper.ProbeHash(position, depth, ply, alpha, beta);
 
             // TT cutoffs
             if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
@@ -92,7 +92,7 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
+            _ttWraper.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
         else if (!pvNode)
@@ -441,7 +441,7 @@ public sealed partial class Engine
                         UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
                     }
 
-                    _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
+                    _ttWraper.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore;
                 }
@@ -455,12 +455,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
+            _ttWraper.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
+        _ttWraper.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
 
         // Node fails low
         return bestScore;
@@ -497,7 +497,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, 0, ply, alpha, beta);
+        var ttProbeResult = _ttWraper.ProbeHash(position, 0, ply, alpha, beta);
         if (ttProbeResult.Score != EvaluationConstants.NoHashEntry)
         {
             return ttProbeResult.Score;
@@ -597,7 +597,7 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    _ttWraper.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore; // The refutation doesn't matter, since it'll be pruned
                 }
@@ -622,12 +622,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
+            _ttWraper.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
+        _ttWraper.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
 
         return bestScore;
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -47,7 +47,7 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _ttWraper.ProbeHash(position, depth, ply, alpha, beta);
+            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
 
             // TT cutoffs
             if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
@@ -92,7 +92,7 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _ttWraper.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
+            _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact);
             return finalPositionEvaluation;
         }
         else if (!pvNode)
@@ -441,7 +441,7 @@ public sealed partial class Engine
                         UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
                     }
 
-                    _ttWraper.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
+                    _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore;
                 }
@@ -455,12 +455,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _ttWraper.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _ttWraper.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
+        _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, bestMove);
 
         // Node fails low
         return bestScore;
@@ -497,7 +497,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _ttWraper.ProbeHash(position, 0, ply, alpha, beta);
+        var ttProbeResult = _tt.ProbeHash(position, 0, ply, alpha, beta);
         if (ttProbeResult.Score != EvaluationConstants.NoHashEntry)
         {
             return ttProbeResult.Score;
@@ -597,7 +597,7 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                    _ttWraper.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
 
                     return bestScore; // The refutation doesn't matter, since it'll be pruned
                 }
@@ -622,12 +622,12 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _ttWraper.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
 
-        _ttWraper.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
+        _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
 
         return bestScore;
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -288,7 +288,7 @@ public sealed partial class Engine
             }
             else if (visitedMovesCounter == 0)
             {
-                PrefetchTTEntry();
+                _tt.PrefetchTTEntry(position);
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
                 score = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
@@ -335,7 +335,7 @@ public sealed partial class Engine
                     }
                 }
 
-                PrefetchTTEntry();
+                _tt.PrefetchTTEntry(position);
 
                 int reduction = 0;
 

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -22,7 +22,7 @@ public sealed partial class Engine
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = Utils.CalculateUCITime(elapsedSeconds),
                     NodesPerSecond = 0,
-                    HashfullPermill = _ttWraper.HashfullPermillApprox(),
+                    HashfullPermill = _tt.HashfullPermillApprox(),
                     WDL = WDL.WDLModel(
                         (int)Math.CopySign(
                             EvaluationConstants.PositiveCheckmateDetectionLimit + (EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore),

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -22,7 +22,7 @@ public sealed partial class Engine
                     Nodes = 666,                // In case some guis proritize the info command with biggest depth
                     Time = Utils.CalculateUCITime(elapsedSeconds),
                     NodesPerSecond = 0,
-                    HashfullPermill = _tt.HashfullPermillApprox(),
+                    HashfullPermill = _ttWraper.HashfullPermillApprox(),
                     WDL = WDL.WDLModel(
                         (int)Math.CopySign(
                             EvaluationConstants.PositiveCheckmateDetectionLimit + (EvaluationConstants.CheckmateDepthFactor * tablebaseResult.MateScore),

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -12,12 +12,14 @@ public sealed class Searcher
     private readonly ChannelWriter<object> _engineWriter;
     private readonly Engine _engine;
     private readonly Logger _logger;
+    private readonly TranspositionTable _tt;
 
-    public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter, Engine engine)
+    public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter, Engine engine, TranspositionTable tt)
     {
         _uciReader = uciReader;
         _engineWriter = engineWriter;
         _engine = engine;
+        _tt = tt;
         _logger = LogManager.GetCurrentClassLogger();
     }
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -10,18 +10,20 @@ public sealed class Searcher
 {
     private readonly ChannelReader<string> _uciReader;
     private readonly ChannelWriter<object> _engineWriter;
-    private readonly Engine _engine;
     private readonly Logger _logger;
     private readonly TranspositionTable _tt;
 
-    public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter, Engine engine, TranspositionTable tt)
+    public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter)
     {
         _uciReader = uciReader;
         _engineWriter = engineWriter;
-        _engine = engine;
-        _tt = tt;
+
+        _tt = new TranspositionTable();
         _logger = LogManager.GetCurrentClassLogger();
+        Engine = new Engine(_engineWriter, _tt);
     }
+
+    public Engine Engine { get; }
 
     public async Task Run(CancellationToken cancellationToken)
     {
@@ -54,9 +56,9 @@ public sealed class Searcher
 
     private void OnGoCommand(GoCommand goCommand)
     {
-        var searchConstraints = TimeManager.CalculateTimeManagement(_engine.Game, goCommand);
+        var searchConstraints = TimeManager.CalculateTimeManagement(Engine.Game, goCommand);
 
-        var searchResult = _engine.Search(goCommand, searchConstraints);
+        var searchResult = Engine.Search(goCommand, searchConstraints);
 
         if (searchResult is not null)
         {

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -48,8 +48,8 @@ public class EvaluationConstantsTest
     {
         Assert.Greater(MaxEval, PositiveCheckmateDetectionLimit + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
         Assert.Greater(MaxEval, CheckMateBaseEvaluation + ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
-        Assert.Greater(MaxEval, TranspositionTableExtensions.RecalculateMateScores(CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
-        Assert.Greater(MaxEval, TranspositionTableExtensions.RecalculateMateScores(CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
+        Assert.Greater(MaxEval, TranspositionTable.RecalculateMateScores(CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
+        Assert.Greater(MaxEval, TranspositionTable.RecalculateMateScores(CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
         Assert.Less(MaxEval, short.MaxValue);
     }
 
@@ -58,8 +58,8 @@ public class EvaluationConstantsTest
     {
         Assert.Less(MinEval, NegativeCheckmateDetectionLimit - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
         Assert.Less(MinEval, -CheckMateBaseEvaluation - ((Constants.AbsoluteMaxDepth + 10) * CheckmateDepthFactor));
-        Assert.Less(MinEval, TranspositionTableExtensions.RecalculateMateScores(-CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
-        Assert.Less(MinEval, TranspositionTableExtensions.RecalculateMateScores(-CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
+        Assert.Less(MinEval, TranspositionTable.RecalculateMateScores(-CheckMateBaseEvaluation, Constants.AbsoluteMaxDepth));
+        Assert.Less(MinEval, TranspositionTable.RecalculateMateScores(-CheckMateBaseEvaluation, -Constants.AbsoluteMaxDepth));
         Assert.Greater(MinEval, short.MinValue);
     }
 

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -21,7 +21,7 @@ public class TranspositionTableTests
     [TestCase(-CheckMateBaseEvaluation + (2 * CheckmateDepthFactor), 4, -CheckMateBaseEvaluation + (6 * CheckmateDepthFactor))]
     public void RecalculateMateScores(int evaluation, int depth, int expectedEvaluation)
     {
-        Assert.AreEqual(expectedEvaluation, TranspositionTableExtensions.RecalculateMateScores(evaluation, depth));
+        Assert.AreEqual(expectedEvaluation, TranspositionTable.RecalculateMateScores(evaluation, depth));
     }
 
     [TestCase(+19, NodeType.Alpha, +20, +30, +19)]
@@ -31,8 +31,8 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        var transpositionTable = new TranspositionTable();
+
         var staticEval = position.StaticEvaluation().Score;
 
         transpositionTable.RecordHash(position, staticEval, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, move: 1234);
@@ -48,8 +48,7 @@ public class TranspositionTableTests
     {
         const int sharedDepth = 5;
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        var transpositionTable = new TranspositionTable();
 
         transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
@@ -65,8 +64,7 @@ public class TranspositionTableTests
     public void RecordHash_ProbeHash_CheckmateDifferentDepth(int recordedEval, int recordedDeph, int probeDepth, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
-        var ttLength = TranspositionTableExtensions.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-        var transpositionTable = new TranspositionTableElement[ttLength];
+        var transpositionTable = new TranspositionTable();
 
         transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 


### PR DESCRIPTION
73c5abecfbaa4ad2a9c34db40cb9d06093e3b9c5

`Non-deterministic bench` error though, probably related to passing around a class with a pinned object.
That is, when executing the binary with `"bench"` argument, results (node count) aren't always the same

```
Test  | refactor/tt-outside-of-engine-2-class-wrapper
Elo   | 3.95 +- 7.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.23 (-2.25, 2.89) [-5.00, 0.00]
Games | 3344: +927 -889 =1528
Penta | [67, 356, 792, 386, 71]
https://openbench.lynx-chess.com/test/908/
```