### PR TITLE
⚡ Avoid array accesses by using `ref`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -258,9 +258,11 @@ public sealed partial class Engine
             // So just find the first unsearched one with the best score and try it
             for (int j = moveIndex + 1; j < pseudoLegalMoves.Length; j++)
             {
-                if (moveScores[j] > moveScores[moveIndex])
+                ref int outerMoveScore = ref moveScores[moveIndex];
+                ref int innerMoveScore = ref moveScores[j];
+                if (innerMoveScore > outerMoveScore)
                 {
-                    (moveScores[moveIndex], moveScores[j], pseudoLegalMoves[moveIndex], pseudoLegalMoves[j]) = (moveScores[j], moveScores[moveIndex], pseudoLegalMoves[j], pseudoLegalMoves[moveIndex]);
+                    (outerMoveScore, innerMoveScore, pseudoLegalMoves[moveIndex], pseudoLegalMoves[j]) = (innerMoveScore, outerMoveScore, pseudoLegalMoves[j], pseudoLegalMoves[moveIndex]);
                 }
             }
 
@@ -627,9 +629,11 @@ public sealed partial class Engine
             // So just find the first unsearched one with the best score and try it
             for (int j = i + 1; j < pseudoLegalMoves.Length; j++)
             {
+                ref int outerMoveScore = ref moveScores[i];
+                ref int innerMoveScore = ref moveScores[j];
                 if (moveScores[j] > moveScores[i])
                 {
-                    (moveScores[i], moveScores[j], pseudoLegalMoves[i], pseudoLegalMoves[j]) = (moveScores[j], moveScores[i], pseudoLegalMoves[j], pseudoLegalMoves[i]);
+                    (outerMoveScore, innerMoveScore, pseudoLegalMoves[i], pseudoLegalMoves[j]) = (innerMoveScore, outerMoveScore, pseudoLegalMoves[j], pseudoLegalMoves[i]);
                 }
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -639,7 +639,7 @@ public sealed partial class Engine
                 ref int innerMove = ref pseudoLegalMoves[j];
                 ref int innerMoveScore = ref moveScores[j];
 
-                if (moveScores[j] > moveScores[i])
+                if (innerMoveScore > outerMoveScore)
                 {
                     (outerMoveScore, innerMoveScore, outerMove, innerMove) = (innerMoveScore, outerMoveScore, innerMove, outerMove);
                 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -253,20 +253,24 @@ public sealed partial class Engine
 
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
+            ref int outerMove = ref pseudoLegalMoves[moveIndex];
+            ref int outerMoveScore = ref moveScores[moveIndex];
+
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
             // There's no need to sort all the moves since most of them don't get checked anyway
             // So just find the first unsearched one with the best score and try it
             for (int j = moveIndex + 1; j < pseudoLegalMoves.Length; j++)
             {
-                ref int outerMoveScore = ref moveScores[moveIndex];
+                ref int innerMove = ref pseudoLegalMoves[j];
                 ref int innerMoveScore = ref moveScores[j];
+
                 if (innerMoveScore > outerMoveScore)
                 {
                     (outerMoveScore, innerMoveScore, pseudoLegalMoves[moveIndex], pseudoLegalMoves[j]) = (innerMoveScore, outerMoveScore, pseudoLegalMoves[j], pseudoLegalMoves[moveIndex]);
                 }
             }
 
-            var move = pseudoLegalMoves[moveIndex];
+            var move = outerMove;
 
             var gameState = position.MakeMove(move);
 
@@ -624,20 +628,24 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
+            ref int outerMove = ref pseudoLegalMoves[i];
+            ref int outerMoveScore = ref moveScores[i];
+
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
             // There's no need to sort all the moves since most of them don't get checked anyway
             // So just find the first unsearched one with the best score and try it
             for (int j = i + 1; j < pseudoLegalMoves.Length; j++)
             {
-                ref int outerMoveScore = ref moveScores[i];
+                ref int innerMove = ref pseudoLegalMoves[j];
                 ref int innerMoveScore = ref moveScores[j];
+
                 if (moveScores[j] > moveScores[i])
                 {
-                    (outerMoveScore, innerMoveScore, pseudoLegalMoves[i], pseudoLegalMoves[j]) = (innerMoveScore, outerMoveScore, pseudoLegalMoves[j], pseudoLegalMoves[i]);
+                    (outerMoveScore, innerMoveScore, outerMove, innerMove) = (innerMoveScore, outerMoveScore, innerMove, outerMove);
                 }
             }
 
-            var move = pseudoLegalMoves[i];
+            var move = outerMove;
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScores[i] < EvaluationConstants.PromotionMoveScoreValue && moveScores[i] >= EvaluationConstants.BadCaptureMoveBaseScoreValue)


### PR DESCRIPTION
```
Test  | perf/scoremoves-ref
Elo   | -0.46 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.12 (-2.25, 2.89) [0.00, 3.00]
Games | 38754: +10999 -11050 =16705
Penta | [982, 4486, 8465, 4489, 955]
https://openbench.lynx-chess.com/test/1335/
```