### PR TITLE
🔍 Use the right score for NMP TT condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -187,7 +187,7 @@ public sealed partial class Engine
                 && staticEvalBetaDiff >= 0
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                && (ttElementType != NodeType.Alpha || ttRawScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
                     + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity


### PR DESCRIPTION
`ttScore` might be set to `NoHashEntry` in the cutoff stage, so probably `ttRawScore` is more accurate here.

No bench change (but should/could?)

```
Test  | search/nmp-tt-score
Elo   | 1.51 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 1.00]
Games | 26190: +7110 -6996 =12084
Penta | [520, 3042, 5863, 3144, 526]
https://openbench.lynx-chess.com/test/1080/
```