### PR TITLE
🔍 Fractional LMR + tune

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,6 +159,21 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Improving { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Cutnode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_TTPV { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_PVNode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_InCheck { get; set; } = 100;
+
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 
@@ -222,7 +237,7 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int CounterMoves_MinDepth { get;set; } = 3;
+    public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
     public int History_BestScoreBetaMargin { get; set; } = 60;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -160,19 +160,19 @@ public sealed class EngineSettings
     public double LMR_Divisor { get; set; } = 3.21;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 100;
+    public int LMR_Improving { get; set; } = 157;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 100;
+    public int LMR_Cutnode { get; set; } = 133;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 100;
+    public int LMR_TTPV { get; set; } = 125;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 100;
+    public int LMR_PVNode { get; set; } = 77;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_InCheck { get; set; } = 100;
+    public int LMR_InCheck { get; set; } = 109;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,5 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
-using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 
 namespace Lynx;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -345,6 +345,46 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_improving":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Improving = value;
+                    }
+                    break;
+                }
+            case "lmr_cutnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Cutnode = value;
+                    }
+                    break;
+                }
+            case "LMR_TTPV":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_TTPV = value;
+                    }
+                    break;
+                }
+            case "lmr_pvnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_PVNode = value;
+                    }
+                    break;
+                }
+            case "lmr_incheck":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_InCheck = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
8+0.08 tune
```
iterations: 1326 (63.07s per iter)
games: 21216 (3.94s per game)
LMR_Improving = 157(+56.91) in [25, 300]
LMR_Cutnode = 133(+33.22) in [25, 300]
LMR_TTPV = 125(+25.13) in [25, 300]
LMR_PVNode = 77(-22.868050) in [25, 300]
LMR_InCheck = 109(+9.35) in [25, 300]
```

![image](https://github.com/user-attachments/assets/06d684de-54a0-45d3-be77-3a0361c512b9)
