### PR TITLE
🔍 Don't clear last search result on a mate out of range discovery

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -488,7 +488,7 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                $"Search cancelled at depth {depth} with no result (hard limit {_searchConstraints.HardLimitTimeBound}ms, soft limit {_searchConstraints.SoftLimitTimeBound}ms), choosing first found legal move as best one";
+                $"Depth {depth}: Search cancelled with no result for position {Game.CurrentPosition.FEN()} (hard limit {_searchConstraints.HardLimitTimeBound}ms, soft limit {_searchConstraints.SoftLimitTimeBound}ms). Choosing first found legal move as best one";
 
             // In the event of a quick ponderhit/stop while pondering because the opponent moved quickly, we don't want no warning triggered here
             //  when cancelling the pondering search

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -313,8 +313,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                     $"[#{_id}] " +
 #endif
-                    "Depth {0}: mate in {1} detected for position {Position}, which is outside of our range. Stopping search",
-                    depth - 1, mate, Game.PositionBeforeLastSearch.FEN());
+                    "Depth {Depth}: mate outside of range detected, stopping search",
+                    depth - 1);
 
                 return false;
             }
@@ -324,7 +324,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                "Depth {0}: mate in {1} detected (score {2}, {3} moves until draw by repetition)", depth - 1, mate, bestScore, winningMateThreshold);
+                "Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+                depth - 1, mate, bestScore, winningMateThreshold);
 
             if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
             {
@@ -346,7 +347,7 @@ public sealed partial class Engine
 
         if (depth >= Configuration.EngineSettings.MaxDepth)
         {
-            _logger.Info("Max depth reached: {0}", Configuration.EngineSettings.MaxDepth);
+            _logger.Info("Max depth reached: {MaxDepth}", Configuration.EngineSettings.MaxDepth);
             return false;
         }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -227,7 +227,6 @@ public sealed partial class Engine
                         "Depth {Depth}: Search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}?) detected",
                         depth, Game.PositionBeforeLastSearch.FEN(), bestScore, mate);
 
-                    lastSearchResult = null;
                     _bestMoveStability = 0;
                     _scoreDelta = 0;
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -180,7 +180,7 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                                "Depth {Depth}: Potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits. Best move {BestMove}",
+                                "Depth {Depth}: Potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
                                 depth, Game.PositionBeforeLastSearch.FEN(), bestScore);
 
                             bestScore = EvaluationConstants.PositiveCheckmateDetectionLimit + 1;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -180,7 +180,7 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                                "Depth {Depth}: Potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
+                                "Depth {Depth}: Potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits. Best move {BestMove}",
                                 depth, Game.PositionBeforeLastSearch.FEN(), bestScore);
 
                             bestScore = EvaluationConstants.PositiveCheckmateDetectionLimit + 1;
@@ -312,8 +312,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                     $"[#{_id}] " +
 #endif
-                    "Depth {Depth}: mate outside of range detected, stopping search",
-                    depth - 1);
+                    "Depth {Depth}: mate outside of range detected, stopping search and playing best move {BestMove}",
+                    depth - 1, bestMove);
 
                 return false;
             }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -180,7 +180,9 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                                "Depth {Depth}: Potential +X checkmate detected, but score {BestScore} outside of the limits", depth, bestScore);
+                                "Depth {Depth}: Potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
+                                depth, Game.PositionBeforeLastSearch.FEN(), bestScore);
+
                             bestScore = EvaluationConstants.PositiveCheckmateDetectionLimit + 1;
 
                             break;
@@ -192,7 +194,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                                "Depth {Depth}: Potential -X checkmate detected, but score {BestScore} outside of the limits", depth, bestScore);
+                                "Depth {Depth}: Potential -X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
+                                depth, Game.PositionBeforeLastSearch.FEN(), bestScore);
 
                             bestScore = EvaluationConstants.NegativeCheckmateDetectionLimit - 1;
 
@@ -221,7 +224,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                        "Depth {Depth}: Search didn't produce a best move. Score {Score} (mate in {Mate}) detected, and/but search continues", depth, bestScore, mate);
+                        "Depth {Depth}: Search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}) detected, and/but search continues",
+                        depth, Game.PositionBeforeLastSearch.FEN(), bestScore, mate);
 
                     lastSearchResult = null;
                     _bestMoveStability = 0;
@@ -267,7 +271,8 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                "Depth {Depth}: Unexpected error ocurred during the search of position {Position}, best move will be returned\n{StackTrace}", depth, Game.PositionBeforeLastSearch.FEN(), e.StackTrace);
+                "Depth {Depth}: Unexpected error ocurred during the search of position {Position}, best move will be returned\n{StackTrace}",
+                depth, Game.PositionBeforeLastSearch.FEN(), e.StackTrace);
         }
         finally
         {
@@ -304,11 +309,13 @@ public sealed partial class Engine
         {
             if (mate == EvaluationConstants.MaxMate || mate == EvaluationConstants.MinMate)
             {
-                _logger.Info(
+                _logger.Warn(
 #if MULTITHREAD_DEBUG
                     $"[#{_id}] " +
 #endif
-                    "Depth {0}: mate in {1} detected, which is outside of our range. Stopping search", depth - 1, mate);
+                    "Depth {0}: mate in {1} detected for position {Position}, which is outside of our range. Stopping search",
+                    depth - 1, mate, Game.PositionBeforeLastSearch.FEN());
+
                 return false;
             }
 
@@ -326,6 +333,7 @@ public sealed partial class Engine
                 $"[#{_id}] " +
 #endif
                     "Stopping search, mate is short enough");
+
                 return false;
             }
 
@@ -479,7 +487,7 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                $"Search cancelled at depth {depth} with no result, choosing first found legal move as best one";
+                $"Search cancelled at depth {depth} with no result (hard limit {_searchConstraints.HardLimitTimeBound}ms, soft limit {_searchConstraints.SoftLimitTimeBound}ms), choosing first found legal move as best one";
 
             // In the event of a quick ponderhit/stop while pondering because the opponent moved quickly, we don't want no warning triggered here
             //  when cancelling the pondering search

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -224,7 +224,7 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 $"[#{_id}] " +
 #endif
-                        "Depth {Depth}: Search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}) detected, and/but search continues",
+                        "Depth {Depth}: Search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}?) detected",
                         depth, Game.PositionBeforeLastSearch.FEN(), bestScore, mate);
 
                     lastSearchResult = null;


### PR DESCRIPTION
* Don't clear last search result on a mate out of range discovery
* Improve warning logs

Example of what can happen when we clear the last search result:
```
|Depth 27: Potential +X checkmate detected in position "1r3k2/8/8/8/2n5/8/8/K7 b - - 0 1", but score 29002 outside of the limits
|Depth 27: Search didn't produce a best move for position "1r3k2/8/8/8/2n5/8/8/K7 b - - 0 1". Score 26001 (mate in 1500?) detected
|Depth 27: Search continues, due to lack of best move
|Depth 28: Search didn't produce a best move for position "1r3k2/8/8/8/2n5/8/8/K7 b - - 0 1". Score 28983 (mate in 9?) detected
|Depth 28: Search continues, due to lack of best move
|Depth 29: Search cancelled with no result for position "1r3k2/8/8/8/2n5/8/8/K7 b - - 0 1" (hard limit 84ms, soft limit 76ms). Choosing first found legal move as best one
```

[-5, 0]
```
Score of Lynx-improve-warning-logs-4874-win-x64 vs Lynx 4867 - main: 562 - 511 - 1067  [0.512] 2140
...      Lynx-improve-warning-logs-4874-win-x64 playing White: 444 - 113 - 513  [0.655] 1070
...      Lynx-improve-warning-logs-4874-win-x64 playing Black: 118 - 398 - 554  [0.369] 1070
...      White vs Black: 842 - 231 - 1067  [0.643] 2140
Elo difference: 8.3 +/- 10.4, LOS: 94.0 %, DrawRatio: 49.9 %
SPRT: llr 1.91 (66.0%), lbound -2.25, ubound 2.89
```