### PR TITLE
⌛ Node time management: Base 2.4 scale 1.65

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,10 +111,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.5;
+    public double NodeTmBase { get; set; } = 2.4;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.5;
+    public double NodeTmScale { get; set; } = 1.65;
 
     #endregion
 


### PR DESCRIPTION
```
Test  | time/node-tm-4
Elo   | 13.33 +- 5.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 5842: +1602 -1378 =2862
Penta | [92, 616, 1311, 780, 122]
https://openbench.lynx-chess.com/test/985/
```