### PR TITLE
🧪 Measure `ChannelWriter` impact

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -65,12 +65,7 @@ public sealed partial class Engine : IDisposable
         }
 
 #if !DEBUG
-        // Temporary channel so that no output is generated
-        _engineWriter = Channel.CreateUnbounded<object>(new UnboundedChannelOptions() { SingleReader = true, SingleWriter = false }).Writer;
         WarmupEngine();
-
-        _engineWriter = engineWriter;
-
         NewGame();
 #endif
     }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -133,8 +133,9 @@ public sealed class Searcher
 
     public async ValueTask RunBench(int depth)
     {
-        var results = _engine.Bench(depth);
-        await _engine.PrintBenchResults(results);
+        var benchEngine = new Engine(_engineWriter);
+        var results = benchEngine.Bench(depth);
+        await benchEngine.PrintBenchResults(results);
     }
 
     private static void InitializeStaticClasses()

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -25,7 +25,7 @@ public sealed class Searcher
         _engineWriter = engineWriter;
 
         _ttWrapper = new TranspositionTable();
-        _engine = new Engine(_engineWriter, in _ttWrapper);
+        _engine = new Engine(SilentChannelWriter<object>.Instance, in _ttWrapper);
 
         _logger = LogManager.GetCurrentClassLogger();
 
@@ -73,6 +73,9 @@ public sealed class Searcher
 
         if (searchResult is not null)
         {
+            // Final info command
+            _engineWriter.TryWrite(searchResult);
+
             // We always print best move, even in case of go ponder + stop, in which case IDEs are expected to ignore it
             _engineWriter.TryWrite(new BestMoveCommand(searchResult));
         }
@@ -113,7 +116,7 @@ public sealed class Searcher
             _ttWrapper = new TranspositionTable();
 
             _engine.FreeResources();
-            _engine = new Engine(_engineWriter, in _ttWrapper);
+            _engine = new Engine(SilentChannelWriter<object>.Instance, in _ttWrapper);
         }
 
         ForceGCCollection();

--- a/src/Lynx/SilentChannelWriter.cs
+++ b/src/Lynx/SilentChannelWriter.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Channels;
+
+namespace Lynx;
+
+public sealed class SilentChannelWriter<T> : ChannelWriter<T>
+{
+    private static readonly ValueTask<bool> _defaultValueTask = new();
+
+    public static SilentChannelWriter<T> Instance { get; } = new();
+
+    /// <summary>
+    /// Explicit static constructor to tell C# compiler not to mark type as beforefieldinit
+    /// https://csharpindepth.com/articles/singleton
+    /// </summary>
+    static SilentChannelWriter() { }
+
+    private SilentChannelWriter() { }
+
+    /// <summary>
+    /// Returns <see langword="true"/>
+    /// </summary>
+    public override bool TryWrite(T item) => true;
+
+    /// <summary>
+    /// Returns a static <see cref="ValueTask"/> wrapping <see langword="true"/>
+    /// </summary>
+    /// <returns>A non-usable <see cref="ValueTask"/></returns>
+    public override ValueTask<bool> WaitToWriteAsync(CancellationToken cancellationToken = default) => _defaultValueTask;
+}


### PR DESCRIPTION
We love having uci `info` commands, but my implementation (it's been there since the beginning!) of having a dedicated engine uci channel obviously needs to have an overhead.

When introducing multithreaded search, the initial strategy is having extra engines populating the TT (#1248), but since their results aren't taken into account in that implementation, there's no need for those engines to send search information to the GUI.

Channels implementation make is very easy to avoid having that noise, but let's measure the performance impact of it in a single-thread environment.

8+0.08
```
Score of Lynx-experiment-measure-channelwriter-impact-4718-win-x64 vs Lynx 4713 - main: 6329 - 6270 - 12121  [0.501] 24720
...      Lynx-experiment-measure-channelwriter-impact-4718-win-x64 playing White: 4965 - 1345 - 6050  [0.646] 12360
...      Lynx-experiment-measure-channelwriter-impact-4718-win-x64 playing Black: 1364 - 4925 - 6071  [0.356] 12360
...      White vs Black: 9890 - 2709 - 12121  [0.645] 24720
Elo difference: 0.8 +/- 3.1, LOS: 70.0 %, DrawRatio: 49.0 %
SPRT: llr -0.809 (-28.0%), lbound -2.25, ubound 2.89
```