### PR TITLE
⌛ Add best move stability

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -250,7 +250,7 @@ public sealed partial class Engine
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
         var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes);
-        _logger.Warn("[TM] Depth {Depth}: Base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+        _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1,  _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)
         {

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -8,10 +8,9 @@ namespace Lynx;
 public static class TimeManager
 {
     /// <summary>
-    /// Source of the values: god, according to disservin
-    /// I saw it in Lizard, Sirius and Clarity though
+    /// Values from Stash
     /// </summary>
-    private static ReadOnlySpan<double> _bestMoveStabilityValues => [2.2, 1.6, 1.4, 1.1, 1, 0.95, 0.9];
+    private static ReadOnlySpan<double> _bestMoveStabilityValues => [2.50, 1.20, 0.90, 0.80, 0.75];
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -103,10 +103,12 @@ public static class TimeManager
         // - bestMoveFraction = 0.25 -> scale = 1.0 x (2 - 0.25) = 1.75
         // - bestMoveFraction = 1.00 -> scale = 1.0 x (2 - 1.00) = 1
         double bestMoveFraction = (double)bestMoveNodeCount / totalNodeCount;
-        var nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
+        double nodeTmFactor = nodeTmBase - (bestMoveFraction * nodeTmScale);
         scale *= nodeTmFactor;
 
-        return (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+        int newSoftTimeLimit = (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale);
+
+        return Math.Min(newSoftTimeLimit, searchConstraints.HardLimitTimeBound);
     }
 
     /// <summary>


### PR DESCRIPTION
8+0.08
```
Score of Lynx-time-best-move-stability-2-4599-win-x64 vs Lynx-time-node-tm-soft-less-or-equal-hard-4591-win-x64: 3955 - 3832 - 6833  [0.504] 14620
...      Lynx-time-best-move-stability-2-4599-win-x64 playing White: 3061 - 917 - 3332  [0.647] 7310
...      Lynx-time-best-move-stability-2-4599-win-x64 playing Black: 894 - 2915 - 3501  [0.362] 7310
...      White vs Black: 5976 - 1811 - 6833  [0.642] 14620
Elo difference: 2.9 +/- 4.1, LOS: 91.8 %, DrawRatio: 46.7 %
SPRT: llr 0.481 (16.6%), lbound -2.25, ubound 2.89
```

40+0.4
```
Test  | time/best-move-stability-2
Elo   | 9.18 +- 5.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 5340: +1414 -1273 =2653
Penta | [68, 578, 1258, 677, 89]
https://openbench.lynx-chess.com/test/994/
```