### PR TITLE
⚖️ Remove king from pawn table key

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -515,7 +515,7 @@ public static class Constants
     /// </summary>
     public const int KingPawnHashSize = 262_144;
 
-    public const int KingPawnHashMask = KingPawnHashSize - 1;
+    public const int PawnHashMask = KingPawnHashSize - 1;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -6,7 +6,7 @@ public readonly struct GameState
 {
     public readonly ulong ZobristKey;
 
-    public readonly ulong KingPawnKey;
+    public readonly ulong PawnKey;
 
     public readonly int IncremetalEvalAccumulator;
 
@@ -16,10 +16,10 @@ public readonly struct GameState
 
     public readonly bool IsIncrementalEval;
 
-    public GameState(ulong zobristKey, ulong kingPawnKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
+    public GameState(ulong zobristKey, ulong pawnKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
-        KingPawnKey = kingPawnKey;
+        PawnKey = pawnKey;
         IncremetalEvalAccumulator = incrementalEvalAccumulator;
         EnPassant = enpassant;
         Castle = castle;

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -129,7 +129,7 @@ public static class ZobristTable
     /// Calculates from scratch the pawn structure hash of a position
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static ulong PawnKingHash(Position position)
+    public static ulong PawnHash(Position position)
     {
         ulong pawnKingHash = 0;
 
@@ -150,12 +150,6 @@ public static class ZobristTable
 
             pawnKingHash ^= PieceHash(pieceSquareIndex, (int)Piece.p);
         }
-
-        var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();
-        pawnKingHash ^= PieceHash(whiteKing, (int)Piece.K);
-
-        var blackKing = position.PieceBitBoards[(int)Piece.k].GetLS1BIndex();
-        pawnKingHash ^= PieceHash(blackKing, (int)Piece.k);
 
         return pawnKingHash;
     }


### PR DESCRIPTION
```
Test  | eval/remove-king-from-kingpawn-key
Elo   | -23.46 +- 9.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 2596: +661 -836 =1099
Penta | [98, 360, 523, 253, 64]
https://openbench.lynx-chess.com/test/1264/
```