### PR TITLE
⌛ Make `EngineGuiCommunicationTimeOverhead` and `MinSearchTime` configurable

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -113,6 +113,18 @@ public sealed class EngineSettings
 
     #region Time management
 
+    /// <summary>
+    /// Time overhead to take into account engine-gui communication process overhead
+    /// </summary>
+    public int EngineGuiCommunicationTimeOverhead { get; set; } = 50;
+
+    /// <summary>
+    /// Min milliseconds left after substracting <see cref="EngineGuiCommunicationTimeOverhead"/>
+    /// from wtime/btime or movetime. This min value is used to avoid 0 or negative time left.
+    /// Resulting milliseconds left are later used to calculate hard and soft time bounds
+    /// </summary>
+    public int MinSearchTime { get; set; } = 50;
+
     public double HardTimeBoundMultiplier { get; set; } = 0.52;
 
     public double SoftTimeBoundMultiplier { get; set; } = 1;

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -34,18 +34,16 @@ public static class TimeManager
         }
 
         // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
-        const int engineGuiCommunicationTimeOverhead = 50;
+       var engineGuiCommunicationTimeOverhead = Configuration.EngineSettings.EngineGuiCommunicationTimeOverhead;
 
         if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
         {
-            const int minSearchTime = 50;
-
             var movesDivisor = goCommand.MovesToGo == 0
                 ? MovesDivisor(ExpectedMovesLeft(game.PositionHashHistoryLength()))
                 : goCommand.MovesToGo;
 
             millisecondsLeft -= engineGuiCommunicationTimeOverhead;
-            millisecondsLeft = Math.Clamp(millisecondsLeft, minSearchTime, int.MaxValue); // Avoiding 0/negative values
+            millisecondsLeft = Math.Clamp(millisecondsLeft, Configuration.EngineSettings.MinSearchTime, int.MaxValue); // Avoiding 0/negative values
 
             hardLimitTimeBound = (int)(millisecondsLeft * Configuration.EngineSettings.HardTimeBoundMultiplier);
 


### PR DESCRIPTION
Idea came to my mind after suffering some timeouts in January tournament part of `nightmare-chess.nl` monthly tournaments, probably due to the winboard <-> UCI overhead when using `winboard.exe`.
After trying w/ single-threaded Lynx in the server I could observe the same error.

Being able to increase the overhead will hopefully help with that.