### PR TITLE
🔍 Pawn history

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -518,6 +518,10 @@ public static class Constants
     public const int KingPawnHashSize = 262_144;
 
     public const int KingPawnHashMask = KingPawnHashSize - 1;
+
+    public const int PawnHistoryKeyLength = 16_384;
+
+    public const ulong PawnHistoryMask = PawnHistoryKeyLength - 1;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -49,6 +49,16 @@ public sealed partial class Engine : IDisposable
             _moveNodeCount[i] = new ulong[64];
         }
 
+        _quietPawnHistory = new int[Constants.PawnHistoryKeyLength][][];
+        for (int i = 0; i < _quietPawnHistory.Length; ++i)
+        {
+            _quietPawnHistory[i] = new int[12][];
+            for (int j = 0; j < _quietPawnHistory[i].Length; ++j)
+            {
+                _quietPawnHistory[i][j] = new int[64];
+            }
+        }
+
 #if !DEBUG
         if (warmup)
         {
@@ -96,6 +106,14 @@ public sealed partial class Engine : IDisposable
         {
             Array.Clear(_quietHistory[i]);
             Array.Clear(_moveNodeCount[i]);
+        }
+
+        for (int i = 0; i < _quietPawnHistory.Length; ++i)
+        {
+            for (int j = 0; j < _quietPawnHistory[i].Length; ++j)
+            {
+                Array.Clear(_quietPawnHistory[i][j]);
+            }
         }
 
         Array.Clear(_captureHistory);

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -18,7 +18,7 @@ public class Position : IDisposable
 
     public ulong UniqueIdentifier { get; private set; }
 
-    private ulong _kingPawnUniqueIdentifier;
+    public ulong _kingPawnUniqueIdentifier { get; private set; }
 
     /// <summary>
     /// Use <see cref="Piece"/> as index

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -28,6 +28,12 @@ public sealed partial class Engine
     private readonly int[][] _quietHistory;
 
     /// <summary>
+    /// <see cref="Constants.PawnHistoryKeyLength"/> x 12 x 64
+    /// pawn key x piece x target square
+    /// </summary>
+    private readonly int[][][] _quietPawnHistory;
+
+    /// <summary>
     /// 12 x 64 x 12,
     /// piece x target square x captured piece
     /// </summary>


### PR DESCRIPTION
STC
```
Score of Lynx-search-pawn-history-5389-win-x64 vs Lynx 5387 - main: 2093 - 2197 - 3778  [0.494] 8068
...      Lynx-search-pawn-history-5389-win-x64 playing White: 1638 - 492 - 1904  [0.642] 4034
...      Lynx-search-pawn-history-5389-win-x64 playing Black: 455 - 1705 - 1874  [0.345] 4034
...      White vs Black: 3343 - 947 - 3778  [0.648] 8068
Elo difference: -4.5 +/- 5.5, LOS: 5.6 %, DrawRatio: 46.8 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

LTC
```
Test  | search/pawn-history
Elo   | -4.24 +- 3.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 10568: +2600 -2729 =5239
Penta | [177, 1310, 2376, 1307, 114]
https://openbench.lynx-chess.com/test/1326/
```