### PR TITLE
🔍 Fractional LMR w/ quantised base

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,6 +159,21 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Improving { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_Cutnode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_TTPV { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_PVNode { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 10)]
+    public int LMR_InCheck { get; set; } = 100;
+
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 
@@ -222,7 +237,7 @@ public sealed class EngineSettings
     /// </summary>
     public int History_MaxMoveRawBonus { get; set; } = 1_896;
 
-    public int CounterMoves_MinDepth { get;set; } = 3;
+    public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
     public int History_BestScoreBetaMargin { get; set; } = 60;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -154,40 +154,40 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base { get; set; } = 0.60;
+    public double LMR_Base { get; set; } = 0.92;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 3.21;
+    public double LMR_Divisor { get; set; } = 2.93;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 100;
+    public int LMR_Improving { get; set; } = 115;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 100;
+    public int LMR_Cutnode { get; set; } = 101;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 100;
+    public int LMR_TTPV { get; set; } = 108;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 100;
+    public int LMR_PVNode { get; set; } = 107;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_InCheck { get; set; } = 100;
+    public int LMR_InCheck { get; set; } = 112;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,18 +159,33 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
     [SPSA<int>(25, 300, 10)]
     public int LMR_Improving { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
     [SPSA<int>(25, 300, 10)]
     public int LMR_Cutnode { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
     [SPSA<int>(25, 300, 10)]
     public int LMR_TTPV { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
     [SPSA<int>(25, 300, 10)]
     public int LMR_PVNode { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
     [SPSA<int>(25, 300, 10)]
     public int LMR_InCheck { get; set; } = 100;
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -32,6 +32,8 @@ public static class EvaluationConstants
     /// </summary>
     public static readonly int[] HistoryBonus = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin];
 
+    public const int LMRScaleFactor = 100;
+
     static EvaluationConstants()
     {
         for (int searchDepth = 1; searchDepth < Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin; ++searchDepth)    // Depth > 0 or we'd be in QSearch
@@ -41,7 +43,8 @@ public static class EvaluationConstants
             for (int movesSearchedCount = 1; movesSearchedCount < Constants.MaxNumberOfPossibleMovesInAPosition; ++movesSearchedCount) // movesSearchedCount > 0 or we wouldn't be applying LMR
             {
                 LMRReductions[searchDepth][movesSearchedCount] = Convert.ToInt32(Math.Round(
-                    Configuration.EngineSettings.LMR_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Divisor)));
+                    LMRScaleFactor *
+                    (Configuration.EngineSettings.LMR_Base + (Math.Log(movesSearchedCount) * Math.Log(searchDepth) / Configuration.EngineSettings.LMR_Divisor))));
             }
 
             HistoryBonus[searchDepth] = Math.Min(

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,5 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
-using System.Reflection.PortableExecutable;
 using System.Runtime.CompilerServices;
 
 namespace Lynx;
@@ -378,35 +377,32 @@ public sealed partial class Engine
                     {
                         reduction = EvaluationConstants.LMRReductions[depth][visitedMovesCounter];
 
-                        var extraReduction = 0;
-
                         if (!improving)
                         {
-                            extraReduction += Configuration.EngineSettings.LMR_Improving;
+                            reduction += Configuration.EngineSettings.LMR_Improving;
                         }
 
                         if (cutnode)
                         {
-                            extraReduction += Configuration.EngineSettings.LMR_Cutnode;
+                            reduction += Configuration.EngineSettings.LMR_Cutnode;
                         }
 
                         if (!ttPv)
                         {
-                            extraReduction += Configuration.EngineSettings.LMR_TTPV;
+                            reduction += Configuration.EngineSettings.LMR_TTPV;
                         }
 
                         if (pvNode)
                         {
-                            extraReduction -= Configuration.EngineSettings.LMR_PVNode;
+                            reduction -= Configuration.EngineSettings.LMR_PVNode;
                         }
 
                         if (position.IsInCheck())   // i.e. move gives check
                         {
-                            extraReduction -= Configuration.EngineSettings.LMR_InCheck;
+                            reduction -= Configuration.EngineSettings.LMR_InCheck;
                         }
 
-                        extraReduction /= 100;
-                        reduction += extraReduction;
+                        reduction /= EvaluationConstants.LMRScaleFactor;
 
                         // -= history/(maxHistory/2)
                         reduction -= 2 * _quietHistory[move.Piece()][move.TargetSquare()] / Configuration.EngineSettings.History_MaxMoveValue;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -345,6 +345,46 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_improving":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Improving = value;
+                    }
+                    break;
+                }
+            case "lmr_cutnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Cutnode = value;
+                    }
+                    break;
+                }
+            case "LMR_TTPV":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_TTPV = value;
+                    }
+                    break;
+                }
+            case "lmr_pvnode":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_PVNode = value;
+                    }
+                    break;
+                }
+            case "lmr_incheck":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_InCheck = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
#1507 or #1506 but with the base quantised + SPSA @ 20+0.2 

```
iterations: 300 (278.51s per iter)
games: 9600 (8.70s per game)
LMR_Base = 92(+32.07) in [10, 200]
LMR_Divisor = 293(-27.621438) in [100, 500]
LMR_Improving = 115(+14.73) in [25, 300]
LMR_Cutnode = 101(+1.38) in [25, 300]
LMR_TTPV = 108(+7.96) in [25, 300]
LMR_PVNode = 107(+6.87) in [25, 300]
LMR_InCheck = 112(+11.75) in [25, 300]
```

![image](https://github.com/user-attachments/assets/5053bdc1-8f58-4b35-a9e6-125ee116b4b5)

```
Test  | search/fractional-lmr-quantised-base-tune-2-22
Elo   | 2.26 +- 2.50 (95%)
SPRT  | 20.0+0.20s Threads=1 Hash=128MB
LLR   | 1.52 (-2.25, 2.89) [0.00, 3.00]
Games | 28890: +7543 -7355 =13992
Penta | [487, 3511, 6335, 3551, 561]
https://openbench.lynx-chess.com/test/1405/
```