### PR TITLE
🔍 Bad capture history pruning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -207,10 +207,16 @@ public sealed class EngineSettings
     public int FP_Margin { get; set; } = 218;
 
     [SPSA<int>(0, 10, 0.5)]
-    public int HistoryPrunning_MaxDepth { get; set; } = 5;
+    public int QuietHistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1940;
+    public int QuietHistoryPrunning_Margin { get; set; } = -1940;
+
+    [SPSA<int>(0, 10, 0.5)]
+    public int CaptureHistoryPrunning_MaxDepth { get; set; } = 5;
+
+    [SPSA<int>(-8192, 0, 512)]
+    public int CaptureHistoryPrunning_Margin { get; set; } = -1940;
 }
 
 [JsonSourceGenerationOptions(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -309,11 +309,20 @@ public sealed partial class Engine
                     }
 
                     // 🔍 History pruning -  all quiet moves can be pruned
-                    // once we find one with a history score too low
-                    if (!isCapture
-                        && moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
-                        && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
-                        && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
+                    // once we find one with a history score too low                    if (isCapture)
+                    if (!isCapture)
+                    {
+                        if (moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
+                            && depth < Configuration.EngineSettings.CaptureHistoryPrunning_MaxDepth    // TODO use LMR depth
+                            && _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())] < Configuration.EngineSettings.CaptureHistoryPrunning_Margin * (depth - 1))
+                        {
+                            RevertMove();
+                            break;
+                        }
+                    }
+                    else if (moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
+                        && depth < Configuration.EngineSettings.QuietHistoryPrunning_MaxDepth    // TODO use LMR depth
+                        && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.QuietHistoryPrunning_Margin * (depth - 1))
                     {
                         RevertMove();
                         break;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -509,19 +509,35 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "historyprunning_maxdepth":
+            case "quiethistoryprunning_maxdepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.HistoryPrunning_MaxDepth = value;
+                        Configuration.EngineSettings.QuietHistoryPrunning_MaxDepth = value;
                     }
                     break;
                 }
-            case "historyprunning_margin":
+            case "quiethistoryprunning_margin":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.HistoryPrunning_Margin = value;
+                        Configuration.EngineSettings.QuietHistoryPrunning_Margin = value;
+                    }
+                    break;
+                }
+            case "capturehistoryprunning_maxdepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CaptureHistoryPrunning_MaxDepth = value;
+                    }
+                    break;
+                }
+            case "capturehistoryprunning_margin":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CaptureHistoryPrunning_Margin = value;
                     }
                     break;
                 }


### PR DESCRIPTION
```
Test  | search/bad-capture-history-pruning
Elo   | -50.87 +- 13.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 1252: +261 -443 =548
Penta | [62, 199, 242, 105, 18]
https://openbench.lynx-chess.com/test/975/
```