### PR TITLE
⚖️ Simplify TT saves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -500,9 +500,9 @@ public sealed partial class Engine
                         UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
                     }
 
-                    _tt.RecordHash(position, staticEval, depth, ply, bestScore, NodeType.Beta, ttPv, bestMove);
+                    nodeType = NodeType.Beta;
 
-                    return bestScore;
+                    break;
                 }
             }
 
@@ -513,15 +513,14 @@ public sealed partial class Engine
         {
             Debug.Assert(bestMove is null);
 
-            var finalEval = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalEval, depth, ply, finalEval, NodeType.Exact, ttPv);
+            bestScore = Position.EvaluateFinalPosition(ply, isInCheck);
 
-            return finalEval;
+            nodeType = NodeType.Exact;
+            staticEval = bestScore;
         }
 
         _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
 
-        // Node fails low
         return bestScore;
     }
 
@@ -683,9 +682,8 @@ public sealed partial class Engine
                 {
                     PrintMessage($"Pruning: {move} is enough to discard this line");
 
-                    _tt.RecordHash(position, staticEval, 0, ply, bestScore, NodeType.Beta, ttPv, bestMove);
-
-                    return bestScore; // The refutation doesn't matter, since it'll be pruned
+                    nodeType = NodeType.Beta;
+                    break;
                 }
 
                 // Improving alpha
@@ -707,10 +705,10 @@ public sealed partial class Engine
         {
             Debug.Assert(bestMove is null);
 
-            var finalEval = Position.EvaluateFinalPosition(ply, position.IsInCheck());
-            _tt.RecordHash(position, finalEval, 0, ply, finalEval, NodeType.Exact, ttPv);
+            bestScore = Position.EvaluateFinalPosition(ply, position.IsInCheck());
 
-            return finalEval;
+            nodeType = NodeType.Exact;
+            staticEval = bestScore;
         }
 
         _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, ttPv, bestMove);


### PR DESCRIPTION
Refactor TT saves so that they don't happen on beta cutoffs and final positions, but at the end of the search/qsearch method.
This is an enabler for SE.

8+0.08 [-5, 0]
```
Score of Lynx-refactor-single-tt-save-5574-win-x64 vs Lynx 5573 - main: 3216 - 3195 - 5624  [0.501] 12035
...      Lynx-refactor-single-tt-save-5574-win-x64 playing White: 2538 - 686 - 2794  [0.654] 6018
...      Lynx-refactor-single-tt-save-5574-win-x64 playing Black: 678 - 2509 - 2830  [0.348] 6017
...      White vs Black: 5047 - 1364 - 5624  [0.653] 12035
Elo difference: 0.6 +/- 4.5, LOS: 60.3 %, DrawRatio: 46.7 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```