### PR TITLE
🔍 Store static eval early in TT

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -122,11 +122,11 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // These extra checks might make sense in a MT environment, TODO check
-        if (entry.Key == 0                                      // No actual entry
-            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
-        {
+        //if (entry.Key == 0                                      // No actual entry
+        //    || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        //{
             entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
-        }
+        //}
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -99,7 +99,9 @@ public readonly struct TranspositionTable
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
                 //+ Configuration.EngineSettings.TTReplacement_DepthOffset
-                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth;           // Higher depth
+                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth    // Higher depth
+                ;
+        // || entry.Type == NodeType.None not needed, since depth condition is always true for those cases
 
         if (!shouldReplace)
         {
@@ -111,6 +113,20 @@ public readonly struct TranspositionTable
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
         entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SaveStaticEval(Position position, int staticEval, bool wasPv)
+    {
+        var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
+        ref var entry = ref _tt[ttIndex];
+
+        // These extra checks might make sense in a MT environment, TODO check
+        if (entry.Key == 0                                      // No actual entry
+            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        {
+            entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        }
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -19,7 +19,12 @@ public enum NodeType : byte
     /// <summary>
     /// LowerBound
     /// </summary>
-    Beta
+    Beta,
+
+    /// <summary>
+    /// i.e. when storing only static evaluation
+    /// </summary>
+    None
 }
 
 /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -129,6 +129,7 @@ public sealed partial class Engine
             if (!ttHit)
             {
                 (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
+                _tt.SaveStaticEval(position, staticEval, ttPv);
             }
             else
             {
@@ -245,6 +246,10 @@ public sealed partial class Engine
         else
         {
             staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
@@ -667,6 +672,11 @@ public sealed partial class Engine
 
         if (!isInCheck)
         {
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
+
             // Standing pat beta-cutoff (updating alpha after this check)
             if (eval >= beta)
             {


### PR DESCRIPTION
[Save static TT eval early on top of ttHit refactoring](https://github.com/lynx-chess/Lynx/commit/ea37616f8773c1c7b12cacc3d85efac63d2cf336)
```
Score of Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 vs Lynx 5726 - main: 1339 - 1422 - 2439  [0.492] 5200
...      Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 playing White: 1060 - 285 - 1255  [0.649] 2600
...      Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 playing Black: 279 - 1137 - 1184  [0.335] 2600
...      White vs Black: 2197 - 564 - 2439  [0.657] 5200
Elo difference: -5.5 +/- 6.9, LOS: 5.7 %, DrawRatio: 46.9 %
SPRT: llr -1.72 (-59.3%), lbound -2.25, ubound 2.89
```

[Remove extra guards when saving static eval](https://github.com/lynx-chess/Lynx/commit/e1d608160a216d036c027e0ece165a3a903c733e)
```
Score of Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 vs Lynx 5726 - main: 1493 - 1592 - 2735  [0.491] 5820
...      Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 playing White: 1178 - 317 - 1415  [0.648] 2910
...      Lynx-search-store-staticeval-early-in-tt-2-5733-win-x64 playing Black: 315 - 1275 - 1320  [0.335] 2910
...      White vs Black: 2453 - 632 - 2735  [0.656] 5820
Elo difference: -5.9 +/- 6.5, LOS: 3.7 %, DrawRatio: 47.0 %
SPRT: llr -2.02 (-70.0%), lbound -2.25, ubound 2.89
```