### PR TITLE
🔍 `NMP_StaticEvalBetaDivisor` 150

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -143,7 +143,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 100;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 150;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;


### PR DESCRIPTION
```
Test  | search/NMP_StaticEvalBetaDivisor-150
Elo   | 0.03 +- 3.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 5.00]
Games | 22604: +6226 -6224 =10154
Penta | [568, 2793, 4624, 2703, 614]
https://openbench.lynx-chess.com/test/942/
```