### PR TITLE
🔍 LMR: split base and history factor in quiet and noisy and tune

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -154,28 +154,28 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Quiet_Base { get; set; } = 0.60;
+    public double LMR_Quiet_Base { get; set; } = 0.64;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Quiet_Divisor { get; set; } = 3.21;
+    public double LMR_Quiet_Divisor { get; set; } = 3.04;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Noisy_Base { get; set; } = 0.60;
+    public double LMR_Noisy_Base { get; set; } = 0.48;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Noisy_Divisor { get; set; } = 3.21;
+    public double LMR_Noisy_Divisor { get; set; } = 3.15;
 
     /// <summary>
     /// <see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_QuietHistory_Divisor { get; set; } = 4096;
+    public int LMR_QuietHistory_Divisor { get; set; } = 4059;
 
     /// <summary>
     /// <see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_Noisy_History_Divisor { get; set; } = 3072;
+    public int LMR_Noisy_History_Divisor { get; set; } = 3184;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -154,10 +154,16 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base { get; set; } = 0.60;
+    public double LMR_Quiet_Base { get; set; } = 0.60;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.21;
+    public double LMR_Quiet_Divisor { get; set; } = 3.21;
+
+    [SPSA<double>(0.1, 2, 0.1)]
+    public double LMR_Noisy_Base { get; set; } = 0.60;
+
+    [SPSA<double>(1, 5, 0.1)]
+    public double LMR_Noisy_Divisor { get; set; } = 3.21;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -165,6 +165,18 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Noisy_Divisor { get; set; } = 3.21;
 
+    /// <summary>
+    /// <see cref="History_MaxMoveValue"/> / 2
+    /// </summary>
+    [SPSA<int>(1, 8192, 128)]
+    public int LMR_QuietHistory_Divisor { get; set; } = 4096;
+
+    /// <summary>
+    /// <see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
+    /// </summary>
+    [SPSA<int>(1, 8192, 128)]
+    public int LMR_Noisy_History_Divisor { get; set; } = 3072;
+
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -23,9 +23,9 @@ public static class EvaluationConstants
     public const int MaxPhase = 24;
 
     /// <summary>
-    /// <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
+    /// 2 x <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>
     /// </summary>
-    public static readonly int[][] LMRReductions = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
+    public static readonly int[][][] LMRReductions = new int[2][][];
 
     /// <summary>
     /// [0, 4, 136, 276, 424, 580, 744, 916, 1096, 1284, 1480, 1684, 1896, 1896, 1896, 1896, ...]
@@ -34,14 +34,21 @@ public static class EvaluationConstants
 
     static EvaluationConstants()
     {
+        var quietReductions = LMRReductions[0] = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
+        var noisyReductions = LMRReductions[1] = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];
+
         for (int searchDepth = 1; searchDepth < Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin; ++searchDepth)    // Depth > 0 or we'd be in QSearch
         {
-            LMRReductions[searchDepth] = new int[Constants.MaxNumberOfPossibleMovesInAPosition];
+            quietReductions[searchDepth] = new int[Constants.MaxNumberOfPossibleMovesInAPosition];
+            noisyReductions[searchDepth] = new int[Constants.MaxNumberOfPossibleMovesInAPosition];
 
             for (int movesSearchedCount = 1; movesSearchedCount < Constants.MaxNumberOfPossibleMovesInAPosition; ++movesSearchedCount) // movesSearchedCount > 0 or we wouldn't be applying LMR
             {
-                LMRReductions[searchDepth][movesSearchedCount] = Convert.ToInt32(Math.Round(
-                    Configuration.EngineSettings.LMR_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Divisor)));
+                quietReductions[searchDepth][movesSearchedCount] = Convert.ToInt32(Math.Round(
+                    Configuration.EngineSettings.LMR_Quiet_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Quiet_Divisor)));
+
+                noisyReductions[searchDepth][movesSearchedCount] = Convert.ToInt32(Math.Round(
+                    Configuration.EngineSettings.LMR_Noisy_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Noisy_Divisor)));
             }
 
             HistoryBonus[searchDepth] = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -378,7 +378,8 @@ public sealed partial class Engine
                         {
                             reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter];
 
-                            reduction -= 2 * _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())] / Configuration.EngineSettings.History_MaxMoveValue;
+                            // ~ history/(0.75 * maxHistory/2/)
+                            reduction -= _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())] / Configuration.EngineSettings.LMR_Noisy_History_Divisor;
                         }
                         else
                         {
@@ -409,8 +410,8 @@ public sealed partial class Engine
                                 ++reduction;
                             }
 
-                            // -= history/(maxHistory/2)
-                            reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;
+                            // ~ history/(maxHistory/2)
+                            reduction -= _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.LMR_QuietHistory_Divisor;
 
                         }
 
@@ -418,6 +419,8 @@ public sealed partial class Engine
                         // depth - 1 - depth +2 = 1, min depth we want
                         reduction = Math.Clamp(reduction, 0, depth - 2);
                     }
+
+                    // TODO move inside of depth conditions
                     // 🔍 Static Exchange Evaluation (SEE) reduction
                     // Bad captures are reduced more
                     if (!isInCheck

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -329,19 +329,35 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "lmr_base":
+            case "lmr_quiet_base":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.LMR_Base = value * 0.01;
+                        Configuration.EngineSettings.LMR_Quiet_Base = value * 0.01;
                     }
                     break;
                 }
-            case "lmr_divisor":
+            case "lmr_quiet_divisor":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
-                        Configuration.EngineSettings.LMR_Divisor = value * 0.01;
+                        Configuration.EngineSettings.LMR_Quiet_Divisor = value * 0.01;
+                    }
+                    break;
+                }
+            case "lmr_noisy_base":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Noisy_Base = value * 0.01;
+                    }
+                    break;
+                }
+            case "lmr_noisy_divisor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Noisy_Divisor = value * 0.01;
                     }
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -361,6 +361,22 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_quiethistory_divisor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_QuietHistory_Divisor = value;
+                    }
+                    break;
+                }
+            case "lmr_noisy_history_divisor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Noisy_History_Divisor = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION

```
iterations: 182 (276.95s per iter)
games: 5824 (8.65s per game)
LMR_Quiet_Base = 64(+4.45) in [10, 200]
LMR_Quiet_Divisor = 304(-17.455455) in [100, 500]
LMR_Noisy_Base = 48(-11.500469) in [10, 200]
LMR_Noisy_Divisor = 315(-5.658506) in [100, 500]
LMR_QuietHistory_Divisor = 4059(-36.886977) in [1, 8192]
LMR_Noisy_History_Divisor = 3184(+112.03) in [1, 8192]
```

![image](https://github.com/user-attachments/assets/afb2a4de-361d-49d1-b0d4-8ac626c85eda)


```
Test  | search/lmr-noisy-tune-1
Elo   | -0.84 +- 4.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.59 (-2.25, 2.89) [0.00, 3.00]
Games | 8320: +2022 -2042 =4256
Penta | [134, 1026, 1856, 1014, 130]
https://openbench.lynx-chess.com/test/1362/
```