### PR TITLE
🔍Don't reuse TTScore as eval when in check 2

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,29 +571,31 @@ public sealed partial class Engine
 
         Game.UpdateStaticEvalInStack(ply, staticEval);
 
-        int eval =
-            (ttNodeType == NodeType.Exact
-                || (ttNodeType == NodeType.Alpha && ttScore < staticEval)
-                || (ttNodeType == NodeType.Beta && ttScore > staticEval))
-            ? ttScore
-            : staticEval;
+        int eval = -EvaluationConstants.CheckMateBaseEvaluation + ply;
 
         var isInCheck = position.IsInCheck();
 
         if (!isInCheck)
         {
+            eval =
+                (ttNodeType == NodeType.Exact
+                    || (ttNodeType == NodeType.Alpha && ttScore < staticEval)
+                    || (ttNodeType == NodeType.Beta && ttScore > staticEval))
+                ? ttScore
+                : staticEval;
+
             // Standing pat beta-cutoff (updating alpha after this check)
             if (eval >= beta)
             {
                 PrintMessage(ply - 1, "Pruning before starting quiescence search");
                 return eval;
             }
-        }
 
-        // Better move
-        if (eval > alpha)
-        {
-            alpha = eval;
+            // Better move
+            if (eval > alpha)
+            {
+                alpha = eval;
+            }
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -571,18 +571,18 @@ public sealed partial class Engine
 
         Game.UpdateStaticEvalInStack(ply, staticEval);
 
-        int eval = -EvaluationConstants.CheckMateBaseEvaluation + ply;
+        int eval = staticEval;
 
         var isInCheck = position.IsInCheck();
 
         if (!isInCheck)
         {
-            eval =
-                (ttNodeType == NodeType.Exact
-                    || (ttNodeType == NodeType.Alpha && ttScore < staticEval)
-                    || (ttNodeType == NodeType.Beta && ttScore > staticEval))
-                ? ttScore
-                : staticEval;
+            if (ttNodeType == NodeType.Exact
+                || (ttNodeType == NodeType.Alpha && ttScore < staticEval)
+                || (ttNodeType == NodeType.Beta && ttScore > staticEval))
+            {
+                eval = ttScore;
+            }
 
             // Standing pat beta-cutoff (updating alpha after this check)
             if (eval >= beta)
@@ -590,12 +590,12 @@ public sealed partial class Engine
                 PrintMessage(ply - 1, "Pruning before starting quiescence search");
                 return eval;
             }
+        }
 
-            // Better move
-            if (eval > alpha)
-            {
-                alpha = eval;
-            }
+        // Better move
+        if (eval > alpha)
+        {
+            alpha = eval;
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];


### PR DESCRIPTION
```
Score of Lynx-search-qsearch-dont-reuse-ttscore-as-eval-when-in-check-2-5221-win-x64 vs Lynx 5218 - main: 7850 - 7813 - 14187  [0.501] 29850
...      Lynx-search-qsearch-dont-reuse-ttscore-as-eval-when-in-check-2-5221-win-x64 playing White: 6118 - 1660 - 7146  [0.649] 14924
...      Lynx-search-qsearch-dont-reuse-ttscore-as-eval-when-in-check-2-5221-win-x64 playing Black: 1732 - 6153 - 7041  [0.352] 14926
...      White vs Black: 12271 - 3392 - 14187  [0.649] 29850
Elo difference: 0.4 +/- 2.9, LOS: 61.6 %, DrawRatio: 47.5 %
SPRT: llr -1.51 (-52.3%), lbound -2.25, ubound 2.89
```