### PR TITLE
⌛ SPSA TM: 2025-2-15, STC

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -132,10 +132,10 @@ public sealed class EngineSettings
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.47;
+    public double NodeTmBase { get; set; } = 2.34;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.77;
+    public double NodeTmScale { get; set; } = 1.70;
 
     //[SPSA<int>(1, 15, 1)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;


### PR DESCRIPTION
Tuned at 8+0.08, so good that it passed at that tc xD

```
iterations: 2495 (112.99s per iter)
games: 79840 (3.53s per game)
NodeTmBase = 234(-8.361029) in [100, 300]
NodeTmScale = 170(-11.042741) in [50, 250]
```

```
Test  | spsa/tm-14-2
Elo   | 4.99 +- 3.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | 13776: +3924 -3726 =6126
Penta | [306, 1597, 2940, 1683, 362]
https://openbench.lynx-chess.com/test/1373/
```

```
Test  | spsa/tm-14-2
Elo   | -2.50 +- 3.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 15828: +3849 -3963 =8016
Penta | [223, 1905, 3774, 1787, 225]
https://openbench.lynx-chess.com/test/1375/
```