### PR TITLE
⌛ Best move stability: another well known array of values

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -250,7 +250,7 @@ public sealed partial class Engine
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
         var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes);
-        _logger.Warn("[TM] Depth {Depth}: Base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+        _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1,  _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)
         {

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -103,10 +103,12 @@ public static class TimeManager
         // - bestMoveFraction = 0.25 -> scale = 1.0 x (2 - 0.25) = 1.75
         // - bestMoveFraction = 1.00 -> scale = 1.0 x (2 - 1.00) = 1
         double bestMoveFraction = (double)bestMoveNodeCount / totalNodeCount;
-        var nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
+        double nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
         scale *= nodeTmFactor;
 
-        return (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+        int newSoftTimeLimit = (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+
+        return Math.Min(newSoftTimeLimit, searchConstraints.HardLimitTimeBound);
     }
 
     /// <summary>


### PR DESCRIPTION
Best move stability: the less best move changes, the less time we spend in the search

Wrong engine order, so it's actually -10
```
Score of Lynx-time-node-tm-soft-less-or-equal-hard-4591-win-x64 vs Lynx-time-best-move-stability-4598-win-x64: 1197 - 1072 - 1951  [0.515] 4220
...      Lynx-time-node-tm-soft-less-or-equal-hard-4591-win-x64 playing White: 858 - 248 - 1004  [0.645] 2110
...      Lynx-time-node-tm-soft-less-or-equal-hard-4591-win-x64 playing Black: 339 - 824 - 947  [0.385] 2110
...      White vs Black: 1682 - 587 - 1951  [0.630] 4220
Elo difference: 10.3 +/- 7.7, LOS: 99.6 %, DrawRatio: 46.2 %
SPRT: llr 2.54 (87.7%), lbound -2.25, ubound 2.89
```