### PR TITLE
🔍 `NMP_StaticEvalBetaDivisor` 75

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -143,7 +143,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 100;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 75;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;


### PR DESCRIPTION
```
Test  | search/NMP_StaticEvalBetaDivisor-75
Elo   | 0.36 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.78 (-2.25, 2.89) [0.00, 3.00]
Games | 34100: +8665 -8630 =16805
Penta | [571, 4165, 7531, 4224, 559]
https://openbench.lynx-chess.com/test/945/
```