### PR TITLE
👷🏼 Stop running benchmarks with sudo

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macOS-latest, macOS-13]
+        os: [ubuntu-latest, windows-latest, macOS-latest, macOS-13]
       fail-fast: false
 
     env:
@@ -44,13 +44,7 @@ jobs:
       working-directory: ./src/Lynx.Benchmark
 
     - name: Run ${{ github.event.inputs.benchmark_name }} benchmark
-      if: matrix.os == 'windows-latest'
       run: dotnet run -c Release --no-build --filter '${{ github.event.inputs.benchmark_name }}'
-      working-directory: ./src/Lynx.Benchmark
-
-    - name: Run ${{ github.event.inputs.benchmark_name }} benchmark with sudo
-      if: matrix.os != 'windows-latest'
-      run: sudo dotnet run -c Release --no-build --filter '${{ github.event.inputs.benchmark_name }}'
       working-directory: ./src/Lynx.Benchmark
 
     - name: 'Upload ${{ matrix.os }} artifacts'


### PR DESCRIPTION
Don't really remember why it was introduced in #410 and couldn't find a documented reason.

So after suffering https://github.com/actions/setup-dotnet/issues/598 when combining `sudo dotnet` with .NET installed using `setup-dotnet` in Ubuntu 24.04, I'm simplifying benchmark runs until a reason not to do so is found again.