### PR TITLE
🟰 Replace `Task.Run()` with `TaskFactory.StartNew()` and a static lambda, using a `record class` or a `readonly struct`

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -124,7 +124,21 @@ public sealed class Searcher
         }
     }
 
-    private sealed record ThreadContext(Engine Engine, GoCommand GoCommand, in SearchConstraints SearchConstraints, CancellationToken CancellationToken);
+    private readonly struct ThreadContext
+    {
+        public readonly Engine Engine;
+        public readonly GoCommand GoCommand;
+        public readonly SearchConstraints SearchConstraints;
+        public readonly CancellationToken CancellationToken;
+
+        public ThreadContext(Engine engine, GoCommand goCommand, SearchConstraints searchConstraints, CancellationToken cancellationToken)
+        {
+            Engine = engine;
+            GoCommand = goCommand;
+            SearchConstraints = searchConstraints;
+            CancellationToken = cancellationToken;
+        }
+    }
 
     private async Task MultiThreadedSearch(GoCommand goCommand)
     {

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -148,7 +148,7 @@ public sealed class Searcher
                 _taskFactory.StartNew(
                     () => engine.Search(goCommand, extraEnginesSearchConstraint, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None),
                     CancellationToken.None,
-                    TaskCreationOptions.DenyChildAttach,
+                    TaskCreationOptions.LongRunning,
                     TaskScheduler.Default))
             .ToArray();
 


### PR DESCRIPTION
Record class
```
Test  | mt/task-factory-static
Elo   | -3.17 +- 4.79 (95%)
SPRT  | 20.0+0.20s Threads=4 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 6910: +1633 -1696 =3581
Penta | [86, 871, 1601, 814, 83]
https://openbench.lynx-chess.com/test/1136/
```

Readonly struct
```
Test  | mt/task-factory-static
Elo   | -0.68 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 15384: +4007 -4037 =7340
Penta | [313, 1914, 3272, 1876, 317]
https://openbench.lynx-chess.com/test/1147/
```