### PR TITLE
⌛ Best move scale: add min depth = 7

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,9 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<int>(1, 15, 1)]
+    public int BestMoveScale_MinDepth { get; set; } = 7;
+
     #endregion
 
     [SPSA<int>(3, 10, 0.5)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -261,7 +261,7 @@ public sealed partial class Engine
         var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
         var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
-        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, bestMoveNodeCount, _nodes, _bestMoveStability);
+        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability);
         _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
         if (elapsedMilliseconds > scaledSoftLimitTimeBound)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -283,6 +283,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "bestmovescale_mindepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BestMoveScale_MinDepth = value * 0.01;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -287,7 +287,7 @@ public sealed class UCIHandler
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.BestMoveScale_MinDepth = value * 0.01;
+                        Configuration.EngineSettings.BestMoveScale_MinDepth = value;
                     }
                     break;
                 }


### PR DESCRIPTION
```
Score of Lynx-time-bmscale-mindepth-4649-win-x64 vs Lynx 4637 - main: 2240 - 2344 - 3957  [0.494] 8541
...      Lynx-time-bmscale-mindepth-4649-win-x64 playing White: 1728 - 571 - 1972  [0.635] 4271
...      Lynx-time-bmscale-mindepth-4649-win-x64 playing Black: 512 - 1773 - 1985  [0.352] 4270
...      White vs Black: 3501 - 1083 - 3957  [0.642] 8541
Elo difference: -4.2 +/- 5.4, LOS: 6.2 %, DrawRatio: 46.3 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```