### PR TITLE
⌛ Add score stability (pow formula with min depth)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<int>(1, 15, 1)]
+    public int ScoreStability_MinDepth { get; set; } = 7;
+
     [SPSA<int>(5, 50, 5)]
     public int ScoreStabilityDelta { get; set; } = 10;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,8 +114,8 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
-    [SPSA<double>(5, 50, 5)]
-    public double ScoreStabilityDelta { get; set; } = 10;
+    [SPSA<int>(5, 50, 5)]
+    public int ScoreStability { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -115,7 +115,7 @@ public sealed class EngineSettings
     public double NodeTmScale { get; set; } = 1.65;
 
     [SPSA<int>(5, 50, 5)]
-    public int ScoreStability { get; set; } = 10;
+    public int ScoreStabilityDelta { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<int>(1, 15, 1)]
+    public int ScoreStabiity_MinDepth { get; set; } = 7;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,12 +114,6 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
-    [SPSA<int>(1, 15, 1)]
-    public int ScoreStability_MinDepth { get; set; } = 7;
-
-    [SPSA<int>(5, 50, 5)]
-    public int ScoreStabilityDelta { get; set; } = 10;
-
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<double>(5, 50, 5)]
+    public double ScoreStabilityDelta { get; set; } = 10;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -82,7 +82,6 @@ public sealed partial class Engine
         int depth = 1;
         bool isMateDetected = false;
         Move firstLegalMove = default;
-        Span<int> searchScores = stackalloc int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
 
         _stopWatch.Restart();
 
@@ -187,8 +186,6 @@ public sealed partial class Engine
                 {
                     _bestMoveStability = 0;
                 }
-
-                searchScores[depth] = lastSearchResult.Score;
 
                 _scoreDelta = oldScore - lastSearchResult.Score;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -190,7 +190,7 @@ public sealed partial class Engine
 
                 searchScores[depth] = lastSearchResult.Score;
 
-                _scoreDelta = lastSearchResult.Score - oldScore;
+                _scoreDelta = oldScore - lastSearchResult.Score;
 
                 _engineWriter.TryWrite(lastSearchResult);
             } while (StopSearchCondition(lastSearchResult.BestMove, ++depth, mate));

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -273,7 +273,7 @@ public sealed partial class Engine
         var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
-        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreStability);
+        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreStability);
         _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -98,6 +98,7 @@ public static class TimeManager
         double nodeTmScale = Configuration.EngineSettings.NodeTmScale;
 
         double scale = 1.0;
+        double scoreStabilityFactor = 1;
 
         // Node time management: scale soft limit time bound by the proportion of nodes spent
         //   searching the best move at root level vs the total nodes searched.
@@ -117,9 +118,12 @@ public static class TimeManager
         double bestMoveStabilityFactor = _bestMoveStabilityValues[Math.Min(bestMoveStability, _bestMoveStabilityValues.Length - 1)];
         scale *= bestMoveStabilityFactor;
 
-        // Score stability: if score improves, we spend less timespend in the search
-        double scoreStabilityFactor = CalculateScoreStability(scoreDelta);
-        scale *= scoreStabilityFactor;
+        if (depth >= Configuration.EngineSettings.ScoreStabiity_MinDepth)
+        {
+            // Score stability: if score improves, we spend less timespend in the search
+            scoreStabilityFactor = CalculateScoreStability(scoreDelta);
+            scale *= scoreStabilityFactor;
+        }
 
         int newSoftTimeLimit = Math.Min(
             (int)Math.Round(searchConstraints.SoftLimitTimeBound * scale),

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -287,7 +287,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                        Configuration.EngineSettings.ScoreStabilityDelta = value;
                     }
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestabilitydelta":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,22 +283,6 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "scorestability_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.ScoreStability_MinDepth = value;
-                    }
-                    break;
-                }
-            case "scorestabilitydelta":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.ScoreStabilityDelta = value;
-                    }
-                    break;
-                }
             #endregion
 
             #region Search tuning

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -287,7 +287,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.ScoreStabiity_MinDepth = value * 0.01;
+                        Configuration.EngineSettings.ScoreStabiity_MinDepth = value;
                     }
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestabiity_mindepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStabiity_MinDepth = value * 0.01;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestability_mindepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStability_MinDepth = value;
+                    }
+                    break;
+                }
             case "scorestabilitydelta":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
This is same as #1214  but with the min depth

```
Test  | time/score-stability-5
Elo   | 2.18 +- 1.74 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 52836: +13409 -13078 =26349
Penta | [710, 6000, 12750, 6165, 793]
https://openbench.lynx-chess.com/test/1014/
```

```
Test  | time/score-stability-5
Elo   | 1.69 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.23 (-2.25, 2.89) [0.00, 3.00]
Games | 8834: +2477 -2434 =3923
Penta | [211, 1049, 1855, 1090, 212]
https://openbench.lynx-chess.com/test/1015/
```

#1214 passed STC

