### PR TITLE
🧹 Remove LMT TT capture dead code

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -367,11 +367,6 @@ public sealed partial class Engine
                         ++reduction;
                     }
 
-                    if (ttBestMove != default && isCapture)
-                    {
-                        ++reduction;
-                    }
-
                     if (cutnode)
                     {
                         ++reduction;


### PR DESCRIPTION
[🔍 LMR: reduce more if there's a TT move and a capture](https://github.com/lynx-chess/Lynx/pull/706/files), despite passing LTC, is actually never triggered and bench doesn't change.