### PR TITLE
🧹 Remove unneeded branch in `Position.MakeMove`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -160,8 +160,8 @@ public class Position : IDisposable
         else if (piece == (int)Piece.K || piece == (int)Piece.k)
         {
             // King (and castling) moves require calculating king buckets twice and recalculating all related parameters, so skipping incremental eval for those cases for now
-            // Not needed to check for move.IsCastle(), see CastlingMovesAreKingMoves test
-            _isIncrementalEval = false; //|| move.IsCastle()
+            // No need to check for move.IsCastle(), see CastlingMovesAreKingMoves test
+            _isIncrementalEval = false;
 
             _kingPawnUniqueIdentifier ^=
                 sourcePieceHash

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -123,13 +123,6 @@ public class Position : IDisposable
         int piece = move.Piece();
         int promotedPiece = move.PromotedPiece();
 
-        // King (and castling) moves require calculating king buckets twice, so skipping incremetal eval for those cases for now
-        _isIncrementalEval = _isIncrementalEval
-            && !(piece == (int)Piece.K
-                || piece == (int)Piece.k
-                //|| move.IsCastle()    // Not needed for now, see CastlingMovesAreKingMoves test
-                );
-
         var newPiece = piece;
         if (promotedPiece != default)
         {
@@ -166,6 +159,10 @@ public class Position : IDisposable
         }
         else if (piece == (int)Piece.K || piece == (int)Piece.k)
         {
+            // King (and castling) moves require calculating king buckets twice and recalculating all related parameters, so skipping incremental eval for those cases for now
+            // Not needed to check for move.IsCastle(), see CastlingMovesAreKingMoves test
+            _isIncrementalEval = false; //|| move.IsCastle()
+
             _kingPawnUniqueIdentifier ^=
                 sourcePieceHash
                 ^ targetPieceHash;


### PR DESCRIPTION
```
Test  | refactor/simplify-makemove-condition
Elo   | 0.84 +- 6.14 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [-10.00, 0.00]
Games | 5758: +1679 -1665 =2414
Penta | [161, 676, 1212, 648, 182]
https://openbench.lynx-chess.com/test/1237/
```