### PR TITLE
🔍 Add `pvNode || cutnode` condition for IIR

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,7 +75,8 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if ((pvNode || cutnode)
+                && ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }


### PR DESCRIPTION
```
Test  | search/iir-pv-node-or-cutnode
Elo   | -0.75 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 34556: +9557 -9632 =15367
Penta | [857, 4228, 7168, 4183, 842]
https://openbench.lynx-chess.com/test/1379/
```