### PR TITLE
⌛ Add node time management

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -110,6 +110,12 @@ public sealed class EngineSettings
 
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
+    [SPSA<double>(1, 3, 0.1)]
+    public double NodeTmBase { get; set; } = 1.5;
+
+    [SPSA<double>(0.5, 2.5, 0.1)]
+    public double NodeTmScale { get; set; } = 1;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]
@@ -121,7 +127,7 @@ public sealed class EngineSettings
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
-    [SPSA<double>(0.1, 2, 0.10)]
+    [SPSA<double>(0.1, 2, 0.1)]
     public double LMR_Base { get; set; } = 0.75;
 
     /// <summary>

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,10 +111,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 1.5;
+    public double NodeTmBase { get; set; } = 2.5;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1;
+    public double NodeTmScale { get; set; } = 1.5;
 
     #endregion
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -90,6 +90,12 @@ public sealed partial class Engine
             + previousMoveTargetSquare;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateMoveNodeCount(Move move, ulong nodesToAdd)
+    {
+        _moveNodeCount[move.Piece()][move.TargetSquare()] += nodesToAdd;
+    }
+
     #region Debugging
 
 #pragma warning disable S125 // Sections of code should not be commented out

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,6 +67,10 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
+        for (int i = 0; i < 12; ++i)
+        {
+            Array.Clear(_moveNodeCount[i]);
+        }
 
         int bestScore = 0;
         int alpha = EvaluationConstants.MinEval;
@@ -246,7 +250,7 @@ public sealed partial class Engine
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
         var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes);
-        _logger.Debug("[TM] Depth {Depth}: Base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+        _logger.Warn("[TM] Depth {Depth}: Base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)
         {

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -40,6 +40,12 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
+    /// <summary>
+    /// 12 x 64
+    /// piece x target square
+    /// </summary>
+    private readonly ulong[][] _moveNodeCount;
+
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
     private ulong _nodes;
@@ -49,11 +55,12 @@ public sealed partial class Engine
     private readonly Move _defaultMove = default;
 
     /// <summary>
-    /// Iterative Deepening Depth-First Search (IDDFS) using alpha-beta pruning
+    /// Iterative Deepening Depth-First Search (IDDFS) using alpha-beta pruning.
+    /// Requires <see cref="_searchConstraints"/> to be populated before invoking it
     /// </summary>
     /// <returns>Not null <see cref="SearchResult"/>, although made nullable in order to match online tb probing signature</returns>
     [SkipLocalsInit]
-    public SearchResult IDDFS(int maxDepth, int softLimitTimeBound)
+    private SearchResult IDDFS()
     {
         // Cleanup
         _nodes = 0;
@@ -163,7 +170,7 @@ public sealed partial class Engine
                 lastSearchResult = UpdateLastSearchResult(lastSearchResult, bestScore, depth, mate);
 
                 _engineWriter.TryWrite(lastSearchResult);
-            } while (StopSearchCondition(++depth, maxDepth, mate, softLimitTimeBound));
+            } while (StopSearchCondition(lastSearchResult.BestMove, ++depth, mate));
         }
         catch (OperationCanceledException)
         {
@@ -200,7 +207,7 @@ public sealed partial class Engine
         return finalSearchResult;
     }
 
-    private bool StopSearchCondition(int depth, int maxDepth, int mate, int softLimitTimeBound)
+    private bool StopSearchCondition(Move bestMove, int depth, int mate)
     {
         if (mate != 0)
         {
@@ -222,6 +229,7 @@ public sealed partial class Engine
             return false;
         }
 
+        var maxDepth = _searchConstraints.MaxDepth;
         if (maxDepth > 0)
         {
             var shouldContinue = depth <= maxDepth;
@@ -236,9 +244,13 @@ public sealed partial class Engine
 
         var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
-        if (elapsedMilliseconds > softLimitTimeBound)
+        var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
+        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes);
+        _logger.Debug("[TM] Depth {Depth}: Base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+
+        if (elapsedMilliseconds > scaledSoftLimitTimeBound)
         {
-            _logger.Info("Stopping at depth {0} (nodes {1}): {2}ms > {3}ms", depth - 1, _nodes, elapsedMilliseconds, softLimitTimeBound);
+            _logger.Info("Stopping at depth {0} (nodes {1}): {2}ms > {3}ms", depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
             return false;
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -251,6 +251,7 @@ public sealed partial class Engine
                 continue;
             }
 
+            var previousNodes = _nodes;
             visitedMoves[visitedMovesCounter] = move;
 
             ++_nodes;
@@ -407,6 +408,11 @@ public sealed partial class Engine
 
             // After making a move
             RevertMove();
+            if (isRoot)
+            {
+                var nodesSpentInThisMove = _nodes - previousNodes;
+                UpdateMoveNodeCount(move, nodesSpentInThisMove);
+            }
 
             PrintMove(position, ply, move, score);
 

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -108,8 +108,9 @@ public static class TimeManager
         double scale = 1.0;
 
         // Node time management: scale soft limit time bound by the proportion of nodes spent
-        // searching the best move at root level vs the total nodes searched
-        // More time spent in best move -> less time for the rest of the search
+        //   searching the best move at root level vs the total nodes searched.
+        // The more time spent in best move -> the more sure we are about our previous results,
+        //   so the less time we spent in the search.
         // i.e. with nodeTmBase = 2 and nodeTmScale = 1
         // - bestMoveFraction = 0.50 -> scale = 1.0 x (2 - 0.5) = 1.5
         // - bestMoveFraction = 0.25 -> scale = 1.0 x (2 - 0.25) = 1.75

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using Lynx.UCI.Commands.GUI;
 using NLog;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lynx;
@@ -98,6 +99,9 @@ public static class TimeManager
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int SoftLimit(SearchConstraints searchConstraints, ulong bestMoveNodeCount, ulong totalNodeCount)
     {
+        Debug.Assert(totalNodeCount > 0);
+        Debug.Assert(totalNodeCount >= bestMoveNodeCount);
+
         double nodeTmBase = Configuration.EngineSettings.NodeTmBase;
         double nodeTmScale = Configuration.EngineSettings.NodeTmScale;
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -266,6 +266,25 @@ public sealed class UCIHandler
                     break;
                 }
 
+            #region Time management
+            case "nodetmbase":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NodeTmBase = value * 0.01;
+                    }
+                    break;
+                }
+            case "nodetmscale":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.NodeTmScale = value * 0.01;
+                    }
+                    break;
+                }
+            #endregion
+
             #region Search tuning
 
             case "lmr_mindepth":
@@ -288,7 +307,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.LMR_Base = (value * 0.01);
+                        Configuration.EngineSettings.LMR_Base = value * 0.01;
                     }
                     break;
                 }
@@ -296,7 +315,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.LMR_Divisor = (value * 0.01);
+                        Configuration.EngineSettings.LMR_Divisor = value * 0.01;
                     }
                     break;
                 }


### PR DESCRIPTION
Node time management: scale soft limit time bound by the proportion of nodes spent searching the best move at root level vs the total nodes searched.
The more time spent in best move -> the more sure we are about our previous results, so the less time we spent in the search.
i.e. with nodeTmBase = 2 and nodeTmScale = 1
 - bestMoveFraction = 0.50 -> scale = 1.0 x (2 - 0.5) = 1.5
 - bestMoveFraction = 0.25 -> scale = 1.0 x (2 - 0.25) = 1.75
 - bestMoveFraction = 1.00 -> scale = 1.0 x (2 - 1.00) = 1

```
Test  | time/node-tm-2
Elo   | 3.59 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | 25340: +7318 -7056 =10966
Penta | [692, 2963, 5130, 3161, 724]
https://openbench.lynx-chess.com/test/979/
```

```
Test  | time/node-tm-2
Elo   | 9.40 +- 5.79 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | 5916: +1667 -1507 =2742
Penta | [113, 696, 1217, 782, 150]
https://openbench.lynx-chess.com/test/980/
```

```
Test  | time/node-tm-2
Elo   | 10.18 +- 5.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | 5054: +1361 -1213 =2480
Penta | [87, 538, 1139, 666, 97]
https://openbench.lynx-chess.com/test/981/
```