### PR TITLE
🐛 Make sure `staticEval` var always gets initialized as part of the search

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -79,12 +79,13 @@ public sealed partial class Engine
         double improvingRate = 0;
 
         bool isInCheck = position.IsInCheck();
-        int staticEval = int.MaxValue;
+        int staticEval;
         int phase = int.MaxValue;
 
         if (isInCheck)
         {
             ++depth;
+            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         }
         else if (depth <= 0)
         {
@@ -214,6 +215,10 @@ public sealed partial class Engine
                     }
                 }
             }
+        }
+        else
+        {
+            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];


### PR DESCRIPTION
Otherwise, the (short) version of `int.MaxValue` gets to the TT.

```
Test  | bugfix/unitialized-staticeval
Elo   | 0.32 +- 2.97 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | 23890: +6620 -6598 =10672
Penta | [618, 2897, 4936, 2833, 661]
https://openbench.lynx-chess.com/test/1085/
```