### PR TITLE
🔍 LMR: allow captures

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -344,8 +344,7 @@ public sealed partial class Engine
                     : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV;
 
                 if (visitedMovesCounter >= minLMRMoves
-                    && depth >= Configuration.EngineSettings.LMR_MinDepth
-                    && !isCapture)
+                    && depth >= Configuration.EngineSettings.LMR_MinDepth)
                 {
                     reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
 


### PR DESCRIPTION
See also #704, with better results

```
Score of Lynx-search-allow-lmr-captures-4654-win-x64 vs Lynx 4637 - main: 788 - 843 - 1349  [0.491] 2980
...      Lynx-search-allow-lmr-captures-4654-win-x64 playing White: 591 - 204 - 695  [0.630] 1490
...      Lynx-search-allow-lmr-captures-4654-win-x64 playing Black: 197 - 639 - 654  [0.352] 1490
...      White vs Black: 1230 - 401 - 1349  [0.639] 2980
Elo difference: -6.4 +/- 9.2, LOS: 8.7 %, DrawRatio: 45.3 %
SPRT: llr -1.07 (-37.1%), lbound -2.25, ubound 2.89
```