### PR TITLE
🟰 Replace `Task.WhenAll` with `Task.WhenEach`

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -224,19 +224,17 @@ public sealed class Searcher
 
             await _absoluteSearchCancellationTokenSource.CancelAsync();
 
-            // We wait just for the node count, so there's room for improvement here with thread voting
-            // and other strategies that take other thread results into account
-            var extraResults = await Task.WhenAll(tasks);
-
 #if MULTITHREAD_DEBUG
             _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
             if (finalSearchResult is not null)
             {
-                foreach (var extraResult in extraResults)
+                // We wait just for the node count, so there's room for improvement here with thread voting
+                // and other strategies that take other thread results into account
+                await foreach (var extraResult in Task.WhenEach(tasks))
                 {
-                    finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                    finalSearchResult.Nodes += (await extraResult)?.Nodes ?? 0;
                 }
 
                 finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);


### PR DESCRIPTION
Parse extra thread results as they come

```
Test  | mt/task-wheneach
Elo   | -0.01 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | 1.33 (-2.25, 2.89) [-3.00, 1.00]
Games | 40582: +10797 -10798 =18987
Penta | [862, 4902, 8760, 4909, 858]
https://openbench.lynx-chess.com/test/1339/
```