### PR TITLE
⌛ Add score stability (array)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,8 +114,8 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
-    [SPSA<double>(5, 50, 5)]
-    public double ScoreStabilityDelta { get; set; } = 10;
+    [SPSA<int>(5, 50, 5)]
+    public int ScoreStability { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -115,7 +115,7 @@ public sealed class EngineSettings
     public double NodeTmScale { get; set; } = 1.65;
 
     [SPSA<int>(5, 50, 5)]
-    public int ScoreStability { get; set; } = 10;
+    public int ScoreStabilityDelta { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<double>(5, 50, 5)]
+    public double ScoreStabilityDelta { get; set; } = 10;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -287,7 +287,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                        Configuration.EngineSettings.ScoreStabilityDelta = value;
                     }
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestabilitydelta":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning


### PR DESCRIPTION
```
Test  | time/score-stability-1
Elo   | -16.52 +- 9.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.32 (-2.25, 2.89) [0.00, 3.00]
Games | 1978: +505 -599 =874
Penta | [56, 264, 423, 210, 36]
https://openbench.lynx-chess.com/test/1001/
```

```
Test  | time/score-stability-1
Elo   | 0.77 +- 4.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.03 (-2.25, 2.89) [0.00, 3.00]
Games | 6732: +1682 -1667 =3383
Penta | [95, 776, 1614, 781, 100]
https://openbench.lynx-chess.com/test/1007/
```

```
Test  | time/score-stability-1-mindepth-7
Elo   | 0.43 +- 3.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.20 (-2.25, 2.89) [0.00, 3.00]
Games | 10474: +2623 -2610 =5241
Penta | [146, 1248, 2441, 1251, 151]
https://openbench.lynx-chess.com/test/1009/
```