### PR TITLE
🐛🔍 Don't use TT static eval in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -556,10 +556,13 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
+        /*
         var staticEval = ttHit
             ? ttProbeResult.StaticEval
             : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+        */
 
+        var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         Debug.Assert(staticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
 
         Game.UpdateStaticEvalInStack(ply, staticEval);


### PR DESCRIPTION
This helps solving the mate in +X/-X issues with scores over mate scores

```
Test  | search/no-tt-staticeval-in-qsearch
Elo   | 4.13 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 24234: +6514 -6226 =11494
Penta | [546, 2846, 5074, 3076, 575]
https://openbench.lynx-chess.com/test/1155/
```