### PR TITLE
🔍 Don't allow LMR reductions with SEE to fall into QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -399,7 +399,7 @@ public sealed partial class Engine
                         && moveScores[moveIndex] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
                     {
                         reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
-                        reduction = Math.Clamp(reduction, 0, depth - 1);
+                        reduction = Math.Min(reduction, depth - 2);
                     }
                 }
 


### PR DESCRIPTION
```
Test  | search/see-LMR-see
Elo   | -1.33 +- 2.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 26666: +7508 -7610 =11548
Penta | [810, 3167, 5401, 3225, 730]
https://openbench.lynx-chess.com/test/1187/
```