### PR TITLE
Plan for whenever ChessGUI wakes up feeling like sending negative `movestogo`

### DIFF
--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -34,11 +34,11 @@ public static class TimeManager
         }
 
         // Inspired by Alexandria: time overhead to avoid timing out in the engine-gui communication process
-       var engineGuiCommunicationTimeOverhead = Configuration.EngineSettings.EngineGuiCommunicationTimeOverhead;
+        var engineGuiCommunicationTimeOverhead = Configuration.EngineSettings.EngineGuiCommunicationTimeOverhead;
 
         if (goCommand.WhiteTime != 0 || goCommand.BlackTime != 0)  // Cutechess sometimes sends negative wtime/btime
         {
-            var movesDivisor = goCommand.MovesToGo == 0
+            var movesDivisor = goCommand.MovesToGo <= 0
                 ? MovesDivisor(ExpectedMovesLeft(game.PositionHashHistoryLength()))
                 : goCommand.MovesToGo;
 


### PR DESCRIPTION
`go wtime 0 btime 0 movestog0 -5` is already handled with a warning log and default depth search (saw in a Cinder game)
However, let's plan for `go wtime -5 btime -5 movestog0 -5` because xD