### PR TITLE
🧹 Ponder: stop modifying `GoCommand.Ponder`

### DIFF
--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -120,7 +120,7 @@ public partial class Engine
             var goCommand = new GoCommand($"go depth {depth}");
             var searchConstraints = TimeManager.CalculateTimeManagement(Game, goCommand);
 
-            var result = BestMove(goCommand, in searchConstraints);
+            var result = BestMove(in searchConstraints);
 
             var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
             totalSeconds += elapsedSeconds;

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -87,7 +87,7 @@ public sealed partial class Engine : IDisposable
         AdjustPosition(Constants.SuperLongPositionCommand);
 
         var searchConstrains = TimeManager.CalculateTimeManagement(Game, command);
-        BestMove(command, in searchConstrains);
+        BestMove(in searchConstrains);
 
         Bench(2);
 
@@ -152,10 +152,10 @@ public sealed partial class Engine : IDisposable
     {
         var searchConstraints = TimeManager.CalculateTimeManagement(Game, goCommand);
 
-        return BestMove(goCommand, in searchConstraints);
+        return BestMove(in searchConstraints);
     }
 
-    public SearchResult BestMove(GoCommand goCommand, in SearchConstraints searchConstrains)
+    public SearchResult BestMove(in SearchConstraints searchConstrains)
     {
         _searchConstraints = searchConstrains;
 
@@ -171,7 +171,7 @@ public sealed partial class Engine : IDisposable
         //SearchResult resultToReturn = await SearchBestMove(maxDepth, decisionTime);
 
         Game.ResetCurrentPositionToBeforeSearchState();
-        if (!goCommand.Ponder
+        if (!_isPondering
             && resultToReturn.BestMove != default
             && !_absoluteSearchCancellationTokenSource.IsCancellationRequested)
         {
@@ -241,12 +241,10 @@ public sealed partial class Engine : IDisposable
         try
         {
             _isPondering = goCommand.Ponder;
-            var searchResult = BestMove(goCommand, in searchConstraints);
+            var searchResult = BestMove(in searchConstraints);
 
             if (_isPondering)
             {
-                // Using either field or local copy for the rest of the method, since goCommand.Ponder could change
-
                 // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
                 // before a potential ponderhit command
                 // _absoluteSearchCancellationTokenSource.IsCancellationRequested isn't reliable because
@@ -257,9 +255,8 @@ public sealed partial class Engine : IDisposable
                 {
                     _isPonderHit = false;
                     _isPondering = false;
-                    goCommand.DisablePonder();
 
-                    searchResult = BestMove(goCommand, in searchConstraints);
+                    searchResult = BestMove(in searchConstraints);
                 }
             }
 

--- a/src/Lynx/UCI/Commands/GUI/GoCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/GoCommand.cs
@@ -58,7 +58,7 @@ public sealed class GoCommand : IGUIBaseCommand
     public int Depth { get; }
     public int MoveTime { get; }
     public bool Infinite { get; }
-    public bool Ponder { get; private set; }
+    public bool Ponder { get; }
 
     public static int Nodes => throw new NotImplementedException();
     public static int Mate => throw new NotImplementedException();
@@ -179,6 +179,4 @@ public sealed class GoCommand : IGUIBaseCommand
     }
 
     public static string Init() => Id;
-
-    public void DisablePonder() => Ponder = false;
 }


### PR DESCRIPTION
Stop modifying `GoCommand.Ponder`, using `_isPondering` instead.
This is an enabler for pondering in multi-threading.

```
Score of Lynx-refactor-stop-relying-on-gocommand-ponder-state-4757-win-x64 vs Lynx 4756 - main: 1602 - 1576 - 3422  [0.502] 6600
...      Lynx-refactor-stop-relying-on-gocommand-ponder-state-4757-win-x64 playing White: 1296 - 303 - 1702  [0.650] 3301
...      Lynx-refactor-stop-relying-on-gocommand-ponder-state-4757-win-x64 playing Black: 306 - 1273 - 1720  [0.353] 3299
...      White vs Black: 2569 - 609 - 3422  [0.648] 6600
Elo difference: 1.4 +/- 5.8, LOS: 67.8 %, DrawRatio: 51.8 %
SPRT: llr 2.2 (76.0%), lbound -2.25, ubound 2.89
```