### PR TITLE
🧹 Move king PSQT outside of incremental logic

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -867,16 +867,16 @@ public class Position : IDisposable
                 }
             }
 
-            // Kings
-            _incrementalEvalAccumulator +=
-                PSQT(0, whiteBucket, (int)Piece.K, whiteKing)
-                + PSQT(1, blackBucket, (int)Piece.K, whiteKing)
-                + PSQT(0, blackBucket, (int)Piece.k, blackKing)
-                + PSQT(1, whiteBucket, (int)Piece.k, blackKing);
-
             packedScore += _incrementalEvalAccumulator;
             _isIncrementalEval = true;
         }
+
+        // Kings - they can't be incremental due to the king buckets
+        packedScore +=
+            PSQT(0, whiteBucket, (int)Piece.K, whiteKing)
+            + PSQT(1, blackBucket, (int)Piece.K, whiteKing)
+            + PSQT(0, blackBucket, (int)Piece.k, blackKing)
+            + PSQT(1, whiteBucket, (int)Piece.k, blackKing);
 
         packedScore +=
             KingAdditionalEvaluation(whiteKing, (int)Side.White, blackPawnAttacks)


### PR DESCRIPTION
```
Test  | refactor/king-psqt-no-incremental
Elo   | 2.42 +- 6.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.10 (-2.25, 2.89) [-10.00, 0.00]
Games | 4312: +1225 -1195 =1892
Penta | [111, 486, 925, 530, 104]
https://openbench.lynx-chess.com/test/1292/
```