### PR TITLE
🔍 LMR TT capture

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -187,6 +187,12 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
+    public int LMR_TTCapture { get; set; } = 100;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
     public int LMR_PVNode { get; set; } = 107;
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -45,6 +45,7 @@ public sealed partial class Engine
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
+        bool ttMoveIsCapture = false;
 
         Debug.Assert(!pvNode || !cutnode);
 
@@ -69,6 +70,8 @@ public sealed partial class Engine
                     ++depth;
                 }
             }
+
+            ttMoveIsCapture = ttElementType != default && ttBestMove != default && position.Board[((int)ttBestMove).TargetSquare()] != (int)Piece.None;
 
             // Internal iterative reduction (IIR)
             // If this position isn't found in TT, it has never been searched before,
@@ -420,6 +423,11 @@ public sealed partial class Engine
                                 if (!ttPv)
                                 {
                                     reduction += Configuration.EngineSettings.LMR_TTPV;
+                                }
+
+                                if (!isCapture && ttMoveIsCapture)
+                                {
+                                    reduction += Configuration.EngineSettings.LMR_TTCapture;
                                 }
 
                                 if (pvNode)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -401,6 +401,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_ttcapture":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_TTCapture = value;
+                    }
+                    break;
+                }
             case "lmr_pvnode":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
Reduce more when move is not a capture but TT move is.

```
Test  | search/lmr-ttcapture
Elo   | 1.87 +- 1.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 84202: +22680 -22227 =39295
Penta | [1856, 10039, 17838, 10532, 1836]
https://openbench.lynx-chess.com/test/1444/
``` 