### PR TITLE
🟰 No soft time limit adjustments in extra threads + no pv table updates

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -20,6 +20,7 @@ public sealed partial class Engine : IDisposable
     private bool _disposedValue;
 
     private bool _isSearching;
+    private readonly bool _isMainEngine;
 
     public double AverageDepth { get; private set; }
 
@@ -34,6 +35,7 @@ public sealed partial class Engine : IDisposable
 #pragma warning restore RCS1163 // Unused parameter
     {
         _id = id;
+        _isMainEngine = _id == Searcher.MainEngineId;
         _engineWriter = engineWriter;
         _tt = tt;
 
@@ -64,8 +66,6 @@ public sealed partial class Engine : IDisposable
 
         _logger.Info("Engine {0} initialized", _id);
     }
-
-    private bool IsMainEngine() => _id == Searcher.MainEngineId;
 
 #pragma warning disable S1144 // Unused private types or members should be removed - used in Release mode
     private void WarmupEngine()

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -21,6 +21,7 @@ public sealed partial class Engine : IDisposable
 
     private bool _isSearching;
     private readonly bool _isMainEngine;
+    private readonly bool _isMainOrBenchEngine;
 
     public double AverageDepth { get; private set; }
 
@@ -36,6 +37,7 @@ public sealed partial class Engine : IDisposable
     {
         _id = id;
         _isMainEngine = _id == Searcher.MainEngineId;
+        _isMainOrBenchEngine = _isMainEngine || _id == Searcher.MainEngineId;
         _engineWriter = engineWriter;
         _tt = tt;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -302,7 +302,7 @@ public sealed partial class Engine
             {
                 score = 0;
 
-                if (_isMainEngine)
+                if (_isMainOrBenchEngine)
                 {
                     // We don't need to evaluate further down to know it's a draw.
                     // Since we won't be evaluating further down, we need to clear the PV table because those moves there
@@ -458,7 +458,7 @@ public sealed partial class Engine
                     alpha = score;
                     bestMove = move;
 
-                    if (_isMainEngine && pvNode)
+                    if (_isMainOrBenchEngine && pvNode)
                     {
                         _pVTable[pvIndex] = move;
                         CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
@@ -686,7 +686,7 @@ public sealed partial class Engine
                     alpha = score;
                     bestMove = move;
 
-                    if (_isMainEngine)
+                    if (_isMainOrBenchEngine)
                     {
                         _pVTable[pvIndex] = move;
                         CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -302,10 +302,13 @@ public sealed partial class Engine
             {
                 score = 0;
 
-                // We don't need to evaluate further down to know it's a draw.
-                // Since we won't be evaluating further down, we need to clear the PV table because those moves there
-                // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
-                Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
+                if (_isMainEngine)
+                {
+                    // We don't need to evaluate further down to know it's a draw.
+                    // Since we won't be evaluating further down, we need to clear the PV table because those moves there
+                    // don't belong to this line and if this move were to beat alpha, they'd incorrectly copied to pv line.
+                    Array.Clear(_pVTable, nextPvIndex, _pVTable.Length - nextPvIndex);
+                }
             }
             else if (visitedMovesCounter == 0)
             {
@@ -455,7 +458,7 @@ public sealed partial class Engine
                     alpha = score;
                     bestMove = move;
 
-                    if (pvNode)
+                    if (_isMainEngine && pvNode)
                     {
                         _pVTable[pvIndex] = move;
                         CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
@@ -683,8 +686,11 @@ public sealed partial class Engine
                     alpha = score;
                     bestMove = move;
 
-                    _pVTable[pvIndex] = move;
-                    CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                    if (_isMainEngine)
+                    {
+                        _pVTable[pvIndex] = move;
+                        CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
+                    }
 
                     nodeType = NodeType.Exact;
                 }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -13,6 +13,7 @@ public sealed class Searcher
     private readonly Logger _logger;
 
     internal const int MainEngineId = 1;
+    internal const int BenchEngineId = -1;
 
     private bool _isProcessingGoCommand;
     private bool _isPonderHit;
@@ -478,7 +479,7 @@ public sealed class Searcher
 
     public async ValueTask RunBench(int depth)
     {
-        using var engine = new Engine(-1, SilentChannelWriter<object>.Instance, in _ttWrapper, warmup: true);
+        using var engine = new Engine(BenchEngineId, SilentChannelWriter<object>.Instance, in _ttWrapper, warmup: true);
         var results = engine.Bench(depth);
 
         // Can't use engine, or results won't be printed


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1306 + no pv table updates

```
Test  | mt/no-extra-ops-in-main-thread
Elo   | 1.35 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 28064: +7479 -7370 =13215
Penta | [542, 3430, 6027, 3443, 590]
https://openbench.lynx-chess.com/test/1259/
```

Very marginal gains, if any, so won't merge it for now