### PR TITLE
🔍 QSearch: Don't save best move to TT

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -627,7 +627,7 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, bestMove);
+                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta);
 
                     return bestScore; // The refutation doesn't matter, since it'll be pruned
                 }
@@ -657,7 +657,7 @@ public sealed partial class Engine
             return finalEval;
         }
 
-        _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, bestMove);
+        _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType);
 
         return bestScore;
     }


### PR DESCRIPTION
Idea by fury

```
Score of Lynx-search-qs-no-tt-bestmove-4732-win-x64 vs Lynx 4728 - main: 1382 - 1399 - 2569  [0.498] 5350
...      Lynx-search-qs-no-tt-bestmove-4732-win-x64 playing White: 1051 - 330 - 1294  [0.635] 2675
...      Lynx-search-qs-no-tt-bestmove-4732-win-x64 playing Black: 331 - 1069 - 1275  [0.362] 2675
...      White vs Black: 2120 - 661 - 2569  [0.636] 5350
Elo difference: -1.1 +/- 6.7, LOS: 37.4 %, DrawRatio: 48.0 %
SPRT: llr -0.666 (-23.0%), lbound -2.25, ubound 2.89
```