### PR TITLE
🔍 QS SEE pruning: not when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -616,7 +616,9 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[i];
 
             // 🔍 QSearch SEE pruning: pruning bad captures
-            if (moveScores[i] < EvaluationConstants.PromotionMoveScoreValue && moveScores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!position.IsInCheck()
+                && moveScores[i] < EvaluationConstants.PromotionMoveScoreValue
+                && moveScores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }


### PR DESCRIPTION
```
Test  | search/qsearch-see-pruning-not-in-check
Elo   | -0.77 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 34492: +9486 -9562 =15444
Penta | [823, 4140, 7369, 4118, 796]
https://openbench.lynx-chess.com/test/1165/
```