### PR TITLE
🔍 Store static eval early in TT II

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -122,11 +122,11 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // These extra checks might make sense in a MT environment, TODO check
-        if (entry.Key == 0                                      // No actual entry
-            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
-        {
+        //if (entry.Key == 0                                      // No actual entry
+        //    || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        //{
             entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
-        }
+        //}
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -99,7 +99,9 @@ public readonly struct TranspositionTable
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
                 //+ Configuration.EngineSettings.TTReplacement_DepthOffset
-                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth;           // Higher depth
+                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth    // Higher depth
+                ;
+        // || entry.Type == NodeType.None not needed, since depth condition is always true for those cases
 
         if (!shouldReplace)
         {
@@ -111,6 +113,20 @@ public readonly struct TranspositionTable
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
         entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SaveStaticEval(Position position, int staticEval, bool wasPv)
+    {
+        var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
+        ref var entry = ref _tt[ttIndex];
+
+        // These extra checks might make sense in a MT environment, TODO check
+        if (entry.Key == 0                                      // No actual entry
+            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        {
+            entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        }
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -7,7 +7,7 @@ namespace Lynx.Model;
 public enum NodeType : byte
 #pragma warning restore S4022 // Enumerations should have "Int32" storage
 {
-    Unknown,    // Making it 0 instead of -1 because of default struct initialization
+    Unknown,    // It needs to be 0 because of default struct initialization
 
     Exact,
 

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -19,7 +19,12 @@ public enum NodeType : byte
     /// <summary>
     /// LowerBound
     /// </summary>
-    Beta
+    Beta,
+
+    /// <summary>
+    /// i.e. when storing only static evaluation
+    /// </summary>
+    None
 }
 
 /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -41,8 +41,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
 
         ShortMove ttBestMove = default;
-        NodeType ttElementType = default;
-        int ttScore = default;
+        NodeType ttElementType = NodeType.Unknown;
+        int ttScore = EvaluationConstants.NoHashEntry;
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
@@ -57,7 +57,9 @@ public sealed partial class Engine
         {
             (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, ply);
 
-            ttHit = ttScore != EvaluationConstants.NoHashEntry;
+            // ttScore shouldn't be used, since it'll be 0 for default structs
+            ttHit = ttElementType != NodeType.Unknown;
+
             ttEntryHasBestMove = ttBestMove != default;
 
             // TT cutoffs
@@ -633,7 +635,7 @@ public sealed partial class Engine
         var ttProbeResult = _tt.ProbeHash(position, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttScore != EvaluationConstants.NoHashEntry;
+        var ttHit = ttNodeType != NodeType.Unknown;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -131,6 +131,7 @@ public sealed partial class Engine
             if (!ttHit)
             {
                 (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
+                _tt.SaveStaticEval(position, staticEval, ttPv);
             }
             else
             {
@@ -247,6 +248,10 @@ public sealed partial class Engine
         else
         {
             staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
@@ -673,6 +678,11 @@ public sealed partial class Engine
 
         if (!isInCheck)
         {
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
+
             // Standing pat beta-cutoff (updating alpha after this check)
             if (eval >= beta)
             {


### PR DESCRIPTION
STC
```
Score of Lynx-search-store-staticeval-early-in-tt-4-5737-win-x64 vs Lynx 5735 - main: 12443 - 12065 - 22365  [0.504] 46873
...      Lynx-search-store-staticeval-early-in-tt-4-5737-win-x64 playing White: 9687 - 2638 - 11113  [0.650] 23438
...      Lynx-search-store-staticeval-early-in-tt-4-5737-win-x64 playing Black: 2756 - 9427 - 11252  [0.358] 23435
...      White vs Black: 19114 - 5394 - 22365  [0.646] 46873
Elo difference: 2.8 +/- 2.3, LOS: 99.2 %, DrawRatio: 47.7 %
SPRT: llr 2.9 (100.4%), lbound -2.25, ubound 2.89 - H1 was accepted
```

LTC
```
Test  | search/store-staticeval-early-in-tt-4
Elo   | 3.63 +- 2.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 19536: +4806 -4602 =10128
Penta | [236, 2270, 4555, 2468, 239]
https://openbench.lynx-chess.com/test/1487/
```

2t, 8+0.08, 128MB hash

```
Score of Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 vs Lynx 5739 - main: 1237 - 1121 - 2234  [0.513] 4592
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing White: 1010 - 189 - 1097  [0.679] 2296
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing Black: 227 - 932 - 1137  [0.346] 2296
...      White vs Black: 1942 - 416 - 2234  [0.666] 4592
Elo difference: 8.8 +/- 7.2, LOS: 99.2 %, DrawRatio: 48.6 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```


4t, 8+0.08, 128MB hash

```
Score of Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 vs Lynx 5739 - main: 4310 - 4231 - 8377  [0.502] 16918
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing White: 3618 - 674 - 4168  [0.674] 8460
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing Black: 692 - 3557 - 4209  [0.331] 8458
...      White vs Black: 7175 - 1366 - 8377  [0.672] 16918
Elo difference: 1.6 +/- 3.7, LOS: 80.4 %, DrawRatio: 49.5 %
SPRT: llr 2.91 (100.8%), lbound -2.25, ubound 2.89 - H1 was accepted
```

8t, 6+0.06, 512MB hash

```
Score of Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 vs Lynx 5739 - main: 2635 - 2592 - 5583  [0.502] 10810
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing White: 2220 - 422 - 2763  [0.666] 5405
...      Lynx-search-store-staticeval-early-in-tt-4-5740-win-x64 playing Black: 415 - 2170 - 2820  [0.338] 5405
...      White vs Black: 4390 - 837 - 5583  [0.664] 10810
Elo difference: 1.4 +/- 4.5, LOS: 72.4 %, DrawRatio: 51.6 %
SPRT: llr 1.76 (61.1%), lbound -2.25, ubound 2.89
```