### PR TITLE
⚡ Reuse array ref for friend and enemy PSQT

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -163,11 +163,8 @@ public class Position : IDisposable
                 (sameSideBucket, opposideSideBucket) = (opposideSideBucket, sameSideBucket);
             }
 
-            _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, piece, sourceSquare);
-            _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, piece, sourceSquare);
-
-            _incrementalEvalAccumulator += PSQT(0, sameSideBucket, newPiece, targetSquare);
-            _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, newPiece, targetSquare);
+            _incrementalEvalAccumulator -= PSQTFriendEnemy(sameSideBucket, opposideSideBucket, piece, sourceSquare);
+            _incrementalEvalAccumulator += PSQTFriendEnemy(sameSideBucket, opposideSideBucket, newPiece, targetSquare);
 
             switch (move.SpecialMoveFlag())
             {
@@ -182,8 +179,7 @@ public class Position : IDisposable
                             OccupancyBitBoards[oppositeSide].PopBit(capturedSquare);
                             UniqueIdentifier ^= ZobristTable.PieceHash(capturedSquare, capturedPiece);
 
-                            _incrementalEvalAccumulator -= PSQT(0, opposideSideBucket, capturedPiece, capturedSquare);
-                            _incrementalEvalAccumulator -= PSQT(1, sameSideBucket, capturedPiece, capturedSquare);
+                            _incrementalEvalAccumulator -= PSQTFriendEnemy(opposideSideBucket, sameSideBucket, capturedPiece, capturedSquare);
                         }
 
                         break;
@@ -217,11 +213,8 @@ public class Position : IDisposable
                             ZobristTable.PieceHash(rookSourceSquare, rookIndex)
                             ^ ZobristTable.PieceHash(rookTargetSquare, rookIndex);
 
-                        _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, rookIndex, rookSourceSquare);
-                        _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, rookIndex, rookSourceSquare);
-
-                        _incrementalEvalAccumulator += PSQT(0, sameSideBucket, rookIndex, rookTargetSquare);
-                        _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, rookIndex, rookTargetSquare);
+                        _incrementalEvalAccumulator -= PSQTFriendEnemy(sameSideBucket, opposideSideBucket, rookIndex, rookSourceSquare);
+                        _incrementalEvalAccumulator += PSQTFriendEnemy(sameSideBucket, opposideSideBucket, rookIndex, rookTargetSquare);
 
                         break;
                     }
@@ -243,11 +236,8 @@ public class Position : IDisposable
                             ZobristTable.PieceHash(rookSourceSquare, rookIndex)
                             ^ ZobristTable.PieceHash(rookTargetSquare, rookIndex);
 
-                        _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, rookIndex, rookSourceSquare);
-                        _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, rookIndex, rookSourceSquare);
-
-                        _incrementalEvalAccumulator += PSQT(0, sameSideBucket, rookIndex, rookTargetSquare);
-                        _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, rookIndex, rookTargetSquare);
+                        _incrementalEvalAccumulator -= PSQTFriendEnemy(sameSideBucket, opposideSideBucket, rookIndex, rookSourceSquare);
+                        _incrementalEvalAccumulator += PSQTFriendEnemy(sameSideBucket, opposideSideBucket, rookIndex, rookTargetSquare);
 
                         break;
                     }
@@ -264,8 +254,7 @@ public class Position : IDisposable
                         Board[capturedSquare] = (int)Piece.None;
                         UniqueIdentifier ^= ZobristTable.PieceHash(capturedSquare, capturedPiece);
 
-                        _incrementalEvalAccumulator -= PSQT(0, opposideSideBucket, capturedPiece, capturedSquare);
-                        _incrementalEvalAccumulator -= PSQT(1, sameSideBucket, capturedPiece, capturedSquare);
+                        _incrementalEvalAccumulator -= PSQTFriendEnemy(opposideSideBucket, sameSideBucket, capturedPiece, capturedSquare);
 
                         break;
                     }
@@ -624,8 +613,7 @@ public class Position : IDisposable
                     var pieceSquareIndex = bitboard.GetLS1BIndex();
                     bitboard.ResetLS1B();
 
-                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, blackBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQTFriendEnemy(whiteBucket, blackBucket, pieceIndex, pieceSquareIndex);
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
@@ -647,8 +635,7 @@ public class Position : IDisposable
                     var pieceSquareIndex = bitboard.GetLS1BIndex();
                     bitboard.ResetLS1B();
 
-                    _incrementalEvalAccumulator += PSQT(0, blackBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQTFriendEnemy(blackBucket, whiteBucket, pieceIndex, pieceSquareIndex);
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
@@ -658,10 +645,8 @@ public class Position : IDisposable
 
             // Kings
             _incrementalEvalAccumulator +=
-                PSQT(0, whiteBucket, (int)Piece.K, whiteKing)
-                + PSQT(1, blackBucket, (int)Piece.K, whiteKing)
-                + PSQT(0, blackBucket, (int)Piece.k, blackKing)
-                + PSQT(1, whiteBucket, (int)Piece.k, blackKing);
+                PSQTFriendEnemy(whiteBucket, blackBucket, (int)Piece.K, whiteKing)
+                + PSQTFriendEnemy(blackBucket, whiteBucket, (int)Piece.k, blackKing);
 
             packedScore += _incrementalEvalAccumulator;
             _isIncrementalEval = true;

--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -109,6 +109,24 @@ public static class EvaluationPSQTs
     /// [2][PSQTBucketCount][12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PSQTFriendEnemy(int friendBucket, int enemyBucket, int piece, int square)
+    {
+        var friendIndex = PSQTIndex(0, friendBucket, piece, square);
+        var enemyIndex = PSQTIndex(1, enemyBucket, piece, square);
+
+        Debug.Assert(friendIndex >= 0 && friendIndex < _packedPSQT.Length);
+        Debug.Assert(enemyBucket >= 0 && enemyBucket < _packedPSQT.Length);
+
+        ref var refArray = ref MemoryMarshal.GetArrayDataReference(_packedPSQT);
+
+        return Unsafe.Add(ref refArray, friendIndex)
+            + Unsafe.Add(ref refArray, enemyIndex);
+    }
+
+    /// <summary>
+    /// [2][PSQTBucketCount][12][64]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int PSQTIndex(int friendEnemy, int bucket, int piece, int square)
     {
         const int friendEnemyOffset = PSQTBucketCount * 12 * 64;


### PR DESCRIPTION
This saves one `MemoryMarshal.GetArrayDataReference` call

```
Test  | perf/PSQT-friend-enemy-reuse-arrayref
Elo   | -4.86 +- 4.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 10016: +2708 -2848 =4460
Penta | [234, 1224, 2204, 1140, 206]
https://openbench.lynx-chess.com/test/1205/
```