### PR TITLE
🔍 Remove razoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,6 @@ _Beware, most of the provided links contain outdated information and don't refle
 
 - Static Exchange Evaluation (SEE) for move ordering, reduction and QSearch pruning
 
-- Razoring [[1](https://www.chessprogramming.org/Razoring)]
-
 - Killer heuristic [[1](https://www.chessprogramming.org/Killer_Heuristic)]
 
 - History heuristic: quiet history, capture history, continuation history, history malus [[1](https://www.chessprogramming.org/History_Heuristic)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -187,15 +187,6 @@ public sealed class EngineSettings
     public int RFP_DepthScalingFactor { get; set; } = 52;
 
     [SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 2;
-
-    [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 68;
-
-    [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 208;
-
-    [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
 
     [SPSA<int>(1, 10, 0.5)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -152,37 +152,6 @@ public sealed partial class Engine
                         return (staticEval + beta) / 2;
 #pragma warning restore S3949 // Calculations should not overflow
                     }
-
-                    // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
-                    if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
-                    {
-                        var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
-
-                        if (score < beta)               // Static evaluation + bonus indicates fail-low node
-                        {
-                            if (depth == 1)
-                            {
-                                var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-
-                                return qSearchScore > score
-                                    ? qSearchScore
-                                    : score;
-                            }
-
-                            score += Configuration.EngineSettings.Razoring_NotDepth1Bonus;
-
-                            if (score < beta)               // Static evaluation indicates fail-low node
-                            {
-                                var qSearchScore = QuiescenceSearch(ply, alpha, beta);
-                                if (qSearchScore < beta)    // Quiescence score also indicates fail-low node
-                                {
-                                    return qSearchScore > score
-                                        ? qSearchScore
-                                        : score;
-                                }
-                            }
-                        }
-                    }
                 }
 
                 var staticEvalBetaDiff = staticEval - beta;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -424,31 +424,6 @@ public sealed class UCIHandler
                     break;
                 }
 
-            case "razoring_maxdepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_MaxDepth = value;
-                    }
-                    break;
-                }
-            case "razoring_depth1bonus":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_Depth1Bonus = value;
-                    }
-                    break;
-                }
-            case "razoring_notdepth1bonus":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.Razoring_NotDepth1Bonus = value;
-                    }
-                    break;
-                }
-
             case "iir_mindepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))

--- a/tests/Lynx.Test/ConfigurationValuesTest.cs
+++ b/tests/Lynx.Test/ConfigurationValuesTest.cs
@@ -11,19 +11,4 @@ namespace Lynx.Test;
 [NonParallelizable]
 public class ConfigurationValuesTest
 {
-    [Test]
-    public void RazoringValues()
-    {
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
-
-        var config = new ConfigurationBuilder()
-            .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
-            .Build();
-
-        var engineSettingsSection = config.GetRequiredSection(nameof(EngineSettings));
-        Assert.IsNotNull(engineSettingsSection);
-        engineSettingsSection.Bind(Configuration.EngineSettings);
-
-        Assert.Greater(Configuration.EngineSettings.RFP_MaxDepth, Configuration.EngineSettings.Razoring_MaxDepth);
-    }
 }


### PR DESCRIPTION
```
Test  | search/remove-razoring
Elo   | -2.75 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 16162: +4344 -4472 =7346
Penta | [403, 2022, 3311, 1990, 355]
https://openbench.lynx-chess.com/test/1086/
```