### PR TITLE
🔍 LMP: legal move counter + `depth * depth` formula 

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -269,10 +269,7 @@ public sealed class EngineSettings
     public int IIR_MinDepth { get; set; } = 4;
 
     //[SPSA<int>(0, 10, 0.5)]
-    public int LMP_BaseMovesToTry { get; set; } = 1;
-
-    //[SPSA<int>(0, 10, 0.5)]
-    public int LMP_MovesDepthMultiplier { get; set; } = 3;
+    public int LMP_BaseMovesToTry { get; set; } = 3;
 
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -289,7 +289,7 @@ public sealed partial class Engine
             {
                 // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                 // after searching the first few given by the move ordering algorithm
-                if (moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1))) // Based on formula suggested by Antares
+                if (visitedMovesCounter >= Configuration.EngineSettings.LMP_BaseMovesToTry + (depth * depth / (improving ? 1 : 2)))
                 {
                     break;
                 }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -559,14 +559,6 @@ public sealed class UCIHandler
                     }
                     break;
                 }
-            case "lmp_movesdepthmultiplier":
-                {
-                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
-                    {
-                        Configuration.EngineSettings.LMP_MovesDepthMultiplier = value;
-                    }
-                    break;
-                }
             case "history_maxmovevalue":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
```
Test  | search/lmp-use-legal-move-counter
Elo   | 0.94 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.05 (-2.25, 2.89) [0.00, 3.00]
Games | 46768: +12604 -12477 =21687
Penta | [1013, 5670, 9928, 5723, 1050]
https://openbench.lynx-chess.com/test/1470/
```

```
Test  | search/lmp-use-legal-move-counter
Elo   | -5.40 +- 4.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [-3.00, 1.00]
Games | 8242: +1904 -2032 =4306
Penta | [109, 1044, 1919, 964, 85]
https://openbench.lynx-chess.com/test/1471/
```