### PR TITLE
⚡ During move ordering avoid counter stuff on null moves+

### DIFF
--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -82,20 +82,22 @@ public sealed partial class Engine
         if (ply >= 1)
         {
             var previousMove = Game.ReadMoveFromStack(ply - 1);
-            Debug.Assert(previousMove != 0);
-            var previousMovePiece = previousMove.Piece();
-            var previousMoveTargetSquare = previousMove.TargetSquare();
-
-            // Countermove
-            if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
+            if (previousMove != 0)   // Null move
             {
-                return CounterMoveValue;
-            }
+                var previousMovePiece = previousMove.Piece();
+                var previousMoveTargetSquare = previousMove.TargetSquare();
 
-            // Counter move history
-            return BaseMoveScore
-                + _quietHistory[move.Piece()][move.TargetSquare()]
-                + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
+                // Countermove
+                if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
+                {
+                    return CounterMoveValue;
+                }
+
+                // Counter move history
+                return BaseMoveScore
+                    + _quietHistory[move.Piece()][move.TargetSquare()]
+                    + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMovePiece, previousMoveTargetSquare, 0)];
+            }
         }
 
         // History move or 0 if not found


### PR DESCRIPTION
```
Test  | perf/move-ordering-no-counter-stuff-on-null-moves+
Elo   | -2.86 +- 3.12 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 20192: +5595 -5761 =8836
Penta | [514, 2347, 4495, 2271, 469]
https://openbench.lynx-chess.com/test/1408/
```