### PR TITLE
🔍 Save in TT when non-TT-hit QSearch beta cutoff

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -540,7 +540,9 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        var staticEval = ttProbeResult.NodeType != NodeType.Unknown
+        var ttHit = ttProbeResult.NodeType != NodeType.Unknown;
+
+        var staticEval = ttHit
             ? ttProbeResult.StaticEval
             : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
 
@@ -550,6 +552,12 @@ public sealed partial class Engine
         if (staticEval >= beta)
         {
             PrintMessage(ply - 1, "Pruning before starting quiescence search");
+
+            if (!ttHit)
+            {
+                _tt.RecordHash(position, staticEval, 0, ply, staticEval, NodeType.Beta);
+            }
+
             return staticEval;
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -553,6 +553,7 @@ public sealed partial class Engine
         {
             PrintMessage(ply - 1, "Pruning before starting quiescence search");
 
+            // Idea by Clover author
             if (!ttHit)
             {
                 _tt.RecordHash(position, staticEval, 0, ply, staticEval, NodeType.Beta);


### PR DESCRIPTION
8+0.08

```
Score of Lynx-search-qsearch-beta-cutoff-tt-store-4962-win-x64 vs Lynx 4951 - main: 15432 - 15332 - 25448  [0.501] 56212
...      Lynx-search-qsearch-beta-cutoff-tt-store-4962-win-x64 playing White: 11850 - 3510 - 12746  [0.648] 28106
...      Lynx-search-qsearch-beta-cutoff-tt-store-4962-win-x64 playing Black: 3582 - 11822 - 12702  [0.353] 28106
...      White vs Black: 23672 - 7092 - 25448  [0.647] 56212
Elo difference: 0.6 +/- 2.1, LOS: 71.6 %, DrawRatio: 45.3 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

LTC

```
Test  | search/qsearch-beta-cutoff-tt-store
Elo   | -0.76 +- 3.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.79 (-2.25, 2.89) [0.00, 3.00]
Games | 11452: +2799 -2824 =5829
Penta | [171, 1410, 2582, 1399, 164]
https://openbench.lynx-chess.com/test/1148/
```