### PR TITLE
⚖️ Disable `PassedPawnBonusNoEnemiesAheadBonus`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1064,10 +1064,10 @@ public class Position : IDisposable
         if ((PieceBitBoards[(int)Piece.p - pieceIndex] & passedPawnsMask) == default)
         {
             // Passed pawn without opponent pieces ahead (in its passed pawn mask)
-            if ((passedPawnsMask & OccupancyBitBoards[oppositeSide]) == 0)
-            {
-                packedBonus += PassedPawnBonusNoEnemiesAheadBonus[bucket][rank];
-            }
+            //if ((passedPawnsMask & OccupancyBitBoards[oppositeSide]) == 0)
+            //{
+            //    packedBonus += PassedPawnBonusNoEnemiesAheadBonus[bucket][rank];
+            //}
 
             // King distance to passed pawn
             var friendlyKingDistance = Constants.ChebyshevDistance[squareIndex][sameSideKingSquare];


### PR DESCRIPTION
Given that we're not keeping track of `PassedPawnBonusNoEnemiesAheadBonus` during incremental updates, let's see if if still serves some purpose. Original PR where added: #1008 

```
Test  | eval/kingpawn-hash-table-with-key-no-PassedPawnBonusNoEnemiesAheadBonus
Elo   | -14.62 +- 7.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 4234: +1159 -1337 =1738
Penta | [163, 556, 814, 464, 120]
https://openbench.lynx-chess.com/test/1221/
```
