### PR TITLE
🔍 `NMP_StaticEvalBetaDivisor` 50

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -143,7 +143,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 100;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 50;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;


### PR DESCRIPTION
```
Test  | search/NMP_StaticEvalBetaDivisor-50
Elo   | -9.87 +- 8.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.33 (-2.25, 2.89) [0.00, 5.00]
Games | 3346: +899 -994 =1453
Penta | [105, 445, 647, 392, 84]
https://openbench.lynx-chess.com/test/941/
```