### PR TITLE
⌛ Node time management: Base 2.6 scale 1.7

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -111,10 +111,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.5;
+    public double NodeTmBase { get; set; } = 2.6;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.5;
+    public double NodeTmScale { get; set; } = 1.7;
 
     #endregion
 


### PR DESCRIPTION
```
Test  | time/node-tm-5
Elo   | -15.00 +- 7.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.92 (-2.25, 2.89) [0.00, 3.00]
Games | 2990: +693 -822 =1475
Penta | [60, 397, 698, 292, 48]
https://openbench.lynx-chess.com/test/987/
```