### PR TITLE
⚡ Don't initialize `Position.UniqueIdentifier` until it's needed

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -16,7 +16,12 @@ public class Position : IDisposable
     private int _incrementalEvalAccumulator;
     private bool _isIncrementalEval;
 
-    public ulong UniqueIdentifier { get; private set; }
+    private ulong? _uniqueIdentifier;
+    public ulong UniqueIdentifier
+    {
+        get => _uniqueIdentifier ??= ZobristTable.PositionHash(this);
+        private set => _uniqueIdentifier = value;
+    }
 
     /// <summary>
     /// Use <see cref="Piece"/> as index


### PR DESCRIPTION
```
Test  | perf/position-uniqueid-init-only-once-needed
Elo   | -4.60 +- 4.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 10736: +2988 -3130 =4618
Penta | [275, 1291, 2373, 1159, 270]
https://openbench.lynx-chess.com/test/1213/
```