### PR TITLE
🔍 Continuation history: use it in LMR and history pruning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -207,13 +207,13 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3560;
+    public int LMR_History_Divisor_Quiet { get; set; } = 3107;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3622;
+    public int LMR_History_Divisor_Noisy { get; set; } = 3451;
 
     [SPSA<int>(20, 100, 8)]
     public int LMR_DeeperBase { get; set; } = 38;
@@ -302,7 +302,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -837;
+    public int HistoryPrunning_Margin { get; set; } = -643;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;


### PR DESCRIPTION
```
iterations: 1495 (84.27s per iter)
games: 11960 (10.53s per game)
LMR_History_Divisor_Quiet = 3107(-452.723919) in [1, 8192]
LMR_History_Divisor_Noisy = 3451(-170.848526) in [1, 8192]
HistoryPrunning_Margin = -643(+193.63) in [-8192, 0]
```

![image](https://github.com/user-attachments/assets/dcd99967-b1bf-4088-b8d3-90ad5e1ea207)

```
Test  | search/continuation-history-pruning-spsa-1
Elo   | 13.60 +- 5.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 5266: +1371 -1165 =2730
Penta | [52, 540, 1258, 716, 67]
https://openbench.lynx-chess.com/test/1475/
```