### PR TITLE
🧹 Move pondering logic from `Engine` to `Searcher`

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -21,24 +21,12 @@ public sealed partial class Engine : IDisposable
 
     private bool _isSearching;
 
-    /// <summary>
-    /// Ongoing search is a pondering one and there has been a ponder hit
-    /// </summary>
-    private bool _isPonderHit;
-
-    /// <summary>
-    /// Ongoing search is a pondering one
-    /// </summary>
-    private bool _isPondering;
-
     public double AverageDepth { get; private set; }
 
     public Game Game { get; private set; }
 
     public bool PendingConfirmation { get; set; }
 
-    private CancellationToken _searchCancellationToken = CancellationToken.None;
-    private CancellationToken _absoluteSearchCancellationToken = CancellationToken.None;
     public Engine(ChannelWriter<object> engineWriter) : this("0", engineWriter, new()) { }
 
 #pragma warning disable RCS1163 // Unused parameter - used in Release mode
@@ -140,11 +128,6 @@ public sealed partial class Engine : IDisposable
         Game = PositionCommand.ParseGame(rawPositionCommand, moves);
     }
 
-    public void PonderHit()
-    {
-        _isPonderHit = true;
-    }
-
     /// <summary>
     /// Uses <see cref="TimeManager.CalculateTimeManagement(Game, GoCommand)"/> internally
     /// </summary>
@@ -152,22 +135,22 @@ public sealed partial class Engine : IDisposable
     {
         var searchConstraints = TimeManager.CalculateTimeManagement(Game, goCommand);
 
-        return BestMove(in searchConstraints, CancellationToken.None, CancellationToken.None);
+        return BestMove(in searchConstraints, isPondering: false, CancellationToken.None, CancellationToken.None);
     }
 
-    public SearchResult BestMove(in SearchConstraints searchConstrains, CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
+    public SearchResult BestMove(in SearchConstraints searchConstrains, bool isPondering, CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
     {
         _searchConstraints = searchConstrains;
 
         using var jointCts = CancellationTokenSource.CreateLinkedTokenSource(absoluteSearchCancellationToken, searchCancellationToken);
 
-        SearchResult resultToReturn = IDDFS(jointCts.Token);
+        SearchResult resultToReturn = IDDFS(isPondering, jointCts.Token);
         //SearchResult resultToReturn = await SearchBestMove(maxDepth, decisionTime);
 
         Game.ResetCurrentPositionToBeforeSearchState();
-        if (!_isPondering
+        if (!isPondering
             && resultToReturn.BestMove != default
-            && !absoluteSearchCancellationToken.IsCancellationRequested)
+            && !absoluteSearchCancellationToken.IsCancellationRequested)    // TODO check thread id, for multithread pondering case, since extra threads are always cancelled like this
         {
             Game.MakeMove(resultToReturn.BestMove);
             Game.UpdateInitialPosition();
@@ -179,14 +162,14 @@ public sealed partial class Engine : IDisposable
     }
 
 #pragma warning disable S1144 // Unused private types or members should be removed - wanna keep this around
-    private async ValueTask<SearchResult> SearchBestMove(CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
+    private async ValueTask<SearchResult> SearchBestMove(bool isPondering, CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
 #pragma warning restore S1144 // Unused private types or members should be removed
     {
         using var jointCts = CancellationTokenSource.CreateLinkedTokenSource(absoluteSearchCancellationToken, searchCancellationToken);
 
         if (!Configuration.EngineSettings.UseOnlineTablebaseInRootPositions || Game.CurrentPosition.CountPieces() > Configuration.EngineSettings.OnlineTablebaseMaxSupportedPieces)
         {
-            return IDDFS(jointCts.Token)!;
+            return IDDFS(isPondering, jointCts.Token)!;
         }
 
         // Local copy of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove so that it doesn't interfere with regular search
@@ -195,7 +178,7 @@ public sealed partial class Engine : IDisposable
         var tasks = new Task<SearchResult?>[] {
                 // Other copies of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove (same reason)
                 ProbeOnlineTablebase(Game.CurrentPosition, Game.CopyPositionHashHistory(),  Game.HalfMovesWithoutCaptureOrPawnMove),
-                Task.Run(()=>(SearchResult?)IDDFS(jointCts.Token))
+                Task.Run(()=>(SearchResult?)IDDFS(isPondering, jointCts.Token))
             };
 
         var resultList = await Task.WhenAll(tasks);
@@ -224,44 +207,19 @@ public sealed partial class Engine : IDisposable
         return tbResult ?? searchResult!;
     }
 
-    public SearchResult? Search(GoCommand goCommand, in SearchConstraints searchConstraints, CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
+    public SearchResult? Search(in SearchConstraints searchConstraints, bool isPondering, CancellationToken absoluteSearchCancellationToken, CancellationToken searchCancellationToken)
     {
         if (_isSearching)
         {
             _logger.Warn("Search already in progress");
         }
-
         _isSearching = true;
-        _absoluteSearchCancellationToken = absoluteSearchCancellationToken;
-        _searchCancellationToken = searchCancellationToken;
 
         Thread.CurrentThread.Priority = ThreadPriority.Highest;
 
-        // TODO consider using linked cancellation token source
-        //using var jointCts = CancellationTokenSource.CreateLinkedTokenSource(absoluteSearchCancellationToken, searchCancellationToken);
-        //_absoluteSearchCancellationToken = jointCts.Token;
-
         try
         {
-            _isPondering = goCommand.Ponder;
-            var searchResult = BestMove(in searchConstraints, absoluteSearchCancellationToken, searchCancellationToken);
-
-            if (_isPondering)
-            {
-                // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
-                // before a potential ponderhit command
-                SpinWait.SpinUntil(() => _isPonderHit || absoluteSearchCancellationToken.IsCancellationRequested);
-
-                if (_isPonderHit && !absoluteSearchCancellationToken.IsCancellationRequested)
-                {
-                    _isPonderHit = false;
-                    _isPondering = false;
-
-                    searchResult = BestMove(in searchConstraints, absoluteSearchCancellationToken, searchCancellationToken);
-                }
-            }
-
-            return searchResult;
+            return BestMove(in searchConstraints, isPondering, absoluteSearchCancellationToken, searchCancellationToken);
         }
         catch (Exception e)
         {
@@ -271,7 +229,6 @@ public sealed partial class Engine : IDisposable
         finally
         {
             _isSearching = false;
-            _isPondering = false;
         }
     }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -175,10 +175,11 @@ public sealed partial class Engine : IDisposable
         // Local copy of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove so that it doesn't interfere with regular search
         var currentHalfMovesWithoutCaptureOrPawnMove = Game.HalfMovesWithoutCaptureOrPawnMove;
 
+        var cancellationToken = jointCts.Token;
         var tasks = new Task<SearchResult?>[] {
                 // Other copies of positionHashHistory and HalfMovesWithoutCaptureOrPawnMove (same reason)
-                ProbeOnlineTablebase(Game.CurrentPosition, Game.CopyPositionHashHistory(),  Game.HalfMovesWithoutCaptureOrPawnMove),
-                Task.Run(()=>(SearchResult?)IDDFS(isPondering, jointCts.Token))
+                ProbeOnlineTablebase(Game.CurrentPosition, Game.CopyPositionHashHistory(),  Game.HalfMovesWithoutCaptureOrPawnMove, cancellationToken),
+                Task.Run(()=>(SearchResult?)IDDFS(isPondering, cancellationToken))
             };
 
         var resultList = await Task.WhenAll(tasks);

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -15,6 +15,7 @@ public sealed class Game : IDisposable
 #pragma warning restore CA1002 // Do not expose generic lists
 #endif
 
+    //private int _positionHashHistoryPointerBeforeLastSearch;
     private int _positionHashHistoryPointer;
     private readonly ulong[] _positionHashHistory;
 
@@ -78,6 +79,7 @@ public sealed class Game : IDisposable
         }
 
         PositionBeforeLastSearch = new Position(CurrentPosition);
+        //_positionHashHistoryPointerBeforeLastSearch = _positionHashHistoryPointer;
     }
 
     /// <summary>
@@ -218,6 +220,7 @@ public sealed class Game : IDisposable
     {
         CurrentPosition.FreeResources();
         CurrentPosition = new(PositionBeforeLastSearch);
+        //_positionHashHistoryPointer = _positionHashHistoryPointerBeforeLastSearch;    // TODO
     }
 
     public void UpdateInitialPosition()

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -103,8 +103,7 @@ public sealed partial class Engine
 
             do
             {
-                _absoluteSearchCancellationToken.ThrowIfCancellationRequested();
-                _searchCancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
                     || lastSearchResult?.Score is null)

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -4,13 +4,13 @@ using System.Diagnostics;
 namespace Lynx;
 public sealed partial class Engine
 {
-    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, ulong[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove)
+    public async Task<SearchResult?> ProbeOnlineTablebase(Position position, ulong[] positionHashHistory, int halfMovesWithoutCaptureOrPawnMove, CancellationToken cancellationToken)
     {
         var stopWatch = Stopwatch.StartNew();
 
         try
         {
-            var tablebaseResult = await OnlineTablebaseProber.RootSearch(position, positionHashHistory, halfMovesWithoutCaptureOrPawnMove, _searchCancellationToken);
+            var tablebaseResult = await OnlineTablebaseProber.RootSearch(position, positionHashHistory, halfMovesWithoutCaptureOrPawnMove, cancellationToken);
 
             if (tablebaseResult.BestMove != 0)
             {

--- a/src/Lynx/Search/OnlineTablebase.cs
+++ b/src/Lynx/Search/OnlineTablebase.cs
@@ -34,7 +34,7 @@ public sealed partial class Engine
                         0)
                 };
 
-                await _engineWriter.WriteAsync(searchResult);
+                await _engineWriter.WriteAsync(searchResult, cancellationToken);
                 //await _searchCancellationTokenSource.CancelAsync();   // TODO revisit
 
                 return searchResult;

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -166,6 +166,8 @@ public sealed class Searcher
                     // Final info command
                     _engineWriter.TryWrite(searchResult);
                 }
+
+                _isPonderHit = false;
             }
 
             if (searchResult is not null)
@@ -189,8 +191,8 @@ public sealed class Searcher
             }
 
 #if MULTITHREAD_DEBUG
-        var sw = System.Diagnostics.Stopwatch.StartNew();
-        var lastElapsed = sw.ElapsedMilliseconds;
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             // Basic lazy SMP implementation
@@ -204,15 +206,15 @@ public sealed class Searcher
                 .ToArray();
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+            _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             SearchResult? finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+            _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             await _absoluteSearchCancellationTokenSource.CancelAsync();
@@ -222,7 +224,7 @@ public sealed class Searcher
             var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
             if (finalSearchResult is not null)
@@ -235,7 +237,7 @@ public sealed class Searcher
                 finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG
-            _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                 // Final info command
@@ -252,7 +254,7 @@ public sealed class Searcher
 
 #if MULTITHREAD_DEBUG
             var sw = System.Diagnostics.Stopwatch.StartNew();
-        var lastElapsed = sw.ElapsedMilliseconds;
+            var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             // Basic lazy SMP implementation
@@ -266,15 +268,15 @@ public sealed class Searcher
                 .ToArray();
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+            _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             SearchResult? finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+            _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
             await _absoluteSearchCancellationTokenSource.CancelAsync();
@@ -284,7 +286,7 @@ public sealed class Searcher
             var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+            _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
             if (finalSearchResult is not null)
@@ -297,7 +299,7 @@ public sealed class Searcher
                 finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                 // Final info command
@@ -316,7 +318,7 @@ public sealed class Searcher
 
 #if MULTITHREAD_DEBUG
                 sw = System.Diagnostics.Stopwatch.StartNew();
-        lastElapsed = sw.ElapsedMilliseconds;
+                lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                 // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
@@ -334,15 +336,15 @@ public sealed class Searcher
                     .ToArray();
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+                _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                 finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-        lastElapsed = sw.ElapsedMilliseconds;
+                _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                 await _absoluteSearchCancellationTokenSource.CancelAsync();
@@ -352,7 +354,7 @@ public sealed class Searcher
                 extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
-        _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                 if (finalSearchResult is not null)
@@ -365,12 +367,14 @@ public sealed class Searcher
                     finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG
-            _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                    _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                     // Final info command
                     _engineWriter.TryWrite(finalSearchResult);
                 }
+
+                _isPonderHit = false;
             }
 
             if (finalSearchResult is not null)

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -14,6 +14,8 @@ public sealed class Searcher
 
     internal const string MainEngineId = "1";
 
+    private bool _isPonderHit;
+
     private int _searchThreadsCount;
     private Engine _mainEngine;
     private Engine[] _extraEngines = [];
@@ -105,88 +107,277 @@ public sealed class Searcher
     private void SingleThreadedSearch(GoCommand goCommand)
     {
         var searchConstraints = TimeManager.CalculateTimeManagement(_mainEngine.Game, goCommand);
+        var isPondering = Configuration.EngineSettings.IsPonder && goCommand.Ponder;
 
-        if (!goCommand.Ponder && searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+        if (!isPondering)
         {
-            _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
+            if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+            {
+                _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
+            }
+
+            var searchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
+
+            if (searchResult is not null)
+            {
+                // Final info command
+                _engineWriter.TryWrite(searchResult);
+
+                // bestmove command
+                _engineWriter.TryWrite(new BestMoveCommand(searchResult));
+            }
         }
-
-        var searchResult = _mainEngine.Search(goCommand, searchConstraints, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
-
-        if (searchResult is not null)
+        else
         {
-            // Final info command
-            _engineWriter.TryWrite(searchResult);
+            // Pondering
+            _logger.Debug("Pondering");
 
-            // We always print best move, even in case of go ponder + stop, in which case IDEs are expected to ignore it
-            _engineWriter.TryWrite(new BestMoveCommand(searchResult));
+            var searchResult = _mainEngine.Search(searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+
+            if (searchResult is not null)
+            {
+                // Final info command
+                _engineWriter.TryWrite(searchResult);
+
+                // We don't print bestmove command when ponder + ponderhit though
+            }
+
+            // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
+            // before a potential ponderhit command
+            SpinWait.SpinUntil(() => _isPonderHit || _absoluteSearchCancellationTokenSource.IsCancellationRequested);
+
+            if (_isPonderHit)
+            {
+                _logger.Debug("Ponder hit - restarting search now with time constraints");
+
+                // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
+                _absoluteSearchCancellationTokenSource.Dispose();
+                _absoluteSearchCancellationTokenSource = new();
+
+                if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+                {
+                    _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
+                }
+
+                searchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
+
+                if (searchResult is not null)
+                {
+                    // Final info command
+                    _engineWriter.TryWrite(searchResult);
+                }
+            }
+
+            if (searchResult is not null)
+            {
+                // We print best move even in case of go ponder + stop, in which case IDEs are expected to ignore it
+                _engineWriter.TryWrite(new BestMoveCommand(searchResult));
+            }
         }
     }
 
     private async Task MultiThreadedSearch(GoCommand goCommand)
     {
         var searchConstraints = TimeManager.CalculateTimeManagement(_mainEngine.Game, goCommand);
+        var isPondering = Configuration.EngineSettings.IsPonder && goCommand.Ponder;
 
-        if (!goCommand.Ponder && searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+        if (!isPondering)
         {
-            _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
-        }
+            if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+            {
+                _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
+            }
 
 #if MULTITHREAD_DEBUG
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-        // Basic lazy SMP implementation
-        // Extra engines run in "go infinite" mode and their purpose is to populate the TT
-        // Not UCI output is produced by them nor their search results are taken into account
-        var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
+            // Basic lazy SMP implementation
+            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
+            // Not UCI output is produced by them nor their search results are taken into account
+            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
 
-        var tasks = _extraEngines
-            .Select(engine =>
-                Task.Run(() => engine.Search(goCommand, extraEnginesSearchConstraint, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
-            .ToArray();
+            var tasks = _extraEngines
+                .Select(engine =>
+                    Task.Run(() => engine.Search(extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                .ToArray();
 
 #if MULTITHREAD_DEBUG
         _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
         lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-        SearchResult? finalSearchResult = _mainEngine.Search(goCommand, searchConstraints, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
+            SearchResult? finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
 
 #if MULTITHREAD_DEBUG
         _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
         lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-        await _absoluteSearchCancellationTokenSource.CancelAsync();
+            await _absoluteSearchCancellationTokenSource.CancelAsync();
 
-        // We wait just for the node count, so there's room for improvement here with thread voting
-        // and other strategies that take other thread results into account
-        var extraResults = await Task.WhenAll(tasks);
+            // We wait just for the node count, so there's room for improvement here with thread voting
+            // and other strategies that take other thread results into account
+            var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
         _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
-        if (finalSearchResult is not null)
-        {
-            foreach (var extraResult in extraResults)
+            if (finalSearchResult is not null)
             {
-                finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
-            }
+                foreach (var extraResult in extraResults)
+                {
+                    finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                }
 
-            finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+                finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG
             _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
-            // Final info command
-            _engineWriter.TryWrite(finalSearchResult);
+                // Final info command
+                _engineWriter.TryWrite(finalSearchResult);
 
-            // We always print best move, even in case of go ponder + stop, in which case IDEs are expected to ignore it
-            _engineWriter.TryWrite(new BestMoveCommand(finalSearchResult));
+                // bestmove command
+                _engineWriter.TryWrite(new BestMoveCommand(finalSearchResult));
+            }
+        }
+        else
+        {
+            // Pondering
+            _logger.Debug("Pondering");
+
+#if MULTITHREAD_DEBUG
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+        var lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+            // Basic lazy SMP implementation
+            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
+            // Not UCI output is produced by them nor their search results are taken into account
+            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
+
+            var tasks = _extraEngines
+                .Select(engine =>
+                    Task.Run(() => engine.Search(extraEnginesSearchConstraint, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                .ToArray();
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+        lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+            SearchResult? finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+        lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+            await _absoluteSearchCancellationTokenSource.CancelAsync();
+
+            // We wait just for the node count, so there's room for improvement here with thread voting
+            // and other strategies that take other thread results into account
+            var extraResults = await Task.WhenAll(tasks);
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+            if (finalSearchResult is not null)
+            {
+                foreach (var extraResult in extraResults)
+                {
+                    finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                }
+
+                finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+
+#if MULTITHREAD_DEBUG
+            _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                // Final info command
+                _engineWriter.TryWrite(finalSearchResult);
+
+                // We don't print bestmove command when ponder + ponderhit though
+            }
+
+            // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
+            // before a potential ponderhit command
+            SpinWait.SpinUntil(() => _isPonderHit || _absoluteSearchCancellationTokenSource.IsCancellationRequested);
+
+            if (_isPonderHit)
+            {
+                _logger.Debug("Ponder hit - restarting search now with time constraints");
+
+#if MULTITHREAD_DEBUG
+                sw = System.Diagnostics.Stopwatch.StartNew();
+        lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
+                _absoluteSearchCancellationTokenSource.Dispose();
+                _absoluteSearchCancellationTokenSource = new();
+
+                if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
+                {
+                    _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
+                }
+
+                tasks = _extraEngines
+                    .Select(engine =>
+                        Task.Run(() => engine.Search(extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    .ToArray();
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+        lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                finalSearchResult = _mainEngine.Search(searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+        lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                await _absoluteSearchCancellationTokenSource.CancelAsync();
+
+                // We wait just for the node count, so there's room for improvement here with thread voting
+                // and other strategies that take other thread results into account
+                extraResults = await Task.WhenAll(tasks);
+
+#if MULTITHREAD_DEBUG
+        _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                if (finalSearchResult is not null)
+                {
+                    foreach (var extraResult in extraResults)
+                    {
+                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                    }
+
+                    finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+
+#if MULTITHREAD_DEBUG
+            _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                    // Final info command
+                    _engineWriter.TryWrite(finalSearchResult);
+                }
+            }
+
+            if (finalSearchResult is not null)
+            {
+                // We print best move even in case of go ponder + stop, in which case IDEs are expected to ignore it
+                _engineWriter.TryWrite(new BestMoveCommand(finalSearchResult));
+            }
         }
     }
 
@@ -200,19 +391,15 @@ public sealed class Searcher
         }
     }
 
-    public void StopSearching()
+    public async Task StopSearching()
     {
-        _absoluteSearchCancellationTokenSource.Cancel();
+        await _absoluteSearchCancellationTokenSource.CancelAsync();
     }
 
-    public void PonderHit()
+    public async Task PonderHit()
     {
-        _mainEngine.PonderHit();
-
-        foreach (var engine in _extraEngines)
-        {
-            engine.PonderHit();
-        }
+        _isPonderHit = true;
+        await _absoluteSearchCancellationTokenSource.CancelAsync();
     }
 
     public void NewGame()

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -57,7 +57,7 @@ public sealed class UCIHandler
                     await HandleIsReady(cancellationToken);
                     break;
                 case PonderHitCommand.Id:
-                    HandlePonderHit();
+                    await HandlePonderHit();
                     break;
                 case PositionCommand.Id:
                     HandlePosition(rawCommand);
@@ -69,7 +69,7 @@ public sealed class UCIHandler
                     HandleSetOption(rawCommand);
                     break;
                 case StopCommand.Id:
-                    HandleStop();
+                    await HandleStop();
                     break;
                 case UCICommand.Id:
                     await HandleUCI(cancellationToken);
@@ -144,7 +144,7 @@ public sealed class UCIHandler
 #endif
     }
 
-    private void HandleStop() => _searcher.StopSearching();
+    private async Task HandleStop() => await _searcher.StopSearching();
 
     private async Task HandleUCI(CancellationToken cancellationToken)
     {
@@ -161,11 +161,11 @@ public sealed class UCIHandler
 
     private async Task HandleIsReady(CancellationToken cancellationToken) => await SendCommand(ReadyOKCommand.Id, cancellationToken);
 
-    private void HandlePonderHit()
+    private async Task HandlePonderHit()
     {
         if (Configuration.EngineSettings.IsPonder)
         {
-            _searcher.PonderHit();
+            await _searcher.PonderHit();
         }
         else
         {

--- a/tests/Lynx.Test/Commands/PositionCommandTest.cs
+++ b/tests/Lynx.Test/Commands/PositionCommandTest.cs
@@ -24,7 +24,7 @@ public class PositionCommandTest
         var searchConstraints = TimeManager.CalculateTimeManagement(engine.Game, goCommand);
 
         using var cts = new CancellationTokenSource();
-        var resultTask = Task.Run(() => engine.BestMove(searchConstraints, cts.Token, CancellationToken.None));
+        var resultTask = Task.Run(() => engine.BestMove(searchConstraints, isPondering: false, cts.Token, CancellationToken.None));
 
         await cts.CancelAsync();
         await resultTask;

--- a/tests/Lynx.Test/Commands/StopCommandTest.cs
+++ b/tests/Lynx.Test/Commands/StopCommandTest.cs
@@ -24,7 +24,7 @@ public class StopCommandTest
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(10_000);
 
-        var resultTask = Task.Run(() => engine.Search(goCommand, searchConstraints, cts.Token, CancellationToken.None));
+        var resultTask = Task.Run(() => engine.Search(searchConstraints, isPondering: false, cts.Token, CancellationToken.None));
         // Wait 2s so that there's some best move available
         await Task.Delay(2000);
 


### PR DESCRIPTION
This effectively fixes pondering, broken by a combination of #1292, #1293 and #1296 