### PR TITLE
🧹 Replace `Unsafe.As<bool, byte>` with `(isWhite ? 1 : 0)`

### DIFF
--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -38,7 +38,7 @@ public static class Utils
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int PieceOffset(bool isWhite)
     {
-        return 6 - (6 * Unsafe.As<bool, byte>(ref isWhite));
+        return 6 - (6 * (isWhite ? 1 : 0));
     }
 
     /// <summary>


### PR DESCRIPTION
[Benchmarks](https://github.com/lynx-chess/Lynx/blob/ecb1c90c4e57aa24c6b4170ac30a1a08ea431ff1/src/Lynx.Benchmark/PieceOffset_Boolean_Benchmark.cs) were not conclusive back in the day about this alleged perf. improvement

In @tannergooding words, `Unsafe.As<bool, byte>(ref isWhite)` can be notably less efficient than `isWhite ? 1 : 0` plus
it technically opens the door to undefined behavior (since bool isn't strictly 0 or 1).
Regarding the benchmarks:
> a lot of this differences are within 1-20 cycles (roughly 5-10ns)
> and they are basically impossible to measure with traditional benchmarking tools
> but, the JIT is set up to recognize and optimize the idiomatic patterns
> so even if the raw difference is small, the potential difference in broader code can be massive
> as it can make the difference on whether things like dead code elimination or constant folding occur

Having `unsafe` code that doesn't bring any benefits doesn't make sense anyway, and this regression test proved that removing the unsafe solution doesn't lose significant elo, so.. merging 
```
Test  | perf/remove-unsafe-cast
Elo   | 0.38 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-3.00, 1.00]
Games | 56200: +15557 -15496 =25147
Penta | [1320, 6574, 12272, 6593, 1341]
https://openbench.lynx-chess.com/test/934/
```