### PR TITLE
🔍 FP and QFP with improving, tuned I

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,8 +200,8 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
-    [SPSAAttribute<int>(0, 200, 10)]
-    public int FP_QS_Margin { get; set; } = 75;
+    [SPSA<int>(50, 250, 10)]
+    public int FP_QS_Margin { get; set; } = 150;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -195,16 +195,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 73;
+    public int FP_DepthScalingFactor { get; set; } = 65;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 100;
+    public int FP_Margin { get; set; } = 130;
 
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin_Improving { get; set; } = 300;
 
     [SPSA<int>(50, 250, 10)]
-    public int FP_QS_Margin { get; set; } = 75;
+    public int FP_QS_Margin { get; set; } = 64;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -200,6 +200,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 218;
 
+    [SPSAAttribute<int>(0, 200, 10)]
+    public int FP_QS_Margin { get; set; } = 75;
+
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -201,7 +201,7 @@ public sealed class EngineSettings
     public int FP_Margin { get; set; } = 218;
 
     [SPSA<int>(50, 250, 10)]
-    public int FP_QS_Margin { get; set; } = 150;
+    public int FP_QS_Margin { get; set; } = 75;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,7 +571,7 @@ public sealed partial class Engine
 
             // QSearch Futility Pruning (FP)
             // Moves without potential to raise alpha are discarded
-            if (!position.IsInCheck() && futilityScore < alpha && !SEE.HasPositiveScore(position, move))
+            if (!position.IsInCheck() && futilityScore < alpha) // TODO SEE score
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -573,6 +573,9 @@ public sealed partial class Engine
             // Moves without potential to raise alpha are discarded
             if (!position.IsInCheck() && futilityScore < alpha && moveScores[i] < EvaluationConstants.PromotionMoveScoreValue) // TODO SEE score
             {
+                if (futilityScore > bestScore)
+                    bestScore = futilityScore;
+
                 continue;
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -333,9 +333,15 @@ public sealed partial class Engine
                     {
                         --reduction;
                     }
+
                     if (position.IsInCheck())   // i.e. move gives check
                     {
                         --reduction;
+                    }
+
+                    if (!improving)
+                    {
+                        ++reduction;
                     }
 
                     if (ttBestMove != default && isCapture)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -535,7 +535,10 @@ public sealed partial class Engine
 
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
-        int bestScore = staticEval;
+        var bestScore = staticEval;
+        var futilityScore = position.IsInCheck()
+            ? EvaluationConstants.MinEval
+            : staticEval + Configuration.EngineSettings.FP_QS_Margin;
 
         bool isAnyCaptureValid = false;
 
@@ -562,6 +565,13 @@ public sealed partial class Engine
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScores[i] < EvaluationConstants.PromotionMoveScoreValue && moveScores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            {
+                continue;
+            }
+
+            // QSearch Futility Pruning (FP)
+            // Moves without potential to raise alpha are discarded
+            if (!position.IsInCheck() && futilityScore < alpha && !SEE.HasPositiveScore(position, move))
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,7 +571,7 @@ public sealed partial class Engine
 
             // QSearch Futility Pruning (FP)
             // Moves without potential to raise alpha are discarded
-            if (!position.IsInCheck() && futilityScore < alpha) // TODO SEE score
+            if (!position.IsInCheck() && futilityScore < alpha && moveScores[i] < EvaluationConstants.PromotionMoveScoreValue) // TODO SEE score
             {
                 continue;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -131,7 +131,7 @@ public sealed partial class Engine
             {
                 // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                 // Return formula by Ciekce, instead of just returning static eval
-                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * depth) >= beta)
+                if (staticEval - (Configuration.EngineSettings.RFP_DepthScalingFactor * (depth - (improving ? 1 : 0))) >= beta)
                 {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                     return (staticEval + beta) / 2;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -493,6 +493,15 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "fp_qs_margin":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.FP_QS_Margin = value;
+                    }
+                    break;
+                }
+
             case "historyprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
Other attempt: #1164 

```
Test  | search/fp-qfp-tune-1
Elo   | -0.49 +- 3.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.73 (-2.25, 2.89) [0.00, 3.00]
Games | 12852: +3231 -3249 =6372
Penta | [203, 1603, 2839, 1571, 210]
https://openbench.lynx-chess.com/test/916/
```