### PR TITLE
⚖️ Keep `_isIncrementalEval` even when king moves if buckets don't change

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,3 +1,4 @@
+using Polly.Caching;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -161,7 +162,7 @@ public class Position : IDisposable
         {
             // King (and castling) moves require calculating king buckets twice and recalculating all related parameters,
             // so skipping incremental eval whenever buckets change
-            _isIncrementalEval = PSQTBucketLayout[sourceSquare] == PSQTBucketLayout[targetSquare];
+            _isIncrementalEval = PSQTBucketLayout[sourceSquare] == PSQTBucketLayout[targetSquare] && !move.IsCapture() && !move.IsCastle();
 
             _kingPawnUniqueIdentifier ^=
                 sourcePieceHash

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -157,11 +157,11 @@ public class Position : IDisposable
                 _kingPawnUniqueIdentifier ^= targetPieceHash;
             }
         }
-        else if (piece == (int)Piece.K || piece == (int)Piece.k)
+        else if (piece == (int)Piece.K || piece == (int)Piece.k)    // No need to check for move.IsCastle(), see CastlingMovesAreKingMoves test
         {
-            // King (and castling) moves require calculating king buckets twice and recalculating all related parameters, so skipping incremental eval for those cases for now
-            // No need to check for move.IsCastle(), see CastlingMovesAreKingMoves test
-            _isIncrementalEval = false;
+            // King (and castling) moves require calculating king buckets twice and recalculating all related parameters,
+            // so skipping incremental eval whenever buckets change
+            _isIncrementalEval = PSQTBucketLayout[sourceSquare] == PSQTBucketLayout[targetSquare];
 
             _kingPawnUniqueIdentifier ^=
                 sourcePieceHash

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1,4 +1,3 @@
-using Polly.Caching;
 using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
```
Test  | eval/incremental-kingmove-nobucketchange
Elo   | -44.07 +- 12.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 1506: +352 -542 =612
Penta | [77, 233, 280, 129, 34]
https://openbench.lynx-chess.com/test/1244/
```
After [Add !capture and !castle as isIncremental conditions](https://github.com/lynx-chess/Lynx/pull/1399/commits/7714251792c01fae57163fa37468553c1e11d060)
```
Test  | eval/incremental-kingmove-nobucketchange
Elo   | -41.70 +- 12.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 1574: +379 -567 =628
Penta | [80, 240, 292, 138, 37]
https://openbench.lynx-chess.com/test/1253/
```