### PR TITLE
⌛ Add score stability (array with min depth)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<int>(1, 15, 1)]
+    public int ScoreStability_MinDepth { get; set; } = 7;
+
     [SPSA<int>(5, 50, 5)]
     public int ScoreStabilityDelta { get; set; } = 10;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,8 +114,8 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
-    [SPSA<double>(5, 50, 5)]
-    public double ScoreStabilityDelta { get; set; } = 10;
+    [SPSA<int>(5, 50, 5)]
+    public int ScoreStability { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -115,7 +115,7 @@ public sealed class EngineSettings
     public double NodeTmScale { get; set; } = 1.65;
 
     [SPSA<int>(5, 50, 5)]
-    public int ScoreStability { get; set; } = 10;
+    public int ScoreStabilityDelta { get; set; } = 10;
 
     #endregion
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<double>(5, 50, 5)]
+    public double ScoreStabilityDelta { get; set; } = 10;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -273,7 +273,7 @@ public sealed partial class Engine
         var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
-        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreStability);
+        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreStability);
         _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -287,7 +287,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                        Configuration.EngineSettings.ScoreStabilityDelta = value;
                     }
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestabilitydelta":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStabilityDelta = value * 0.01;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "scorestability_mindepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ScoreStability_MinDepth = value;
+                    }
+                    break;
+                }
             case "scorestabilitydelta":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
```
Test  | time/score-stability-1-mindepth-7
Elo   | 0.53 +- 3.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.16 (-2.25, 2.89) [0.00, 3.00]
Games | 10492: +2630 -2614 =5248
Penta | [146, 1249, 2446, 1253, 152]
https://openbench.lynx-chess.com/test/1009/
```