### PR TITLE
🔍 Add TT replacement depth offset = 1

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -248,6 +248,9 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
+    //[SPSA<int>(0, 6, 0.5)]
+    public int TTReplacement_DepthOffset { get; set; } = 1;
+
     #endregion
 }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -95,7 +95,7 @@ public readonly struct TranspositionTable
             entry.Key == 0                                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
-            || depth >= entry.Depth;                            // Higher depth
+            || depth + Configuration.EngineSettings.TTReplacement_DepthOffset >= entry.Depth;                            // Higher depth
 
         if (!shouldReplace)
         {

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -575,6 +575,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "ttreplacement_depthoffset":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.TTReplacement_DepthOffset = value;
+                    }
+                    break;
+                }
 
             #endregion
 


### PR DESCRIPTION
Stopped
```
Score of Lynx-tt-replace-depth-offset-1-5443-win-x64 vs Lynx 5442 - main: 125 - 136 - 239  [0.489] 500
...      Lynx-tt-replace-depth-offset-1-5443-win-x64 playing White: 96 - 29 - 125  [0.634] 250
...      Lynx-tt-replace-depth-offset-1-5443-win-x64 playing Black: 29 - 107 - 114  [0.344] 250
...      White vs Black: 203 - 58 - 239  [0.645] 500
Elo difference: -7.6 +/- 22.0, LOS: 24.8 %, DrawRatio: 47.8 %
SPRT: llr -0.218 (-7.5%), lbound -2.25, ubound 2.89
```

See #1468 (2), #1469 (4), #1471 (6)