### PR TITLE
🔍 RFP improving: cutnode cut by a quarter

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -138,6 +138,11 @@ public sealed partial class Engine
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
                 improving = evalDiff >= 0;
                 improvingRate = evalDiff / 50.0;
+
+                if (cutnode)
+                {
+                    improvingRate /= 2;
+                }
             }
 
             // From smol.cs

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -141,7 +141,7 @@ public sealed partial class Engine
 
                 if (cutnode)
                 {
-                    improvingRate /= 2;
+                    improvingRate -= improvingRate / 4;
                 }
             }
 


### PR DESCRIPTION
```
Test  | search/improving-cutnode-cut-by-a-quarter
Elo   | -0.76 +- 2.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 34312: +9095 -9170 =16047
Penta | [761, 4181, 7308, 4184, 722]
https://openbench.lynx-chess.com/test/1446/
```