### PR TITLE
🔍 TT cutoffs: only allow if `ttScore <= alpha` or cutnode

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
+using System.Formats.Tar;
 using System.Runtime.CompilerServices;
 using System.Security.Authentication;
 using System.Xml.Linq;
@@ -51,7 +52,9 @@ public sealed partial class Engine
             (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
 
             // TT cutoffs
-            if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
+            if (!pvNode
+                && ttScore != EvaluationConstants.NoHashEntry
+                && (ttScore <= alpha || cutnode))
             {
                 return ttScore;
             }


### PR DESCRIPTION
```
Test  | search/tt-cutoffs-cutnode-alpha
Elo   | -3.54 +- 3.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 13556: +3613 -3751 =6192
Penta | [359, 1676, 2811, 1608, 324]
https://openbench.lynx-chess.com/test/1034/
```

```
Test  | search/tt-cutoffs-cutnode-alpha
Elo   | -4.03 +- 5.34 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 5942: +1429 -1498 =3015
Penta | [103, 730, 1354, 701, 83]
https://openbench.lynx-chess.com/test/1038/
```