### PR TITLE
🐛 Limit checkmate scores whenever probing/saving to TT

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+using NLog;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -178,13 +178,28 @@ public readonly struct TranspositionTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int RecalculateMateScores(int score, int ply)
     {
+        const int maxCheckMateScore = EvaluationConstants.CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + Constants.ArrayDepthMargin) * EvaluationConstants.CheckmateDepthFactor;
+        const int minCheckMateScore = -EvaluationConstants.CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + Constants.ArrayDepthMargin) * EvaluationConstants.CheckmateDepthFactor;
+
         if (score > EvaluationConstants.PositiveCheckmateDetectionLimit)
         {
-            return score - (EvaluationConstants.CheckmateDepthFactor * ply);
+            var newScore = score - (EvaluationConstants.CheckmateDepthFactor * ply);
+
+            if (newScore > maxCheckMateScore)
+            {
+                newScore = maxCheckMateScore;
+            }
+            return newScore;
         }
         else if (score < EvaluationConstants.NegativeCheckmateDetectionLimit)
         {
-            return score + (EvaluationConstants.CheckmateDepthFactor * ply);
+            var newScore = score + (EvaluationConstants.CheckmateDepthFactor * ply);
+
+            if (newScore < minCheckMateScore)
+            {
+                newScore = minCheckMateScore;
+            }
+            return newScore;
         }
 
         return score;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -165,7 +165,7 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Clamp(bestScore + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                            if (failHighReduction <= depth - 2)
+                            if (failHighReduction <= 3)
                             {
                                 ++failHighReduction;
                             }


### PR DESCRIPTION
This is a workaround for an issue that implies abnormally growing checkmate scores in both directions.
```
Test  | experiment/fix-wrong-mate-scorez
Elo   | -4.94 +- 4.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 10766: +2838 -2991 =4937
Penta | [292, 1374, 2156, 1317, 244]
https://openbench.lynx-chess.com/test/1093/
```