### PR TITLE
⚡  Make `AdditionalPieceEvaluation` always return positive numbers

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -584,7 +584,7 @@ public class Position : IDisposable
                     bitboard.ResetLS1B();
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
-                    packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndex, (int)Side.White, whiteKing, blackKing, blackPawnAttacks);
+                    packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndex, whiteKing, blackKing, blackPawnAttacks);
                 }
             }
 
@@ -603,7 +603,7 @@ public class Position : IDisposable
                     bitboard.ResetLS1B();
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
-                    packedScore -= AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndex, (int)Side.Black, blackKing, whiteKing, whitePawnAttacks);
+                    packedScore += AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndex, blackKing, whiteKing, whitePawnAttacks);
                 }
             }
         }
@@ -629,7 +629,7 @@ public class Position : IDisposable
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
-                    packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndex, (int)Side.White, whiteKing, blackKing, blackPawnAttacks);
+                    packedScore += AdditionalPieceEvaluation(whiteBucket, pieceSquareIndex, pieceIndex, whiteKing, blackKing, blackPawnAttacks);
                 }
             }
 
@@ -652,7 +652,7 @@ public class Position : IDisposable
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
-                    packedScore -= AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndex, (int)Side.Black, blackKing, whiteKing, whitePawnAttacks);
+                    packedScore += AdditionalPieceEvaluation(blackBucket, pieceSquareIndex, pieceIndex, blackKing, whiteKing, whitePawnAttacks);
                 }
             }
 
@@ -816,15 +816,28 @@ public class Position : IDisposable
     /// Doesn't include <see cref="Piece.K"/> and <see cref="Piece.k"/> evaluation
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int AdditionalPieceEvaluation(int bucket, int pieceSquareIndex, int pieceIndex, int pieceSide, int sameSideKingSquare, int oppositeSideKingSquare, BitBoard enemyPawnAttacks)
+    internal int AdditionalPieceEvaluation(int bucket, int pieceSquareIndex, int pieceIndex, int sameSideKingSquare, int oppositeSideKingSquare, BitBoard enemyPawnAttacks)
     {
         return pieceIndex switch
         {
-            (int)Piece.P or (int)Piece.p => PawnAdditionalEvaluation(bucket, pieceSquareIndex, pieceIndex, sameSideKingSquare, oppositeSideKingSquare),
-            (int)Piece.R or (int)Piece.r => RookAdditionalEvaluation(pieceSquareIndex, pieceIndex, pieceSide, oppositeSideKingSquare, enemyPawnAttacks),
-            (int)Piece.B or (int)Piece.b => BishopAdditionalEvaluation(pieceSquareIndex, pieceIndex, pieceSide, oppositeSideKingSquare, enemyPawnAttacks),
-            (int)Piece.N or (int)Piece.n => KnightAdditionalEvaluation(pieceSquareIndex, pieceSide, oppositeSideKingSquare, enemyPawnAttacks),
-            (int)Piece.Q or (int)Piece.q => QueenAdditionalEvaluation(pieceSquareIndex, pieceSide, oppositeSideKingSquare, enemyPawnAttacks),
+            (int)Piece.P => PawnAdditionalEvaluation(bucket, pieceSquareIndex, (int)Piece.P, sameSideKingSquare, oppositeSideKingSquare),
+            (int)Piece.p => -PawnAdditionalEvaluation(bucket, pieceSquareIndex, (int)Piece.p, sameSideKingSquare, oppositeSideKingSquare),
+
+            (int)Piece.R => RookAdditionalEvaluation(pieceSquareIndex, (int)Piece.R, (int)Side.White, oppositeSideKingSquare, enemyPawnAttacks),
+            (int)Piece.r => -RookAdditionalEvaluation(pieceSquareIndex, (int)Piece.r, (int)Side.Black, oppositeSideKingSquare, enemyPawnAttacks),
+
+            (int)Piece.B => BishopAdditionalEvaluation(pieceSquareIndex, (int)Piece.B, (int)Side.White, oppositeSideKingSquare, enemyPawnAttacks),
+            (int)Piece.b => -BishopAdditionalEvaluation(pieceSquareIndex, (int)Piece.b, (int)Side.Black, oppositeSideKingSquare, enemyPawnAttacks),
+
+            (int)Piece.N => KnightAdditionalEvaluation(pieceSquareIndex, (int)Side.White, oppositeSideKingSquare, enemyPawnAttacks),
+            (int)Piece.n => -KnightAdditionalEvaluation(pieceSquareIndex, (int)Side.Black, oppositeSideKingSquare, enemyPawnAttacks),
+
+            (int)Piece.Q => QueenAdditionalEvaluation(pieceSquareIndex, (int)Side.White, oppositeSideKingSquare, enemyPawnAttacks),
+            (int)Piece.q => -QueenAdditionalEvaluation(pieceSquareIndex, (int)Side.Black, oppositeSideKingSquare, enemyPawnAttacks),
+
+            (int)Piece.K => KingAdditionalEvaluation(pieceSquareIndex, (int)Side.White, enemyPawnAttacks),
+            (int)Piece.k => -KingAdditionalEvaluation(pieceSquareIndex, (int)Side.Black, enemyPawnAttacks),
+
             _ => 0
         };
     }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -993,7 +993,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
+            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, (int)piece, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
         }
 
         return eval;

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -210,7 +210,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-            - AdditionalPieceEvaluation(position, Piece.p);
+            + AdditionalPieceEvaluation(position, Piece.p);
 
         if (position.Side == Side.Black)
         {
@@ -390,7 +390,7 @@ public class PositionTest
     {
         var position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-            - AdditionalPieceEvaluation(position, Piece.p);
+            + AdditionalPieceEvaluation(position, Piece.p);
 
         var rank = Constants.Rank[(int)square];
         var pieceIndex = (int)Piece.P;
@@ -451,7 +451,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+            + AdditionalPieceEvaluation(position, Piece.r);
 
         if (position.Side == Side.Black)
         {
@@ -483,7 +483,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+            + AdditionalPieceEvaluation(position, Piece.r);
 
         if (position.Side == Side.Black)
         {
@@ -514,7 +514,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+            + AdditionalPieceEvaluation(position, Piece.r);
 
         if (position.Side == Side.Black)
         {
@@ -546,7 +546,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+            + AdditionalPieceEvaluation(position, Piece.r);
 
         if (position.Side == Side.Black)
         {
@@ -580,7 +580,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+            + AdditionalKingEvaluation(position, Piece.k);
 
         if (position.Side == Side.Black)
         {
@@ -610,7 +610,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+            + AdditionalKingEvaluation(position, Piece.k);
 
         if (position.Side == Side.Black)
         {
@@ -642,7 +642,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+            + AdditionalKingEvaluation(position, Piece.k);
 
         if (position.Side == Side.Black)
         {
@@ -674,7 +674,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+            + AdditionalKingEvaluation(position, Piece.k);
 
         if (position.Side == Side.Black)
         {
@@ -722,7 +722,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+            + AdditionalKingEvaluation(position, Piece.k);
 
         if (position.Side == Side.Black)
         {
@@ -768,7 +768,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.B)
-            - AdditionalPieceEvaluation(position, Piece.b);
+            + AdditionalPieceEvaluation(position, Piece.b);
 
         if (position.Side == Side.Black)
         {
@@ -862,7 +862,7 @@ public class PositionTest
     {
         Position position = new Position(fen);
         int evaluation = AdditionalPieceEvaluation(position, Piece.Q)
-            - AdditionalPieceEvaluation(position, Piece.q);
+            + AdditionalPieceEvaluation(position, Piece.q);
 
         BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
         BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
@@ -982,9 +982,7 @@ public class PositionTest
             ? blackPawnAttacks
             : whitePawnAttacks;
 
-        var pieceSide = (int)piece <= (int)Piece.K
-            ? (int)Side.White
-            : (int)Side.Black;
+        int pìeceInt = (int)piece;
 
         var bitBoard = position.PieceBitBoards[(int)piece];
         int eval = 0;
@@ -993,7 +991,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, (int)piece, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
+            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, pìeceInt, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
         }
 
         return eval;
@@ -1018,7 +1016,7 @@ public class PositionTest
 
         return UnpackEG(piece == Piece.K
             ? position.KingAdditionalEvaluation(bitBoard, (int)Side.White, blackPawnAttacks)
-            : position.KingAdditionalEvaluation(bitBoard, (int)Side.Black, whitePawnAttacks));
+            : -position.KingAdditionalEvaluation(bitBoard, (int)Side.Black, whitePawnAttacks));
     }
 
     private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)


### PR DESCRIPTION
I'd swear I've tried this in the past with similar awful results

```
Score of Lynx-refactor-additionalpieceeval-positive-5109-win-x64 vs Lynx 5107 - main: 300 - 375 - 535  [0.469] 1210
...      Lynx-refactor-additionalpieceeval-positive-5109-win-x64 playing White: 237 - 101 - 267  [0.612] 605
...      Lynx-refactor-additionalpieceeval-positive-5109-win-x64 playing Black: 63 - 274 - 268  [0.326] 605
...      White vs Black: 511 - 164 - 535  [0.643] 1210
Elo difference: -21.6 +/- 14.6, LOS: 0.2 %, DrawRatio: 44.2 %
SPRT: llr -1.48 (-51.2%), lbound -2.25, ubound 2.89
```