### PR TITLE
⚡ Move king attacks last in `IsSquareAttacked`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1449,11 +1449,11 @@ public class Position : IDisposable
         // I tried to order them from most to least likely - not tested
         return
             IsSquareAttackedByPawns(squareIndex, sideToMoveInt, offset)
-            || IsSquareAttackedByKing(squareIndex, offset)
             || IsSquareAttackedByKnights(squareIndex, offset)
             || IsSquareAttackedByBishops(squareIndex, offset, bothSidesOccupancy, out var bishopAttacks)
             || IsSquareAttackedByRooks(squareIndex, offset, bothSidesOccupancy, out var rookAttacks)
-            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks);
+            || IsSquareAttackedByQueens(offset, bishopAttacks, rookAttacks)
+            || IsSquareAttackedByKing(squareIndex, offset);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Score of Lynx-perf-issquareattacked-kings-last-5676-win-x64 vs Lynx 5675 - main: 19591 - 19428 - 31943  [0.501] 70962
...      Lynx-perf-issquareattacked-kings-last-5676-win-x64 playing White: 14906 - 4591 - 15983  [0.645] 35480
...      Lynx-perf-issquareattacked-kings-last-5676-win-x64 playing Black: 4685 - 14837 - 15960  [0.357] 35482
...      White vs Black: 29743 - 9276 - 31943  [0.644] 70962
Elo difference: 0.8 +/- 1.9, LOS: 79.5 %, DrawRatio: 45.0 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```