### PR TITLE
🔍 LMR: reduce more when TT move is a capture

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -45,6 +45,7 @@ public sealed partial class Engine
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
+        bool ttMoveCapture = false;
 
         Debug.Assert(!pvNode || !cutnode);
 
@@ -79,6 +80,8 @@ public sealed partial class Engine
             {
                 --depth;
             }
+
+            ttMoveCapture = ttBestMove != default && position.Board[((Move)ttBestMove).TargetSquare()] != default;
         }
 
         var ttPv = pvNode || ttWasPv;
@@ -398,6 +401,11 @@ public sealed partial class Engine
                         }
 
                         if (cutnode)
+                        {
+                            ++reduction;
+                        }
+
+                        if(ttMoveCapture)
                         {
                             ++reduction;
                         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -81,7 +81,7 @@ public sealed partial class Engine
                 --depth;
             }
 
-            ttMoveCapture = ttBestMove != default && position.Board[((Move)ttBestMove).TargetSquare()] != default;
+            ttMoveCapture = ttBestMove != default && position.Board[((Move)ttBestMove).TargetSquare()] != (int)Piece.None;
         }
 
         var ttPv = pvNode || ttWasPv;


### PR DESCRIPTION
```
Test  | search/lmr++-ttMoveCapture
Elo   | -0.42 +- 2.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 42722: +11927 -11979 =18816
Penta | [1110, 5175, 8874, 5061, 1141]
https://openbench.lynx-chess.com/test/1387/
```

```
Test  | search/lmr++-ttMoveCapture
Elo   | -7.21 +- 8.44 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | -0.87 (-2.25, 2.89) [0.00, 3.00]
Games | 2794: +696 -754 =1344
Penta | [68, 368, 570, 336, 55]
https://openbench.lynx-chess.com/test/1388/
```