### PR TITLE
⚖️ Scale pawn island bonus with 8 - pawn count

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1302,7 +1302,8 @@ public class Position : IDisposable
         var whiteIslandCount = IdentifyIslands(whitePawns);
         var blackIslandCount = IdentifyIslands(blackPawns);
 
-        return PawnIslandsBonus[whiteIslandCount] - PawnIslandsBonus[blackIslandCount];
+        return (PawnIslandsBonus[whiteIslandCount] * (8 - whitePawns.CountBits()))
+            - (PawnIslandsBonus[blackIslandCount] * (8 - blackPawns.CountBits()));
 
         static int IdentifyIslands(BitBoard pawns)
         {


### PR DESCRIPTION
Can't divide packed scores though, I'd like to do (8-count)/8
See also #1432 

```
Test  | pawn-islands-scale-with-pawns-left-2
Elo   | -17.66 +- 8.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 3406: +925 -1098 =1383
Penta | [132, 438, 681, 375, 77]
https://openbench.lynx-chess.com/test/1309/
```