### PR TITLE
🔍 RFP improving: cutnode cut by a half

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -138,6 +138,11 @@ public sealed partial class Engine
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
                 improving = evalDiff >= 0;
                 improvingRate = evalDiff / 50.0;
+
+                if (cutnode)
+                {
+                    improvingRate /= 2;
+                }
             }
 
             // From smol.cs


### PR DESCRIPTION
```
Test  | search/improving-cutnode-but-by-half
Elo   | -0.25 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 48006: +12751 -12786 =22469
Penta | [1014, 5864, 10245, 5903, 977]
https://openbench.lynx-chess.com/test/1445/
```