### PR TITLE
🔍 TT replacement: add depth offset = 2

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -250,7 +250,7 @@ public sealed class EngineSettings
 
     //[SPSA<int>(0, 6, 0.5)]
 #pragma warning disable CA1805 // Do not initialize unnecessarily
-    public int TTReplacement_DepthOffset { get; set; } = 0;
+    public int TTReplacement_DepthOffset { get; set; } = 2;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 
     //[SPSA<int>(0, 10, 0.5)]

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -98,7 +98,7 @@ public readonly struct TranspositionTable
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
-                //+ Configuration.EngineSettings.TTReplacement_DepthOffset
+                + Configuration.EngineSettings.TTReplacement_DepthOffset
                 + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth;           // Higher depth
 
         if (!shouldReplace)


### PR DESCRIPTION

```
Score of Lynx-tt-replace-depth-offset-2-2-5481-win-x64 vs Lynx 5477 - main: 1468 - 1483 - 2779  [0.499] 5730
...      Lynx-tt-replace-depth-offset-2-2-5481-win-x64 playing White: 1145 - 344 - 1376  [0.640] 2865
...      Lynx-tt-replace-depth-offset-2-2-5481-win-x64 playing Black: 323 - 1139 - 1403  [0.358] 2865
...      White vs Black: 2284 - 667 - 2779  [0.641] 5730
Elo difference: -0.9 +/- 6.4, LOS: 39.1 %, DrawRatio: 48.5 %
SPRT: llr -0.666 (-23.1%), lbound -2.25, ubound 2.89
```