### PR TITLE
Add UCI `quietbench` command

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -13,7 +13,7 @@ public sealed partial class Engine
     internal const int DefaultMaxDepth = 5;
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-    private readonly ChannelWriter<object> _engineWriter;
+    private ChannelWriter<object> _engineWriter;
 
     private bool _isSearching;
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -88,7 +88,11 @@ public sealed class UCIHandler
                     await HandleDivide(rawCommand);
                     break;
                 case "bench":
-                    await HandleBench(rawCommand);
+                    await HandleBench(rawCommand, quiet: false);
+                    HandleQuit();
+                    break;
+                case "quietbench":
+                    await HandleBench(rawCommand, quiet: true);
                     HandleQuit();
                     break;
                 case "printsettings":
@@ -578,7 +582,7 @@ public sealed class UCIHandler
         }
     }
 
-    private async ValueTask HandleBench(string rawCommand)
+    private async ValueTask HandleBench(string rawCommand, bool quiet)
     {
         var items = rawCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
@@ -586,7 +590,7 @@ public sealed class UCIHandler
         {
             depth = Configuration.EngineSettings.BenchDepth;
         }
-        var results = _engine.Bench(depth);
+        var results = _engine.Bench(depth, quiet);
         await _engine.PrintBenchResults(results);
     }
 


### PR DESCRIPTION
8+0.08
```
Score of Lynx-uci-quietbench-4491-win-x64 vs Lynx 4489 - main: 7691 - 7787 - 13106  [0.498] 28584
...      Lynx-uci-quietbench-4491-win-x64 playing White: 5927 - 1830 - 6536  [0.643] 14293
...      Lynx-uci-quietbench-4491-win-x64 playing Black: 1764 - 5957 - 6570  [0.353] 14291
...      White vs Black: 11884 - 3594 - 13106  [0.645] 28584
Elo difference: -1.2 +/- 3.0, LOS: 22.0 %, DrawRatio: 45.9 %
SPRT: llr 2.92 (100.9%), lbound -2.25, ubound 2.89 - H1 was accepted
```