### PR TITLE
🔍 Remove LVA part of MVV-LVA II

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -83,8 +83,8 @@ public static class EvaluationConstants
 
     public static ReadOnlySpan<int> MVV_PieceValues =>
     [
-        100, 350, 400, 500, 1100, 0,
-        100, 350, 400, 500, 1100, 0,
+        100, 300, 300, 500, 1200, 0,
+        100, 300, 300, 500, 1200, 0,
         0
     ];
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -83,8 +83,8 @@ public static class EvaluationConstants
 
     public static ReadOnlySpan<int> MVV_PieceValues =>
     [
-        1000, 3500, 4000, 5000, 11000, 0,
-        1000, 3500, 4000, 5000, 11000, 0,
+        100, 350, 400, 500, 1100, 0,
+        100, 350, 400, 500, 1100, 0,
         0
     ];
 

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -48,8 +48,7 @@ public sealed partial class Engine
             Debug.Assert(capturedPiece != (int)Piece.K && capturedPiece != (int)Piece.k, $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN()}");
 
             return baseCaptureScore
-                + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
-                //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
+                + MVV_PieceValues[capturedPiece]
                 + _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
         }
 


### PR DESCRIPTION
```
Score of Lynx-move-ordering-mvv-2-4674-win-x64 vs Lynx 4665 - main: 1593 - 1703 - 2984  [0.491] 6280
...      Lynx-move-ordering-mvv-2-4674-win-x64 playing White: 1231 - 415 - 1494  [0.630] 3140
...      Lynx-move-ordering-mvv-2-4674-win-x64 playing Black: 362 - 1288 - 1490  [0.353] 3140
...      White vs Black: 2519 - 777 - 2984  [0.639] 6280
Elo difference: -6.1 +/- 6.2, LOS: 2.8 %, DrawRatio: 47.5 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```