### PR TITLE
🧹 Engine initialization/cleanup refactoring

### DIFF
--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -129,11 +129,6 @@ public partial class Engine
 
         _engineWriter.TryWrite($"Total time: {Utils.CalculateUCITime(totalSeconds)}");
 
-        // Cleanup game
-        NewGame();
-        _isNewGameComing = false;
-        _isNewGameCommandSupported = false;
-
         return (totalNodes, Utils.CalculateNps(totalNodes, totalSeconds));
     }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -288,6 +288,9 @@ public sealed partial class Engine : IDisposable
     {
         Game.FreeResources();
 
+        _absoluteSearchCancellationTokenSource.Dispose();
+        _searchCancellationTokenSource.Dispose();
+
         _disposedValue = true;
     }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -34,11 +34,6 @@ public sealed partial class Engine : IDisposable
     /// </summary>
     private bool _stopRequested;
 
-#pragma warning disable IDE0052, CS0414, S4487 // Remove unread private members
-    private bool _isNewGameCommandSupported;
-    private bool _isNewGameComing;
-#pragma warning restore IDE0052, CS0414 // Remove unread private members
-
     public double AverageDepth { get; private set; }
 
     public Game Game { get; private set; }
@@ -54,7 +49,6 @@ public sealed partial class Engine : IDisposable
     {
         AverageDepth = 0;
         Game = new Game(Constants.InitialPositionFEN);
-        _isNewGameComing = true;
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
         _engineWriter = engineWriter;
@@ -133,8 +127,6 @@ public sealed partial class Engine : IDisposable
         AverageDepth = 0;
         Game.FreeResources();
         Game = new Game(Constants.InitialPositionFEN);
-        _isNewGameComing = true;
-        _isNewGameCommandSupported = true;
         _stopRequested = false;
 
         ResetEngine();
@@ -146,7 +138,6 @@ public sealed partial class Engine : IDisposable
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         Game.FreeResources();
         Game = PositionCommand.ParseGame(rawPositionCommand, moves);
-        _isNewGameComing = false;
         _stopRequested = false;
     }
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -18,6 +18,8 @@ public sealed class Searcher
 
     public string FEN => _engine.Game.FEN;
 
+    //private bool _isNewGameCommandSupported;
+
     public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter)
     {
         _uciReader = uciReader;
@@ -92,6 +94,8 @@ public sealed class Searcher
 
     public void NewGame()
     {
+        //_isNewGameCommandSupported = true;
+
         var averageDepth = _engine.AverageDepth;
         if (averageDepth > 0 && averageDepth < int.MaxValue)
         {

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -27,6 +27,8 @@ public sealed class Searcher
         _engine = new Engine(_engineWriter, _ttWrapper);
 
         _logger = LogManager.GetCurrentClassLogger();
+
+        InitializeStaticClasses();
     }
 
     public async Task Run(CancellationToken cancellationToken)
@@ -97,6 +99,11 @@ public sealed class Searcher
         }
 
         _engine.NewGame();
+
+#pragma warning disable S1215 // "GC.Collect" should not be called
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+#pragma warning restore S1215 // "GC.Collect" should not be called
     }
 
     public void Quit()
@@ -112,5 +119,16 @@ public sealed class Searcher
     {
         var results = _engine.Bench(depth);
         await _engine.PrintBenchResults(results);
+    }
+
+    private static void InitializeStaticClasses()
+    {
+        _ = PVTable.Indexes[0];
+        _ = Attacks.KingAttacks;
+        _ = ZobristTable.SideHash();
+        _ = Masks.FileMasks;
+        _ = EvaluationConstants.HistoryBonus[1];
+        _ = MoveGenerator.Init();
+        _ = GoCommand.Init();
     }
 }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -18,8 +18,6 @@ public sealed class Searcher
 
     public string FEN => _engine.Game.FEN;
 
-    //private bool _isNewGameCommandSupported;
-
     public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter)
     {
         _uciReader = uciReader;
@@ -94,8 +92,6 @@ public sealed class Searcher
 
     public void NewGame()
     {
-        //_isNewGameCommandSupported = true;
-
         var averageDepth = _engine.AverageDepth;
         if (averageDepth > 0 && averageDepth < int.MaxValue)
         {


### PR DESCRIPTION
- Move static class initialization from Engine to Searcher (prep for multiple, shorter-lived engines)
- Move forced GC collection from Engine to Searcher (prep for multiple engines)
- Prepare engine to be disposed, aka allowing it to be clear its resources (prep for multiple engines, and potential engine re-allocation)
- Remove Engine `_isNewGameCommandSupported` and `_isNewGameComing`
- Dispose Engine `_searchCancellationTokenSource` and `_absoluteSearchCancellationTokenSource`