### PR TITLE
⚡ Add another `GameState` constructor for null moves

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -16,6 +16,17 @@ public readonly struct GameState
 
     public readonly bool IsIncrementalEval;
 
+    /// <summary>
+    /// Null moves
+    /// </summary>
+    /// <param name="zobristKey"></param>
+    /// <param name="enpassant"></param>
+    public GameState(ulong zobristKey, BoardSquare enpassant)
+    {
+        ZobristKey = zobristKey;
+        EnPassant = enpassant;
+    }
+
     public GameState(ulong zobristKey, ulong kingPawnKey, int incrementalEvalAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -534,7 +534,7 @@ public class Position : IDisposable
             ZobristTable.SideHash()
             ^ ZobristTable.EnPassantHash((int)oldEnPassant);
 
-        return new GameState(oldUniqueIdentifier, _kingPawnUniqueIdentifier, _incrementalEvalAccumulator, oldEnPassant, byte.MaxValue, _isIncrementalEval);
+        return new GameState(oldUniqueIdentifier, oldEnPassant);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -543,9 +543,6 @@ public class Position : IDisposable
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;
         UniqueIdentifier = gameState.ZobristKey;
-        _kingPawnUniqueIdentifier = gameState.KingPawnKey;
-        _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
-        _isIncrementalEval = gameState.IsIncrementalEval;
     }
 
     /// <summary>


### PR DESCRIPTION
```
Test  | perf/make-unmake-null-moves
Elo   | -4.43 +- 4.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 11372: +3255 -3400 =4717
Penta | [334, 1319, 2475, 1274, 284]
https://openbench.lynx-chess.com/test/1274/
```