### PR TITLE
🔍 SPSA TM 2024-1-2

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,19 +113,20 @@ public sealed class EngineSettings
 
     #region Time management
 
-    public double HardTimeBoundMultiplier { get; set; } = 0.52;
+    [SPSA<double>(0.1, 1, 0.1)]
+    public double HardTimeBoundMultiplier { get; set; } = 0.60;
 
-    public double SoftTimeBoundMultiplier { get; set; } = 1;
+    [SPSA<double>(0.5, 1.5, 0.1)]
+    public double SoftTimeBoundMultiplier { get; set; } = 1.04;
 
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
+    [SPSA<double>(0.1, 2, 0.2)]
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 1.22;
 
-    [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.4;
+    [SPSA<double>(1, 2, 0.2)]
+    public double NodeTmBase { get; set; } = 1.65;
 
-    [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.65;
+    public int NodeTmScale { get; set; } = 1;
 
-    [SPSA<int>(1, 15, 1)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;
 
     #endregion

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -276,22 +276,6 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "nodetmscale":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.NodeTmScale = value * 0.01;
-                    }
-                    break;
-                }
-            case "scorestabiity_mindepth":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.ScoreStabiity_MinDepth = value;
-                    }
-                    break;
-                }
             #endregion
 
             #region Search tuning


### PR DESCRIPTION
```
iterations: 508 (294.21s per iter)
games: 16256 (9.19s per game)
Final parameters:
HardTimeBoundMultiplier = 60(-6.241739) in [10, 100]
SoftTimeBoundMultiplier = 104(+0.69) in [50, 150]
SoftTimeBaseIncrementMultiplier = 122(+45.52) in [10, 200]
NodeTmBase = 165(-5.058911) in [100, 200]
```

![image](https://github.com/user-attachments/assets/0f7c3b71-b138-4d7c-af4f-60562dbf1626)

8+0.08
```
Score of Lynx-spsa-tm-1-2-5007-win-x64 vs Lynx 5000 - main: 1098 - 1086 - 1966  [0.501] 4150
...      Lynx-spsa-tm-1-2-5007-win-x64 playing White: 875 - 221 - 979  [0.658] 2075
...      Lynx-spsa-tm-1-2-5007-win-x64 playing Black: 223 - 865 - 987  [0.345] 2075
...      White vs Black: 1740 - 444 - 1966  [0.656] 4150
Elo difference: 1.0 +/- 7.7, LOS: 60.1 %, DrawRatio: 47.4 %
SPRT: llr -0.0972 (-3.4%), lbound -2.25, ubound 2.89
```
