### PR TITLE
🔍 LMRDepth - FP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -337,7 +337,7 @@ public sealed partial class Engine
 
                     // 🔍 Futility Pruning (FP) - all quiet moves can be pruned
                     // once it's considered that they don't have potential to raise alpha
-                    if (depth <= Configuration.EngineSettings.FP_MaxDepth
+                    if (lmrDepth <= Configuration.EngineSettings.FP_MaxDepth
                         && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
                     {
                         RevertMove();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -303,6 +303,9 @@ public sealed partial class Engine
             }
             else
             {
+                var baseLMRReduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
+                var lmrDepth = Math.Max(0, depth - baseLMRReduction);
+
                 // If we prune while getting checmated, we risk not finding any move and having an empty PV
                 bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
@@ -357,7 +360,7 @@ public sealed partial class Engine
                                 ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
                                 : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV))
                     {
-                        reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
+                        reduction = baseLMRReduction;
 
                         if (pvNode)
                         {


### PR DESCRIPTION
```
Score of Lynx-search-lmrdepth-fp-4972-win-x64 vs Lynx 4968 - main: 2905 - 2999 - 5005  [0.496] 10909
...      Lynx-search-lmrdepth-fp-4972-win-x64 playing White: 2240 - 680 - 2534  [0.643] 5454
...      Lynx-search-lmrdepth-fp-4972-win-x64 playing Black: 665 - 2319 - 2471  [0.348] 5455
...      White vs Black: 4559 - 1345 - 5005  [0.647] 10909
Elo difference: -3.0 +/- 4.8, LOS: 11.1 %, DrawRatio: 45.9 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```