### PR TITLE
🔍 RFP: only when no TT move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,7 +155,7 @@ public sealed partial class Engine
             // Fail-high pruning (moves with high scores) - prune more when improving
             if (isNotGettingCheckmated)
             {
-                if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
+                if (depth <= Configuration.EngineSettings.RFP_MaxDepth && ttBestMove == default)
                 {
                     // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                     // Return formula by Ciekce, instead of just returning static eval

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -165,7 +165,7 @@ public sealed partial class Engine
 
                     var rfpThreshold = rfpMargin + improvingFactor;
 
-                    if (staticEval - rfpThreshold >= beta)
+                    if (staticEval - rfpThreshold >= beta && ttBestMove == default)
                     {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                         return (staticEval + beta) / 2;


### PR DESCRIPTION
```
Test  | search/rfp-no-ttmove
Elo   | -9.47 +- 5.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 5688: +1466 -1621 =2601
Penta | [132, 739, 1230, 638, 105]
https://openbench.lynx-chess.com/test/1464/
```