### PR TITLE
🔍Recalculate static eval on TT read/write + always store static eval for TT

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -72,8 +72,9 @@ public readonly struct TranspositionTable
         // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
         // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
         var recalculatedScore = RecalculateMateScores(entry.Score, ply);
+        var recalculatedStaticEval = RecalculateMateScores(entry.StaticEval, ply);
 
-        return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth);
+        return (recalculatedScore, entry.Move, entry.Type, recalculatedStaticEval, entry.Depth);
     }
 
     /// <summary>
@@ -105,8 +106,9 @@ public readonly struct TranspositionTable
         // We want to store the distance to the checkmate position relative to the current node, independently from the root
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
+        var recalculatedStaticEval = RecalculateMateScores(staticEval, -ply);
 
-        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, move);
+        entry.Update(position.UniqueIdentifier, recalculatedScore, recalculatedStaticEval, depth, nodeType, move);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -497,7 +497,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalEval, depth, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
@@ -556,13 +556,10 @@ public sealed partial class Engine
 
         _maxDepthReached[ply] = ply;
 
-        /*
         var staticEval = ttHit
             ? ttProbeResult.StaticEval
             : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
-        */
 
-        var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
         Debug.Assert(staticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
 
         Game.UpdateStaticEvalInStack(ply, staticEval);
@@ -677,7 +674,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, finalEval, 0, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }


### PR DESCRIPTION
Restore #1091 vs #1288 

Only recalculation attempted in #1313  

```
Test  | MOAB-4
Elo   | -2.91 +- 3.58 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 15182: +3883 -4010 =7289
Penta | [341, 1906, 3197, 1833, 314]
https://openbench.lynx-chess.com/test/1161/
```