### PR TITLE
⚡ Move TT cutoffs logic outside of TT

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -129,11 +129,6 @@ public static class EvaluationConstants
     public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1;
 
     /// <summary>
-    /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
-    /// </summary>
-    public const int NoHashEntry = 25_000;
-
-    /// <summary>
     /// Evaluation to be returned when there's one single legal move
     /// </summary>
     public const int SingleMoveScore = 200;

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -1,6 +1,4 @@
-﻿using NLog;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
@@ -63,7 +61,7 @@ public struct TranspositionTableElement
     /// <summary>
     /// Struct size in bytes
     /// </summary>
-    public static ulong Size => (ulong)Marshal.SizeOf(typeof(TranspositionTableElement));
+    public static ulong Size => (ulong)Marshal.SizeOf<TranspositionTableElement>();
 
     public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, Move? move)
     {
@@ -74,4 +72,7 @@ public struct TranspositionTableElement
         _type = nodeType;
         _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly bool IsTTHit() => Type != NodeType.Unknown;
 }


### PR DESCRIPTION
Move TT cutoffs logic outside of TT, given the can avoid evaluating it under some conditions (i.e. pvNodes mainly)


```
Test  | perf/tt-cutoffs-outside
Elo   | -7.57 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.20 (-2.25, 2.89) [0.00, 3.00]
Games | 6474: +1668 -1809 =2997
Penta | [144, 782, 1488, 717, 106]
https://openbench.lynx-chess.com/test/1046/
```