### PR TITLE
⌛ Soft limit <= hard limit

### DIFF
--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -103,10 +103,12 @@ public static class TimeManager
         // - bestMoveFraction = 0.25 -> scale = 1.0 x (2 - 0.25) = 1.75
         // - bestMoveFraction = 1.00 -> scale = 1.0 x (2 - 1.00) = 1
         double bestMoveFraction = (double)bestMoveNodeCount / totalNodeCount;
-        var nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
+        double nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
         scale *= nodeTmFactor;
 
-        return (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+        int newSoftTimeLimit = (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+
+        return Math.Min(newSoftTimeLimit, searchConstraints.HardLimitTimeBound);
     }
 
     /// <summary>


### PR DESCRIPTION
```
Test  | time/node-tm-soft-less-or-equal-hard
Elo   | 2.32 +- 3.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | 19656: +5573 -5442 =8641
Penta | [478, 2291, 4189, 2362, 508]
https://openbench.lynx-chess.com/test/990/
```

```
Test  | time/node-tm-soft-less-or-equal-hard
Elo   | 0.17 +- 3.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.69 (-2.25, 2.89) [-3.00, 1.00]
Games | 15950: +4075 -4067 =7808
Penta | [236, 1706, 4057, 1766, 210]
https://openbench.lynx-chess.com/test/989/
```