### PR TITLE
🐛 Don't allow the search to stop if no best move is found

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -226,6 +226,12 @@ public sealed partial class Engine
 
     private bool StopSearchCondition(Move bestMove, int depth, int mate)
     {
+        if (bestMove == default)
+        {
+            _logger.Warn("Search at depth {0} didn't produce a best move. Mate in {1} detected, and/but search continues", depth - 1, mate);
+            return true;
+        }
+
         if (mate != 0)
         {
             var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;


### PR DESCRIPTION
Don't allow the search to stop if no best move is found.

If we ever prune while being checkmated, it could happen that we end up without a best move.
This prevents an illegal move from being played if that's ever the case.