### PR TITLE
🐛 Use TT recalculated scores everywhere and move TT cutoffs to NegaMax and QSearch methods

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1083,19 +1083,19 @@ static void TranspositionTableMethod()
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
     transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
-    var entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    var entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 20
 
     transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 12_345_678
 
     transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 12_345_678
 
     transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
-    entry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: 20, beta: 30);
+    entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 30
 }
 

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -7,8 +7,17 @@ public enum NodeType : byte
 #pragma warning restore S4022 // Enumerations should have "Int32" storage
 {
     Unknown,    // Making it 0 instead of -1 because of default struct initialization
+
     Exact,
+
+    /// <summary>
+    /// UpperBound
+    /// </summary>
     Alpha,
+
+    /// <summary>
+    /// LowerBound
+    /// </summary>
     Beta
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -40,17 +40,22 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
         NodeType ttElementType = default;
         int ttScore = default;
-        int ttRawScore = default;
         int ttStaticEval = int.MinValue;
+        int ttDepth = default;
 
         Debug.Assert(!pvNode || !cutnode);
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttRawScore, ttStaticEval) = _tt.ProbeHash(position, depth, ply, alpha, beta);
+            (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth) = _tt.ProbeHash(position, ply);
 
             // TT cutoffs
-            if (!pvNode && ttScore != EvaluationConstants.NoHashEntry)
+            if (!pvNode
+                && ttScore != EvaluationConstants.NoHashEntry
+                && ttDepth >= depth
+                && (ttElementType == NodeType.Exact
+                    || (ttElementType == NodeType.Alpha && ttScore <= alpha)
+                    || (ttElementType == NodeType.Beta && ttScore >= beta)))
             {
                 return ttScore;
             }
@@ -124,9 +129,9 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttElementType != default && ttElementType != (ttRawScore > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttElementType != default && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
-                staticEval = ttRawScore;
+                staticEval = ttScore;
             }
 
             bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
@@ -190,7 +195,7 @@ public sealed partial class Engine
                     && staticEvalBetaDiff >= 0
                     && !parentWasNullMove
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                    && (ttElementType != NodeType.Alpha || ttRawScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                    && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
                 {
                     var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
                         + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
@@ -531,7 +536,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, 0, ply, alpha, beta);
+        var ttProbeResult = _tt.ProbeHash(position, ply);
         if (ttProbeResult.Score != EvaluationConstants.NoHashEntry)
         {
             return ttProbeResult.Score;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -542,8 +542,9 @@ public sealed partial class Engine
         var ttHit = ttNodeType != NodeType.Unknown;
 
         // QS TT cutoff
+        Debug.Assert(ttProbeResult.Depth >= 0, "Assertion failed", "We would need to add it as a TT cutoff condition");
+
         if (ttHit
-            && ttProbeResult.Depth >= 0
             && (ttNodeType == NodeType.Exact
                 || (ttNodeType == NodeType.Alpha && ttScore <= alpha)
                 || (ttNodeType == NodeType.Beta && ttScore >= beta)))

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -24,11 +24,11 @@ public class TranspositionTableTests
         Assert.AreEqual(expectedEvaluation, TranspositionTable.RecalculateMateScores(evaluation, depth));
     }
 
-    [TestCase(+19, NodeType.Alpha, +20, +30, +19)]
-    [TestCase(+21, NodeType.Alpha, +20, +30, NoHashEntry)]
-    [TestCase(+29, NodeType.Beta, +20, +30, NoHashEntry)]
-    [TestCase(+31, NodeType.Beta, +20, +30, +31)]
-    public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int probeAlpha, int probeBeta, int expectedProbeEval)
+    [TestCase(+19, NodeType.Alpha, +19)]
+    [TestCase(+21, NodeType.Alpha, NoHashEntry)]
+    [TestCase(+29, NodeType.Beta, NoHashEntry)]
+    [TestCase(+31, NodeType.Beta, +31)]
+    public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int expectedProbeEval)
     {
         var position = new Position(Constants.InitialPositionFEN);
         var transpositionTable = new TranspositionTable();
@@ -37,7 +37,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, staticEval, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 5, ply: 3, alpha: probeAlpha, beta: probeBeta);
+        var ttEntry = transpositionTable.ProbeHash(position, ply: 3);
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(staticEval, ttEntry.StaticEval);
     }
@@ -52,7 +52,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 7, ply: sharedDepth, alpha: 50, beta: 100);
+        var ttEntry = transpositionTable.ProbeHash(position, ply: sharedDepth);
         Assert.AreEqual(recordedEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }
@@ -68,7 +68,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, recordedEval, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, depth: 7, ply: probeDepth, alpha: 50, beta: 100);
+        var ttEntry = transpositionTable.ProbeHash(position, ply: probeDepth);
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -25,8 +25,6 @@ public class TranspositionTableTests
     }
 
     [TestCase(+19, NodeType.Alpha, +19)]
-    [TestCase(+21, NodeType.Alpha, NoHashEntry)]
-    [TestCase(+29, NodeType.Beta, NoHashEntry)]
     [TestCase(+31, NodeType.Beta, +31)]
     public void RecordHash_ProbeHash(int recordedEval, NodeType recordNodeType, int expectedProbeEval)
     {


### PR DESCRIPTION
```
Test  | MOAB-2
Elo   | -1.04 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.38 (-2.25, 2.89) [-3.00, 1.00]
Games | 114900: +31380 -31725 =51795
Penta | [2602, 13592, 25293, 13475, 2488]
https://openbench.lynx-chess.com/test/1146/
```