### PR TITLE
🔍 TTPV + LMR

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1083,19 +1083,19 @@ static void TranspositionTableMethod()
     //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, false, move: 1234);
     var entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 20
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, false, move: 1234);
     entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, false, move: 1234);
     entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 12_345_678
 
-    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, move: 1234);
+    transpositionTable.RecordHash(position, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, false, move: 1234);
     entry = transpositionTable.ProbeHash(position, ply: 3);
     Console.WriteLine(entry); // Expected 30
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -249,7 +249,12 @@ public sealed class EngineSettings
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
     //[SPSA<int>(0, 6, 0.5)]
-    public int TTReplacement_DepthOffset { get; set; } = 4;
+#pragma warning disable CA1805 // Do not initialize unnecessarily
+    public int TTReplacement_DepthOffset { get; set; } = 0;
+#pragma warning restore CA1805 // Do not initialize unnecessarily
+
+    //[SPSA<int>(0, 10, 0.5)]
+    public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -248,6 +248,9 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
+    //[SPSA<int>(0, 6, 0.5)]
+    public int TTReplacement_DepthOffset { get; set; } = 1;
+
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -249,7 +249,7 @@ public sealed class EngineSettings
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
     //[SPSA<int>(0, 6, 0.5)]
-    public int TTReplacement_DepthOffset { get; set; } = 1;
+    public int TTReplacement_DepthOffset { get; set; } = 2;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -249,7 +249,7 @@ public sealed class EngineSettings
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
     //[SPSA<int>(0, 6, 0.5)]
-    public int TTReplacement_DepthOffset { get; set; } = 2;
+    public int TTReplacement_DepthOffset { get; set; } = 4;
 
     #endregion
 }

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -95,7 +95,7 @@ public readonly struct TranspositionTable
             entry.Key == 0                                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
-            || depth >= entry.Depth;                            // Higher depth
+            || depth + Configuration.EngineSettings.TTReplacement_DepthOffset >= entry.Depth;                            // Higher depth
 
         if (!shouldReplace)
         {

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -59,21 +59,21 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public (int Score, ShortMove BestMove, NodeType NodeType, int StaticEval, int Depth) ProbeHash(Position position, int ply)
+    public (int Score, ShortMove BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv) ProbeHash(Position position, int ply)
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
         var entry = _tt[ttIndex];
 
         if ((ushort)position.UniqueIdentifier != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default, default, EvaluationConstants.NoHashEntry, default);
+            return (EvaluationConstants.NoHashEntry, default, default, EvaluationConstants.NoHashEntry, default, default);
         }
 
         // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
         // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
         var recalculatedScore = RecalculateMateScores(entry.Score, ply);
 
-        return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth);
+        return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
     }
 
     /// <summary>
@@ -81,7 +81,7 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void RecordHash(Position position, int staticEval, int depth, int ply, int score, NodeType nodeType, Move? move = null)
+    public void RecordHash(Position position, int staticEval, int depth, int ply, int score, NodeType nodeType, bool wasPv, Move? move = null)
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
         ref var entry = ref _tt[ttIndex];
@@ -91,11 +91,15 @@ public readonly struct TranspositionTable
         //    _logger.Warn("TT collision");
         //}
 
+        var wasPvInt = wasPv ? 1 : 0;
+
         bool shouldReplace =
             entry.Key == 0                                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
-            || depth + Configuration.EngineSettings.TTReplacement_DepthOffset >= entry.Depth;                            // Higher depth
+            || depth
+                + Configuration.EngineSettings.TTReplacement_DepthOffset
+                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * 2 * wasPvInt) >= entry.Depth;           // Higher depth
 
         if (!shouldReplace)
         {
@@ -106,7 +110,7 @@ public readonly struct TranspositionTable
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
-        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, move);
+        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -36,7 +36,15 @@ public struct TranspositionTableElement
 
     private byte _depth;        // 1 byte
 
-    private NodeType _type;     // 1 byte
+    /// <summary>
+    /// 1 byte
+    /// Binary move bits    Hexadecimal
+    /// 0000 0001              0x1           Was PV (0-1)
+    /// 0000 1110              0xE           NodeType (0-3)
+    /// </summary>
+    private byte _type_WasPv;
+
+    private const int NodeTypeOffset = 1;
 
     /// <summary>
     /// 16 MSB of Position's Zobrist key
@@ -69,20 +77,22 @@ public struct TranspositionTableElement
     /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
     /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
     /// </summary>
-    public readonly NodeType Type => _type;
+    public readonly NodeType Type => (NodeType)((_type_WasPv & 0xE) >> NodeTypeOffset);
+
+    public readonly bool WasPv => (_type_WasPv & 0x1) == 1;
 
     /// <summary>
     /// Struct size in bytes
     /// </summary>
     public static ulong Size => (ulong)Marshal.SizeOf<TranspositionTableElement>();
 
-    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, Move? move)
+    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
     {
         _key = (ushort)key;
         _score = (short)score;
         _staticEval = (short)staticEval;
         _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
-        _type = nodeType;
+        _type_WasPv = (byte)(wasPv | ((int)nodeType << NodeTypeOffset));
         _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
     }
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -382,6 +382,11 @@ public sealed partial class Engine
                             --reduction;
                         }
 
+                        if (ttPv)
+                        {
+                            --reduction;
+                        }
+
                         if (position.IsInCheck())   // i.e. move gives check
                         {
                             --reduction;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -575,6 +575,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "ttreplacement_depthoffset":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.TTReplacement_DepthOffset = value;
+                    }
+                    break;
+                }
 
             #endregion
 


### PR DESCRIPTION
See also #1473 

```
Score of Lynx-search-ttpv-lmr-reduction-5454-win-x64 vs Lynx 5452 - main: 809 - 933 - 1541  [0.481] 3283
...      Lynx-search-ttpv-lmr-reduction-5454-win-x64 playing White: 625 - 192 - 824  [0.632] 1641
...      Lynx-search-ttpv-lmr-reduction-5454-win-x64 playing Black: 184 - 741 - 717  [0.330] 1642
...      White vs Black: 1366 - 376 - 1541  [0.651] 3283
Elo difference: -13.1 +/- 8.6, LOS: 0.1 %, DrawRatio: 46.9 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```