### PR TITLE
🔍 Remove LVA part of MVV-LVA I

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -83,8 +83,8 @@ public static class EvaluationConstants
 
     public static ReadOnlySpan<int> MVV_PieceValues =>
     [
-        1000, 3500, 4000, 5000, 11000, 0,
-        1000, 3500, 4000, 5000, 11000, 0,
+        100, 350, 400, 500, 1100, 0,
+        100, 350, 400, 500, 1100, 0,
         0
     ];
 

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -48,8 +48,7 @@ public sealed partial class Engine
             Debug.Assert(capturedPiece != (int)Piece.K && capturedPiece != (int)Piece.k, $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN()}");
 
             return baseCaptureScore
-                + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
-                //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
+                + MVV_PieceValues[capturedPiece]
                 + _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
         }
 


### PR DESCRIPTION
```
Score of Lynx-move-ordering-mvv-1-4673-win-x64 vs Lynx 4665 - main: 2062 - 2129 - 3639  [0.496] 7830
...      Lynx-move-ordering-mvv-1-4673-win-x64 playing White: 1592 - 529 - 1794  [0.636] 3915
...      Lynx-move-ordering-mvv-1-4673-win-x64 playing Black: 470 - 1600 - 1845  [0.356] 3915
...      White vs Black: 3192 - 999 - 3639  [0.640] 7830
Elo difference: -3.0 +/- 5.6, LOS: 15.0 %, DrawRatio: 46.5 %
SPRT: llr -1.63 (-56.3%), lbound -2.25, ubound 2.89
```