### PR TITLE
⚡ Try to 'unroll' sums

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -624,8 +624,8 @@ public class Position : IDisposable
                     var pieceSquareIndex = bitboard.GetLS1BIndex();
                     bitboard.ResetLS1B();
 
-                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, blackBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(1, blackBucket, pieceIndex, pieceSquareIndex);
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
@@ -647,8 +647,8 @@ public class Position : IDisposable
                     var pieceSquareIndex = bitboard.GetLS1BIndex();
                     bitboard.ResetLS1B();
 
-                    _incrementalEvalAccumulator += PSQT(0, blackBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(0, blackBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(1, whiteBucket, pieceIndex, pieceSquareIndex);
 
                     gamePhase += GamePhaseByPiece[pieceIndex];
 
@@ -657,19 +657,17 @@ public class Position : IDisposable
             }
 
             // Kings
-            _incrementalEvalAccumulator +=
-                PSQT(0, whiteBucket, (int)Piece.K, whiteKing)
-                + PSQT(1, blackBucket, (int)Piece.K, whiteKing)
-                + PSQT(0, blackBucket, (int)Piece.k, blackKing)
-                + PSQT(1, whiteBucket, (int)Piece.k, blackKing);
+            _incrementalEvalAccumulator += PSQT(0, whiteBucket, (int)Piece.K, whiteKing);
+            _incrementalEvalAccumulator += PSQT(1, blackBucket, (int)Piece.K, whiteKing);
+            _incrementalEvalAccumulator += PSQT(0, blackBucket, (int)Piece.k, blackKing);
+            _incrementalEvalAccumulator += PSQT(1, whiteBucket, (int)Piece.k, blackKing);
 
             packedScore += _incrementalEvalAccumulator;
             _isIncrementalEval = true;
         }
 
-        packedScore +=
-            KingAdditionalEvaluation(whiteKing, (int)Side.White, blackPawnAttacks)
-            - KingAdditionalEvaluation(blackKing, (int)Side.Black, whitePawnAttacks);
+        packedScore += KingAdditionalEvaluation(whiteKing, (int)Side.White, blackPawnAttacks);
+        packedScore -= KingAdditionalEvaluation(blackKing, (int)Side.Black, whitePawnAttacks);
 
         // Bishop pair bonus
         if (PieceBitBoards[(int)Piece.B].CountBits() >= 2)


### PR DESCRIPTION
```
Test  | experiment/unroll
Elo   | -0.71 +- 2.42 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 35584: +10280 -10353 =14951
Penta | [984, 4124, 7636, 4077, 971]
https://openbench.lynx-chess.com/test/1204/
```