### PR TITLE
🧪 Remove QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -89,7 +89,7 @@ public sealed partial class Engine
         {
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
             {
-                return QuiescenceSearch(ply, alpha, beta, cancellationToken);
+                return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);


### PR DESCRIPTION
```
Score of Lynx-search-remove-qs-4960-win-x64 vs Lynx 4951 - main: 8 - 79 - 53  [0.246] 140
...      Lynx-search-remove-qs-4960-win-x64 playing White: 5 - 27 - 38  [0.343] 70
...      Lynx-search-remove-qs-4960-win-x64 playing Black: 3 - 52 - 15  [0.150] 70
...      White vs Black: 57 - 30 - 53  [0.596] 140
Elo difference: -194.2 +/- 47.2, LOS: 0.0 %, DrawRatio: 37.9 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```