### PR TITLE
🔍 IIIR: on `!ttHit` -> on `!ttHit || !ttMove`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,8 +75,8 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if ((ttElementType == default || ttBestMove == default)
-                && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (depth >= Configuration.EngineSettings.IIR_MinDepth
+                && (ttElementType == default || ttBestMove == default))
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,7 +75,8 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if ((ttElementType == default || ttBestMove == default)
+                && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }


### PR DESCRIPTION
```
Test  | search/iir-when-no-tt-move
Elo   | 11.63 +- 5.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 7172: +2040 -1800 =3332
Penta | [138, 820, 1471, 978, 179]
https://openbench.lynx-chess.com/test/1418/
```