### PR TITLE
🔍 PVS SEE pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ _Beware, most of the provided links contain outdated information and don't refle
 
 - TT PV / wasPv
 
+- PVS SEE pruning
+
 ### Evaluation
 
 - Piece-Square Tables (PSQT) [[1](https://www.chessprogramming.org/Piece-Square_Tables)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -304,6 +304,12 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
+    [SPSA<int>(-100, -10, 10)]
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -15;
+
+    [SPSA<int>(-150, -50, 10)]
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -110;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -317,7 +317,7 @@ public sealed partial class Engine
 
                 if (!SEE.HasPositiveScore(position, move, threshold))
                 {
-                    break;
+                    continue;
                 }
             }
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -664,6 +664,23 @@ public sealed class UCIHandler
                     break;
                 }
 
+            case "pvs_see_threshold_quiet":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.PVS_SEE_Threshold_Quiet = value;
+                    }
+                    break;
+                }
+            case "pvs_see_threshold_noisy":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.PVS_SEE_Threshold_Noisy = value;
+                    }
+                    break;
+                }
+
             #endregion
 
             default:


### PR DESCRIPTION
After #1515 + #1520 as refactoring enablers.

```
Test  | search/pvs-see-2
Elo   | 9.14 +- 4.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 9092: +2576 -2337 =4179
Penta | [167, 1019, 1977, 1174, 209]
https://openbench.lynx-chess.com/test/1435/
```

```
Test  | search/pvs-see-2
Elo   | 14.32 +- 5.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 5024: +1304 -1097 =2623
Penta | [43, 540, 1172, 681, 76]
https://openbench.lynx-chess.com/test/1436/
```