### PR TITLE
🔍 High-level tune SEE piece values 

### DIFF
--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -12,8 +12,8 @@ public static class SEE
 
     private static ReadOnlySpan<int> _pieceValues =>
     [
-        100, 450, 450, 650, 1250, 0,
-        100, 450, 450, 650, 1250, 0,
+        147, 455, 508, 634, 1267, 0,
+        147, 455, 508, 634, 1267, 0,
         0
     ];
 


### PR DESCRIPTION
Tuned from `search/see-tuning-1-all-0-1500` branch
Note the `[0, 1500]` range

8+0.08
```
iterations: 1163 (112.55s per iter)
games: 37216 (3.52s per game)
SEE_Pawn = 147(+46.80) in [0, 1500]
SEE_Knight = 455(+5.33) in [0, 1500]
SEE_Bishop = 508(+57.77) in [0, 1500]
SEE_Rook = 634(-15.799078) in [0, 1500]
SEE_Queen = 1267(+17.06) in [0, 1500]
```

```
Test  | spsa/see-1
Elo   | -3.94 +- 4.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 12424: +3399 -3540 =5485
Penta | [342, 1552, 2549, 1443, 326]
https://openbench.lynx-chess.com/test/946/
```