### PR TITLE
⌛ Reduce softbound on mate detected but low time

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -301,7 +301,15 @@ public sealed partial class Engine
 
             if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
             {
-                _logger.Info("[#{EngineId}] Could stop search, since mate is short enough", _id);
+                var newSoftLimitBound = _searchConstraints.SoftLimitTimeBound * 3 / 4;
+
+                _logger.Debug("[#{EngineId}] Could stop search, since mate is short enough. Reducing soft limit time bound instead ({CurrentLimit}) -> ({NewLimit})",
+                    _id, _searchConstraints.SoftLimitTimeBound, newSoftLimitBound);
+
+                _searchConstraints = new SearchConstraints(
+                    _searchConstraints.HardLimitTimeBound,
+                    newSoftLimitBound,
+                    _searchConstraints.MaxDepth);
             }
 
             _logger.Info("[#{EngineId}] Search continues, hoping to find a faster mate", _id);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -301,7 +301,7 @@ public sealed partial class Engine
 
             if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
             {
-                var newSoftLimitBound = _searchConstraints.SoftLimitTimeBound * 3 / 4;
+                var newSoftLimitBound = _searchConstraints.SoftLimitTimeBound / 4;
 
                 _logger.Debug("[#{EngineId}] Could stop search, since mate is short enough. Reducing soft limit time bound instead ({CurrentLimit}) -> ({NewLimit})",
                     _id, _searchConstraints.SoftLimitTimeBound, newSoftLimitBound);


### PR DESCRIPTION
x 3 / 4
```
Test  | tm/reduce-softbound-onmate
Elo   | 0.40 +- 2.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | -0.46 (-2.25, 2.89) [0.00, 3.00]
Games | 21556: +5846 -5821 =9889
Penta | [446, 2505, 4849, 2534, 444]
https://openbench.lynx-chess.com/test/1246/
```

```
Test  | tm/reduce-softbound-onmate
Elo   | -4.27 +- 7.72 (95%)
SPRT  | 10.0+0.00s Threads=1 Hash=32MB
LLR   | -0.69 (-2.25, 2.89) [0.00, 3.00]
Games | 3584: +951 -995 =1638
Penta | [111, 420, 757, 410, 94]
https://openbench.lynx-chess.com/test/1249/
```

/ 4
```
Test  | tm/reduce-softbound-onmate
Elo   | -4.27 +- 7.72 (95%)
SPRT  | 10.0+0.00s Threads=1 Hash=32MB
LLR   | -0.69 (-2.25, 2.89) [0.00, 3.00]
Games | 3584: +951 -995 =1638
Penta | [111, 420, 757, 410, 94]
https://openbench.lynx-chess.com/test/1249/
```