### PR TITLE
🔍 2025-1-23

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -125,20 +125,20 @@ public sealed class EngineSettings
     [SPSA<double>(0.5, 2.5, 0.1)]
     public double NodeTmScale { get; set; } = 1.77;
 
-    [SPSA<int>(1, 15, 1)]
+    //[SPSA<int>(1, 15, 1)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;
 
     #endregion
 
     #region Search
 
-    [SPSA<int>(3, 10, 0.5)]
+    //[SPSA<int>(3, 10, 0.5)]
     public int LMR_MinDepth { get; set; } = 3;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 5;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     /// <summary>
@@ -153,22 +153,22 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 
-    [SPSA<int>(1, 5, 0.5)]
+    //[SPSA<int>(1, 5, 0.5)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
-    [SPSA<int>(0, 10, 0.5)]
+    //[SPSA<int>(0, 10, 0.5)]
     public int NMP_DepthIncrement { get; set; } = 0;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
     public int NMP_StaticEvalBetaDivisor { get; set; } = 111;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
@@ -177,16 +177,16 @@ public sealed class EngineSettings
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
 
-    [SPSA<int>(1, 20, 1)]
+    //[SPSA<int>(1, 20, 1)]
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
     public int RFP_DepthScalingFactor { get; set; } = 55;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
@@ -195,16 +195,16 @@ public sealed class EngineSettings
     [SPSA<int>(1, 300, 15)]
     public int Razoring_NotDepth1Bonus { get; set; } = 220;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 8;
 
-    [SPSA<int>(0, 10, 0.5)]
+    //[SPSA<int>(0, 10, 0.5)]
     public int LMP_BaseMovesToTry { get; set; } = 1;
 
-    [SPSA<int>(0, 10, 0.5)]
+    //[SPSA<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
@@ -217,10 +217,10 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 200, 10)]
     public int History_BestScoreBetaMargin { get; set; } = 60;
 
-    [SPSA<int>(0, 6, 0.5)]
+    //[SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
 
-    [SPSA<int>(1, 10, 0.5)]
+    //[SPSA<int>(1, 10, 0.5)]
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
@@ -229,13 +229,13 @@ public sealed class EngineSettings
     [SPSA<int>(0, 500, 25)]
     public int FP_Margin { get; set; } = 167;
 
-    [SPSA<int>(0, 10, 0.5)]
+    //[SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
     public int HistoryPrunning_Margin { get; set; } = -1345;
 
-    [SPSA<int>(0, 10, 0.5)]
+    //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
     #endregion

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -145,13 +145,13 @@ public sealed class EngineSettings
     /// Value originally from Stormphrax, who apparently took it from Viridithas
     /// </summary>
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base { get; set; } = 0.75;
+    public double LMR_Base { get; set; } = 0.60;
 
     /// <summary>
     /// Value originally from Akimbo
     /// </summary>
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.49;
+    public double LMR_Divisor { get; set; } = 3.21;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -120,10 +120,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.4;
+    public double NodeTmBase { get; set; } = 2.47;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.65;
+    public double NodeTmScale { get; set; } = 1.77;
 
     [SPSA<int>(1, 15, 1)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;
@@ -166,13 +166,13 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 100;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 111;
 
     [SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 13;
+    public int AspirationWindow_Base { get; set; } = 11;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -184,16 +184,16 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 52;
+    public int RFP_DepthScalingFactor { get; set; } = 55;
 
     [SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 68;
+    public int Razoring_Depth1Bonus { get; set; } = 87;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 208;
+    public int Razoring_NotDepth1Bonus { get; set; } = 220;
 
     [SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -224,16 +224,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 73;
+    public int FP_DepthScalingFactor { get; set; } = 87;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 218;
+    public int FP_Margin { get; set; } = 167;
 
     [SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1940;
+    public int HistoryPrunning_Margin { get; set; } = -1345;
 
     [SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;


### PR DESCRIPTION
20+0.2 WF tuning
```
iterations: 290 (277.86s per iter)
games: 9280 (8.68s per game)
NodeTmBase = 247(+7.46) in [100, 300]
NodeTmScale = 177(+11.91) in [50, 250]
LMR_Base = 60(-14.919522) in [10, 200]
LMR_Divisor = 321(-28.154340) in [100, 500]
NMP_StaticEvalBetaDivisor = 111(+11.36) in [50, 350]
AspirationWindow_Base = 11(-1.705617) in [5, 30]
RFP_DepthScalingFactor = 55(+3.11) in [1, 300]
Razoring_Depth1Bonus = 87(+19.48) in [1, 300]
Razoring_NotDepth1Bonus = 220(+11.97) in [1, 300]
FP_DepthScalingFactor = 87(+13.63) in [1, 200]
FP_Margin = 167(-50.830481) in [0, 500]
HistoryPrunning_Margin = -1345(+595.20) in [-8192, 0]
```

![image](https://github.com/user-attachments/assets/edbf22bf-faea-4c22-86c8-0971b4807d66)

```
Test  | spsa/23-1
Elo   | 15.60 +- 6.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 4992: +1394 -1170 =2428
Penta | [63, 571, 1057, 689, 116]
https://openbench.lynx-chess.com/test/1258/
```

```
Test  | spsa/23-1
Elo   | 3.05 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.36 (-2.25, 2.89) [0.00, 3.00]
Games | 31778: +9085 -8806 =13887
Penta | [862, 3729, 6446, 3972, 880]
https://openbench.lynx-chess.com/test/1261/
```