### PR TITLE
🔍 SPSA LMR 2025-3-1

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -154,58 +154,58 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base_Quiet { get; set; } = 1.10;
+    public double LMR_Base_Quiet { get; set; } = 1.22;
 
     [SPSA<double>(0.1, 2, 0.1)]
-    public double LMR_Base_Noisy { get; set; } = 0.60;
+    public double LMR_Base_Noisy { get; set; } = 0.53;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.70;
+    public double LMR_Divisor_Quiet { get; set; } = 3.95;
 
     [SPSA<double>(1, 5, 0.1)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.85;
+    public double LMR_Divisor_Noisy { get; set; } = 2.30;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Improving { get; set; } = 115;
+    public int LMR_Improving { get; set; } = 91;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_Cutnode { get; set; } = 101;
+    public int LMR_Cutnode { get; set; } = 94;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_TTPV { get; set; } = 108;
+    public int LMR_TTPV { get; set; } = 33;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_PVNode { get; set; } = 107;
+    public int LMR_PVNode { get; set; } = 56;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 10)]
-    public int LMR_InCheck { get; set; } = 112;
+    public int LMR_InCheck { get; set; } = 166;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3750;
+    public int LMR_History_Divisor_Quiet { get; set; } = 4476;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 128)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3200;
+    public int LMR_History_Divisor_Noisy { get; set; } = 4054;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -153,58 +153,58 @@ public sealed class EngineSettings
     //[SPSA<int>(1, 10, 0.5)]
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
-    [SPSA<double>(0.1, 2, 0.1)]
+    [SPSA<double>(0.1, 2, 0.2)]
     public double LMR_Base_Quiet { get; set; } = 1.22;
 
-    [SPSA<double>(0.1, 2, 0.1)]
+    [SPSA<double>(0.1, 2, 0.2)]
     public double LMR_Base_Noisy { get; set; } = 0.53;
 
-    [SPSA<double>(1, 5, 0.1)]
+    [SPSA<double>(1, 5, 0.4)]
     public double LMR_Divisor_Quiet { get; set; } = 3.95;
 
-    [SPSA<double>(1, 5, 0.1)]
+    [SPSA<double>(1, 5, 0.4)]
     public double LMR_Divisor_Noisy { get; set; } = 2.30;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
-    [SPSA<int>(25, 300, 10)]
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Improving { get; set; } = 91;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
-    [SPSA<int>(25, 300, 10)]
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Cutnode { get; set; } = 94;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
-    [SPSA<int>(25, 300, 10)]
+    [SPSA<int>(25, 300, 30)]
     public int LMR_TTPV { get; set; } = 33;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
-    [SPSA<int>(25, 300, 10)]
+    [SPSA<int>(25, 300, 30)]
     public int LMR_PVNode { get; set; } = 56;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
-    [SPSA<int>(25, 300, 10)]
+    [SPSA<int>(25, 300, 30)]
     public int LMR_InCheck { get; set; } = 166;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
-    [SPSA<int>(1, 8192, 128)]
+    [SPSA<int>(1, 8192, 512)]
     public int LMR_History_Divisor_Quiet { get; set; } = 4476;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
-    [SPSA<int>(1, 8192, 128)]
+    [SPSA<int>(1, 8192, 512)]
     public int LMR_History_Divisor_Noisy { get; set; } = 4054;
 
     //[SPSA<int>(1, 10, 0.5)]


### PR DESCRIPTION
Steps increased to ~10% the range vs what I attempted in #1517. They are reflected in the PR code
```
iterations: 1564 (149.44s per iter)
games: 25024 (9.34s per game)
LMR_Base_Quiet = 122(+11.66) in [10, 200]
LMR_Base_Noisy = 53(-7.413709) in [10, 200]
LMR_Divisor_Quiet = 395(+124.67) in [100, 500]
LMR_Divisor_Noisy = 230(-55.368313) in [100, 500]
LMR_Improving = 91(-23.995727) in [25, 300]
LMR_Cutnode = 94(-7.375963) in [25, 300]
LMR_TTPV = 33(-74.902667) in [25, 300]
LMR_PVNode = 56(-50.954615) in [25, 300]
LMR_InCheck = 166(+54.49) in [25, 300]
LMR_History_Divisor_Quiet = 4476(+725.84) in [2048, 8192]
LMR_History_Divisor_Noisy = 4054(+854.24) in [2048, 8192]
```

![image](https://github.com/user-attachments/assets/a909ecb5-d01e-4403-bab2-ff9eaa69ad45)

```
Test  | spsa/lmr-1-3
Elo   | -6.74 +- 4.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 6912: +1672 -1806 =3434
Penta | [103, 842, 1675, 758, 78]
https://openbench.lynx-chess.com/test/1441/
```

```
Test  | spsa/lmr-1-3
Elo   | -2.79 +- 3.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 15798: +4223 -4350 =7225
Penta | [367, 1995, 3301, 1870, 366]
https://openbench.lynx-chess.com/test/1438/
```