### PR TITLE
🐛 Avoid quick return when pondering is on, even if there's one single move

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -93,7 +93,7 @@ public sealed partial class Engine
 
         try
         {
-            if (OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
+            if (!isPondering && OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
             {
                 _engineWriter.TryWrite(onlyOneLegalMoveSearchResult);
 


### PR DESCRIPTION
This aims to fix some cutechess warnings:
> Warning: Premature bestmove while pondering from <xyz>

We found some pondering elo on our way.

```
Score of Lynx-ponder-onelegalmove-no-quick-return-5231-win-x64 vs Lynx 5228 - main: 711 - 591 - 1267  [0.523] 2569
...      Lynx-ponder-onelegalmove-no-quick-return-5231-win-x64 playing White: 544 - 112 - 629  [0.668] 1285
...      Lynx-ponder-onelegalmove-no-quick-return-5231-win-x64 playing Black: 167 - 479 - 638  [0.379] 1284
...      White vs Black: 1023 - 279 - 1267  [0.645] 2569
Elo difference: 16.2 +/- 9.6, LOS: 100.0 %, DrawRatio: 49.3 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

