### PR TITLE
⚡Pawn islands: Use `[SkipLocalsInit]` and `Span.Clear()`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1304,9 +1304,11 @@ public class Position : IDisposable
 
         return PawnIslandsBonus[whiteIslandCount] - PawnIslandsBonus[blackIslandCount];
 
+        [SkipLocalsInit]
         static int IdentifyIslands(BitBoard pawns)
         {
             Span<int> files = stackalloc int[8];
+            files.Clear();
 
             while (pawns != default)
             {


### PR DESCRIPTION
```
Test  | perf/pawnislands-skiplocalsinit
Elo   | -0.35 +- 2.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 44574: +12532 -12577 =19465
Penta | [1090, 5175, 9779, 5176, 1067]
https://openbench.lynx-chess.com/test/1315/
```