### PR TITLE
🔍 SPSA LMR 2025-2-26

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -157,55 +157,55 @@ public sealed class EngineSettings
     public double LMR_Base_Quiet { get; set; } = 1.10;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base_Noisy { get; set; } = 0.60;
+    public double LMR_Base_Noisy { get; set; } = 0.49;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.70;
+    public double LMR_Divisor_Quiet { get; set; } = 2.63;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.85;
+    public double LMR_Divisor_Noisy { get; set; } = 3.17;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 115;
+    public int LMR_Improving { get; set; } = 116;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 101;
+    public int LMR_Cutnode { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 108;
+    public int LMR_TTPV { get; set; } = 123;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 107;
+    public int LMR_PVNode { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_InCheck { get; set; } = 112;
+    public int LMR_InCheck { get; set; } = 94;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3750;
+    public int LMR_History_Divisor_Quiet { get; set; } = 5100;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3200;
+    public int LMR_History_Divisor_Noisy { get; set; } = 4649;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;


### PR DESCRIPTION
Tuned at 20+0.2:
<details>

<Summary>Steps</Summary>

```json
{
  "LMR_Base_Quiet": {
    "value": 110,
    "min_value": 10,
    "max_value": 200,
    "step": 10
  },
  "LMR_Base_Noisy": {
    "value": 60,
    "min_value": 10,
    "max_value": 200,
    "step": 10
  },
  "LMR_Divisor_Quiet": {
    "value": 270,
    "min_value": 100,
    "max_value": 500,
    "step": 10
  },
  "LMR_Divisor_Noisy": {
    "value": 285,
    "min_value": 100,
    "max_value": 500,
    "step": 15
  },
  "LMR_Improving": {
    "value": 115,
    "min_value": 25,
    "max_value": 300,
    "step": 15
  },
  "LMR_Cutnode": {
    "value": 101,
    "min_value": 25,
    "max_value": 300,
    "step": 15
  },
  "LMR_TTPV": {
    "value": 108,
    "min_value": 25,
    "max_value": 300,
    "step": 15
  },
  "LMR_PVNode": {
    "value": 107,
    "min_value": 25,
    "max_value": 300,
    "step": 15
  },
  "LMR_InCheck": {
    "value": 112,
    "min_value": 25,
    "max_value": 300,
    "step": 15
  },
  "LMR_History_Divisor_Quiet": {
    "value": 3750,
    "min_value": 1024,
    "max_value": 8192,
    "step": 512
  },
  "LMR_History_Divisor_Noisy": {
    "value": 3200,
    "min_value": 1024,
    "max_value": 8192,
    "step": 512
  }
}
```

</details>

```
iterations: 1564 (149.82s per iter)
games: 25024 (9.36s per game)
LMR_Base_Quiet = 110(-0.031866) in [10, 200]
LMR_Base_Noisy = 49(-10.545704) in [10, 200]
LMR_Divisor_Quiet = 263(-7.430507) in [100, 500]
LMR_Divisor_Noisy = 317(+31.64) in [100, 500]
LMR_Improving = 116(+1.20) in [25, 300]
LMR_Cutnode = 100(-1.462290) in [25, 300]
LMR_TTPV = 123(+15.06) in [25, 300]
LMR_PVNode = 100(-7.328029) in [25, 300]
LMR_InCheck = 94(-17.723871) in [25, 300]
LMR_History_Divisor_Quiet = 5100(+1350.40) in [1024, 8192]
LMR_History_Divisor_Noisy = 4649(+1449.03) in [1024, 8192]
```

```
Test  | spsa/lmr-tune-26-2
Elo   | -6.31 +- 5.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.95 (-2.25, 2.89) [0.00, 3.00]
Games | 6446: +1515 -1632 =3299
Penta | [86, 856, 1438, 775, 68]
https://openbench.lynx-chess.com/test/1432/
```

![image](https://github.com/user-attachments/assets/f0011b60-f6e6-4497-a7d7-e8e8798e6784)
