### PR TITLE
🔍 TTPV: allow LMR also on `!ttPv`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -368,7 +368,7 @@ public sealed partial class Engine
                 // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
                 if (isNotGettingCheckmated)
                 {
-                    if (!isCapture
+                    if ((!isCapture || !ttPv)
                         && depth >= Configuration.EngineSettings.LMR_MinDepth
                         && visitedMovesCounter >=
                             (pvNode


### PR DESCRIPTION
```
Score of Lynx-search-ttpv-lmr-5486-win-x64 vs Lynx 5477 - main: 1634 - 1745 - 3014  [0.491] 6393
...      Lynx-search-ttpv-lmr-5486-win-x64 playing White: 1287 - 376 - 1534  [0.642] 3197
...      Lynx-search-ttpv-lmr-5486-win-x64 playing Black: 347 - 1369 - 1480  [0.340] 3196
...      White vs Black: 2656 - 723 - 3014  [0.651] 6393
Elo difference: -6.0 +/- 6.2, LOS: 2.8 %, DrawRatio: 47.1 %
SPRT: llr -2.26 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```