### PR TITLE
🔍 Improving, use >= instead of >

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -114,7 +114,7 @@ public sealed partial class Engine
 
             if (ply >= 2)
             {
-                improving = staticEval > Game.ReadStaticEvalFromStack(ply - 2);
+                improving = staticEval >= Game.ReadStaticEvalFromStack(ply - 2);
             }
 
             // From smol.cs


### PR DESCRIPTION
Looks OK stc, not really LTC
```
Test  | search/improving-greater-or-eqyal
Elo   | 1.25 +- 1.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.76 (-2.25, 2.89) [0.00, 3.00]
Games | 191388: +52923 -52232 =86233
Penta | [4914, 22973, 39353, 23416, 5038]
https://openbench.lynx-chess.com/test/933/
```

```
Test  | search/improving-greater-or-eqyal
Elo   | -0.07 +- 2.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.31 (-2.25, 2.89) [0.00, 3.00]
Games | 32492: +8258 -8265 =15969
Penta | [548, 3999, 7196, 3918, 585]
https://openbench.lynx-chess.com/test/936/
```