### PR TITLE
Include 50mr counter in Zobrist key

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -40,7 +40,7 @@ public sealed class Game : IDisposable
 
     public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool)
     {
-        Debug.Assert(Constants.MaxNumberMovesInAGame <= 1024, "Assert fail", "Need to customized ArrayPool due to desired array size requirements");
+        Debug.Assert(Constants.MaxNumberMovesInAGame <= 1024, "Assert fail", "Need to customize ArrayPool due to desired array size requirements");
         _positionHashHistory = ArrayPool<ulong>.Shared.Rent(Constants.MaxNumberMovesInAGame);
         _gameStack = ArrayPool<PlyStackEntry>.Shared.Rent(Constants.MaxNumberMovesInAGame);
 
@@ -192,7 +192,7 @@ public sealed class Game : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move moveToPlay)
     {
-        var gameState = CurrentPosition.MakeMove(moveToPlay);
+        var gameState = CurrentPosition.MakeMove(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
 
         if (CurrentPosition.WasProduceByAValidMove())
         {

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -400,7 +400,7 @@ public static class MoveExtensions
             .Where(m =>
             {
                 // If any illegal moves exist with the same simple representation there's no need to disambiguate
-                var gameState = position.MakeMove(m);
+                var gameState = position.MakeMove(m, 0);
                 var isLegal = position.WasProduceByAValidMove();
                 position.UnmakeMove(m, gameState);
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -60,7 +60,7 @@ public class Position : IDisposable
     }
 
     public Position((BitBoard[] PieceBitBoards, BitBoard[] OccupancyBitBoards, int[] Board, Side Side, byte Castle, BoardSquare EnPassant,
-        int _/*, int FullMoveCounter*/) parsedFEN)
+        int HalfMovesWithoutCaptureOrPawnMove/*, int FullMoveCounter*/) parsedFEN)
     {
         PieceBitBoards = parsedFEN.PieceBitBoards;
         OccupancyBitBoards = parsedFEN.OccupancyBitBoards;
@@ -70,7 +70,7 @@ public class Position : IDisposable
         EnPassant = parsedFEN.EnPassant;
 
 #pragma warning disable S3366 // "this" should not be exposed from constructors
-        UniqueIdentifier = ZobristTable.PositionHash(this);
+        UniqueIdentifier = ZobristTable.PositionHash(this, parsedFEN.HalfMovesWithoutCaptureOrPawnMove);
         _kingPawnUniqueIdentifier = ZobristTable.PawnKingHash(this);
 #pragma warning restore S3366 // "this" should not be exposed from constructors
 
@@ -106,7 +106,7 @@ public class Position : IDisposable
     #region Move making
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public GameState MakeMove(Move move)
+    public GameState MakeMove(Move move, int halfMovesWithoutCaptureOrPawnMove)
     {
         byte castleCopy = Castle;
         BoardSquare enpassantCopy = EnPassant;
@@ -150,7 +150,8 @@ public class Position : IDisposable
             ^ sourcePieceHash
             ^ targetPieceHash
             ^ ZobristTable.EnPassantHash((int)EnPassant)            // We clear the existing enpassant square, if any
-            ^ ZobristTable.CastleHash(Castle);                      // We clear the existing castle rights
+            ^ ZobristTable.CastleHash(Castle)                       // We clear the existing castle rights
+            ^ ZobristTable.HalfMovesWithoutCaptureOrPawnMoveHash(halfMovesWithoutCaptureOrPawnMove);
 
         if (piece == (int)Piece.P || piece == (int)Piece.p)
         {

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -644,7 +644,7 @@ public static class MoveGenerator
         }
 #endif
 
-        var gameState = position.MakeMove(move);
+        var gameState = position.MakeMove(move, 0);
 
         bool result = position.WasProduceByAValidMove();
         position.UnmakeMove(move, gameState);

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -129,7 +129,7 @@ public static class OnlineTablebaseProber
                         }
 
                         using var newPosition = new Position(position);
-                        newPosition.MakeMove(moveCandidate.Value);
+                        newPosition.MakeMove(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
 
                         var oldValue = halfMovesWithoutCaptureOrPawnMove;
                         halfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
@@ -190,7 +190,7 @@ public static class OnlineTablebaseProber
                         }
 
                         using var newPosition = new Position(position);
-                        newPosition.MakeMove(moveCandidate.Value);
+                        newPosition.MakeMove(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
 
                         var oldValue = halfMovesWithoutCaptureOrPawnMove;
                         halfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
@@ -253,7 +253,7 @@ public static class OnlineTablebaseProber
                         }
 
                         using var newPosition = new Position(position);
-                        newPosition.MakeMove(moveCandidate.Value);
+                        newPosition.MakeMove(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
 
                         var oldValue = halfMovesWithoutCaptureOrPawnMove;
                         halfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
@@ -313,7 +313,7 @@ public static class OnlineTablebaseProber
                         }
 
                         using var newPosition = new Position(position);
-                        newPosition.MakeMove(moveCandidate.Value);
+                        newPosition.MakeMove(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);
 
                         var oldValue = halfMovesWithoutCaptureOrPawnMove;
                         halfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveCandidate.Value, halfMovesWithoutCaptureOrPawnMove);

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -41,7 +41,7 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                var state = position.MakeMove(move, 0);
 
                 if (position.WasProduceByAValidMove())
                 {
@@ -64,7 +64,7 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                var state = position.MakeMove(move, 0);
 
                 if (position.WasProduceByAValidMove())
                 {

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -121,7 +121,7 @@ public sealed partial class Engine
 #pragma warning disable CA2000 // Dispose objects before losing scope - disposing it fixes the existing logic, and this is a debug-only method anyway
             var newPosition = new Position(position);
 #pragma warning restore CA2000 // Dispose objects before losing scope
-            newPosition.MakeMove(move);
+            newPosition.MakeMove(move, Game.HalfMovesWithoutCaptureOrPawnMove);
             if (!newPosition.WasProduceByAValidMove())
             {
                 throw new LynxException($"Invalid position after move {move.UCIString()} from position {position.FEN()}");

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -368,7 +368,7 @@ public sealed partial class Engine
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, moves))
         {
-            var gameState = Game.CurrentPosition.MakeMove(move);
+            var gameState = Game.CurrentPosition.MakeMove(move, Game.HalfMovesWithoutCaptureOrPawnMove);
             bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
             Game.CurrentPosition.UnmakeMove(move, gameState);
 
@@ -535,7 +535,7 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[i];
 
-            var gameState = position.MakeMove(move);
+            var gameState = position.MakeMove(move, Game.HalfMovesWithoutCaptureOrPawnMove);
             if (!position.WasProduceByAValidMove())
             {
                 position.UnmakeMove(move, gameState);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -334,7 +334,7 @@ public sealed partial class Engine
                 }
             }
 
-            var gameState = position.MakeMove(move);
+            var gameState = position.MakeMove(move, Game.HalfMovesWithoutCaptureOrPawnMove);
 
             if (!position.WasProduceByAValidMove())
             {
@@ -713,7 +713,7 @@ public sealed partial class Engine
                 continue;
             }
 
-            var gameState = position.MakeMove(move);
+            var gameState = position.MakeMove(move, Game.HalfMovesWithoutCaptureOrPawnMove);
             if (!position.WasProduceByAValidMove())
             {
                 position.UnmakeMove(move, gameState);

--- a/tests/Lynx.Test/ZobristTableTest.cs
+++ b/tests/Lynx.Test/ZobristTableTest.cs
@@ -88,10 +88,10 @@ public class ZobristTableTest
     public void CastleHash(string fen)
     {
         var positionWithoutCastlingRights = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R b - - 0 1");
-        var positionWithoutCastlingRightsHash = ZobristTable.PositionHash(positionWithoutCastlingRights);
+        var positionWithoutCastlingRightsHash = ZobristTable.PositionHash(positionWithoutCastlingRights, 0);
 
         var position = new Position(fen);
-        var positionHash = ZobristTable.PositionHash(position);
+        var positionHash = ZobristTable.PositionHash(position, 0);
 
         var castleHash = ZobristTable.CastleHash(position.Castle);
 
@@ -112,7 +112,7 @@ public class ZobristTableTest
         var position = new Position(fen);
 
         var originalHash = OriginalPositionHash(position);
-        var currentHash = ZobristTable.PositionHash(position);
+        var currentHash = ZobristTable.PositionHash(position, 0);
 
         Assert.AreEqual(originalHash, currentHash);
     }


### PR DESCRIPTION
```
Test  | zobrist/50mr-counter
Elo   | -113.94 +- 15.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 660: +58 -267 =335
Penta | [31, 170, 107, 21, 1]
https://openbench.lynx-chess.com/test/1455/
```