### PR TITLE
🧪 Remove countermoves

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -100,7 +100,6 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_captureHistory);
         Array.Clear(_continuationHistory);
-        Array.Clear(_counterMoves);
 
         Array.Clear(_pawnEvalTable);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -17,11 +17,6 @@ public sealed partial class Engine
 
     /// <summary>
     /// 12 x 64
-    /// </summary>
-    private readonly int[] _counterMoves = GC.AllocateArray<int>(12 * 64, pinned: true);
-
-    /// <summary>
-    /// 12 x 64
     /// piece x target square
     /// </summary>
     private readonly int[][] _quietHistory;

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -80,12 +80,6 @@ public sealed partial class Engine
             var previousMovePiece = previousMove.Piece();
             var previousMoveTargetSquare = previousMove.TargetSquare();
 
-            // Countermove
-            if (_counterMoves[CounterMoveIndex(previousMovePiece, previousMoveTargetSquare)] == move)
-            {
-                return CounterMoveValue;
-            }
-
             // Counter move history
             return BaseMoveScore
                 + _quietHistory[move.Piece()][move.TargetSquare()]
@@ -155,7 +149,7 @@ public sealed partial class Engine
     /// Quiet history, contination history, killers and counter moves
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot, bool pvNode)
+    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot)
     {
         // 🔍 Quiet history moves
         // Doing this only in beta cutoffs (instead of when eval > alpha) was suggested by Sirius author
@@ -234,12 +228,6 @@ public sealed partial class Engine
             }
 
             _killerMoves[thisPlyKillerMovesBaseIndex] = move;
-
-            if (!isRoot && (depth >= Configuration.EngineSettings.CounterMoves_MinDepth || pvNode))
-            {
-                // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
-                _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
-            }
         }
     }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -575,7 +575,7 @@ public sealed partial class Engine
                     }
                     else
                     {
-                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
+                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot);
                     }
 
                     nodeType = NodeType.Beta;


### PR DESCRIPTION
```
Test  | search/no-countermoves
Elo   | -6.84 +- 5.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 7472: +1990 -2137 =3345
Penta | [191, 994, 1496, 881, 174]
https://openbench.lynx-chess.com/test/1488/
```