### PR TITLE
Don't allow FEN parsing `Position` instances without (or with more than) a white and a black king

### DIFF
--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -57,11 +57,17 @@ public static class FENParser
             //{
             //    _logger.Debug("No full move counter detected");
             //}
+
+            if (pieceBitBoards[(int)Piece.K].CountBits() != 1
+                || pieceBitBoards[(int)Piece.k].CountBits() != 1)
+            {
+                throw new LynxException("Missing or extra kings");
+            }
         }
 #pragma warning disable S2139 // Exceptions should be either logged or rethrown but not both - meh
         catch (Exception e)
         {
-            _logger.Error(e, "Error parsing FEN");
+            _logger.Error(e, "Error parsing FEN {Fen}", fen.ToString());
             success = false;
             throw;
         }

--- a/tests/Lynx.Test/FENParserTest.cs
+++ b/tests/Lynx.Test/FENParserTest.cs
@@ -109,7 +109,7 @@ public class FENParserTest
         Assert.True(pieceBitBoards[(int)Piece.K].GetBit(BoardSquare.e1));
     }
 
-    [TestCase("8/8/8/8/8/8/8/8 w - - 0 1")]
+    [TestCase("K1k5/8/8/8/8/8/8/8 w - - 0 1")]
     [TestCase("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1 ")]
     [TestCase(Constants.TrickyTestPositionFEN)]
     [TestCase(Constants.KillerTestPositionFEN)]
@@ -187,7 +187,7 @@ public class FENParserTest
     {
         // Arrange
         // Make sure a previous Fen doesn't change anything
-        const string previuosFen = "8/8/8/8/8/8/8/8 w KQkq - 0 1";
+        const string previuosFen = "K15k/8/8/8/8/8/8/8 w KQkq - 0 1";
         Assert.DoesNotThrow(() => FENParser.ParseFEN(previuosFen));
 
         if (expectedCastleResult >= 0)
@@ -230,9 +230,9 @@ public class FENParserTest
         Assert.Throws<LynxException>(() => FENParser.ParseFEN(fen));
     }
 
-    [TestCase("8/8/8/8/8/8/8/8 w KQkq - 0 1", 0)]
-    [TestCase("8/8/8/8/8/8/8/8 w KQkq - 1 1", 1)]
-    [TestCase("8/8/8/8/8/8/8/8 w KQkq - 51 1", 51)]
+    [TestCase("K1k/8/8/8/8/8/8/8 w KQkq - 0 1", 0)]
+    [TestCase("K1k/8/8/8/8/8/8/8 w KQkq - 1 1", 1)]
+    [TestCase("K1k/8/8/8/8/8/8/8 w KQkq - 51 1", 51)]
     public void HalfMoveClock(string fen, int expectedHalfMoves)
     {
         var result = FENParser.ParseFEN(fen);

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -78,12 +78,18 @@ public class PositionTest
         }
     }
 
-    [TestCase(Constants.EmptyBoardFEN, false)]
-    [TestCase("K/8/8/8/8/8/8/8 w - - 0 1", false)]
-    [TestCase("K/8/8/8/8/8/8/8 b - - 0 1", false)]
-    [TestCase("k/8/8/8/8/8/8/8 w - - 0 1", false)]
-    [TestCase("k/8/8/8/8/8/8/8 b - - 0 1", false)]
+    [TestCase(Constants.EmptyBoardFEN)]
+    [TestCase("K/8/8/8/8/8/8/8 w - - 0 1")]
+    [TestCase("K/8/8/8/8/8/8/8 b - - 0 1")]
+    [TestCase("k/8/8/8/8/8/8/8 w - - 0 1")]
+    [TestCase("k/8/8/8/8/8/8/8 b - - 0 1")]
+    public void MissingKings(string fen)
+    {
+        Assert.Throws<LynxException>(() => new Position(fen));
+    }
+
     [TestCase(Constants.InitialPositionFEN, true)]
+    [TestCase("r1k5/1K6/8/8/8/8/8/8 w - - 0 1", false)]
     [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1", false)]
     [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 1", true)]
     [TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR b KQkq - 0 1", false)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
@@ -18,7 +18,7 @@ public class GenerateKnightMovesTest
     }
 
     [TestCase(Constants.InitialPositionFEN, 4)]
-    [TestCase("1K1k3/8/8/8/8/P1P2P1P/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)]
+    [TestCase("1k6/8/8/8/8/P1P2P1P/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 0)]
     [TestCase("rnbqkbnr/pppppppp/p1p2p1p/8/8/8/8/1K6 b KQkq - 0 1", 0)]
     [TestCase("1K1k3/8/2P1P3/1P3P2/3N4/1P3P2/2P1P3/8 w - - 0 1", 0)]
     [TestCase("1K1k3/8/2p1p3/1p3p2/3N4/1p3p2/2p1p3/8 w - - 0 1", 8)]


### PR DESCRIPTION
Follow-up of ec0b847e4af6f11ab811cfd03a02d468184c2563
There's till the workaround of manually removing them afterwards.
