### PR TITLE
🔍 Allow IIR in root move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -69,17 +69,17 @@ public sealed partial class Engine
                     ++depth;
                 }
             }
+        }
 
-            // Internal iterative reduction (IIR)
-            // If this position isn't found in TT, it has never been searched before,
-            // so the search will be potentially expensive.
-            // Therefore, we search with reduced depth for now, expecting to record a TT move
-            // which we'll be able to use later for the full depth search
-            if (depth >= Configuration.EngineSettings.IIR_MinDepth
-                && (ttElementType == default || ttBestMove == default))
-            {
-                --depth;
-            }
+        // Internal iterative reduction (IIR)
+        // If this position isn't found in TT, it has never been searched before,
+        // so the search will be potentially expensive.
+        // Therefore, we search with reduced depth for now, expecting to record a TT move
+        // which we'll be able to use later for the full depth search
+        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            && (ttElementType == default || ttBestMove == default))
+        {
+            --depth;
         }
 
         var ttPv = pvNode || ttWasPv;


### PR DESCRIPTION
```
Test  | search/iir-root
Elo   | 0.21 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.19 (-2.25, 2.89) [0.00, 3.00]
Games | 41048: +10927 -10902 =19219
Penta | [856, 4990, 8806, 5017, 855]
https://openbench.lynx-chess.com/test/1430/
```