### PR TITLE
⌛ Node time management: Base 2 scale 1.35

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,10 +111,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.5;
+    public double NodeTmBase { get; set; } = 2;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.5;
+    public double NodeTmScale { get; set; } = 1.35;
 
     #endregion
 


### PR DESCRIPTION
Before #1206 
```
Score of Lynx-time-node-tm-3-4581-win-x64 vs Lynx 4579 - main: 648 - 601 - 1271  [0.509] 2520
...      Lynx-time-node-tm-3-4581-win-x64 playing White: 522 - 82 - 655  [0.675] 1259
...      Lynx-time-node-tm-3-4581-win-x64 playing Black: 126 - 519 - 616  [0.344] 1261
...      White vs Black: 1041 - 208 - 1271  [0.665] 2520
Elo difference: 6.5 +/- 9.5, LOS: 90.8 %, DrawRatio: 50.4 %
SPRT: llr 0.838 (29.0%), lbound -2.25, ubound 2.89
```

vs 1206
```
Test  | time/node-tm-3
Elo   | 3.83 +- 6.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.48 (-2.25, 2.89) [0.00, 3.00]
Games | 4084: +1073 -1028 =1983
Penta | [62, 485, 921, 494, 80]
https://openbench.lynx-chess.com/test/988/
```

After some time
```
Test  | time/node-tm-3-2
Elo   | -0.98 +- 2.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.90 (-2.25, 2.89) [0.00, 3.00]
Games | 24074: +5858 -5926 =12290
Penta | [314, 2911, 5677, 2799, 336]
https://openbench.lynx-chess.com/test/1097/
```