### PR TITLE
🔍 LMR: Don't decrease LMR reduction when TT move is capture 

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -367,6 +367,13 @@ public sealed partial class Engine
                         ++reduction;
                     }
 
+                    if (moveScores[0] == EvaluationConstants.TTMoveScoreValue
+                        && moves[0].IsCapture())
+                    {
+                        Debug.Assert((ShortMove)moves[0] == ttBestMove);
+                        ++reduction;
+                    }
+
                     if (cutnode)
                     {
                         ++reduction;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -367,11 +367,10 @@ public sealed partial class Engine
                         ++reduction;
                     }
 
-                    if (moveScores[0] == EvaluationConstants.TTMoveScoreValue
-                        && moves[0].IsCapture())
+                    if (moveScores[0] != EvaluationConstants.TTMoveScoreValue
+                        || !moves[0].IsCapture())
                     {
-                        Debug.Assert((ShortMove)moves[0] == ttBestMove);
-                        ++reduction;
+                        --reduction;
                     }
 
                     if (cutnode)


### PR DESCRIPTION
Another implementation of the idea in #1241 https://github.com/lynx-chess/Lynx/pull/1241 and https://github.com/lynx-chess/Lynx/pull/706
```
Test  | search/lmr-tt-capture-2
Elo   | -8.09 +- 6.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.84 (-2.25, 2.89) [0.00, 3.00]
Games | 5496: +1413 -1541 =2542
Penta | [150, 733, 1093, 639, 133]
https://openbench.lynx-chess.com/test/1042/
```