### PR TITLE
⚡ Calculate pieces attacked by queen together with bishop and rook ones

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1451,9 +1451,8 @@ public class Position : IDisposable
             IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset)
             || IsSquareAttackedByKing(squareIndex, offset)
             || IsSquareAttackedByKnights(squareIndex, offset)
-            || IsSquareAttackedByBishops(squareIndex, offset, bothSidesOccupancy, out var bishopAttacks)
-            || IsSquareAttackedByRooks(squareIndex, offset, bothSidesOccupancy, out var rookAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks);
+            || IsSquareAttackedByBishopsOrQueens(squareIndex, offset, bothSidesOccupancy)
+            || IsSquareAttackedByRooksOrQueens(squareIndex, offset, bothSidesOccupancy);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1468,9 +1467,8 @@ public class Position : IDisposable
 
         // I tried to order them from most to least likely - not tested
         return
-            IsSquareAttackedByRooks(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var rookAttacks)
-            || IsSquareAttackedByBishops(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var bishopAttacks)
-            || IsSquareAttackedByQueens(oppositeSideOffset, bishopAttacks, rookAttacks)
+            IsSquareAttackedByRooksOrQueens(kingSquare, oppositeSideOffset, bothSidesOccupancy)
+            || IsSquareAttackedByBishopsOrQueens(kingSquare, oppositeSideOffset, bothSidesOccupancy)
             || IsSquareAttackedByKnights(kingSquare, oppositeSideOffset)
             || IsSquareAttackedByPawns(kingSquare, oppositeSideInt, oppositeSideOffset);
     }
@@ -1514,6 +1512,20 @@ public class Position : IDisposable
     {
         var queenAttacks = Attacks.QueenAttacks(rookAttacks, bishopAttacks);
         return (queenAttacks & PieceBitBoards[(int)Piece.Q + offset]) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsSquareAttackedByBishopsOrQueens(int squareIndex, int offset, BitBoard bothSidesOccupancy)
+    {
+        var bishopAttacks = Attacks.BishopAttacks(squareIndex, bothSidesOccupancy);
+        return (bishopAttacks & (PieceBitBoards[(int)Piece.B + offset] | PieceBitBoards[(int)Piece.Q + offset])) != default;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool IsSquareAttackedByRooksOrQueens(int squareIndex, int offset, BitBoard bothSidesOccupancy)
+    {
+        var rookAttacks = Attacks.RookAttacks(squareIndex, bothSidesOccupancy);
+        return (rookAttacks & (PieceBitBoards[(int)Piece.R + offset] | PieceBitBoards[(int)Piece.Q + offset])) != default;
     }
 
     #endregion


### PR DESCRIPTION
```
Test  | perf/queen-attacks
Elo   | -4.58 +- 4.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 10540: +2798 -2937 =4805
Penta | [250, 1223, 2404, 1202, 191]
https://openbench.lynx-chess.com/test/1456/
```