### PR TITLE
🔍Recalculate static eval on TT read/write

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -72,8 +72,9 @@ public readonly struct TranspositionTable
         // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
         // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
         var recalculatedScore = RecalculateMateScores(entry.Score, ply);
+        var recalculatedStaticEval = RecalculateMateScores(entry.StaticEval, ply);
 
-        return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth);
+        return (recalculatedScore, entry.Move, entry.Type, recalculatedStaticEval, entry.Depth);
     }
 
     /// <summary>
@@ -105,8 +106,9 @@ public readonly struct TranspositionTable
         // We want to store the distance to the checkmate position relative to the current node, independently from the root
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
+        var recalculatedStaticEval = RecalculateMateScores(staticEval, -ply);
 
-        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, move);
+        entry.Update(position.UniqueIdentifier, recalculatedScore, recalculatedStaticEval, depth, nodeType, move);
     }
 
     /// <summary>


### PR DESCRIPTION
vs main before #1312
```
Test  | MOAB-3
Elo   | 0.49 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.03 (-2.25, 2.89) [0.00, 3.00]
Games | 57582: +15234 -15152 =27196
Penta | [1155, 6811, 12800, 6847, 1178]
https://openbench.lynx-chess.com/test/1156/
```

vs main after #1312
```
Test  | MOAB-3
Elo   | -4.49 +- 4.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 10768: +2763 -2902 =5103
Penta | [267, 1309, 2319, 1274, 215]
https://openbench.lynx-chess.com/test/1157/
```