### PR TITLE
🔍 Reuse TT static eval III

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -109,8 +109,6 @@ public sealed partial class Engine
 
         Debug.Assert(staticEval != EvaluationConstants.NoHashEntry);
 
-        Game.UpdateStaticEvalInStack(ply, staticEval);
-
         if (isInCheck)
         {
             ++depth;
@@ -129,6 +127,7 @@ public sealed partial class Engine
         }
         else if (!pvNode)
         {
+            Game.UpdateStaticEvalInStack(ply, staticEval);
 
             if (ply >= 2)
             {


### PR DESCRIPTION
```
Test  | search/re-reuse-tt-staticeval-3
Elo   | -20.24 +- 8.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 2990: +765 -939 =1286
Penta | [110, 414, 581, 320, 70]
https://openbench.lynx-chess.com/test/1341/
```