### PR TITLE
🧹 Refactor `ttHit`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -41,8 +41,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
 
         ShortMove ttBestMove = default;
-        NodeType ttElementType = default;
-        int ttScore = default;
+        NodeType ttElementType = NodeType.Unknown;
+        int ttScore = EvaluationConstants.NoHashEntry;
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
@@ -57,7 +57,9 @@ public sealed partial class Engine
         {
             (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, ply);
 
-            ttHit = ttScore != EvaluationConstants.NoHashEntry;
+            // ttScore shouldn't be used, since it'll be 0 for default structs
+            ttHit = ttElementType != NodeType.Unknown;
+
             ttEntryHasBestMove = ttBestMove != default;
 
             // TT cutoffs
@@ -633,7 +635,7 @@ public sealed partial class Engine
         var ttProbeResult = _tt.ProbeHash(position, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttScore != EvaluationConstants.NoHashEntry;
+        var ttHit = ttNodeType != NodeType.Unknown;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff


### PR DESCRIPTION
Uninitialized TT entries were being treated as valid ones.

```
Test  | refactor/tthit
Elo   | -0.75 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | 53940: +14527 -14644 =24769
Penta | [1129, 6318, 12146, 6295, 1082]
https://openbench.lynx-chess.com/test/1485/
```