### PR TITLE
🔍SPSA 2025-01-24

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,10 +142,10 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base { get; set; } = 0.60;
+    public double LMR_Base { get; set; } = 0.56;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.21;
+    public double LMR_Divisor { get; set; } = 3.22;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
@@ -160,13 +160,13 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 111;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 104;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 11;
+    public int AspirationWindow_Base { get; set; } = 12;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -178,16 +178,16 @@ public sealed class EngineSettings
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 300, 15)]
-    public int RFP_DepthScalingFactor { get; set; } = 55;
+    public int RFP_DepthScalingFactor { get; set; } = 47;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 87;
+    public int Razoring_Depth1Bonus { get; set; } = 94;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 220;
+    public int Razoring_NotDepth1Bonus { get; set; } = 221;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -218,16 +218,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 87;
+    public int FP_DepthScalingFactor { get; set; } = 86;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 167;
+    public int FP_Margin { get; set; } = 124;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1345;
+    public int HistoryPrunning_Margin { get; set; } = -1557;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;


### PR DESCRIPTION
Continuation of #1405, without tm adjustments

```
iterations: 824 (278.36s per iter)
games: 26368 (8.70s per game)
NodeTmBase = 249(+9.25) in [100, 300]
NodeTmScale = 185(+19.71) in [50, 250]
LMR_Base = 56(-19.372356) in [10, 200]
LMR_Divisor = 322(-26.896276) in [100, 500]
NMP_StaticEvalBetaDivisor = 104(+4.34) in [50, 350]
AspirationWindow_Base = 12(-1.488073) in [5, 30]
RFP_DepthScalingFactor = 47(-5.003669) in [1, 300]
Razoring_Depth1Bonus = 94(+25.65) in [1, 300]
Razoring_NotDepth1Bonus = 221(+12.83) in [1, 300]
FP_DepthScalingFactor = 86(+13.23) in [1, 200]
FP_Margin = 124(-94.033649) in [0, 500]
HistoryPrunning_Margin = -1557(+382.55) in [-8192, 0]
```

```
Test  | spsa/24-1
Elo   | -2.57 +- 3.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 16114: +4122 -4241 =7751
Penta | [302, 1975, 3571, 1958, 251]
https://openbench.lynx-chess.com/test/1263/
```