### PR TITLE
🐛 IDDFS finishes some depths with no moves

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -155,17 +155,14 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Min(bestScore + window, EvaluationConstants.MaxEval);
-                            ++failHighReduction;
+                            if (failHighReduction <= depth - 2)
+                            {
+                                ++failHighReduction;
+                            }
                         }
                         else
                         {
                             break;
-                        }
-
-                        // We don't reduce if we're being checkmated
-                        if (failHighReduction >= depth)
-                        {
-                            failHighReduction = 0;
                         }
                     }
                 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -134,10 +134,15 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        _logger.Debug("Aspiration windows depth {Depth}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                            depth, alpha, beta, bestScore, _nodes);
+                        // We don't reduce if we're being checkmated
+                        var reduction = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit
+                            ? failHighReduction
+                            : 0;
 
-                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode: false);
+                        _logger.Debug("Aspiration windows depth {Depth} ({DepthWithoutReduction} - {Reduction}): [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
+                            depth - reduction, depth, reduction, alpha, beta, bestScore, _nodes);
+
+                        bestScore = NegaMax(depth: depth - reduction, ply: 0, alpha, beta, cutnode: false);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, |EvaluationConstants.MaxEval|, 40965
                         window += window >> 1;   // window / 2
@@ -252,6 +257,7 @@ public sealed partial class Engine
                 $"[#{_id}] " +
 #endif
                 "Search continues, due to lack of best move at depth {0}", depth - 1);
+
             return true;
         }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -134,15 +134,10 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        // We don't reduce if we're being checkmated
-                        var reduction = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit
-                            ? failHighReduction
-                            : 0;
-
                         _logger.Debug("Aspiration windows depth {Depth} ({DepthWithoutReduction} - {Reduction}): [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                            depth - reduction, depth, reduction, alpha, beta, bestScore, _nodes);
+                            depth - failHighReduction, depth, failHighReduction, alpha, beta, bestScore, _nodes);
 
-                        bestScore = NegaMax(depth: depth - reduction, ply: 0, alpha, beta, cutnode: false);
+                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode: false);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, |EvaluationConstants.MaxEval|, 40965
                         window += window >> 1;   // window / 2
@@ -162,6 +157,12 @@ public sealed partial class Engine
                         else
                         {
                             break;
+                        }
+
+                        // We don't reduce if we're being checkmated
+                        if (bestScore >= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                        {
+                            failHighReduction = 0;
                         }
                     }
                 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -160,7 +160,7 @@ public sealed partial class Engine
                         }
 
                         // We don't reduce if we're being checkmated
-                        if (bestScore <= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                        if (failHighReduction >= depth)
                         {
                             failHighReduction = 0;
                         }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -134,10 +134,13 @@ public sealed partial class Engine
 
                     while (true)
                     {
-                        _logger.Debug("Aspiration windows depth {Depth} ({DepthWithoutReduction} - {Reduction}): [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                            depth - failHighReduction, depth, failHighReduction, alpha, beta, bestScore, _nodes);
+                        var depthToSearch = depth - failHighReduction;
+                        Debug.Assert(depthToSearch > 0);
 
-                        bestScore = NegaMax(depth: depth - failHighReduction, ply: 0, alpha, beta, cutnode: false);
+                        _logger.Debug("Aspiration windows depth {Depth} ({DepthWithoutReduction} - {Reduction}): [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
+                            depthToSearch, depth, failHighReduction, alpha, beta, bestScore, _nodes);
+
+                        bestScore = NegaMax(depth: depthToSearch, ply: 0, alpha, beta, cutnode: false);
 
                         // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, |EvaluationConstants.MaxEval|, 40965
                         window += window >> 1;   // window / 2

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -304,7 +304,7 @@ public sealed partial class Engine
         {
             var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
-            var bestMoveNodeCount = _moveNodeCount[bestMove.Piece()][bestMove.TargetSquare()];
+            var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
             var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
             _logger.Debug(
 #if MULTITHREAD_DEBUG

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -160,7 +160,7 @@ public sealed partial class Engine
                         }
 
                         // We don't reduce if we're being checkmated
-                        if (bestScore >= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                        if (bestScore <= EvaluationConstants.NegativeCheckmateDetectionLimit)
                         {
                             failHighReduction = 0;
                         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -18,6 +18,8 @@ public sealed partial class Engine
     [SkipLocalsInit]
     private int NegaMax(int depth, int ply, int alpha, int beta, bool cutnode, bool parentWasNullMove = false)
     {
+        Debug.Assert(depth > 0);
+
         var position = Game.CurrentPosition;
 
         // Prevents runtime failure in case depth is increased due to check extension, since we're using ply when calculating pvTable index,

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -18,8 +18,6 @@ public sealed partial class Engine
     [SkipLocalsInit]
     private int NegaMax(int depth, int ply, int alpha, int beta, bool cutnode, bool parentWasNullMove = false)
     {
-        Debug.Assert(depth > 0);
-
         var position = Game.CurrentPosition;
 
         // Prevents runtime failure in case depth is increased due to check extension, since we're using ply when calculating pvTable index,


### PR DESCRIPTION
It turns out that after #800 some positions (while being checkmated) were searched at depth 0 due to the fail high reduction introduced for aspiration windows grew as high as the depth.

This PR fixes that limiting the reduction to depth -1, hence searching at least depth 1.

```
Score of Lynx-bugfix-detect-no-bestmove-4792-win-x64 vs Lynx 4778 - main: 2761 - 2734 - 5195  [0.501] 10690
...      Lynx-bugfix-detect-no-bestmove-4792-win-x64 playing White: 2124 - 644 - 2577  [0.638] 5345
...      Lynx-bugfix-detect-no-bestmove-4792-win-x64 playing Black: 637 - 2090 - 2618  [0.364] 5345
...      White vs Black: 4214 - 1281 - 5195  [0.637] 10690
Elo difference: 0.9 +/- 4.7, LOS: 64.2 %, DrawRatio: 48.6 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```

No warnings in logs no, although I managed to produce them while playing 2 threads and pondering vs 2 threads and pondering in 3/3k games
```
Score of Lynx-bugfix-detect-no-bestmove-mt-debug-4803-win-x64 vs Lynx-bugfix-detect-no-bestmove-mt-debug-4803-win-x64: 536 - 509 - 1915  [0.505] 2960
...      Lynx-bugfix-detect-no-bestmove-mt-debug-4803-win-x64 playing White: 306 - 204 - 970  [0.534] 1480
...      Lynx-bugfix-detect-no-bestmove-mt-debug-4803-win-x64 playing Black: 230 - 305 - 945  [0.475] 1480
...      White vs Black: 611 - 434 - 1915  [0.530] 2960
Elo difference: 3.2 +/- 7.4, LOS: 79.8 %, DrawRatio: 64.7 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf
```

```
2024-12-11 07:30:36.2542|0|18996|WARN|Lynx.Engine|[#1] Search at depth 2 didn't produce a best move. Score -32000 (mate in -150) detected, and/but search continues 
2024-12-11 07:30:36.2542|0|18996|WARN|Lynx.Engine|[#2] Search at depth 2 didn't produce a best move. Score -32000 (mate in -150) detected, and/but search continues 

```