### PR TITLE
🧹 Make engine id an integer

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -12,7 +12,7 @@ public sealed partial class Engine : IDisposable
     internal const int DefaultMaxDepth = 5;
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-    private readonly string _id;
+    private readonly int _id;
     private readonly ChannelWriter<object> _engineWriter;
     private readonly TranspositionTable _tt;
     private SearchConstraints _searchConstraints;
@@ -39,10 +39,10 @@ public sealed partial class Engine : IDisposable
 
     private CancellationToken _searchCancellationToken = CancellationToken.None;
     private CancellationToken _absoluteSearchCancellationToken = CancellationToken.None;
-    public Engine(ChannelWriter<object> engineWriter) : this("0", engineWriter, new()) { }
+    public Engine(ChannelWriter<object> engineWriter) : this(0, engineWriter, new()) { }
 
 #pragma warning disable RCS1163 // Unused parameter - used in Release mode
-    public Engine(string id, ChannelWriter<object> engineWriter, in TranspositionTable tt, bool warmup = false)
+    public Engine(int id, ChannelWriter<object> engineWriter, in TranspositionTable tt, bool warmup = false)
 #pragma warning restore RCS1163 // Unused parameter
     {
         _id = id;

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -5,7 +5,7 @@ namespace Lynx.Model;
 public sealed class SearchResult
 {
 #if MULTITHREAD_DEBUG
-    public string EngineId { get; init; }
+    public int EngineId { get; init; }
 #endif
 
     public Move[] Moves { get; init; }
@@ -32,14 +32,14 @@ public sealed class SearchResult
 
 #if MULTITHREAD_DEBUG
     public SearchResult(Move bestMove, int score, int targetDepth, Move[] moves, int mate = default)
-        : this("-1", bestMove, score, targetDepth, moves, mate)
+        : this(-2, bestMove, score, targetDepth, moves, mate)
     {
     }
 #endif
 
     public SearchResult(
 #if MULTITHREAD_DEBUG
-        string engineId,
+        int engineId,
 #endif
         Move bestMove, int score, int targetDepth, Move[] moves, int mate = default)
     {

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -12,7 +12,7 @@ public sealed class Searcher
     private readonly ChannelWriter<object> _engineWriter;
     private readonly Logger _logger;
 
-    internal const string MainEngineId = "1";
+    internal const int MainEngineId = 1;
 
     private int _searchThreadsCount;
     private Engine _mainEngine;
@@ -277,7 +277,7 @@ public sealed class Searcher
 
     public async ValueTask RunBench(int depth)
     {
-        using var engine = new Engine("bench", SilentChannelWriter<object>.Instance, in _ttWrapper, warmup: true);
+        using var engine = new Engine(-1, SilentChannelWriter<object>.Instance, in _ttWrapper, warmup: true);
         var results = engine.Bench(depth);
 
         // Can't use engine, or results won't be printed
@@ -286,7 +286,7 @@ public sealed class Searcher
 
     public async ValueTask RunVerboseBench(int depth)
     {
-        using var engine = new Engine("verbosebench", _engineWriter, in _ttWrapper, warmup: true);
+        using var engine = new Engine(-1, _engineWriter, in _ttWrapper, warmup: true);
         var results = engine.Bench(depth);
 
         await engine.PrintBenchResults(results);
@@ -308,7 +308,7 @@ public sealed class Searcher
 
             for (int i = 0; i < _searchThreadsCount - mainEngineOffset; ++i)
             {
-                _extraEngines[i] = new Engine($"{i + 2}",
+                _extraEngines[i] = new Engine(i + 2,
 #if MULTITHREAD_DEBUG
                     _engineWriter,
 #else


### PR DESCRIPTION
Thread id logging was somehow broken by #1294, since double quotes were using for the id.
This addresses this issue and makes ids an integer as well.