### PR TITLE
⚡ Basic incremental static evaluation

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -6,15 +6,21 @@ public readonly struct GameState
 {
     public readonly ulong ZobristKey;
 
+    public readonly int IncremetalEvalAccumulator;
+
     public readonly BoardSquare EnPassant;
 
     public readonly byte Castle;
 
-    public GameState(ulong zobristKey, BoardSquare enpassant, byte castle)
+    public readonly bool IsIncrementalEval;
+
+    public GameState(ulong zobristKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
+        IncremetalEvalAccumulator = incrementalEvalAccumulator;
         EnPassant = enpassant;
         Castle = castle;
+        IsIncrementalEval = isIncrementalEval;
     }
 }
 

--- a/tests/Lynx.Test/IncrementalEvalTest.cs
+++ b/tests/Lynx.Test/IncrementalEvalTest.cs
@@ -1,0 +1,18 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+namespace Lynx.Test;
+public class IncrementalEvalTest
+{
+    /// <summary>
+    /// If castling moves are ever refactored, i.e. when adding FRC support, this should break.
+    /// That'll mean that incremental eval condition in <see cref="Position.MakeMove(int)"/> needs to change
+    /// </summary>
+    [Test]
+    public void CastlingMovesAreKingMoves()
+    {
+        Assert.AreEqual((int)Piece.K, MoveGenerator.WhiteShortCastle.Piece());
+        Assert.AreEqual((int)Piece.K, MoveGenerator.WhiteLongCastle.Piece());
+        Assert.AreEqual((int)Piece.k, MoveGenerator.BlackShortCastle.Piece());
+        Assert.AreEqual((int)Piece.k, MoveGenerator.BlackLongCastle.Piece());
+    }
+}


### PR DESCRIPTION
Once a position explores a king move , static eval down the tree stops being incremental.

```
Test  | eval/incremental-2
Elo   | 5.06 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 18686: +5366 -5094 =8226
Penta | [420, 2136, 4010, 2306, 471]
https://openbench.lynx-chess.com/test/1202/
```