### PR TITLE
⚖️ Pawn islands - transverse pawns instead of squares tracking counted pawns

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1304,30 +1304,38 @@ public class Position : IDisposable
 
         return PawnIslandsBonus[whiteIslandCount] - PawnIslandsBonus[blackIslandCount];
 
+        [SkipLocalsInit]
         static int IdentifyIslands(BitBoard pawns)
         {
+            var pawnsCount = pawns.CountBits();
+
             Span<int> files = stackalloc int[8];
+            files.Clear();
 
             while (pawns != default)
             {
                 var squareIndex = pawns.GetLS1BIndex();
                 pawns.ResetLS1B();
 
-                files[Constants.File[squareIndex]] = 1;
+                files[Constants.File[squareIndex]] += 1;
             }
 
             var islandCount = 0;
             var isIsland = false;
 
-            for (int file = 0; file < 8; ++file)
+            var exploredPawns = 0;
+            for (int file = 0; file < 8 && exploredPawns < pawnsCount; ++file)
             {
-                if (files[file] == 1)
+                var pawnsOnThatFile = files[file];
+                if (pawnsOnThatFile > 0)
                 {
                     if (!isIsland)
                     {
                         isIsland = true;
                         ++islandCount;
                     }
+
+                    exploredPawns += pawnsOnThatFile;
                 }
                 else
                 {


### PR DESCRIPTION
Attempt of perf imporvement over  #1429 

```
Test  | eval/pawn-islands-transverse-pawns-no-squares-count-pawns
Elo   | -1.66 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 22434: +6213 -6320 =9901
Penta | [549, 2628, 4967, 2527, 546]
https://openbench.lynx-chess.com/test/1307/
```