### PR TITLE
⚖️ Pawn eval table - score only

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -509,6 +509,16 @@ public static class Constants
         [7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 6, 5, 4, 4, 4, 4, 4, 4, 6, 5, 4, 3, 3, 3, 3, 3, 6, 5, 4, 3, 2, 2, 2, 2, 6, 5, 4, 3, 2, 1, 1, 1, 6, 5, 4, 3, 2, 1, 0, 1],
         [7, 7, 7, 7, 7, 7, 7, 7, 7, 6, 6, 6, 6, 6, 6, 6, 7, 6, 5, 5, 5, 5, 5, 5, 7, 6, 5, 4, 4, 4, 4, 4, 7, 6, 5, 4, 3, 3, 3, 3, 7, 6, 5, 4, 3, 2, 2, 2, 7, 6, 5, 4, 3, 2, 1, 1, 7, 6, 5, 4, 3, 2, 1, 0]
     ];
+
+    /// <summary>
+    /// 262_144 * 8 / 1024 = 4MB
+    /// 4 -> sizeof(int)
+    /// </summary>
+    public const int KingPawnHashSize = 262_144;
+
+    public const int KingPawnHashMask = KingPawnHashSize - 1;
+
+    public const int DefaultKingPawnValue =  -32_000;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -49,6 +49,8 @@ public sealed partial class Engine : IDisposable
             _moveNodeCount[i] = new ulong[64];
         }
 
+        Array.Fill(_kingPawnHashTable, Constants.DefaultKingPawnValue);
+
 #if !DEBUG
         if (warmup)
         {
@@ -101,6 +103,9 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_captureHistory);
         Array.Clear(_continuationHistory);
         Array.Clear(_counterMoves);
+
+        // Array.Clear() would set it to 0
+        Array.Fill(_kingPawnHashTable, Constants.DefaultKingPawnValue);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -6,6 +6,8 @@ public readonly struct GameState
 {
     public readonly ulong ZobristKey;
 
+    public readonly ulong KingPawnKey;
+
     public readonly int IncremetalEvalAccumulator;
 
     public readonly BoardSquare EnPassant;
@@ -14,9 +16,10 @@ public readonly struct GameState
 
     public readonly bool IsIncrementalEval;
 
-    public GameState(ulong zobristKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
+    public GameState(ulong zobristKey, ulong kingPawnKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
+        KingPawnKey = kingPawnKey;
         IncremetalEvalAccumulator = incrementalEvalAccumulator;
         EnPassant = enpassant;
         Castle = castle;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -18,6 +18,8 @@ public class Position : IDisposable
 
     public ulong UniqueIdentifier { get; private set; }
 
+    public ulong KingPawnUniqueIdentifier { get; private set; }
+
     /// <summary>
     /// Use <see cref="Piece"/> as index
     /// </summary>
@@ -68,6 +70,7 @@ public class Position : IDisposable
 
 #pragma warning disable S3366 // "this" should not be exposed from constructors
         UniqueIdentifier = ZobristTable.PositionHash(this);
+        KingPawnUniqueIdentifier = ZobristTable.PawnKingHash(this);
 #pragma warning restore S3366 // "this" should not be exposed from constructors
 
         _isIncrementalEval = false;
@@ -80,6 +83,7 @@ public class Position : IDisposable
     public Position(Position position)
     {
         UniqueIdentifier = position.UniqueIdentifier;
+        KingPawnUniqueIdentifier = position.KingPawnUniqueIdentifier;
         PieceBitBoards = ArrayPool<BitBoard>.Shared.Rent(12);
         Array.Copy(position.PieceBitBoards, PieceBitBoards, position.PieceBitBoards.Length);
 
@@ -105,6 +109,7 @@ public class Position : IDisposable
         byte castleCopy = Castle;
         BoardSquare enpassantCopy = EnPassant;
         ulong uniqueIdentifierCopy = UniqueIdentifier;
+        ulong kingPawnKeyUniqueIdentifierCopy = KingPawnUniqueIdentifier;
         int incrementalEvalAccumulatorCopy = _incrementalEvalAccumulator;
         // We also save a copy of _isIncrementalEval, so that current move doesn't affect 'sibling' moves exploration
         bool isIncrementalEvalCopy = _isIncrementalEval;
@@ -368,7 +373,7 @@ public class Position : IDisposable
 
         UniqueIdentifier ^= ZobristTable.CastleHash(Castle);
 
-        return new GameState(uniqueIdentifierCopy, incrementalEvalAccumulatorCopy, enpassantCopy, castleCopy, isIncrementalEvalCopy);
+        return new GameState(uniqueIdentifierCopy, kingPawnKeyUniqueIdentifierCopy, incrementalEvalAccumulatorCopy, enpassantCopy, castleCopy, isIncrementalEvalCopy);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -469,6 +474,7 @@ public class Position : IDisposable
         Castle = gameState.Castle;
         EnPassant = gameState.EnPassant;
         UniqueIdentifier = gameState.ZobristKey;
+        KingPawnUniqueIdentifier = gameState.KingPawnKey;
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _isIncrementalEval = gameState.IsIncrementalEval;
     }
@@ -479,6 +485,7 @@ public class Position : IDisposable
         Side = (Side)Utils.OppositeSide(Side);
         var oldEnPassant = EnPassant;
         var oldUniqueIdentifier = UniqueIdentifier;
+        var oldKingPawnUniqueIdentifier = KingPawnUniqueIdentifier;
         EnPassant = BoardSquare.noSquare;
 
         UniqueIdentifier ^=
@@ -494,6 +501,7 @@ public class Position : IDisposable
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;
         UniqueIdentifier = gameState.ZobristKey;
+        KingPawnUniqueIdentifier = gameState.KingPawnKey;
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _isIncrementalEval = gameState.IsIncrementalEval;
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -48,6 +48,11 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
+    /// <summary>
+    /// <see cref="Constants.KingPawnHashSize"/>
+    /// </summary>
+    private readonly int[] _kingPawnHashTable = GC.AllocateArray<int>(Constants.KingPawnHashSize, pinned: true);
+
     private ulong _nodes;
 
     private SearchResult? _previousSearchResult;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -24,7 +24,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         }
 
         _maxDepthReached[ply] = ply;
@@ -95,7 +95,7 @@ public sealed partial class Engine
         if (isInCheck)
         {
             ++depth;
-            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         }
         else if (depth <= 0)
         {
@@ -112,7 +112,7 @@ public sealed partial class Engine
         {
             if (ttElementType == default)
             {
-                (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove);
+                (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable);
             }
             else
             {
@@ -228,7 +228,7 @@ public sealed partial class Engine
         }
         else
         {
-            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
@@ -535,7 +535,7 @@ public sealed partial class Engine
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
             _logger.Info("Max depth {0} reached", Configuration.EngineSettings.MaxDepth);
-            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+            return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         }
 
         var pvIndex = PVTable.Indexes[ply];
@@ -565,10 +565,10 @@ public sealed partial class Engine
         /*
         var staticEval = ttHit
             ? ttProbeResult.StaticEval
-            : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+            : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         */
 
-        var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove).Score;
+        var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         Debug.Assert(staticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
 
         Game.UpdateStaticEvalInStack(ply, staticEval);

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -116,6 +116,43 @@ public static class ZobristTable
     }
 
     /// <summary>
+    /// Calculates from scratch the pawn structure hash of a position
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong PawnKingHash(Position position)
+    {
+        ulong pawnKingHash = 0;
+
+        var whitePawns = position.PieceBitBoards[(int)Piece.P];
+        while (whitePawns != default)
+        {
+            var pieceSquareIndex = whitePawns.GetLS1BIndex();
+            whitePawns.ResetLS1B();
+
+            pawnKingHash ^= PieceHash(pieceSquareIndex, (int)Piece.P);
+        }
+
+        var blackPawns = position.PieceBitBoards[(int)Piece.p];
+        while (blackPawns != default)
+        {
+            var pieceSquareIndex = blackPawns.GetLS1BIndex();
+            blackPawns.ResetLS1B();
+
+            pawnKingHash ^= PieceHash(pieceSquareIndex, (int)Piece.p);
+        }
+
+        var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();
+        pawnKingHash ^= PieceHash(whiteKing, (int)Piece.K);
+
+        var blackKing = position.PieceBitBoards[(int)Piece.k].GetLS1BIndex();
+        pawnKingHash ^= PieceHash(blackKing, (int)Piece.k);
+
+        pawnKingHash ^= SideHash();
+
+        return pawnKingHash;
+    }
+
+    /// <summary>
     /// Initializes Zobrist table (long[64][12])
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -1,6 +1,5 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
-
 using static Lynx.EvaluationConstants;
 using static Lynx.EvaluationParams;
 using static Lynx.EvaluationPSQTs;
@@ -361,5 +360,15 @@ public class EvaluationConstantsTest
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// If this fails after a change, pawn eval calculations should be revisited, because phase isn't being added there
+    /// </summary>
+    [Test]
+    public void GamePhaseByPiece_ForPawns_ShouldBeZero()
+    {
+        Assert.Zero(GamePhaseByPiece[(int)Piece.P]);
+        Assert.Zero(GamePhaseByPiece[(int)Piece.p]);
     }
 }


### PR DESCRIPTION
Table with king-pawn key to cache pawn additional eval.

The table in this first, 'naive' attempt stores only scores, relying on zobrist hashing to find the right entry, without extra verifications

```
Test  | eval/kingpawn-hash-table-score-only
Elo   | -180.10 +- 27.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 552: +82 -345 =125
Penta | [105, 78, 71, 19, 3]
https://openbench.lynx-chess.com/test/1214/
```