### PR TITLE
Detect scores outside of valid ranges and stop searching

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -114,9 +114,13 @@ public static class EvaluationConstants
     public const int PositiveCheckmateDetectionLimit = 26_000; // CheckMateBaseEvaluation - (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
 
     /// <summary>
-    /// Minimum evaluation for a position to be Black checkmate
+    /// Maximum evaluation for a position to be Black checkmate
     /// </summary>
     public const int NegativeCheckmateDetectionLimit = -26_000; // -CheckMateBaseEvaluation + (Constants.AbsoluteMaxDepth + 45) * DepthCheckmateFactor;
+
+    public const int MaxMate = 1500; // Utils.CalculateMateInX(PositiveCheckmateDetectionLimit + 1);
+
+    public const int MinMate = -1500; // Utils.CalculateMateInX(NegativeCheckmateDetectionLimit -1);
 
     /// <summary>
     /// Max static eval. It doesn't include checkmate values and it's below <see cref="PositiveCheckmateDetectionLimit"/>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -164,7 +164,7 @@ public sealed partial class Engine
                         else if (beta <= bestScore)     // Fail high
                         {
                             beta = Math.Clamp(bestScore + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                            if (failHighReduction < 3)
+                            if (failHighReduction <= depth - 2)
                             {
                                 ++failHighReduction;
                             }


### PR DESCRIPTION
Add check for scores outside of `[-CheckMateBaseEvaluation, +CheckMateBaseEvaluation]`, acknowledging the bug, and don't waste time with them: just play the best move from that or the previous depth

```
Test  | perf/ack-bug-and-not-waste-time
Elo   | 0.65 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 43078: +11755 -11674 =19649
Penta | [886, 4955, 9760, 5068, 870]
https://openbench.lynx-chess.com/test/1100/
```