### PR TITLE
⚡ Reshuffle `NodeType` to detect ttHit with only one comparison

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -122,11 +122,11 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // These extra checks might make sense in a MT environment, TODO check
-        if (entry.Key == 0                                      // No actual entry
-            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
-        {
+        //if (entry.Key == 0                                      // No actual entry
+        //    || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        //{
             entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
-        }
+        //}
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -99,7 +99,9 @@ public readonly struct TranspositionTable
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
                 //+ Configuration.EngineSettings.TTReplacement_DepthOffset
-                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth;           // Higher depth
+                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth    // Higher depth
+                ;
+        // || entry.Type == NodeType.None not needed, since depth condition is always true for those cases
 
         if (!shouldReplace)
         {
@@ -111,6 +113,20 @@ public readonly struct TranspositionTable
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
         entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SaveStaticEval(Position position, int staticEval, bool wasPv)
+    {
+        var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
+        ref var entry = ref _tt[ttIndex];
+
+        // These extra checks might make sense in a MT environment, TODO check
+        if (entry.Key == 0                                      // No actual entry
+            || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
+        {
+            entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        }
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -7,7 +7,7 @@ namespace Lynx.Model;
 public enum NodeType : byte
 #pragma warning restore S4022 // Enumerations should have "Int32" storage
 {
-    Unknown,    // Making it 0 instead of -1 because of default struct initialization
+    Unknown,    // It needs to be 0 because of default struct initialization
 
     Exact,
 

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -19,7 +19,12 @@ public enum NodeType : byte
     /// <summary>
     /// LowerBound
     /// </summary>
-    Beta
+    Beta,
+
+    /// <summary>
+    /// i.e. when storing only static evaluation
+    /// </summary>
+    None
 }
 
 /// <summary>

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -7,7 +7,12 @@ namespace Lynx.Model;
 public enum NodeType : byte
 #pragma warning restore S4022 // Enumerations should have "Int32" storage
 {
-    Unknown,    // It needs to be 0 because of default struct initialization
+    Unknown = 0,    // It needs to be 0 because of default struct initialization
+
+    /// <summary>
+    /// i.e. when storing only static evaluation
+    /// </summary>
+    None = 1,
 
     Exact,
 
@@ -19,12 +24,7 @@ public enum NodeType : byte
     /// <summary>
     /// LowerBound
     /// </summary>
-    Beta,
-
-    /// <summary>
-    /// i.e. when storing only static evaluation
-    /// </summary>
-    None
+    Beta
 }
 
 /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -41,8 +41,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
 
         ShortMove ttBestMove = default;
-        NodeType ttElementType = default;
-        int ttScore = default;
+        NodeType ttElementType = NodeType.Unknown;
+        int ttScore = EvaluationConstants.NoHashEntry;
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
@@ -57,7 +57,9 @@ public sealed partial class Engine
         {
             (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, ply);
 
-            ttHit = ttScore != EvaluationConstants.NoHashEntry;
+            // ttScore shouldn't be used, since it'll be 0 for default structs
+            ttHit = ttElementType != NodeType.Unknown;
+
             ttEntryHasBestMove = ttBestMove != default;
 
             // TT cutoffs
@@ -633,7 +635,7 @@ public sealed partial class Engine
         var ttProbeResult = _tt.ProbeHash(position, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttScore != EvaluationConstants.NoHashEntry;
+        var ttHit = ttNodeType != NodeType.Unknown;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -131,6 +131,7 @@ public sealed partial class Engine
             if (!ttHit)
             {
                 (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
+                _tt.SaveStaticEval(position, staticEval, ttPv);
             }
             else
             {
@@ -247,6 +248,10 @@ public sealed partial class Engine
         else
         {
             staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
@@ -673,6 +678,11 @@ public sealed partial class Engine
 
         if (!isInCheck)
         {
+            if (!ttHit)
+            {
+                _tt.SaveStaticEval(position, staticEval, ttPv);
+            }
+
             // Standing pat beta-cutoff (updating alpha after this check)
             if (eval >= beta)
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -58,7 +58,7 @@ public sealed partial class Engine
             (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, ply);
 
             // ttScore shouldn't be used, since it'll be 0 for default structs
-            ttHit = ttElementType != NodeType.Unknown && ttElementType != NodeType.None;
+            ttHit = ttElementType > NodeType.None;
 
             ttEntryHasBestMove = ttBestMove != default;
 
@@ -640,7 +640,7 @@ public sealed partial class Engine
         var ttProbeResult = _tt.ProbeHash(position, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttNodeType != NodeType.Unknown && ttNodeType != NodeType.None;
+        var ttHit = ttNodeType > NodeType.None;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff


### PR DESCRIPTION
See #1561 
```
Score of Lynx-search-store-staticeval-early-in-tt-4-faster-5738-win-x64 vs Lynx 5735 - main: 2845 - 2935 - 5232  [0.496] 11012
...      Lynx-search-store-staticeval-early-in-tt-4-faster-5738-win-x64 playing White: 2203 - 646 - 2657  [0.641] 5506
...      Lynx-search-store-staticeval-early-in-tt-4-faster-5738-win-x64 playing Black: 642 - 2289 - 2575  [0.350] 5506
...      White vs Black: 4492 - 1288 - 5232  [0.645] 11012
Elo difference: -2.8 +/- 4.7, LOS: 11.8 %, DrawRatio: 47.5 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```