### PR TITLE
🧹 Simplify static evaluation calculation

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -98,10 +98,21 @@ public sealed partial class Engine
         int staticEval;
         int phase = int.MaxValue;
 
+        if (ttElementType == default)
+        {
+            (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
+        }
+        else
+        {
+            Debug.Assert(ttStaticEval != int.MinValue);
+
+            staticEval = ttStaticEval;
+            phase = position.Phase();
+        }
+
         if (isInCheck)
         {
             ++depth;
-            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         }
         else if (depth <= 0)
         {
@@ -112,22 +123,11 @@ public sealed partial class Engine
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
             _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
+
             return finalPositionEvaluation;
         }
         else if (!pvNode)
         {
-            if (ttElementType == default)
-            {
-                (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
-            }
-            else
-            {
-                Debug.Assert(ttStaticEval != int.MinValue);
-
-                staticEval = ttStaticEval;
-                phase = position.Phase();
-            }
-
             Game.UpdateStaticEvalInStack(ply, staticEval);
 
             if (ply >= 2)
@@ -231,10 +231,6 @@ public sealed partial class Engine
                     }
                 }
             }
-        }
-        else
-        {
-            staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];


### PR DESCRIPTION
```
Score of Lynx-refactor-static-eval-5651-win-x64 vs Lynx 5650 - main: 745 - 854 - 1533  [0.483] 3132
...      Lynx-refactor-static-eval-5651-win-x64 playing White: 604 - 197 - 765  [0.630] 1566
...      Lynx-refactor-static-eval-5651-win-x64 playing Black: 141 - 657 - 768  [0.335] 1566
...      White vs Black: 1261 - 338 - 1533  [0.647] 3132
Elo difference: -12.1 +/- 8.7, LOS: 0.3 %, DrawRatio: 48.9 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```