### PR TITLE
🐛 Clear `PlyStackEntry` shared array on return

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -261,7 +261,7 @@ public sealed class Game : IDisposable
 
     public void FreeResources()
     {
-        ArrayPool<PlyStackEntry>.Shared.Return(_gameStack);
+        ArrayPool<PlyStackEntry>.Shared.Return(_gameStack, clearArray: true);
         ArrayPool<ulong>.Shared.Return(_positionHashHistory);
 
         CurrentPosition.FreeResources();


### PR DESCRIPTION
Not clearing it causes an issue when attempting to refactor TT initialization in https://github.com/lynx-chess/Lynx/pull/1150, when:
This issue appears when:
- TT initialization is moved outside of `Engine.cs` (i.e. to top level `Program.cs` in repro below, other class than engine in PR above)
- TT initialization uses `pinned: true`
- GC mode is Workstation 

Better reproduced in https://github.com/lynx-chess/Lynx/pull/1181

```
Test  | bugfix/clear-PlyStackEntry-sharedarray-onreturn
Elo   | 4.76 +- 5.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | 7224: +2072 -1973 =3179
Penta | [157, 828, 1563, 887, 177]
https://openbench.lynx-chess.com/test/957/
```