### PR TITLE
🔍 LMR: Deeper/shallower

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -215,7 +215,7 @@ public sealed class EngineSettings
     [SPSA<int>(1, 8192, 512)]
     public int LMR_History_Divisor_Noisy { get; set; } = 3200;
 
-    [SPSA<int>(20, 100, 5)]
+    [SPSA<int>(20, 100, 8)]
     public int LMR_DeeperBase { get; set; } = 38;
 
     //[SPSA<int>(1, 10, 1)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -159,6 +159,12 @@ public sealed class EngineSettings
     [SPSA<double>(1, 5, 0.1)]
     public double LMR_Divisor { get; set; } = 3.21;
 
+    [SPSA<int>(20, 100, 5)]
+    public int LMR_DeeperBase { get; set; } = 38;
+
+    //[SPSA<int>(1, 10, 1)]
+    public int LMR_DeeperDepthMultiplier { get; set; } = 2;
+
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -464,11 +464,13 @@ public sealed partial class Engine
                         }
                     }
 
+                    var reducedDepth = newDepth - reduction;
+
                     // Search with reduced depth and zero window
-                    score = -NegaMax(newDepth - reduction, ply + 1, -alpha - 1, -alpha, cutnode: true, cancellationToken);
+                    score = -NegaMax(reducedDepth, ply + 1, -alpha - 1, -alpha, cutnode: true, cancellationToken);
 
                     // 🔍 Principal Variation Search (PVS)
-                    if (score > alpha && reduction > 0)
+                    if (score > alpha && newDepth > reducedDepth)
                     {
                         // Optimistic search, validating that the rest of the moves are worse than bestmove.
                         // It should produce more cutoffs and therefore be faster.
@@ -479,15 +481,18 @@ public sealed partial class Engine
 
                         if (deeper && !shallower && depth < Configuration.EngineSettings.MaxDepth)
                         {
-                            ++depth;
+                            ++newDepth;
                         }
                         else if (shallower && !deeper && depth > 1)
                         {
-                            --depth;
+                            --newDepth;
                         }
 
-                        // Search with full depth but narrowed score bandwidth (zero-window search)
-                        score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
+                        if (newDepth > reducedDepth)
+                        {
+                            // Search with full depth but narrowed score bandwidth (zero-window search)
+                            score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
+                        }
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,11 +435,11 @@ public sealed partial class Engine
                     var deeper = score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
                     var shallower = score < bestScore + depth;
 
-                    if (deeper && !shallower)
+                    if (deeper && !shallower && depth < Configuration.EngineSettings.MaxDepth)
                     {
                         ++depth;
                     }
-                    else if (shallower && !deeper)
+                    else if (shallower && !deeper && depth > 1)
                     {
                         --depth;
                     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using NLog.Config;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -430,6 +431,18 @@ public sealed partial class Engine
                     // Optimistic search, validating that the rest of the moves are worse than bestmove.
                     // It should produce more cutoffs and therefore be faster.
                     // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+
+                    var deeper = score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
+                    var shallower = score < bestScore + depth;
+
+                    if (deeper && !shallower)
+                    {
+                        ++depth;
+                    }
+                    else if (shallower && !deeper)
+                    {
+                        --depth;
+                    }
 
                     // Search with full depth but narrowed score bandwidth
                     score = -NegaMax(depth - 1, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using NLog.Config;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 


### PR DESCRIPTION
Initial impl

```
Test  | search/deeper-shallower
Elo   | -7.07 +- 7.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.05 (-2.25, 2.89) [0.00, 3.00]
Games | 3442: +922 -992 =1528
Penta | [88, 443, 715, 401, 74]
https://openbench.lynx-chess.com/test/1395/
```

w/ guard (https://github.com/lynx-chess/Lynx/pull/1535/commits/76d56b04a2536990e3954d4403a5cf543dcff2c0)
```
Test  | search/deeper-shallower
Elo   | 3.11 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 35406: +9590 -9273 =16543
Penta | [735, 4272, 7472, 4389, 835]
https://openbench.lynx-chess.com/test/1449/
```