### PR TITLE
🧪 Add quick and dirty `BitBoard` wrapper

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,6 @@
   <ItemGroup>
     <Using Include="System.Int32" Alias="Move" />
     <Using Include="System.Int16" Alias="ShortMove" />
-    <Using Include="System.UInt64" Alias="BitBoard" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByRank" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount7" />
     <Using Include="System.Int32[]" Alias="TaperedEvaluationTermByCount8" />

--- a/src/Lynx.Benchmark/PieceAtSquare_Benchmark.cs
+++ b/src/Lynx.Benchmark/PieceAtSquare_Benchmark.cs
@@ -224,7 +224,7 @@ public class PieceAtSquare_Benchmark : BaseBenchmark
     /// </summary>
     private static int PieceAt(Position position, int targetSquare)
     {
-        var bit = BitBoardExtensions.SquareBit(targetSquare);
+        var bit = BitBoard.SquareBit(targetSquare);
 
         Side color;
 

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -65,7 +65,7 @@ const string CmkPosition = Constants.CmkTestPositionFEN;
 
 static void _2_GettingStarted()
 {
-    var board = 4UL;
+    BitBoard board = new(4UL);
     board.SetBit(BoardSquare.e4);
     board.Print();
     board.PopBit(BoardSquare.e4);
@@ -146,7 +146,7 @@ static void _8_Slider_Pieces_Attacks()
     block.Print();
     bishopAttacks.Print();
 
-    block = BitBoardExtensions.Initialize(BoardSquare.d3, BoardSquare.b4, BoardSquare.d7, BoardSquare.h4);
+    block = new(BoardSquare.d3, BoardSquare.b4, BoardSquare.d7, BoardSquare.h4);
 
     var rookAttacks = AttackGenerator.GenerateRookAttacksOnTheFly((int)BoardSquare.d4, block);
     block.Print();
@@ -155,12 +155,12 @@ static void _8_Slider_Pieces_Attacks()
 
 static void _9_BitCount()
 {
-    BitBoard bitBoard = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
+    BitBoard bitBoard = new(BoardSquare.d5, BoardSquare.e4);
 
     bitBoard.ResetLS1B();
     bitBoard.Print();
 
-    var bb = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
+    BitBoard bb = new(BoardSquare.d5, BoardSquare.e4);
 
     Console.WriteLine(bb.GetLS1BIndex());
     Console.WriteLine(bb.GetLS1BIndex());
@@ -205,7 +205,7 @@ static void _11_OccupancyBitCountLookupTables()
     {
         for (var file = 0; file < 8; ++file)
         {
-            int square = BitBoardExtensions.SquareIndex(rank, file);
+            int square = BitBoard.SquareIndex(rank, file);
 
             var bishopOccupancy = AttackGenerator.MaskBishopOccupancy(square);
             Console.Write($"{bishopOccupancy.CountBits()}, ");
@@ -218,7 +218,7 @@ static void _11_OccupancyBitCountLookupTables()
     {
         for (var file = 0; file < 8; ++file)
         {
-            int square = BitBoardExtensions.SquareIndex(rank, file);
+            int square = BitBoard.SquareIndex(rank, file);
 
             var bishopOccupancy = AttackGenerator.MaskRookOccupancy(square);
             Console.Write($"{bishopOccupancy.CountBits()}, ");
@@ -240,12 +240,12 @@ static void _13_GeneratingMagicNumbersCandidates()
     // int(uint really), which is 32 bits -> ulong, 64 bits leaves the seconf half of the board empty
     // The slicing leaves the second quarter empty as well
     var randomBoard = randomNumber;
-    randomBoard.Print();
+    new BitBoard(randomBoard).Print();
 
     var candidate = MagicNumberGenerator.GenerateMagicNumber();
 
     var board = candidate;
-    board.Print();
+    new BitBoard(board).Print();
 }
 
 static void _14_GeneratingMagicNumbersByBruteForce()
@@ -1172,7 +1172,7 @@ static void PieceSquareTables()
                     Console.Write($"{8 - rank}  ");
                 }
 
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                var squareIndex = BitBoard.SquareIndex(rank, file);
 
                 Console.Write($" {bitboard[squareIndex]}\t");
             }
@@ -1195,9 +1195,9 @@ static void NewMasks()
     Masks.WhiteKnightOutpostMask.Print();
     Masks.BlackKnightOutpostMask.Print();
 
-    Masks.LightSquaresMask.Print();
-    Masks.DarkSquaresMask.Print();
-    (Masks.DarkSquaresMask ^ Masks.LightSquaresMask).Print();
+    new BitBoard(Masks.LightSquaresMask).Print();
+    new BitBoard(Masks.DarkSquaresMask).Print();
+    new BitBoard(Masks.DarkSquaresMask ^ Masks.LightSquaresMask).Print();
 
     Console.WriteLine(((Masks.LightSquaresMask >> (int)BoardSquare.h1) & 1) != 0);
     Console.WriteLine((((9 * (int)BoardSquare.h1) + 8) & 8) != 0);
@@ -1205,7 +1205,7 @@ static void NewMasks()
     Console.WriteLine((((9 * (int)BoardSquare.a1) + 8) & 8) != 0);
 }
 
-static void PrintBitBoardArray(ulong[] bb)
+static void PrintBitBoardArray(BitBoard[] bb)
 {
     for (int i = 0; i < 64; ++i)
     {
@@ -1222,12 +1222,12 @@ static void PrintBitBoardArray(ulong[] bb)
 
 static void DarkLightSquares()
 {
-    Constants.DarkSquaresBitBoard.Print();
-    Constants.LightSquaresBitBoard.Print();
+    new BitBoard(Constants.DarkSquaresBitBoard).Print();
+    new BitBoard(Constants.LightSquaresBitBoard).Print();
 
     for (int i = 0; i < 64; ++i)
     {
-        Debug.Assert(Constants.DarkSquaresBitBoard.GetBit(i) ^ Constants.LightSquaresBitBoard.GetBit(i));
+        Debug.Assert(new BitBoard(Constants.DarkSquaresBitBoard).GetBit(i) ^ new BitBoard(Constants.LightSquaresBitBoard).GetBit(i));
     }
 }
 

--- a/src/Lynx/AttackGenerator.cs
+++ b/src/Lynx/AttackGenerator.cs
@@ -422,7 +422,7 @@ public static class AttackGenerator
     public static BitBoard MaskBishopOccupancy(int squareIndex)
     {
         // Results attack bitboard
-        BitBoard attacks = default;
+        ulong attacks = default;
 
         int rank, file;
 
@@ -440,7 +440,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1, file = targetFile + 1; rank <= 6 && file <= 6; ++rank, ++file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, file);
         }
 
         /*
@@ -452,7 +452,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1, file = targetFile - 1; rank >= 1 && file >= 1; --rank, --file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, file);
         }
 
         /*
@@ -464,7 +464,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1, file = targetFile + 1; rank >= 1 && file <= 6; --rank, ++file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, file);
         }
 
         /*
@@ -476,10 +476,10 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1, file = targetFile - 1; rank <= 6 && file >= 1; ++rank, --file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, file);
         }
 
-        return attacks;
+        return new(attacks);
     }
 
     /// <summary>
@@ -490,7 +490,7 @@ public static class AttackGenerator
     public static BitBoard MaskRookOccupancy(int squareIndex)
     {
         // Results attack bitboard
-        BitBoard attacks = default;
+        ulong attacks = default;
 
         int rank, file;
 
@@ -508,7 +508,7 @@ public static class AttackGenerator
          */
         for (file = targetFile + 1; file <= 6; ++file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(targetRank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(targetRank, file);
         }
 
         /*
@@ -520,7 +520,7 @@ public static class AttackGenerator
          */
         for (file = targetFile - 1; file >= 1; --file)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(targetRank, file);
+            attacks |= 1UL << BitBoard.SquareIndex(targetRank, file);
         }
 
         /*
@@ -532,7 +532,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1; rank <= 6; ++rank)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, targetFile);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, targetFile);
         }
 
         /*
@@ -544,10 +544,10 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1; rank >= 1; --rank)
         {
-            attacks |= 1UL << BitBoardExtensions.SquareIndex(rank, targetFile);
+            attacks |= 1UL << BitBoard.SquareIndex(rank, targetFile);
         }
 
-        return attacks;
+        return new(attacks);
     }
 
     /// <summary>
@@ -588,7 +588,7 @@ public static class AttackGenerator
     public static BitBoard GenerateBishopAttacksOnTheFly(int squareIndex, BitBoard occupiedSquares)
     {
         // Results attack bitboard
-        BitBoard attacks = default;
+        ulong attacks = default;
 
         int rank, file;
 
@@ -606,7 +606,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1, file = targetFile + 1; rank <= 7 && file <= 7; ++rank, ++file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -624,7 +624,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1, file = targetFile - 1; rank >= 0 && file >= 0; --rank, --file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -642,7 +642,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1, file = targetFile + 1; rank >= 0 && file <= 7; --rank, ++file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -660,7 +660,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1, file = targetFile - 1; rank <= 7 && file >= 0; ++rank, --file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -669,13 +669,13 @@ public static class AttackGenerator
             }
         }
 
-        return attacks;
+        return new(attacks);
     }
 
     public static BitBoard GenerateRookAttacksOnTheFly(int squareIndex, BitBoard occupiedSquares)
     {
         // Results attack bitboard
-        BitBoard attacks = default;
+        ulong attacks = default;
 
         int rank, file;
 
@@ -693,7 +693,7 @@ public static class AttackGenerator
          */
         for (file = targetFile + 1; file <= 7; ++file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(targetRank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(targetRank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -711,7 +711,7 @@ public static class AttackGenerator
          */
         for (file = targetFile - 1; file >= 0; --file)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(targetRank, file);
+            ulong square = 1UL << BitBoard.SquareIndex(targetRank, file);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -729,7 +729,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank + 1; rank <= 7; ++rank)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, targetFile);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, targetFile);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -747,7 +747,7 @@ public static class AttackGenerator
          */
         for (rank = targetRank - 1; rank >= 0; --rank)
         {
-            ulong square = 1UL << BitBoardExtensions.SquareIndex(rank, targetFile);
+            ulong square = 1UL << BitBoard.SquareIndex(rank, targetFile);
             attacks |= square;
 
             if ((square & occupiedSquares) != default)
@@ -756,6 +756,6 @@ public static class AttackGenerator
             }
         }
 
-        return attacks;
+        return new(attacks);
     }
 }

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -19,7 +19,7 @@ public static class Constants
     /// 1   1 1 1 1 1 1 1 1
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard FullBoard = ulong.MaxValue;
+    public const ulong FullBoard = ulong.MaxValue;
 
     /// <summary>
     /// 8   1 0 0 0 0 0 0 0
@@ -32,7 +32,7 @@ public static class Constants
     /// 1   1 0 0 0 0 0 0 0
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard AFile = 0x101010101010101;
+    public const ulong AFile = 0x101010101010101;
 
     /// <summary>
     /// 8   0 1 1 1 1 1 1 1
@@ -45,7 +45,7 @@ public static class Constants
     /// 1   0 1 1 1 1 1 1 1
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard NotAFile = 0xFEFEFEFEFEFEFEFE;
+    public const ulong NotAFile = 0xFEFEFEFEFEFEFEFE;
 
     /// <summary>
     /// 8   0 0 0 0 0 0 0 1
@@ -58,7 +58,7 @@ public static class Constants
     /// 1   0 0 0 0 0 0 0 1
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard HFile = 0x8080808080808080;
+    public const ulong HFile = 0x8080808080808080;
 
     /// <summary>
     /// 8   1 1 1 1 1 1 1 0
@@ -71,7 +71,7 @@ public static class Constants
     /// 1   1 1 1 1 1 1 1 0
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard NotHFile = 0x7F7F7F7F7F7F7F7F;
+    public const ulong NotHFile = 0x7F7F7F7F7F7F7F7F;
 
     /// <summary>
     /// 8   1 1 1 1 1 1 0 0
@@ -84,7 +84,7 @@ public static class Constants
     /// 1   1 1 1 1 1 1 0 0
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard NotHGFiles = 0x3F3F3F3F3F3F3F3F;
+    public const ulong NotHGFiles = 0x3F3F3F3F3F3F3F3F;
 
     /// <summary>
     /// 8   0 0 1 1 1 1 1 1
@@ -97,7 +97,7 @@ public static class Constants
     /// 1   0 0 1 1 1 1 1 1
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard NotABFiles = 0xFCFCFCFCFCFCFCFC;
+    public const ulong NotABFiles = 0xFCFCFCFCFCFCFCFC;
 
     public static readonly string[] Coordinates =
     [
@@ -196,7 +196,7 @@ public static class Constants
         12, 11, 11, 11, 11, 11, 11, 12
     ];
 
-    public static ReadOnlySpan<BitBoard> RookMagicNumbers =>
+    public static ReadOnlySpan<ulong> RookMagicNumbers =>
     [
         0x8080104000208000,   0xa240004020021004,   0x880200080081000,    0x2080058010010800,   0x1001001020408008,   0x4200011042000884,   0x6001c020002c805,    0x2000100802a0044,
         0x20800020804000,     0x5000c00020005000,   0x801000802002,       0x8005001001002208,   0x2000412000820,      0x23000218140100,     0x100a002600081401,   0x2520800060800100,
@@ -208,7 +208,7 @@ public static class Constants
         0x8096800102104025,   0x8004204204110082,   0xd042200011000843,   0x422208c0900f001,    0x61001002080005,     0x4002001028218422,   0x2040104088020104,   0x300108b104064082,
     ];
 
-    public static ReadOnlySpan<BitBoard> BishopMagicNumbers =>
+    public static ReadOnlySpan<ulong> BishopMagicNumbers =>
     [
         0x10440804a02200,     0x2002241404004050,   0x808008c10800204,    0x8204848201002,      0x8411104001420404,   0x422080208050010,    0x8002020120880e44,   0x3084800880800,
         0x1904210042080,      0x1004103018888888,   0x20264802404a0000,   0x21042402800002,     0x8400840420400002,   0x4102042220901800,   0x840004108201004,    0x40008404010501,
@@ -396,7 +396,7 @@ public static class Constants
     /// 1   0 1 0 1 0 1 0 1
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard LightSquaresBitBoard = 0xAA55AA55AA55AA55UL;
+    public static readonly BitBoard LightSquaresBitBoard = new(0xAA55AA55AA55AA55UL);
 
     /// <summary>
     /// 8   0 1 0 1 0 1 0 1
@@ -409,7 +409,7 @@ public static class Constants
     /// 1   1 0 1 0 1 0 1 0
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard DarkSquaresBitBoard = 0x55AA55AA55AA55AAUL;
+    public static readonly BitBoard DarkSquaresBitBoard = new(0x55AA55AA55AA55AAUL);
 
     /// <summary>
     /// 8   0 0 1 1 1 1 0 0
@@ -422,9 +422,9 @@ public static class Constants
     /// 1   0 0 1 1 1 1 0 0
     ///     a b c d e f g h
     /// </summary>
-    public const BitBoard CentralFiles = 0x3c3c3c3c3c3c3c3c;
+    public static readonly BitBoard CentralFiles = new(0x3c3c3c3c3c3c3c3c);
 
-    public const BitBoard CentralSquares = 0x1818000000;
+    public static readonly BitBoard CentralSquares = new(0x1818000000);
 
     public static ReadOnlySpan<char> FileString => [ 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' ];
 

--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -4,7 +4,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-using ParseResult = (ulong[] PieceBitBoards, ulong[] OccupancyBitBoards, int[] board, Lynx.Model.Side Side, byte Castle, Lynx.Model.BoardSquare EnPassant,
+using ParseResult = (Lynx.Model.BitBoard[] PieceBitBoards, Lynx.Model.BitBoard[] OccupancyBitBoards, int[] board, Lynx.Model.Side Side, byte Castle, Lynx.Model.BoardSquare EnPassant,
             int HalfMoveClock/*, int FullMoveCounter*/);
 
 namespace Lynx;
@@ -126,8 +126,8 @@ public static class FENParser
 
                 if (piece != Piece.None)
                 {
-                    var square = BitBoardExtensions.SquareIndex(rankIndex, fileIndex);
-                    pieceBitBoards[(int)piece] = pieceBitBoards[(int)piece].SetBit(square);
+                    var square = BitBoard.SquareIndex(rankIndex, fileIndex);
+                    pieceBitBoards[(int)piece].SetBit(square);
                     board[square] = (int)piece;
                     ++fileIndex;
                 }

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -152,19 +152,19 @@ public static class Masks
     /// <summary>
     /// __builtin_bswap64(<see cref="LightSquaresMask"/>)
     /// </summary>
-    public const BitBoard DarkSquaresMask = 0x55AA_55AA_55AA_55AA;
+    public const ulong DarkSquaresMask = 0x55AA_55AA_55AA_55AA;
 
     /// <summary>
     /// https://www.chessprogramming.org/Color_of_a_Square
     /// </summary>
-    public const BitBoard LightSquaresMask = 0xAA55_AA55_AA55_AA55;
+    public const ulong LightSquaresMask = 0xAA55_AA55_AA55_AA55;
 
     static Masks()
     {
         InitializeMasks();
 
 #pragma warning disable S3353 // Unchanged local variables should be "const" - FP https://community.sonarsource.com/t/fp-s3353-value-modified-in-ref-extension-method/132389
-        ulong whiteKnightOutpostMask = 0, blackKnightOutpostMask = 0;
+        BitBoard whiteKnightOutpostMask = new(), blackKnightOutpostMask = new();
 #pragma warning restore S3353 // Unchanged local variables should be "const"
         for (int rank = 0; rank < 8; ++rank)
         {
@@ -172,7 +172,7 @@ public static class Masks
             {
                 if (rank < 4 && file > 0 && file < 7)
                 {
-                    var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                    var squareIndex = BitBoard.SquareIndex(rank, file);
 
                     whiteKnightOutpostMask.SetBit(squareIndex);
                     blackKnightOutpostMask.SetBit(squareIndex ^ 56);
@@ -190,7 +190,7 @@ public static class Masks
         {
             for (int file = 0; file < 8; ++file)
             {
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                var squareIndex = BitBoard.SquareIndex(rank, file);
 
                 FileMasks[squareIndex] |= SetFileRankMask(file, -1);
                 RankMasks[squareIndex] |= SetFileRankMask(-1, rank);
@@ -209,8 +209,8 @@ public static class Masks
                 {
                     for (int j = 0; j < 8; ++j)
                     {
-                        WhitePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
-                        WhiteSidePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
+                        WhitePassedPawnMasks[squareIndex].PopBit(BitBoard.SquareIndex(i, j));
+                        WhiteSidePassedPawnMasks[squareIndex].PopBit(BitBoard.SquareIndex(i, j));
                     }
                 }
 
@@ -226,8 +226,8 @@ public static class Masks
                 {
                     for (int j = 0; j < 8; ++j)
                     {
-                        BlackPassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
-                        BlackSidePassedPawnMasks[squareIndex].PopBit(BitBoardExtensions.SquareIndex(i, j));
+                        BlackPassedPawnMasks[squareIndex].PopBit(BitBoard.SquareIndex(i, j));
+                        BlackSidePassedPawnMasks[squareIndex].PopBit(BitBoard.SquareIndex(i, j));
                     }
                 }
             }
@@ -239,14 +239,14 @@ public static class Masks
     private static BitBoard SetFileRankMask(int fileIndex, int rankIndex)
     {
 #pragma warning disable S3353 // Unchanged local variables should be "const" - FP https://community.sonarsource.com/t/fp-s3353-value-modified-in-ref-extension-method/132389
-        BitBoard mask = 0;
+        BitBoard mask = new();
 #pragma warning restore S3353 // Unchanged local variables should be "const"
 
         for (int rank = 0; rank < 8; ++rank)
         {
             for (int file = 0; file < 8; ++file)
             {
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                var squareIndex = BitBoard.SquareIndex(rank, file);
 
                 if (fileIndex != -1)
                 {

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1390,7 +1390,7 @@ public class Position : IDisposable
     /// <param name="rooks">Includes Queen bitboard</param>
     /// <param name="bishops">Includes Queen bitboard</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ulong AllAttackersTo(int square, BitBoard occupancy, BitBoard rooks, BitBoard bishops)
+    public BitBoard AllAttackersTo(int square, BitBoard occupancy, BitBoard rooks, BitBoard bishops)
     {
         Debug.Assert(square != (int)BoardSquare.noSquare);
 
@@ -1533,7 +1533,7 @@ public class Position : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int PieceAt(int square)
     {
-        var bit = BitBoardExtensions.SquareBit(square);
+        var bit = BitBoard.SquareBit(square);
 
         Side color;
 
@@ -1680,7 +1680,7 @@ public class Position : IDisposable
                     Console.Write($"{8 - rank}  ");
                 }
 
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                var squareIndex = BitBoard.SquareIndex(rank, file);
 
                 var piece = -1;
 
@@ -1734,7 +1734,7 @@ public class Position : IDisposable
                     Console.Write($"{8 - rank}  ");
                 }
 
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+                var squareIndex = BitBoard.SquareIndex(rank, file);
 
                 var pieceRepresentation = IsSquareAttacked(squareIndex, sideToMove)
                     ? '1'

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -51,8 +51,8 @@ public static class SEE
         var targetSquare = move.TargetSquare();
 
         var occupancy = position.OccupancyBitBoards[(int)Side.Both]
-            ^ BitBoardExtensions.SquareBit(move.SourceSquare())
-            ^ BitBoardExtensions.SquareBit(targetSquare);
+            ^ BitBoard.SquareBit(move.SourceSquare())
+            ^ BitBoard.SquareBit(targetSquare);
 
         var queens = position.Queens;
         var bishops = queens | position.Bishops;
@@ -137,8 +137,8 @@ public static class SEE
         var targetSquare = move.TargetSquare();
 
         var occupancy = position.OccupancyBitBoards[(int)Side.Both]
-            ^ BitBoardExtensions.SquareBit(move.SourceSquare())
-            ^ BitBoardExtensions.SquareBit(targetSquare);
+            ^ BitBoard.SquareBit(move.SourceSquare())
+            ^ BitBoard.SquareBit(targetSquare);
 
         var queens = position.Queens;
         var bishops = queens | position.Bishops;


### PR DESCRIPTION
```
Test  | refactor/bitboard-wrapper
Elo   | -20.44 +- 10.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 1634: +403 -499 =732
Penta | [41, 241, 340, 163, 32]
https://openbench.lynx-chess.com/test/1363/
```