### PR TITLE
🔍 LMR: reduce more on cutnode

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -115,7 +115,7 @@ public sealed partial class Engine
                 if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
                     || lastSearchResult?.Score is null)
                 {
-                    bestScore = NegaMax(depth: depth, ply: 0, alpha, beta);
+                    bestScore = NegaMax(depth: depth, ply: 0, alpha, beta, cutnode: false);
                 }
                 else
                 {
@@ -139,7 +139,7 @@ public sealed partial class Engine
                         _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
                             depth, alpha, beta, bestScore, _nodes);
 
-                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta);
+                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode:false);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, |EvaluationConstants.MaxEval|, 40965
                         window += window >> 1;   // window / 2

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
+using System.Xml.Linq;
 
 namespace Lynx;
 
@@ -17,7 +18,7 @@ public sealed partial class Engine
     /// Best score Side's to move's opponent can achieve, assuming best play by Side to move.
     /// </param>
     [SkipLocalsInit]
-    private int NegaMax(int depth, int ply, int alpha, int beta, bool parentWasNullMove = false)
+    private int NegaMax(int depth, int ply, int alpha, int beta, bool cutnode, bool parentWasNullMove = false)
     {
         var position = Game.CurrentPosition;
 
@@ -42,6 +43,8 @@ public sealed partial class Engine
         int ttScore = default;
         int ttRawScore = default;
         int ttStaticEval = int.MinValue;
+
+        Debug.Assert(!pvNode || !cutnode);
 
         if (!isRoot)
         {
@@ -200,7 +203,7 @@ public sealed partial class Engine
                 //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                 var gameState = position.MakeNullMove();
-                var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, parentWasNullMove: true);
+                var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, parentWasNullMove: true);
                 position.UnMakeNullMove(gameState);
 
                 if (nmpScore >= beta)
@@ -287,8 +290,9 @@ public sealed partial class Engine
             else if (visitedMovesCounter == 0)
             {
                 _tt.PrefetchTTEntry(position);
+                bool isCutNode = !pvNode && !cutnode;   // Linter 'simplification' of pvNode ? false : !cutnode
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-                score = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                score = -NegaMax(depth - 1, ply + 1, -beta, -alpha, isCutNode);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
             }
             else
@@ -374,6 +378,8 @@ public sealed partial class Engine
                     // Don't allow LMR to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want
                     reduction = Math.Clamp(reduction, 0, depth - 2);
+
+                    Debug.Assert(!pvNode || !cutnode);
                 }
 
                 // 🔍 Static Exchange Evaluation (SEE) reduction
@@ -386,8 +392,9 @@ public sealed partial class Engine
                     reduction = Math.Clamp(reduction, 0, depth - 1);
                 }
 
+                cutnode = reduction > 0;
                 // Search with reduced depth
-                score = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha);
+                score = -NegaMax(depth - 1 - reduction, ply + 1, -alpha - 1, -alpha, cutnode);
 
                 // 🔍 Principal Variation Search (PVS)
                 if (score > alpha && reduction > 0)
@@ -397,14 +404,14 @@ public sealed partial class Engine
                     // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
                     // Search with full depth but narrowed score bandwidth
-                    score = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha);
+                    score = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha, !cutnode);
                 }
 
                 if (score > alpha && score < beta)
                 {
                     // PVS Hypothesis invalidated -> search with full depth and full score bandwidth
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
-                    score = -NegaMax(depth - 1, ply + 1, -beta, -alpha);
+                    score = -NegaMax(depth - 1, ply + 1, -beta, -alpha, cutnode: false);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
                 }
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -383,8 +383,6 @@ public sealed partial class Engine
                     // Don't allow LMR to drop into qsearch or increase the depth
                     // depth - 1 - depth +2 = 1, min depth we want
                     reduction = Math.Clamp(reduction, 0, depth - 2);
-
-                    Debug.Assert(!pvNode || !cutnode);
                 }
 
                 // 🔍 Static Exchange Evaluation (SEE) reduction

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -372,6 +372,11 @@ public sealed partial class Engine
                         ++reduction;
                     }
 
+                    if (cutnode)
+                    {
+                        ++reduction;
+                    }
+
                     // -= history/(maxHistory/2)
                     reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
 


### PR DESCRIPTION
```
Test  | search/cutnode-lmr
Elo   | 9.34 +- 4.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 9560: +2797 -2540 =4223
Penta | [221, 1112, 1955, 1173, 319]
https://openbench.lynx-chess.com/test/1022/
```

```
Test  | search/cutnode-lmr
Elo   | 1.69 +- 6.92 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.11 (-2.25, 2.89) [0.00, 3.00]
Games | 3496: +850 -833 =1813
Penta | [61, 391, 815, 432, 49]
https://openbench.lynx-chess.com/test/1026/
```


Slowdown?
![image](https://github.com/user-attachments/assets/50c66070-543f-4239-bfd2-5f58ac7a595b)
