### PR TITLE
⚡  Re-use PSQT array ref

### DIFF
--- a/src/Lynx.Benchmark/ArrayCopy_Benchmark.cs
+++ b/src/Lynx.Benchmark/ArrayCopy_Benchmark.cs
@@ -218,7 +218,7 @@ public class ArrayCopy_Benchmark : BaseBenchmark
         Enumerable.Range(0,256).ToArray(),
         Enumerable.Range(0,512).ToArray(),
         Enumerable.Range(0,1024).ToArray(),
-        EvaluationPSQTs._packedPSQT
+        PSQT.PSQTArray
     ];
 #pragma warning restore S2365 // Properties should not make collection or array copies
 

--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -6,7 +6,7 @@ using static Lynx.TunableEvalParameters;
 
 namespace Lynx;
 
-public static class EvaluationPSQTs
+public static class PSQT
 {
     public const int PSQTBucketCount = 23;
 
@@ -27,9 +27,9 @@ public static class EvaluationPSQTs
     /// <summary>
     /// 2 x PSQTBucketCount x 12 x 64
     /// </summary>
-    internal static readonly int[] _packedPSQT = GC.AllocateArray<int>(2 * PSQTBucketCount * 12 * 64, pinned: true);
+    public static readonly int[] PSQTArray = GC.AllocateArray<int>(2 * PSQTBucketCount * 12 * 64, pinned: true);
 
-    static EvaluationPSQTs()
+    static PSQT()
     {
         short[][][][] mgPositionalTables =
         [
@@ -80,11 +80,11 @@ public static class EvaluationPSQTs
                 {
                     for (int sq = 0; sq < 64; ++sq)
                     {
-                        _packedPSQT[PSQTIndex(friendEnemy, bucket, piece, sq)] = Utils.Pack(
+                        PSQTArray[PSQTIndex(friendEnemy, bucket, piece, sq)] = Utils.Pack(
                             (short)(MiddleGamePieceValues[friendEnemy][bucket][piece] + mgPositionalTables[friendEnemy][piece][bucket][sq]),
                             (short)(EndGamePieceValues[friendEnemy][bucket][piece] + egPositionalTables[friendEnemy][piece][bucket][sq]));
 
-                        _packedPSQT[PSQTIndex(friendEnemy, bucket, piece + 6, sq)] = Utils.Pack(
+                        PSQTArray[PSQTIndex(friendEnemy, bucket, piece + 6, sq)] = Utils.Pack(
                             (short)(MiddleGamePieceValues[friendEnemy][bucket][piece + 6] - mgPositionalTables[friendEnemy][piece][bucket][sq ^ 56]),
                             (short)(EndGamePieceValues[friendEnemy][bucket][piece + 6] - egPositionalTables[friendEnemy][piece][bucket][sq ^ 56]));
                     }
@@ -97,12 +97,12 @@ public static class EvaluationPSQTs
     /// [2][PSQTBucketCount][12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int PSQT(int friendEnemy, int bucket, int piece, int square)
+    public static int GetElement(int friendEnemy, int bucket, int piece, int square)
     {
         var index = PSQTIndex(friendEnemy, bucket, piece, square);
-        Debug.Assert(index >= 0 && index < _packedPSQT.Length);
+        Debug.Assert(index >= 0 && index < PSQTArray.Length);
 
-        return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_packedPSQT), index);
+        return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(PSQTArray), index);
     }
 
     /// <summary>

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 
 using static Lynx.EvaluationConstants;
 using static Lynx.EvaluationParams;
-using static Lynx.EvaluationPSQTs;
+using static Lynx.PSQT;
 using static Lynx.TunableEvalParameters;
 using static Lynx.Utils;
 


### PR DESCRIPTION
Same idea as in #1356, same spectacular failure

```
Test  | perf/psqt-reuse-arrayref
Elo   | -23.22 +- 8.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 2458: +634 -798 =1026
Penta | [74, 336, 543, 232, 44]
https://openbench.lynx-chess.com/test/1207/
```