### PR TITLE
⚡ Lazy quiet history 

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -274,7 +274,9 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[moveIndex];
             var moveScore = moveScores[moveIndex];
             var isCapture = move.IsCapture();
-            var quietMoveHistory = new Lazy<int>(() => _quietHistory[move.Piece()][move.TargetSquare()]);
+            var quietMoveHistory = new Lazy<int>(
+                () => _quietHistory[move.Piece()][move.TargetSquare()],
+                isThreadSafe: false);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;


### PR DESCRIPTION
Thread safe:
```
Score of Lynx-perf-lazy-quiet-history-5715-win-x64 vs Lynx 5713 - main: 49 - 90 - 121  [0.421] 260
...      Lynx-perf-lazy-quiet-history-5715-win-x64 playing White: 38 - 22 - 71  [0.561] 131
...      Lynx-perf-lazy-quiet-history-5715-win-x64 playing Black: 11 - 68 - 50  [0.279] 129
...      White vs Black: 106 - 33 - 121  [0.640] 260
Elo difference: -55.2 +/- 31.0, LOS: 0.0 %, DrawRatio: 46.5 %
SPRT: llr -0.891 (-30.8%), lbound -2.25, ubound 2.89
```
Non thread safe:
```
Score of Lynx-perf-lazy-quiet-history-5716-win-x64 vs Lynx 5713 - main: 475 - 587 - 893  [0.471] 1955
...      Lynx-perf-lazy-quiet-history-5716-win-x64 playing White: 371 - 145 - 462  [0.616] 978
...      Lynx-perf-lazy-quiet-history-5716-win-x64 playing Black: 104 - 442 - 431  [0.327] 977
...      White vs Black: 813 - 249 - 893  [0.644] 1955
Elo difference: -19.9 +/- 11.3, LOS: 0.0 %, DrawRatio: 45.7 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```

```
Score of Lynx-perf-lazy-quiet-history-5716-win-x64 vs Lynx 5713 - main: 538 - 657 - 884  [0.471] 2079
...      Lynx-perf-lazy-quiet-history-5716-win-x64 playing White: 405 - 175 - 460  [0.611] 1040
...      Lynx-perf-lazy-quiet-history-5716-win-x64 playing Black: 133 - 482 - 424  [0.332] 1039
...      White vs Black: 887 - 308 - 884  [0.639] 2079
Elo difference: -19.9 +/- 11.3, LOS: 0.0 %, DrawRatio: 42.5 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```