### PR TITLE
🔍 SPSA - 2025-3-7

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -156,67 +156,67 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.85;
+    public double LMR_Base_Quiet { get; set; } = 0.54;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.52;
+    public double LMR_Base_Noisy { get; set; } = 0.89;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.70;
+    public double LMR_Divisor_Quiet { get; set; } = 2.73;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.67;
+    public double LMR_Divisor_Noisy { get; set; } = 2.89;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 75;
+    public int LMR_Improving { get; set; } = 142;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 141;
+    public int LMR_Cutnode { get; set; } = 180;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 82;
+    public int LMR_TTPV { get; set; } = 59;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 100;
+    public int LMR_TTCapture { get; set; } = 109;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 60;
+    public int LMR_PVNode { get; set; } = 101;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 79;
+    public int LMR_InCheck { get; set; } = 27;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3560;
+    public int LMR_History_Divisor_Quiet { get; set; } = 3866;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3622;
+    public int LMR_History_Divisor_Noisy { get; set; } = 4290;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 38;
+    public int LMR_DeeperBase { get; set; } = 28;
 
     //[SPSA<int>(1, 10, 1)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -236,13 +236,13 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 113;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 101;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 10;
+    public int AspirationWindow_Base { get; set; } = 11;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -260,10 +260,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 104;
+    public int Razoring_Depth1Bonus { get; set; } = 133;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 190;
+    public int Razoring_NotDepth1Bonus { get; set; } = 206;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -287,7 +287,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 86;
+    public int History_BestScoreBetaMargin { get; set; } = 83;
 
     //[SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -296,16 +296,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 105;
+    public int FP_DepthScalingFactor { get; set; } = 103;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 108;
+    public int FP_Margin { get; set; } = 133;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -837;
+    public int HistoryPrunning_Margin { get; set; } = -779;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -319,10 +319,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -42;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -44;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -112;
 
     #endregion
 }


### PR DESCRIPTION
```
iterations: 579 (275.16s per iter)
games: 18528 (8.60s per game)
LMR_Base_Quiet = 54(-31.055653) in [10, 200]
LMR_Base_Noisy = 89(+37.36) in [10, 200]
LMR_Divisor_Quiet = 273(+2.64) in [100, 500]
LMR_Divisor_Noisy = 289(+22.08) in [100, 500]
LMR_Improving = 142(+66.56) in [25, 300]
LMR_Cutnode = 180(+39.28) in [25, 300]
LMR_TTPV = 59(-22.507491) in [25, 300]
LMR_TTCapture = 109(+8.95) in [25, 300]
LMR_PVNode = 101(+40.93) in [25, 300]
LMR_InCheck = 27(-51.995530) in [25, 300]
LMR_History_Divisor_Quiet = 3866(+305.75) in [1, 8192]
LMR_History_Divisor_Noisy = 4290(+668.10) in [1, 8192]
LMR_DeeperBase = 28(-9.883093) in [20, 100]
NMP_StaticEvalBetaDivisor = 101(-12.385698) in [50, 350]
AspirationWindow_Base = 11(+1.36) in [5, 30]
Razoring_Depth1Bonus = 133(+28.97) in [1, 300]
Razoring_NotDepth1Bonus = 206(+16.19) in [1, 300]
History_BestScoreBetaMargin = 83(-2.946838) in [0, 200]
FP_DepthScalingFactor = 103(-1.732708) in [1, 200]
FP_Margin = 133(+25.18) in [0, 500]
HistoryPrunning_Margin = -779(+58.45) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -44(-1.512588) in [-100, -10]
PVS_SEE_Threshold_Noisy = -112(+4.65) in [-150, -50]
```

![image](https://github.com/user-attachments/assets/3c553bb0-e903-4b8c-aabb-cfe690745337)


```
Test  | spsa/7-3
Elo   | -2.78 +- 3.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 14986: +3708 -3828 =7450
Penta | [221, 1873, 3441, 1721, 237]
https://openbench.lynx-chess.com/test/1466/
```