### PR TITLE
⚡ Simplify additional eval methods after pawn table

### DIFF
--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -993,7 +993,7 @@ public class PositionTest
         {
             var pieceSquareIndex = bitBoard.GetLS1BIndex();
             bitBoard.ResetLS1B();
-            eval += UnpackMG(position.AdditionalPieceEvaluation(0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
+            eval += UnpackMG(position.AdditionalPieceEvaluation_Test(0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
         }
 
         return eval;


### PR DESCRIPTION
Directly invoke pawn additional eval (saving indirection) and simplify the generic method, given that it doesn't need to deal with pawns any more.

```
Test  | perf/simplify-additional-eval-methods
Elo   | 1.37 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 28420: +7965 -7853 =12602
Penta | [665, 3297, 6229, 3299, 720]
https://openbench.lynx-chess.com/test/1224/
```