### PR TITLE
🔍 SPSA BM 2025-1-4

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -125,6 +125,21 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.65;
 
+    [SPSA<double>(2, 3.5, 0.2)]
+    public double BM_Stability_0 { get; set; } = 2.59;
+
+    [SPSA<double>(1, 2, 0.2)]
+    public double BM_Stability_1 { get; set; } = 1.42;
+
+    [SPSA<double>(0.5, 1.5, 0.2)]
+    public double BM_Stability_2 { get; set; } = 1.15;
+
+    [SPSA<double>(0.25, 1.25, 0.2)]
+    public double BM_Stability_3 { get; set; } = 0.75;
+
+    [SPSA<double>(0, 1, 0.2)]
+    public double BM_Stability_4 { get; set; } = 0.98;
+
     [SPSA<int>(1, 15, 1)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;
 

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -10,7 +10,14 @@ public static class TimeManager
     /// <summary>
     /// Values from Stash
     /// </summary>
-    private static ReadOnlySpan<double> BestMoveStabilityValues => [2.50, 1.20, 0.90, 0.80, 0.75];
+    private static readonly double[] BestMoveStabilityValues =
+    [
+        Configuration.EngineSettings.BM_Stability_0,
+        Configuration.EngineSettings.BM_Stability_1,
+        Configuration.EngineSettings.BM_Stability_2,
+        Configuration.EngineSettings.BM_Stability_3,
+        Configuration.EngineSettings.BM_Stability_4
+    ];
 
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -284,6 +284,46 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "bm_stability_0":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BM_Stability_0 = value * 0.01;
+                    }
+                    break;
+                }
+            case "bm_stability_1":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BM_Stability_1 = value * 0.01;
+                    }
+                    break;
+                }
+            case "bm_stability_2":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BM_Stability_2 = value * 0.01;
+                    }
+                    break;
+                }
+            case "bm_stability_3":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BM_Stability_3 = value * 0.01;
+                    }
+                    break;
+                }
+            case "bm_stability_4":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.BM_Stability_4 = value * 0.01;
+                    }
+                    break;
+                }
             case "scorestabiity_mindepth":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
```
iterations: 1016 (295.25s per iter)
games: 32512 (9.23s per game)
Final parameters:
HardTimeBoundMultiplier = 69(+2.90) in [10, 100]
SoftTimeBoundMultiplier = 107(-2.126716) in [50, 150]
SoftTimeBaseIncrementMultiplier = 71(+4.53) in [10, 200]
NodeTmBase = 172(+15.44) in [100, 200]
BM_Stability_0 = 259(-13.043147) in [200, 350]
BM_Stability_1 = 142(+24.63) in [100, 200]
BM_Stability_2 = 115(+14.05) in [50, 150]
BM_Stability_3 = 75(+4.96) in [25, 125]
BM_Stability_4 = 98(+13.35) in [0, 100]
```

```
Test  | spsa/tm-bm-4-1
Elo   | -9.23 +- 6.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.96 (-2.25, 2.89) [0.00, 3.00]
Games | 4820: +1156 -1284 =2380
Penta | [96, 628, 1071, 538, 77]
https://openbench.lynx-chess.com/test/1176/
```