### PR TITLE
🔍 SPSA Fractional LMR STC 2025-2-22

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -154,34 +154,34 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base { get; set; } = 0.92;
+    public double LMR_Base { get; set; } = 0.68;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor { get; set; } = 2.93;
+    public double LMR_Divisor { get; set; } = 3.15;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 115;
+    public int LMR_Improving { get; set; } = 74;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 101;
+    public int LMR_Cutnode { get; set; } = 93;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 108;
+    public int LMR_TTPV { get; set; } = 117;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 107;
+    public int LMR_PVNode { get; set; } = 92;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>


### PR DESCRIPTION
Alternative to https://github.com/lynx-chess/Lynx/pull/1510 but tuned @ 8+0.08 and with 16 games instead of 32
```
iterations: 1957 (62.10s per iter)
games: 31312 (3.88s per game)
Final parameters:
LMR_Base = 68(+7.66) in [10, 200]
LMR_Divisor = 315(-6.322150) in [100, 500]
LMR_Improving = 74(-25.589115) in [25, 300]
LMR_Cutnode = 93(-6.508568) in [25, 300]
LMR_TTPV = 117(+16.90) in [25, 300]
LMR_PVNode = 92(-8.309171) in [25, 300]
LMR_InCheck = 112(+11.65) in [25, 300]
```

![image](https://github.com/user-attachments/assets/eeeace4e-9515-4d9f-b3d3-8a06ef3adfa4)
