### PR TITLE
🐛 Fix crash when multithreading and pondering when GUI doesn't wait for `bestmove` after a `stop`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
-          !artifacts/**/*.pdb
         if-no-files-found: error
 
     - name: Publish library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
         name: Lynx-${{ env.GITHUB_REF_SLUG }}-${{ github.run_number }}-${{ matrix.runtime-identifier }}
         path: |
           artifacts/${{ matrix.runtime-identifier }}/
+          !artifacts/**/*.pdb
         if-no-files-found: error
 
     - name: Publish library


### PR DESCRIPTION
1t
```
Test  | bugfix/mt-pondering-winboard
Elo   | 4.17 +- 4.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | 7990: +2279 -2183 =3528
Penta | [200, 874, 1742, 988, 191]
https://openbench.lynx-chess.com/test/1242/
```

2t
```
Test  | bugfix/mt-pondering-winboard
Elo   | 0.29 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 23772: +6574 -6554 =10644
Penta | [576, 2885, 4962, 2869, 594]
https://openbench.lynx-chess.com/test/1243/
```

2t + pondering
```
Score of Lynx-bugfix-mt-pondering-winboard-5232-win-x64 vs Lynx 5228 - main: 1130 - 1127 - 2563  [0.500] 4820
...      Lynx-bugfix-mt-pondering-winboard-5232-win-x64 playing White: 929 - 223 - 1258  [0.646] 2410
...      Lynx-bugfix-mt-pondering-winboard-5232-win-x64 playing Black: 201 - 904 - 1305  [0.354] 2410
...      White vs Black: 1833 - 424 - 2563  [0.646] 4820
Elo difference: 0.2 +/- 6.7, LOS: 52.5 %, DrawRatio: 53.2 %
SPRT: llr 1.16 (40.1%), lbound -2.25, ubound 2.89
```