### PR TITLE
🔍LMRDepth - History pruning

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -328,7 +328,7 @@ public sealed partial class Engine
                     // once we find one with a history score too low
                     if (!isCapture
                         && moveScores[moveIndex] < EvaluationConstants.CounterMoveValue
-                        && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
+                        && lmrDepth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
                         && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                     {
                         RevertMove();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -303,6 +303,9 @@ public sealed partial class Engine
             }
             else
             {
+                var baseLMRReduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
+                var lmrDepth = Math.Max(0, depth - baseLMRReduction);
+
                 // If we prune while getting checmated, we risk not finding any move and having an empty PV
                 bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
@@ -357,7 +360,7 @@ public sealed partial class Engine
                                 ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
                                 : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV))
                     {
-                        reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
+                        reduction = baseLMRReduction;
 
                         if (pvNode)
                         {


### PR DESCRIPTION
```
Score of Lynx-search-lmrdepth-historypruning-4971-win-x64 vs Lynx 4968 - main: 1813 - 1923 - 3234  [0.492] 6970
...      Lynx-search-lmrdepth-historypruning-4971-win-x64 playing White: 1382 - 475 - 1628  [0.630] 3485
...      Lynx-search-lmrdepth-historypruning-4971-win-x64 playing Black: 431 - 1448 - 1606  [0.354] 3485
...      White vs Black: 2830 - 906 - 3234  [0.638] 6970
Elo difference: -5.5 +/- 6.0, LOS: 3.6 %, DrawRatio: 46.4 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```