### PR TITLE
🔍 IIR `ttDepth` offset 3

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -255,7 +255,7 @@ public sealed class EngineSettings
     public int IIR_MinDepth { get; set; } = 4;
 
     //[SPSA<int>(1, 10, 0.5)]
-    public int IIR_TTDepthOffset { get; set; } = 4;
+    public int IIR_TTDepthOffset { get; set; } = 3;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 8;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -255,6 +255,9 @@ public sealed class EngineSettings
     public int IIR_MinDepth { get; set; } = 4;
 
     //[SPSA<int>(1, 10, 0.5)]
+    public int IIR_TTDepthOffset { get; set; } = 4;
+
+    //[SPSA<int>(1, 10, 0.5)]
     public int LMP_MaxDepth { get; set; } = 8;
 
     //[SPSA<int>(0, 10, 0.5)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,8 +75,8 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if ((ttElementType == default || ttBestMove == default)
-                && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if (depth >= Configuration.EngineSettings.IIR_MinDepth
+                && (ttElementType == default || ttBestMove == default))
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -76,7 +76,9 @@ public sealed partial class Engine
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
             if (depth >= Configuration.EngineSettings.IIR_MinDepth
-                && (ttElementType == default || ttBestMove == default))
+                && (ttElementType == default
+                    || ttBestMove == default
+                    || depth > ttDepth + Configuration.EngineSettings.IIR_TTDepthOffset))
             {
                 --depth;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -75,7 +75,8 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (ttElementType == default && depth >= Configuration.EngineSettings.IIR_MinDepth)
+            if ((ttElementType == default || ttBestMove == default)
+                && depth >= Configuration.EngineSettings.IIR_MinDepth)
             {
                 --depth;
             }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -542,6 +542,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "iir_ttdepthoffset":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.IIR_TTDepthOffset = value;
+                    }
+                    break;
+                }
 
             case "lmp_maxdepth":
                 {


### PR DESCRIPTION
```
Test  | search/iir-ttDepth-2
Elo   | -1.23 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 26728: +7110 -7205 =12413
Penta | [588, 3296, 5690, 3203, 587]
https://openbench.lynx-chess.com/test/1425/
```