### PR TITLE
🔍 Use recalculated TT sccores for non-cutoffs

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -67,21 +67,16 @@ public readonly struct TranspositionTable
         }
 
         var type = entry.Type;
-        var rawScore = entry.Score;
+        var rawScore = RecalculateMateScores(entry.Score, ply);
         var score = EvaluationConstants.NoHashEntry;
 
-        if (entry.Depth >= depth)
+        if (entry.Depth >= depth && (type == NodeType.Exact
+                || (type == NodeType.Alpha && rawScore <= alpha)
+                || (type == NodeType.Beta && rawScore >= beta)))
         {
-            var recalculatedScore = RecalculateMateScores(rawScore, ply);
-
-            if (type == NodeType.Exact
-                || (type == NodeType.Alpha && recalculatedScore <= alpha)
-                || (type == NodeType.Beta && recalculatedScore >= beta))
-            {
-                // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
-                // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
-                score = recalculatedScore;
-            }
+            // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
+            // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
+            score = rawScore;
         }
 
         return (score, entry.Move, entry.Type, rawScore, entry.StaticEval);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -187,7 +187,7 @@ public sealed partial class Engine
                 && staticEvalBetaDiff >= 0
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                && (ttElementType != NodeType.Alpha || ttRawScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
                     + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity


### PR DESCRIPTION
```
Test  | search/recalculate-non-cutoff-mate-scores
Elo   | -1.20 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [-3.00, 1.00]
Games | 79118: +21216 -21490 =36412
Penta | [1765, 9391, 17459, 9241, 1703]
https://openbench.lynx-chess.com/test/1084/
```