### PR TITLE
🔍 Clamp improving rate to [-1, 1]

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -119,7 +119,7 @@ public sealed partial class Engine
             {
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
                 improving = evalDiff >= 0;
-                improvingRate = evalDiff / 50.0;
+                improvingRate = Math.Clamp(evalDiff / 50.0, -1.0, +1.0);
             }
 
             // From smol.cs


### PR DESCRIPTION
```
Test  | search/improving-clamp--1-1
Elo   | -1.34 +- 2.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 25918: +6918 -7018 =11982
Penta | [622, 3174, 5438, 3132, 593]
https://openbench.lynx-chess.com/test/1036/
```