### PR TITLE
🧹 Simplify `PieceOffset`

### DIFF
--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -36,10 +36,7 @@ public static class Utils
     /// </summary>
     /// <param name="isWhite"></param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int PieceOffset(bool isWhite)
-    {
-        return 6 - (6 * (isWhite ? 1 : 0));
-    }
+    public static int PieceOffset(bool isWhite) => isWhite ? 0 : 6;
 
     /// <summary>
     /// Side.Black -> Side.White


### PR DESCRIPTION
As pointed out by @vitorhnn in https://github.com/lynx-chess/Lynx/pull/1155#issuecomment-2471478266