### PR TITLE
🔍 Move draw detection after fail low pruning

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -341,7 +341,7 @@ public sealed partial class Engine
                 }
             }
 
-            int score = int.MinValue;
+            int score = 0;
 
             if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -341,7 +341,7 @@ public sealed partial class Engine
                 }
             }
 
-            int score = 0;
+            int score = int.MinValue;
 
             if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -446,14 +446,15 @@ public sealed partial class Engine
                         // It should produce more cutoffs and therefore be faster.
                         // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
-                        // Search with full depth but narrowed score bandwidth
+                        // Search with full depth but narrowed score bandwidth (zero-window search)
                         score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
                     }
                 }
 
+                // First searched move is always searched with full depth and full score bandwidth
+                // Same if PVS hypothesis is invalidated
                 if (visitedMovesCounter == 0 || (score > alpha && score < beta))
                 {
-                    // PVS Hypothesis invalidated -> search with full depth and full score bandwidth
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
                     score = -NegaMax(newDepth, ply + 1, -beta, -alpha, cutnode: false, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1515/commits/c91d02556938c5b52eaa5c99748e24f36e340a0f
```
Test  | search/drawdetection-rewrite
Elo   | 7.56 +- 5.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | 7124: +2045 -1890 =3189
Penta | [173, 801, 1463, 948, 177]
https://openbench.lynx-chess.com/test/1412/
```

```
Test  | C91D02556938C5B5
Elo   | 0.52 +- 2.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.70 (-2.25, 2.89) [0.00, 3.00]
Games | 39656: +10812 -10753 =18091
Penta | [911, 4790, 8377, 4829, 921]
https://openbench.lynx-chess.com/test/1415/
```


e65f5e9c06761e16dde898fee660c5be1dff2570

```
Test  | search/drawdetection-rewrite
Elo   | -1.81 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 21070: +5686 -5796 =9588
Penta | [489, 2539, 4563, 2481, 463]
https://openbench.lynx-chess.com/test/1414/
```