### PR TITLE
⚡ Add inline hints to `TTElement` getters

### DIFF
--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
 
@@ -49,27 +50,48 @@ public struct TranspositionTableElement
     /// <summary>
     /// 16 MSB of Position's Zobrist key
     /// </summary>
-    public readonly ushort Key => _key;
+    public readonly ushort Key
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _key;
+    }
 
     /// <summary>
     /// Best move found in the position. 0 if the search failed low (score <= alpha)
     /// </summary>
-    public readonly ShortMove Move => _move;
+    public readonly ShortMove Move
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _move;
+    }
 
     /// <summary>
     /// Position's score
     /// </summary>
-    public readonly int Score => _score;
+    public readonly int Score
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _score;
+    }
 
     /// <summary>
     /// Position's static evaluation
     /// </summary>
-    public readonly int StaticEval => _staticEval;
+    public readonly int StaticEval
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _staticEval;
+    }
 
     /// <summary>
     /// How deep the recorded search went. For us this numberis targetDepth - ply
     /// </summary>
-    public readonly int Depth => _depth;
+
+    public readonly int Depth
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _depth;
+    }
 
     /// <summary>
     /// Node (position) type:
@@ -77,15 +99,28 @@ public struct TranspositionTableElement
     /// <see cref="NodeType.Alpha"/>: &lt;= <see cref="Score"/>,
     /// <see cref="NodeType.Beta"/>: &gt;= <see cref="Score"/>
     /// </summary>
-    public readonly NodeType Type => (NodeType)((_type_WasPv & 0xE) >> NodeTypeOffset);
+    public readonly NodeType Type
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (NodeType)((_type_WasPv & 0xE) >> NodeTypeOffset);
+    }
 
-    public readonly bool WasPv => (_type_WasPv & 0x1) == 1;
+    public readonly bool WasPv
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (_type_WasPv & 0x1) == 1;
+    }
 
     /// <summary>
     /// Struct size in bytes
     /// </summary>
-    public static ulong Size => (ulong)Marshal.SizeOf<TranspositionTableElement>();
+    public static ulong Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ulong)Marshal.SizeOf<TranspositionTableElement>();
+    }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
     {
         _key = (ushort)key;


### PR DESCRIPTION
6+0.06
```
Score of Lynx-perf-ttelement-inlining-5585-win-x64 vs Lynx 5580 - main: 23937 - 23710 - 38531  [0.501] 86178
...      Lynx-perf-ttelement-inlining-5585-win-x64 playing White: 18166 - 5579 - 19344  [0.646] 43089
...      Lynx-perf-ttelement-inlining-5585-win-x64 playing Black: 5771 - 18131 - 19187  [0.357] 43089
...      White vs Black: 36297 - 11350 - 38531  [0.645] 86178
Elo difference: 0.9 +/- 1.7, LOS: 85.1 %, DrawRatio: 44.7 %
SPRT: llr -2.27 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```