### PR TITLE
🔍 IIR: Only allow  in pvnodes and cutnodes

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Xml.Linq;
@@ -61,7 +62,9 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (ttElementType == default
+                && depth >= Configuration.EngineSettings.IIR_MinDepth
+                && (pvNode || cutnode))
             {
                 --depth;
             }


### PR DESCRIPTION
```
Test  | search/iir-pvnode-or-cutnode
Elo   | -6.73 +- 5.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.02 (-2.25, 2.89) [0.00, 3.00]
Games | 6812: +1768 -1900 =3144
Penta | [154, 887, 1433, 801, 131]
https://openbench.lynx-chess.com/test/1035/
```

Scheduled LTC, just in case
```
Test  | search/iir-pvnode-or-cutnode
Elo   | -2.79 +- 5.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.51 (-2.25, 2.89) [0.00, 5.00]
Games | 5098: +1228 -1269 =2601
Penta | [85, 613, 1176, 608, 67]
https://openbench.lynx-chess.com/test/1037/
```