### PR TITLE
⌛ Reduce `MinSearchTime` to 10ms

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -123,7 +123,7 @@ public sealed class EngineSettings
     /// from wtime/btime or movetime. This min value is used to avoid 0 or negative time left.
     /// Resulting milliseconds left are later used to calculate hard and soft time bounds
     /// </summary>
-    public int MinSearchTime { get; set; } = 50;
+    public int MinSearchTime { get; set; } = 10;
 
     public double HardTimeBoundMultiplier { get; set; } = 0.52;
 


### PR DESCRIPTION
6+0.06, no draw or resign adj
```
Score of Lynx-main-5387-tm-tweaks-win-x64 vs Lynx 5392 - main: 10232 - 9889 - 16142  [0.505] 36263
...      Lynx-main-5387-tm-tweaks-win-x64 playing White: 7550 - 2521 - 8061  [0.639] 18132
...      Lynx-main-5387-tm-tweaks-win-x64 playing Black: 2682 - 7368 - 8081  [0.371] 18131
...      White vs Black: 14918 - 5203 - 16142  [0.634] 36263
Elo difference: 3.3 +/- 2.7, LOS: 99.2 %, DrawRatio: 44.5 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

8+0.08
```
Score of Lynx-tm-reduce-min-search-time-5413-win-x64 vs Lynx 5406 - main: 4549 - 4704 - 7926  [0.495] 17179
...      Lynx-tm-reduce-min-search-time-5413-win-x64 playing White: 3535 - 1036 - 4018  [0.645] 8589
...      Lynx-tm-reduce-min-search-time-5413-win-x64 playing Black: 1014 - 3668 - 3908  [0.346] 8590
...      White vs Black: 7203 - 2050 - 7926  [0.650] 17179
Elo difference: -3.1 +/- 3.8, LOS: 5.4 %, DrawRatio: 46.1 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```
```
Test  | tm/reduce-min-search-time
Elo   | -1.45 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.32 (-2.25, 2.89) [-3.00, 1.00]
Games | 57312: +16164 -16404 =24744
Penta | [1441, 6661, 12677, 6451, 1426]
https://openbench.lynx-chess.com/test/1331/
```