### PR TITLE
🔍 SPSA: Continuation history pruning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -207,13 +207,13 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3107;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2907;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3451;
+    public int LMR_History_Divisor_Noisy { get; set; } = 3414;
 
     [SPSA<int>(20, 100, 8)]
     public int LMR_DeeperBase { get; set; } = 38;
@@ -302,7 +302,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -643;
+    public int HistoryPrunning_Margin { get; set; } = -661;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;


### PR DESCRIPTION
```
iterations: 2035 (84.31s per iter)
games: 16280 (10.54s per game)
LMR_History_Divisor_Quiet = 2907(-652.892467) in [1, 8192]
LMR_History_Divisor_Noisy = 3414(-207.658773) in [1, 8192]
HistoryPrunning_Margin = -661(+175.85) in [-8192, 0]
```

```
Test  | search/continuation-history-pruning-spsa-3
Elo   | 0.29 +- 2.39 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 27394: +6601 -6578 =14215
Penta | [343, 3248, 6476, 3303, 327]
https://openbench.lynx-chess.com/test/1480/
```