### PR TITLE
🐛 Fix pondering after `TimeManager` refactoring

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -162,7 +162,7 @@ public sealed partial class Engine : IDisposable
         _searchCancellationTokenSource = new();
         _absoluteSearchCancellationTokenSource = new();
 
-        if (searchConstrains.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+        if (!_isPondering && searchConstrains.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
         {
             _searchCancellationTokenSource.CancelAfter(searchConstrains.HardLimitTimeBound);
         }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -137,7 +137,7 @@ public sealed partial class Engine
                         _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
                             depth, alpha, beta, bestScore, _nodes);
 
-                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode:false);
+                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode: false);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, |EvaluationConstants.MaxEval|, 40965
                         window += window >> 1;   // window / 2
@@ -265,16 +265,19 @@ public sealed partial class Engine
             return shouldContinue;
         }
 
-        var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
-
-        var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
-        var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
-        _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
-
-        if (elapsedMilliseconds > scaledSoftLimitTimeBound)
+        if (!_isPondering)
         {
-            _logger.Info("Stopping at depth {0} (nodes {1}): {2}ms > {3}ms", depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
-            return false;
+            var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
+
+            var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
+            var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
+            _logger.Debug("[TM] Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}, scaled soft limit {ScaledSoftLimit}", depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+
+            if (elapsedMilliseconds > scaledSoftLimitTimeBound)
+            {
+                _logger.Info("Stopping at depth {0} (nodes {1}): {2}ms > {3}ms", depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
+                return false;
+            }
         }
 
         return true;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,8 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Security.Authentication;
-using System.Xml.Linq;
 
 namespace Lynx;
 

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -38,51 +38,43 @@ public static class TimeManager
         // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
         const int engineGuiCommunicationTimeOverhead = 50;
 
-        if (!isPondering)
+        if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
         {
-            if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
-            {
-                const int minSearchTime = 50;
+            const int minSearchTime = 50;
 
-                var movesDivisor = goCommand.MovesToGo == 0
-                    ? MovesDivisor(ExpectedMovesLeft(game.PositionHashHistoryLength()))
-                    : goCommand.MovesToGo;
+            var movesDivisor = goCommand.MovesToGo == 0
+                ? MovesDivisor(ExpectedMovesLeft(game.PositionHashHistoryLength()))
+                : goCommand.MovesToGo;
 
-                millisecondsLeft -= engineGuiCommunicationTimeOverhead;
-                millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
+            millisecondsLeft -= engineGuiCommunicationTimeOverhead;
+            millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
 
-                hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
+            hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
 
-                var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * Configuration.EngineSettings.SoftTimeBaseIncrementMultiplier);
-                softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * Configuration.EngineSettings.SoftTimeBoundMultiplier));
+            var softLimitBase = (millisecondsLeft / movesDivisor) + (millisecondsIncrement * Configuration.EngineSettings.SoftTimeBaseIncrementMultiplier);
+            softLimitTimeBound = Math.Min(hardLimitTimeBound, (int)(softLimitBase * Configuration.EngineSettings.SoftTimeBoundMultiplier));
 
-                _logger.Info("Soft time bound: {0}s", 0.001 * softLimitTimeBound);
-                _logger.Info("Hard time bound: {0}s", 0.001 * hardLimitTimeBound);
-            }
-            else if (goCommand.MoveTime > 0)
-            {
-                softLimitTimeBound = hardLimitTimeBound = goCommand.MoveTime - engineGuiCommunicationTimeOverhead;
-                _logger.Info("Time to move: {0}s", 0.001 * hardLimitTimeBound);
-            }
-            else if (goCommand.Depth > 0)
-            {
-                maxDepth = goCommand.Depth > Constants.AbsoluteMaxDepth ? Constants.AbsoluteMaxDepth : goCommand.Depth;
-            }
-            else if (goCommand.Infinite)
-            {
-                maxDepth = Configuration.EngineSettings.MaxDepth;
-                _logger.Info("Infinite search (depth {0})", maxDepth);
-            }
-            else
-            {
-                maxDepth = Engine.DefaultMaxDepth;
-                _logger.Warn("Unexpected or unsupported go command");
-            }
+            _logger.Info("Soft time bound: {0}s", 0.001 * softLimitTimeBound);
+            _logger.Info("Hard time bound: {0}s", 0.001 * hardLimitTimeBound);
+        }
+        else if (goCommand.MoveTime > 0)
+        {
+            softLimitTimeBound = hardLimitTimeBound = goCommand.MoveTime - engineGuiCommunicationTimeOverhead;
+            _logger.Info("Time to move: {0}s", 0.001 * hardLimitTimeBound);
+        }
+        else if (goCommand.Depth > 0)
+        {
+            maxDepth = goCommand.Depth > Constants.AbsoluteMaxDepth ? Constants.AbsoluteMaxDepth : goCommand.Depth;
+        }
+        else if (goCommand.Infinite)
+        {
+            maxDepth = Configuration.EngineSettings.MaxDepth;
+            _logger.Info("Infinite search (depth {0})", maxDepth);
         }
         else
         {
-            maxDepth = Configuration.EngineSettings.MaxDepth;
-            _logger.Info("Pondering search (depth {0})", maxDepth);
+            maxDepth = Engine.DefaultMaxDepth;
+            _logger.Warn("Unexpected or unsupported go command");
         }
 
         return new(hardLimitTimeBound, softLimitTimeBound, maxDepth);


### PR DESCRIPTION
Fix pondering after `TimeManager` refactoring in #1147 .

Now we always parse search constrains in `TimeManager.CalculateTimeManagement`, given that's only invoked once, regardless of pondering or not.

`_isPondering` flag is used to control whether hard time cancellation is scheduled and soft time bound is used to check for cancellation