### PR TITLE
🧪 Measure and compare AOT performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Publish library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Upload Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
@@ -109,6 +111,8 @@ jobs:
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
           !artifacts/**/*.pdb
+          !artifacts/**/*.dbg
+          !artifacts/**/Lynx.Cli.dsym/**
         if-no-files-found: error
 
     - name: Deterministic build

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -28,6 +28,12 @@
 
     <PublishAot>true</PublishAot>
     <OptimizationPreference>Speed</OptimizationPreference>
+
+    <!--'native' instruction set optimizes for the running CPU-->
+    <!--https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md-->
+    <!--This is not useful for cross-compiling, but for this PoC it'll do.-->
+    <!--See Lizard's makefile for an example how to provide multiple instruction sets to produce different binaries-->
+    <IlcInstructionSet>native</IlcInstructionSet>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -25,6 +25,9 @@
 
     <!--https://learn.microsoft.com/en-us/dotnet/core/compatibility/interop/9.0/cet-support-->
     <CETCompat>false</CETCompat>
+
+    <PublishAot>true</PublishAot>
+    <OptimizationPreference>Speed</OptimizationPreference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <!--This just enables AOT compatibility analyzers-->
+    <!--https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#aot-compatibility-analyzers-->
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -43,9 +49,9 @@
     </AssemblyAttribute>
   </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\Lynx.Generator\Lynx.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lynx.Generator\Lynx.Generator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+  </ItemGroup>
 
   <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>


### PR DESCRIPTION
For reference, in Lizard: 16.24 +- 5.63, see https://github.com/liamt19/Lizard/pull/52

Without [CPU optimization](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md):
```
Test  | experiment/aot-speed
Elo   | -44.89 +- 10.63 (95%)
Conf  | 6.0+0.06s Threads=1 Hash=32MB
Games | 2000: +432 -689 =879
Penta | [86, 335, 365, 178, 36]
https://openbench.lynx-chess.com/test/1070/
```

With [CPU optimization](https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/docs/optimizing.md) (https://github.com/lynx-chess/Lynx/pull/1260/commits/cf6a4c61be39764ed95ae3707fcf2b481b7b5036):

```
Test  | experiment/aot-speed
Elo   | -16.89 +- 4.59 (95%)
Conf  | 6.0+0.06s Threads=1 Hash=32MB
Games | 10004: +2613 -3099 =4292
Penta | [333, 1311, 2082, 1061, 215]
https://openbench.lynx-chess.com/test/1073/
```

And there's a clear increase in bench NPS, but yeah

![image](https://github.com/user-attachments/assets/5ac727ac-7a07-4203-ac04-41d7e653b1c9)
![image](https://github.com/user-attachments/assets/111ca673-46a7-44e4-88a3-64d55adc335c)

