### PR TITLE
⚡ Wrap additional evaluation parameters into a context ref readonly struct 

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -627,7 +627,29 @@ public class Position : IDisposable
         };
     }
 
-    internal readonly record struct AdditionalPieceEvaluationContext(int Bucket, int PieceSquareIndex, int PieceIndex, int PieceSide, int SameSideKingSquare, int OppositeSideKingSquare, ulong EnemyPawnAttacks);
+    internal readonly ref struct AdditionalPieceEvaluationContext
+    {
+        public readonly int Bucket;
+        public readonly int PieceSquareIndex;
+        public readonly int PieceIndex;
+        public readonly int PieceSide;
+        public readonly int SameSideKingSquare;
+        public readonly int OppositeSideKingSquare;
+        public readonly ulong EnemyPawnAttacks;
+
+        public AdditionalPieceEvaluationContext(
+            int bucket, int pieceSquareIndex, int pieceIndex, int pieceSide,
+            int sameSideKingSquare, int oppositeSideKingSquare, ulong enemyPawnAttacks)
+        {
+            Bucket = bucket;
+            PieceSquareIndex = pieceSquareIndex;
+            PieceIndex = pieceIndex;
+            PieceSide = pieceSide;
+            SameSideKingSquare = sameSideKingSquare;
+            OppositeSideKingSquare = oppositeSideKingSquare;
+            EnemyPawnAttacks = enemyPawnAttacks;
+        }
+    };
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int PawnAdditionalEvaluation(in AdditionalPieceEvaluationContext context)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -989,7 +989,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
+            eval += UnpackMG(position.AdditionalPieceEvaluation(new(0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks)));
         }
 
         return eval;


### PR DESCRIPTION
```
Test  | perf/AdditionalPieceEvaluationContext-1
Elo   | -11.74 +- 6.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 4560: +1165 -1319 =2076
Penta | [97, 615, 988, 505, 75]
https://openbench.lynx-chess.com/test/1044/
```