### PR TITLE
🔍 Split and tune max history values

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -215,21 +215,21 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
-    [SPSA<int>(1_896, 16384, 512)]
-    public int QuietHistory_MaxValue { get; set; } = 8_192;
+    [SPSA<int>(1_896, 16384, 1024)]
+    public int QuietHistory_MaxValue { get; set; } = 9_086;
 
-    [SPSA<int>(1_896, 16384, 512)]
-    public int CaptureHistory_MaxValue { get; set; } = 8_192;
+    [SPSA<int>(1_896, 16384, 1024)]
+    public int CaptureHistory_MaxValue { get; set; } = 7_477;
 
-    [SPSA<int>(1_896, 16384, 512)]
-    public int ContinuationHistory_MaxValue { get; set; } = 8_192;
+    [SPSA<int>(1_896, 16384, 1024)]
+    public int ContinuationHistory_MaxValue { get; set; } = 6_829;
 
     /// <summary>
     /// 1896: constant from depth 12
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int CounterMoves_MinDepth { get;set; } = 3;
+    public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
     public int History_BestScoreBetaMargin { get; set; } = 60;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -215,7 +215,14 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
-    public int History_MaxMoveValue { get; set; } = 8_192;
+    [SPSA<int>(1_896, 16384, 512)]
+    public int QuietHistory_MaxValue { get; set; } = 8_192;
+
+    [SPSA<int>(1_896, 16384, 512)]
+    public int CaptureHistory_MaxValue { get; set; } = 8_192;
+
+    [SPSA<int>(1_896, 16384, 512)]
+    public int ContinuationHistory_MaxValue { get; set; } = 8_192;
 
     /// <summary>
     /// 1896: constant from depth 12

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -216,13 +216,13 @@ public sealed class EngineSettings
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     [SPSA<int>(1_896, 16384, 1024)]
-    public int QuietHistory_MaxValue { get; set; } = 9_086;
+    public int QuietHistory_MaxValue { get; set; } = 8_192;
 
     [SPSA<int>(1_896, 16384, 1024)]
-    public int CaptureHistory_MaxValue { get; set; } = 7_477;
+    public int CaptureHistory_MaxValue { get; set; } = 16_384;
 
     [SPSA<int>(1_896, 16384, 1024)]
-    public int ContinuationHistory_MaxValue { get; set; } = 6_829;
+    public int ContinuationHistory_MaxValue { get; set; } = 16_384;
 
     /// <summary>
     /// 1896: constant from depth 12

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -298,8 +298,12 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus, int maxHistoryValue)
     {
-        Debug.Assert(rawHistoryBonus <= maxHistoryValue);
+        Debug.Assert(Math.Abs(rawHistoryBonus) <= maxHistoryValue);
 
-        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / maxHistoryValue);
+        score = score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / maxHistoryValue);
+
+        Debug.Assert(Math.Abs(score) <= maxHistoryValue);
+
+        return score;
     }
 }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -170,7 +170,8 @@ public sealed partial class Engine
 
         _quietHistory[piece][targetSquare] = ScoreHistoryMove(
             _quietHistory[piece][targetSquare],
-            HistoryBonus[depth]);
+            HistoryBonus[depth],
+            Configuration.EngineSettings.QuietHistory_MaxValue);
 
         int continuationHistoryIndex;
         int previousMovePiece = -1;
@@ -190,7 +191,8 @@ public sealed partial class Engine
 
             _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
                 _continuationHistory[continuationHistoryIndex],
-                HistoryBonus[depth]);
+                HistoryBonus[depth],
+                Configuration.EngineSettings.ContinuationHistory_MaxValue);
 
             //    var previousPreviousMove = Game.MoveStack[ply - 2];
             //    var previousPreviousMovePiece = previousPreviousMove.Piece();
@@ -214,7 +216,8 @@ public sealed partial class Engine
                 // When a quiet move fails high, penalize previous visited quiet moves
                 _quietHistory[visitedMovePiece][visitedMoveTargetSquare] = ScoreHistoryMove(
                     _quietHistory[visitedMovePiece][visitedMoveTargetSquare],
-                    -HistoryBonus[depth]);
+                    -HistoryBonus[depth],
+                    Configuration.EngineSettings.QuietHistory_MaxValue);
 
                 if (!isRoot)
                 {
@@ -223,7 +226,8 @@ public sealed partial class Engine
 
                     _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
                         _continuationHistory[continuationHistoryIndex],
-                        -HistoryBonus[depth]);
+                        -HistoryBonus[depth],
+                        Configuration.EngineSettings.ContinuationHistory_MaxValue);
                 }
             }
         }
@@ -263,7 +267,8 @@ public sealed partial class Engine
         var captureHistoryIndex = CaptureHistoryIndex(piece, targetSquare, capturedPiece);
         _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
             _captureHistory[captureHistoryIndex],
-            HistoryBonus[depth]);
+            HistoryBonus[depth],
+            Configuration.EngineSettings.CaptureHistory_MaxValue);
 
         // 🔍 Capture history penalty/malus
         // When a capture fails high, penalize previous visited captures
@@ -281,7 +286,8 @@ public sealed partial class Engine
 
                 _captureHistory[captureHistoryIndex] = ScoreHistoryMove(
                     _captureHistory[captureHistoryIndex],
-                    -HistoryBonus[depth]);
+                    -HistoryBonus[depth],
+                    Configuration.EngineSettings.CaptureHistory_MaxValue);
             }
         }
     }
@@ -291,8 +297,10 @@ public sealed partial class Engine
     /// Formula taken from EP discord, https://discord.com/channels/1132289356011405342/1132289356447625298/1141102105847922839
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ScoreHistoryMove(int score, int rawHistoryBonus)
+    private static int ScoreHistoryMove(int score, int rawHistoryBonus, int maxHistoryValue)
     {
-        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
+        Debug.Assert(rawHistoryBonus <= maxHistoryValue);
+
+        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / maxHistoryValue);
     }
 }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -293,8 +293,7 @@ public sealed partial class Engine
     }
 
     /// <summary>
-    /// Soft caps history score
-    /// Formula taken from EP discord, https://discord.com/channels/1132289356011405342/1132289356447625298/1141102105847922839
+    /// History gravity: soft cap of history score
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ScoreHistoryMove(int score, int rawHistoryBonus, int maxHistoryValue)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -394,7 +394,7 @@ public sealed partial class Engine
                         }
 
                         // -= history/(maxHistory/2)
-                        reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
+                        reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.QuietHistory_MaxValue;
 
                         // Don't allow LMR to drop into qsearch or increase the depth
                         // depth - 1 - depth +2 = 1, min depth we want

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -486,11 +486,27 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "history_maxmovevalue":
+            case "history_maxvalue":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.History_MaxMoveValue = value;
+                        Configuration.EngineSettings.QuietHistory_MaxValue = value;
+                    }
+                    break;
+                }
+            case "capturehistory_maxvalue":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CaptureHistory_MaxValue = value;
+                    }
+                    break;
+                }
+            case "continuationhistory_maxvalue":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.ContinuationHistory_MaxValue = value;
                     }
                     break;
                 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/84ecbf91-6c43-4400-b334-8e05dbad5551)


8+0.08
```
Score of Lynx-search-split-history-maxvalue-increase-5423-win-x64 vs Lynx 5422 - main: 176 - 233 - 341  [0.462] 750
...      Lynx-search-split-history-maxvalue-increase-5423-win-x64 playing White: 134 - 57 - 184  [0.603] 375
...      Lynx-search-split-history-maxvalue-increase-5423-win-x64 playing Black: 42 - 176 - 157  [0.321] 375
...      White vs Black: 310 - 99 - 341  [0.641] 750
Elo difference: -26.5 +/- 18.4, LOS: 0.2 %, DrawRatio: 45.5 %
SPRT: llr -0.959 (-33.2%), lbound -2.25, ubound 2.89
```
40+0.4
```
Score of Lynx-search-split-history-maxvalue-increase-5423-win-x64 vs Lynx 5422 - main: 781 - 892 - 1697  [0.484] 3370
...      Lynx-search-split-history-maxvalue-increase-5423-win-x64 playing White: 680 - 124 - 881  [0.665] 1685
...      Lynx-search-split-history-maxvalue-increase-5423-win-x64 playing Black: 101 - 768 - 816  [0.302] 1685
...      White vs Black: 1448 - 225 - 1697  [0.681] 3370
Elo difference: -11.4 +/- 8.3, LOS: 0.3 %, DrawRatio: 50.4 %
SPRT: llr -2.19 (-75.7%), lbound -2.25, ubound 2.89
```