### PR TITLE
🐛 Limit checkmate scores whenever probing/saving to TT II

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -1,4 +1,4 @@
-﻿using NLog;
+using NLog;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -178,13 +178,28 @@ public readonly struct TranspositionTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int RecalculateMateScores(int score, int ply)
     {
+        const int maxCheckMateScore = EvaluationConstants.CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + Constants.ArrayDepthMargin) * EvaluationConstants.CheckmateDepthFactor;
+        const int minCheckMateScore = -EvaluationConstants.CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + Constants.ArrayDepthMargin) * EvaluationConstants.CheckmateDepthFactor;
+
         if (score > EvaluationConstants.PositiveCheckmateDetectionLimit)
         {
-            return score - (EvaluationConstants.CheckmateDepthFactor * ply);
+            var newScore = score - (EvaluationConstants.CheckmateDepthFactor * ply);
+
+            if (newScore > maxCheckMateScore)
+            {
+                newScore = maxCheckMateScore;
+            }
+            return newScore;
         }
         else if (score < EvaluationConstants.NegativeCheckmateDetectionLimit)
         {
-            return score + (EvaluationConstants.CheckmateDepthFactor * ply);
+            var newScore = score + (EvaluationConstants.CheckmateDepthFactor * ply);
+
+            if (newScore < minCheckMateScore)
+            {
+                newScore = minCheckMateScore;
+            }
+            return newScore;
         }
 
         return score;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -165,7 +165,7 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Clamp(bestScore + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                            if (failHighReduction <= depth - 2)
+                            if (failHighReduction <= 3)
                             {
                                 ++failHighReduction;
                             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -137,7 +137,7 @@ public sealed partial class Engine
             if (isNotGettingCheckmated)
             {
                 if (depth <= Configuration.EngineSettings.RFP_MaxDepth
-                    && staticEval < EvaluationConstants.PositiveCheckmateDetectionLimit)
+                    && staticEval < EvaluationConstants.PositiveCheckmateDetectionLimit)    // Fail retard and razoring bonuses mess with mate scores
                 {
                     // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                     // Return formula by Ciekce, instead of just returning static eval
@@ -149,7 +149,8 @@ public sealed partial class Engine
 
                     if (staticEval - rfpThreshold >= beta)
                     {
-                        // return (staticEval + beta) / 2; Also causes issues when beta is very high/low
+                        // Fail medium, aka fail 'retard'
+                        //return (staticEval + beta) / 2; //Also causes issues when beta is very high/low
                         return staticEval;
                     }
 
@@ -166,7 +167,7 @@ public sealed partial class Engine
 
                                 return qSearchScore > score
                                     ? qSearchScore
-                                    : staticEval;
+                                    : score;
                             }
 
                             score += Configuration.EngineSettings.Razoring_NotDepth1Bonus;
@@ -178,7 +179,7 @@ public sealed partial class Engine
                                 {
                                     return qSearchScore > score
                                         ? qSearchScore
-                                        : staticEval;
+                                        : score;
                                 }
                             }
                         }


### PR DESCRIPTION
This is a workaround for an issue that implies abnormally growing checkmate scores in both directions:
- Limit mate scores on TT read/save
- Remove fail medium from RFP



```
Test  | experiment/fix-wrong-mate-scorez-2
Elo   | -3.32 +- 3.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 16726: +4439 -4599 =7688
Penta | [413, 2043, 3563, 1979, 365]
https://openbench.lynx-chess.com/test/1094/
```