### PR TITLE
⚖️ Scale pawn island bonus with pawn count

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1302,7 +1302,8 @@ public class Position : IDisposable
         var whiteIslandCount = IdentifyIslands(whitePawns);
         var blackIslandCount = IdentifyIslands(blackPawns);
 
-        return PawnIslandsBonus[whiteIslandCount] - PawnIslandsBonus[blackIslandCount];
+        return (PawnIslandsBonus[whiteIslandCount] * whitePawns.CountBits())
+            - (PawnIslandsBonus[blackIslandCount] * blackPawns.CountBits());
 
         static int IdentifyIslands(BitBoard pawns)
         {


### PR DESCRIPTION
Can't divide packed scores though, I'd like to do count/8

```
Test  | eval/pawn-islands-scale-with-pawns-left
Elo   | -64.11 +- 15.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 1140: +271 -479 =390
Penta | [88, 177, 183, 99, 23]
https://openbench.lynx-chess.com/test/1308/
```