### PR TITLE
🔍 Fractional LMR + tune II

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,6 +159,21 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Improving { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Cutnode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_TTPV { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_PVNode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_InCheck { get; set; } = 100;
+
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 
@@ -222,7 +237,7 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int CounterMoves_MinDepth { get;set; } = 3;
+    public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
     public int History_BestScoreBetaMargin { get; set; } = 60;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -160,19 +160,19 @@ public sealed class EngineSettings
     public double LMR_Divisor { get; set; } = 3.21;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 100;
+    public int LMR_Improving { get; set; } = 94;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 100;
+    public int LMR_Cutnode { get; set; } = 109;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 100;
+    public int LMR_TTPV { get; set; } = 90;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 100;
+    public int LMR_PVNode { get; set; } = 107;
 
     [SPSA<int>(25, 300, 10)]
-    public int LMR_InCheck { get; set; } = 100;
+    public int LMR_InCheck { get; set; } = 120;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -345,6 +345,46 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_improving":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Improving = value;
+                    }
+                    break;
+                }
+            case "lmr_cutnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Cutnode = value;
+                    }
+                    break;
+                }
+            case "LMR_TTPV":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_TTPV = value;
+                    }
+                    break;
+                }
+            case "lmr_pvnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_PVNode = value;
+                    }
+                    break;
+                }
+            case "lmr_incheck":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_InCheck = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
See also #1506 

Tuned 20+0.2

```
iterations: 485 (279.69s per iter)
games: 15520 (8.74s per game)
LMR_Improving = 94(-6.446097) in [25, 300]
LMR_Cutnode = 109(+8.50) in [25, 300]
LMR_TTPV = 90(-10.249874) in [25, 300]
LMR_PVNode = 107(+6.67) in [25, 300]
LMR_InCheck = 120(+20.15) in [25, 300]
```
![image](https://github.com/user-attachments/assets/be808f7d-bed4-4817-8a4b-8c4d495d1f39)
