### PR TITLE
🔍 Razoring: simplified implementation

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -187,13 +187,10 @@ public sealed class EngineSettings
     public int RFP_DepthScalingFactor { get; set; } = 52;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 2;
+    public int Razoring_MaxDepth { get; set; } = 4;
 
-    [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 68;
-
-    [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 208;
+    [SPSA<int>(100, 500, 25)]
+    public int RazoringMargin { get; set; } = 300;
 
     [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -153,35 +153,15 @@ public sealed partial class Engine
 #pragma warning restore S3949 // Calculations should not overflow
                     }
 
-                    // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
-                    if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
+                    // 🔍 Razoring - Stormphrax implementation
+                    if (depth <= Configuration.EngineSettings.Razoring_MaxDepth
+                        && Math.Abs(alpha) < 2000
+                        && staticEval + Configuration.EngineSettings.RazoringMargin * depth <= alpha)
                     {
-                        var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
+                        var qSearchScore = QuiescenceSearch(ply, alpha, beta);
 
-                        if (score < beta)               // Static evaluation + bonus indicates fail-low node
-                        {
-                            if (depth == 1)
-                            {
-                                var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-
-                                return qSearchScore > score
-                                    ? qSearchScore
-                                    : score;
-                            }
-
-                            score += Configuration.EngineSettings.Razoring_NotDepth1Bonus;
-
-                            if (score < beta)               // Static evaluation indicates fail-low node
-                            {
-                                var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-                                if (qSearchScore < beta)    // Quiescence score also indicates fail-low node
-                                {
-                                    return qSearchScore > score
-                                        ? qSearchScore
-                                        : score;
-                                }
-                            }
-                        }
+                        if (qSearchScore <= alpha)
+                            return qSearchScore;
                     }
                 }
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -432,19 +432,12 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "razoring_depth1bonus":
+
+            case "razoringmargin":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.Razoring_Depth1Bonus = value;
-                    }
-                    break;
-                }
-            case "razoring_notdepth1bonus":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_NotDepth1Bonus = value;
+                        Configuration.EngineSettings.RazoringMargin = value;
                     }
                     break;
                 }


### PR DESCRIPTION
Alternative impl. based on Stormphrax

```
Test  | search/razoring-simplified
Elo   | -4.29 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 11582: +3103 -3246 =5233
Penta | [303, 1464, 2367, 1387, 270]
https://openbench.lynx-chess.com/test/1087/
```