### PR TITLE
🔍 LMR: increase pv min moves

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -123,7 +123,7 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
+    public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 1;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -120,10 +120,10 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 3;
+    public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 1;
+    public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -120,7 +120,10 @@ public sealed class EngineSettings
     public int LMR_MinDepth { get; set; } = 3;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int LMR_MinFullDepthSearchedMoves { get; set; } = 3;
+    public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 3;
+
+    [SPSA<int>(1, 10, 0.5)]
+    public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     /// <summary>
     /// Value originally from Stormphrax, who apparently took it from Viridithas

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -339,7 +339,11 @@ public sealed partial class Engine
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth
                 // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
-                if (visitedMovesCounter >= (pvNode ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves - 1)
+                var minLMRMoves = pvNode
+                    ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
+                    : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV;
+
+                if (visitedMovesCounter >= minLMRMoves
                     && depth >= Configuration.EngineSettings.LMR_MinDepth
                     && !isCapture)
                 {

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -295,11 +295,19 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "lmr_minfulldepthsearchedmoves":
+            case "lmr_minfulldepthsearchedmoves_pv":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves = value;
+                        Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV = value;
+                    }
+                    break;
+                }
+            case "lmr_minfulldepthsearchedmoves_nonpv":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV = value;
                     }
                     break;
                 }


### PR DESCRIPTION
```
Score of Lynx-search-lmr-pv-nonpv-2-4651-win-x64 vs Lynx 4637 - main: 212 - 244 - 424  [0.482] 880
...      Lynx-search-lmr-pv-nonpv-2-4651-win-x64 playing White: 166 - 54 - 220  [0.627] 440
...      Lynx-search-lmr-pv-nonpv-2-4651-win-x64 playing Black: 46 - 190 - 204  [0.336] 440
...      White vs Black: 356 - 100 - 424  [0.645] 880
Elo difference: -12.6 +/- 16.5, LOS: 6.7 %, DrawRatio: 48.2 %
SPRT: llr -0.597 (-20.7%), lbound -2.25, ubound 2.89
```