### PR TITLE
⚡ Split `ScoreMove` between regular search and qsearch

### DIFF
--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -5,13 +5,14 @@ using System.Runtime.CompilerServices;
 using static Lynx.EvaluationConstants;
 
 namespace Lynx;
+
 public sealed partial class Engine
 {
     /// <summary>
     /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int ply, bool isNotQSearch, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int ply, ShortMove bestMoveTTCandidate = default)
     {
         if ((ShortMove)move == bestMoveTTCandidate)
         {
@@ -58,50 +59,99 @@ public sealed partial class Engine
             return PromotionMoveScoreValue;
         }
 
-        if (isNotQSearch)
+        var thisPlyKillerMovesBaseIndex = ply * 3;
+
+        // 1st killer move
+        if (_killerMoves[thisPlyKillerMovesBaseIndex] == move)
         {
-            var thisPlyKillerMovesBaseIndex = ply * 3;
+            return FirstKillerMoveValue;
+        }
 
-            // 1st killer move
-            if (_killerMoves[thisPlyKillerMovesBaseIndex] == move)
+        // 2nd killer move
+        if (_killerMoves[thisPlyKillerMovesBaseIndex + 1] == move)
+        {
+            return SecondKillerMoveValue;
+        }
+
+        // 3rd killer move
+        if (_killerMoves[thisPlyKillerMovesBaseIndex + 2] == move)
+        {
+            return ThirdKillerMoveValue;
+        }
+
+        if (ply >= 1)
+        {
+            var previousMove = Game.ReadMoveFromStack(ply - 1);
+            Debug.Assert(previousMove != 0);
+            var previousMovePiece = previousMove.Piece();
+            var previousMoveTargetSquare = previousMove.TargetSquare();
+
+            // Countermove
+            if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
             {
-                return FirstKillerMoveValue;
+                return CounterMoveValue;
             }
 
-            // 2nd killer move
-            if (_killerMoves[thisPlyKillerMovesBaseIndex + 1] == move)
-            {
-                return SecondKillerMoveValue;
-            }
-
-            // 3rd killer move
-            if (_killerMoves[thisPlyKillerMovesBaseIndex + 2] == move)
-            {
-                return ThirdKillerMoveValue;
-            }
-
-            if (ply >= 1)
-            {
-                var previousMove = Game.ReadMoveFromStack(ply - 1);
-                Debug.Assert(previousMove != 0);
-                var previousMovePiece = previousMove.Piece();
-                var previousMoveTargetSquare = previousMove.TargetSquare();
-
-                // Countermove
-                if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
-                {
-                    return CounterMoveValue;
-                }
-
-                // Counter move history
-                return BaseMoveScore
-                    + _quietHistory[move.Piece()][move.TargetSquare()]
-                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
-            }
-
-            // History move or 0 if not found
+            // Counter move history
             return BaseMoveScore
-                + _quietHistory[move.Piece()][move.TargetSquare()];
+                + _quietHistory[move.Piece()][move.TargetSquare()]
+                + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
+        }
+
+        // History move or 0 if not found
+        return BaseMoveScore
+            + _quietHistory[move.Piece()][move.TargetSquare()];
+    }
+
+    /// <summary>
+    /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int ScoreMoveQSearch(Move move, ShortMove bestMoveTTCandidate = default)
+    {
+        if ((ShortMove)move == bestMoveTTCandidate)
+        {
+            return TTMoveScoreValue;
+        }
+
+        var promotedPiece = move.PromotedPiece();
+        var isPromotion = promotedPiece != default;
+        var isCapture = move.IsCapture();
+
+        // Queen promotion
+        if ((promotedPiece + 2) % 6 == 0)
+        {
+            if (isCapture)
+            {
+                return QueenPromotionWithCaptureBaseValue + move.CapturedPiece();
+            }
+
+            return PromotionMoveScoreValue
+                + (SEE.HasPositiveScore(Game.CurrentPosition, move)
+                    ? GoodCaptureMoveBaseScoreValue
+                    : BadCaptureMoveBaseScoreValue);
+        }
+
+        if (isCapture)
+        {
+            var baseCaptureScore = (isPromotion || move.IsEnPassant() || SEE.IsGoodCapture(Game.CurrentPosition, move))
+                ? GoodCaptureMoveBaseScoreValue
+                : BadCaptureMoveBaseScoreValue;
+
+            var piece = move.Piece();
+            var capturedPiece = move.CapturedPiece();
+
+            Debug.Assert(capturedPiece != (int)Piece.K && capturedPiece != (int)Piece.k, $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN()}");
+
+            return baseCaptureScore
+                + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
+                //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
+                + _captureHistory[CaptureHistoryIndex(piece, move.TargetSquare(), capturedPiece)];
+        }
+
+        if (isPromotion)
+        {
+            return PromotionMoveScoreValue;
         }
 
         return BaseMoveScore;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -240,7 +240,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: true, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
         }
 
         var nodeType = NodeType.Alpha;
@@ -617,7 +617,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, isNotQSearch: false, ttBestMove);
+            moveScores[i] = ScoreMoveQSearch(pseudoLegalMoves[i], ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)


### PR DESCRIPTION
```
Test  | perf/split-scoremove
Elo   | 2.33 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 56018: +15982 -15606 =24430
Penta | [1307, 6394, 12310, 6612, 1386]
https://openbench.lynx-chess.com/test/1265/
```