### PR TITLE
⚡ Replace FileMasks[] access with `Constants.AFile << (square % 8)`

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -977,7 +977,6 @@ static void FileAndRankMasks()
     const int square = (int)BoardSquare.e4;
 
     Masks.RankMasks[square].Print();
-    Masks.FileMasks[square].Print();
     Masks.IsolatedPawnMasks[square].Print();
     Masks.WhitePassedPawnMasks[square].Print();
     Masks.BlackPassedPawnMasks[square].Print();

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -20,7 +20,6 @@ public static class Masks
     /// </summary>
     public static BitBoard[] FileMasks { get; } = new BitBoard[64];
 
-
     /// <summary>
     /// Rank mask for square a6 (same one for b6, c6, etc.)
     /// 8  0 0 0 0 0 0 0 0

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -4,6 +4,8 @@ namespace Lynx;
 
 public static class Masks
 {
+    public static BitBoard FileMask(int square) => Constants.AFile << (square % 8);
+
     /// <summary>
     /// File mask for square f2 (same one as f3, f4, etc.)
     ///  8  0 0 0 0 0 1 0 0
@@ -17,6 +19,7 @@ public static class Masks
     ///     a b c d e f g h
     /// </summary>
     public static BitBoard[] FileMasks { get; } = new BitBoard[64];
+
 
     /// <summary>
     /// Rank mask for square a6 (same one for b6, c6, etc.)

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -9,20 +9,6 @@ public static class Masks
     public static BitBoard FileMask(int square) => Constants.AFile << (square % 8);
 
     /// <summary>
-    /// File mask for square f2 (same one as f3, f4, etc.)
-    ///  8  0 0 0 0 0 1 0 0
-    ///  7  0 0 0 0 0 1 0 0
-    ///  6  0 0 0 0 0 1 0 0
-    ///  5  0 0 0 0 0 1 0 0
-    ///  4  0 0 0 0 0 1 0 0
-    ///  3  0 0 0 0 0 1 0 0
-    ///  2  0 0 0 0 0 1 0 0
-    ///  1  0 0 0 0 0 1 0 0
-    ///     a b c d e f g h
-    /// </summary>
-    public static BitBoard[] FileMasks { get; } = new BitBoard[64];
-
-    /// <summary>
     /// Rank mask for square a6 (same one for b6, c6, etc.)
     /// 8  0 0 0 0 0 0 0 0
     /// 7  0 0 0 0 0 0 0 0
@@ -162,7 +148,6 @@ public static class Masks
                     blackKnightOutpostMask.SetBit(squareIndex ^ 56);
                 }
 
-                FileMasks[squareIndex] |= SetFileRankMask(file, -1);
                 RankMasks[squareIndex] |= SetFileRankMask(-1, rank);
                 IsolatedPawnMasks[squareIndex] |= SetFileRankMask(file - 1, -1);
                 IsolatedPawnMasks[squareIndex] |= SetFileRankMask(file + 1, -1);

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -1,9 +1,11 @@
 ﻿using Lynx.Model;
+using System.Runtime.CompilerServices;
 
 namespace Lynx;
 
 public static class Masks
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static BitBoard FileMask(int square) => Constants.AFile << (square % 8);
 
     /// <summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1140,12 +1140,12 @@ public class Position : IDisposable
         var packedBonus = RookMobilityBonus[attacksCount];
 
         // Rook on open file
-        if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMasks[squareIndex]) == default)
+        if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMask(squareIndex)) == default)
         {
             packedBonus += OpenFileRookBonus;
         }
         // Rook on semi-open file
-        else if ((PieceBitBoards[pieceIndex - pawnToRookOffset] & Masks.FileMasks[squareIndex]) == default)
+        else if ((PieceBitBoards[pieceIndex - pawnToRookOffset] & Masks.FileMask(squareIndex)) == default)
         {
             packedBonus += SemiOpenFileRookBonus;
         }
@@ -1298,12 +1298,12 @@ public class Position : IDisposable
         if (PieceBitBoards[(int)Piece.r - kingSideOffset] + PieceBitBoards[(int)Piece.q - kingSideOffset] != 0)
         {
             // King on open file
-            if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMasks[squareIndex]) == 0)
+            if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMask(squareIndex)) == 0)
             {
                 packedBonus += OpenFileKingPenalty;
             }
             // King on semi-open file
-            else if ((PieceBitBoards[(int)Piece.P + kingSideOffset] & Masks.FileMasks[squareIndex]) == 0)
+            else if ((PieceBitBoards[(int)Piece.P + kingSideOffset] & Masks.FileMask(squareIndex)) == 0)
             {
                 packedBonus += SemiOpenFileKingPenalty;
             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1139,13 +1139,15 @@ public class Position : IDisposable
 
         var packedBonus = RookMobilityBonus[attacksCount];
 
+        var file = Masks.FileMask(squareIndex);
+
         // Rook on open file
-        if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMask(squareIndex)) == default)
+        if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & file) == default)
         {
             packedBonus += OpenFileRookBonus;
         }
         // Rook on semi-open file
-        else if ((PieceBitBoards[pieceIndex - pawnToRookOffset] & Masks.FileMask(squareIndex)) == default)
+        else if ((PieceBitBoards[pieceIndex - pawnToRookOffset] & file) == default)
         {
             packedBonus += SemiOpenFileRookBonus;
         }
@@ -1297,13 +1299,15 @@ public class Position : IDisposable
         // Opposite side rooks or queens on the board
         if (PieceBitBoards[(int)Piece.r - kingSideOffset] + PieceBitBoards[(int)Piece.q - kingSideOffset] != 0)
         {
+            var file = Masks.FileMask(squareIndex);
+
             // King on open file
-            if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & Masks.FileMask(squareIndex)) == 0)
+            if (((PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]) & file) == 0)
             {
                 packedBonus += OpenFileKingPenalty;
             }
             // King on semi-open file
-            else if ((PieceBitBoards[(int)Piece.P + kingSideOffset] & Masks.FileMask(squareIndex)) == 0)
+            else if ((PieceBitBoards[(int)Piece.P + kingSideOffset] & file) == 0)
             {
                 packedBonus += SemiOpenFileKingPenalty;
             }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -527,7 +527,7 @@ public sealed class Searcher
         _ = PVTable.Indexes[0];
         _ = Attacks.KingAttacks;
         _ = ZobristTable.SideHash();
-        _ = Masks.FileMasks;
+        _ = Masks.IsolatedPawnMasks;
         _ = EvaluationConstants.HistoryBonus[1];
         _ = MoveGenerator.Init();
         _ = GoCommand.Init();

--- a/tests/Lynx.Test/MasksTest.cs
+++ b/tests/Lynx.Test/MasksTest.cs
@@ -3,22 +3,8 @@ using NUnit.Framework;
 
 namespace Lynx.Test;
 
-internal class MasksTest
+public class MasksTest
 {
-    [TestCase(BoardSquare.a8, "P7/P7/P7/P7/P7/P7/P7/P4K1k w - - 0 1")]
-    [TestCase(BoardSquare.a6, "P7/P7/P7/P7/P7/P7/P7/P4K1k w - - 0 1")]
-    [TestCase(BoardSquare.b5, "1P6/1P6/1P6/1P6/1P6/1P6/1P6/1P3K1k w - - 0 1")]
-    [TestCase(BoardSquare.b1, "1P6/1P6/1P6/1P6/1P6/1P6/1P6/1P3K1k w - - 0 1")]
-    public void FileMasks(BoardSquare square, string fen)
-    {
-        var position = new Position(fen);
-
-        var expectedBitBoard = position.PieceBitBoards[(int)Piece.P] | position.PieceBitBoards[(int)Piece.p];
-        var actualBitBoard = Masks.FileMasks[(int)square];
-
-        Assert.AreEqual(expectedBitBoard, actualBitBoard);
-    }
-
     [TestCase(BoardSquare.a8, "PPPPPPPP/8/8/8/8/8/8/K1k5 w - - 0 1")]
     [TestCase(BoardSquare.c8, "PPPPPPPP/8/8/8/8/8/8/K1k5 w - - 0 1")]
     [TestCase(BoardSquare.b2, "K1k5/8/8/8/8/8/PPPPPPPP/8 w - - 0 1")]


### PR DESCRIPTION
```
Test  | perf/filemask
Elo   | -0.31 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 45454: +12178 -12219 =21057
Penta | [903, 5231, 10480, 5230, 883]
https://openbench.lynx-chess.com/test/1490/
```

```
Test  | perf/filemask
Elo   | 1.40 +- 2.62 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | 27228: +7557 -7447 =12224
Penta | [595, 3091, 6110, 3245, 573]
https://openbench.lynx-chess.com/test/1493/
```