### PR TITLE
🟰 Replace `Task.Run()` with `TaskFactory.StartNew()` and `LongRunning` task

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -148,7 +148,7 @@ public sealed class Searcher
                 _taskFactory.StartNew(
                     () => engine.Search(goCommand, extraEnginesSearchConstraint, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None),
                     CancellationToken.None,
-                    TaskCreationOptions.DenyChildAttach,
+                    TaskCreationOptions.LongRunning,
                     TaskScheduler.Default))
             .ToArray();
 


### PR DESCRIPTION
```
Test  | mt/task-factory-longrunning
Elo   | -2.40 +- 4.43 (95%)
SPRT  | 20.0+0.20s Threads=4 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 8394: +2027 -2085 =4282
Penta | [130, 1024, 1924, 1012, 107]
https://openbench.lynx-chess.com/test/1133/
```