### PR TITLE
🔍 LMR: ACTUALLY Increase LMR reduction when TT move is capture

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -367,6 +367,13 @@ public sealed partial class Engine
                         ++reduction;
                     }
 
+                    if (moveScores[0] == EvaluationConstants.TTMoveScoreValue
+                        && moves[0].IsCapture())
+                    {
+                        Debug.Assert((ShortMove)moves[0] == ttBestMove);
+                        ++reduction;
+                    }
+
                     if (cutnode)
                     {
                         ++reduction;


### PR DESCRIPTION
Wrongly implemented in #706, cleaned up in #1239 after realizing that had no effect)

```
Test  | search/lmr-tt-capture
Elo   | -3.99 +- 4.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 12108: +3149 -3288 =5671
Penta | [288, 1511, 2581, 1400, 274]
https://openbench.lynx-chess.com/test/1039/
```