### PR TITLE
🔍 Extend on TT hit at low depths when TT cutoff doesn't happen but TT depth > depth

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -235,6 +235,9 @@ public sealed class EngineSettings
     [SPSA<int>(-8192, 0, 512)]
     public int HistoryPrunning_Margin { get; set; } = -1940;
 
+    [SPSA<int>(0, 10, 0.5)]
+    public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -60,8 +60,9 @@ public sealed partial class Engine
                 {
                     return ttScore;
                 }
-                else if (depth <= 6)
+                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
                 {
+                    // Extension idea from Stormphrax
                     ++depth;
                 }
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -52,12 +52,18 @@ public sealed partial class Engine
             // TT cutoffs
             if (!pvNode
                 && ttScore != EvaluationConstants.NoHashEntry
-                && ttDepth >= depth
-                && (ttElementType == NodeType.Exact
-                    || (ttElementType == NodeType.Alpha && ttScore <= alpha)
-                    || (ttElementType == NodeType.Beta && ttScore >= beta)))
+                && ttDepth >= depth)
             {
-                return ttScore;
+                if (ttElementType == NodeType.Exact
+                    || (ttElementType == NodeType.Alpha && ttScore <= alpha)
+                    || (ttElementType == NodeType.Beta && ttScore >= beta))
+                {
+                    return ttScore;
+                }
+                else if (depth <= 6)
+                {
+                    ++depth;
+                }
             }
 
             // Internal iterative reduction (IIR)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -558,6 +558,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "tthit_nocutoffextension_maxdepth":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth = value;
+                    }
+                    break;
+                }
 
             #endregion
 


### PR DESCRIPTION
```
Test  | search/ciekce-tt-extension
Elo   | 2.84 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.05 (-2.25, 2.89) [0.00, 3.00]
Games | 45812: +13184 -12809 =19819
Penta | [1232, 5434, 9276, 5655, 1309]
https://openbench.lynx-chess.com/test/1195/
```