### PR TITLE
🔍 Don't do alpha update when `staticEval > alpha` when in check II

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -588,12 +588,12 @@ public sealed partial class Engine
                 PrintMessage(ply - 1, "Pruning before starting quiescence search");
                 return eval;
             }
-        }
 
-        // Better move
-        if (eval > alpha)
-        {
-            alpha = eval;
+            // Better move
+            if (eval > alpha)
+            {
+                alpha = eval;
+            }
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];


### PR DESCRIPTION
```
Score of Lynx-search-qsearch-no-alpha-staticeval-improvement-when-in-check-2-5219-win-x64 vs Lynx 5218 - main: 3009 - 3098 - 5440  [0.496] 11547
...      Lynx-search-qsearch-no-alpha-staticeval-improvement-when-in-check-2-5219-win-x64 playing White: 2370 - 693 - 2710  [0.645] 5773
...      Lynx-search-qsearch-no-alpha-staticeval-improvement-when-in-check-2-5219-win-x64 playing Black: 639 - 2405 - 2730  [0.347] 5774
...      White vs Black: 4775 - 1332 - 5440  [0.649] 11547
Elo difference: -2.7 +/- 4.6, LOS: 12.7 %, DrawRatio: 47.1 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```