### PR TITLE
🔍 RFP, razoring: only when no TT move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,7 +155,7 @@ public sealed partial class Engine
             // Fail-high pruning (moves with high scores) - prune more when improving
             if (isNotGettingCheckmated)
             {
-                if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
+                if (depth <= Configuration.EngineSettings.RFP_MaxDepth && ttBestMove == default)
                 {
                     // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                     // Return formula by Ciekce, instead of just returning static eval


### PR DESCRIPTION
```
Test  | search/rfp-razoring-no-ttmove
Elo   | -4.71 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.92 (-2.25, 2.89) [0.00, 3.00]
Games | 8714: +2284 -2402 =4028
Penta | [211, 1044, 1911, 1034, 157]
https://openbench.lynx-chess.com/test/1454/
```