### PR TITLE
🔍 Go back to storing only pure static eval in TT, no final scores

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -497,7 +497,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalEval, depth, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, depth, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }
@@ -677,7 +677,7 @@ public sealed partial class Engine
             Debug.Assert(bestMove is null);
 
             var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, finalEval, 0, ply, finalEval, NodeType.Exact);
+            _tt.RecordHash(position, staticEval, 0, ply, finalEval, NodeType.Exact);
 
             return finalEval;
         }


### PR DESCRIPTION
Going back to https://github.com/lynx-chess/Lynx/pull/1091 after #1288, see story in #1312.

```
Test  | search/tt-static-eval-always
Elo   | -3.20 +- 3.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 14130: +3796 -3926 =6408
Penta | [319, 1708, 3118, 1624, 296]
https://openbench.lynx-chess.com/test/1162/
```