### PR TITLE
⚡ Use `Unsafe.Add` for `PSQT()`

### DIFF
--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -1,5 +1,7 @@
 ﻿using Lynx.Model;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using static Lynx.TunableEvalParameters;
 
 namespace Lynx;
@@ -99,16 +101,11 @@ public static class EvaluationPSQTs
     public static int PSQT(int friendEnemy, int bucket, int piece, int square)
     {
         var index = PSQTIndex(friendEnemy, bucket, piece, square);
+        Debug.Assert(index >= 0 && index < _packedPSQT.Length);
 
         unsafe
         {
-            // Since _tt is a pinned array
-            // This is no-op pinning as it does not influence the GC compaction
-            // https://tooslowexception.com/pinned-object-heap-in-net-5/
-            fixed (int* psqtPtr = &_packedPSQT[0])
-            {
-                return psqtPtr[index];
-            }
+            return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_packedPSQT), index);
         }
     }
 


### PR DESCRIPTION
- Use `Unsafe.Add` to properly avoid bound checks when querying PSQTs (if we're going unsafe, let's do it 'right' in the most performant way)
- Add Assert to for manually verify bounds in debug mode

Part of planned https://github.com/lynx-chess/Backlog/issues/300, and was brought up again by @tannergooding in C# Discord while reviewing unsafe usage 😻

```
Test  | perft/psqt-unsafe-add
Elo   | 4.30 +- 4.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 1.00]
Games | 11646: +3304 -3160 =5182
Penta | [259, 1294, 2604, 1376, 290]
https://openbench.lynx-chess.com/test/935/
```