### PR TITLE
🔍 Low level tune SEE piece values

### DIFF
--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -12,8 +12,8 @@ public static class SEE
 
     private static ReadOnlySpan<int> _pieceValues =>
     [
-        100, 450, 450, 650, 1250, 0,
-        100, 450, 450, 650, 1250, 0,
+        92, 422, 474, 606, 1256, 0,
+        92, 422, 474, 606, 1256, 0,
         0
     ];
 

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -12,8 +12,8 @@ public static class SEE
 
     private static ReadOnlySpan<int> _pieceValues =>
     [
-        92, 422, 474, 606, 1256, 0,
-        92, 422, 474, 606, 1256, 0,
+        88, 445, 480, 600, 1262, 0,
+        88, 435, 480, 600, 1262, 0,
         0
     ];
 


### PR DESCRIPTION

See also equally bad #1171 

```
iterations: 1157 (112.29s per iter)
games: 37024 (3.51s per game)
SEE_Pawn = 92(-8.278845) in [0, 200]
SEE_Knight = 422(-28.134712) in [200, 600]
SEE_Bishop = 474(+23.60) in [200, 600]
SEE_Rook = 606(-44.279655) in [400, 800]
SEE_Queen = 1256(+6.17) in [900, 1300]
```

```
Test  | spsa/see-2
Elo   | -1.06 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 29690: +8398 -8489 =12803
Penta | [840, 3604, 6045, 3519, 837]
https://openbench.lynx-chess.com/test/947/
```