### PR TITLE
🔍 IIR -> `depth -= 2`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -74,7 +74,7 @@ public sealed partial class Engine
             // which we'll be able to use later for the full depth search
             if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
-                --depth;
+                depth -= 2;
             }
         }
 


### PR DESCRIPTION
```
Test  | search/moar-iir
Elo   | -12.38 +- 6.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 4634: +1215 -1380 =2039
Penta | [160, 582, 946, 521, 108]
https://openbench.lynx-chess.com/test/1212/
```

```
Test  | search/moar-iir
Elo   | -5.19 +- 5.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 5.00]
Games | 4958: +1224 -1298 =2436
Penta | [82, 621, 1138, 565, 73]
https://openbench.lynx-chess.com/test/1222/
```