### PR TITLE
🔍 RFP: add history factor - simple impl with quiet history

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -186,6 +186,9 @@ public sealed class EngineSettings
     [SPSA<int>(1, 300, 15)]
     public int RFP_DepthScalingFactor { get; set; } = 52;
 
+    [SPSA<int>(200, 600, 20)]
+    public int RFP_HistoryDivisor { get; set; } = 400;
+
     [SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -148,8 +148,10 @@ public sealed partial class Engine
                     var improvingFactor = improvingRate * (0.75 * depth);
 
                     var rfpThreshold = rfpMargin + improvingFactor;
+                    var previousMove = Game.ReadMoveFromStack(ply - 1);
+                    var previousMoveHistory = _quietHistory[previousMove.Piece()][previousMove.TargetSquare()];
 
-                    if (staticEval - rfpThreshold >= beta)
+                    if (staticEval - rfpThreshold >= beta + previousMoveHistory / Configuration.EngineSettings.RFP_HistoryDivisor)
                     {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                         return (staticEval + beta) / 2;


### PR DESCRIPTION
Idea by Sirius
```
Test  | search/rfp-history-quiet
Elo   | -3.04 +- 3.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 15218: +4164 -4297 =6757
Penta | [436, 1837, 3148, 1800, 388]
https://openbench.lynx-chess.com/test/1185/
```