### PR TITLE
🔍Improving: take cutnode into account for improving rate

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -119,7 +119,7 @@ public sealed partial class Engine
             {
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
                 improving = evalDiff >= 0;
-                improvingRate = evalDiff / 50.0;
+                improvingRate = Math.Clamp(evalDiff / 50.0, -1.0, +1.0);
             }
 
             // From smol.cs

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -119,7 +119,7 @@ public sealed partial class Engine
             {
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
                 improving = evalDiff >= 0;
-                improvingRate = Math.Clamp(evalDiff / 50.0, -1.0, +1.0);
+                improvingRate = Math.Clamp(evalDiff / 50.0, cutnode ? -1.5 : -1.0, +1.0);
             }
 
             // From smol.cs


### PR DESCRIPTION
Inspired by Potential's https://github.com/ProgramciDusunur/Potential/pull/87/files

```
Test  | search/improving-clamp-cutnode
Elo   | -8.77 +- 5.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 6220: +1561 -1718 =2941
Penta | [152, 815, 1321, 682, 140]
https://openbench.lynx-chess.com/test/1041/
```