### PR TITLE
🔍 Add extra checks right before saving early static eval

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -121,12 +121,12 @@ public readonly struct TranspositionTable
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier);
         ref var entry = ref _tt[ttIndex];
 
-        // These extra checks might make sense in a MT environment, TODO check
-        //if (entry.Key == 0                                      // No actual entry
-        //    || (position.UniqueIdentifier >> 48) != entry.Key)   // Different key: collision
-        //{
+        // These extra checks might make sense in a MT environment
+        if (entry.Key == 0                                          // No actual entry
+            || (position.UniqueIdentifier >> 48) != entry.Key)      // Different key: collision
+        {
             entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
-        //}
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Followup of #1561 

[-3, 1] 6+0.06
```
Score of Lynx-mt-early-static-eval-extra-checks-5750-win-x64 vs Lynx 5749 - main: 6662 - 6593 - 10923  [0.501] 24178
...      Lynx-mt-early-static-eval-extra-checks-5750-win-x64 playing White: 4999 - 1585 - 5505  [0.641] 12089
...      Lynx-mt-early-static-eval-extra-checks-5750-win-x64 playing Black: 1663 - 5008 - 5418  [0.362] 12089
...      White vs Black: 10007 - 3248 - 10923  [0.640] 24178
Elo difference: 1.0 +/- 3.2, LOS: 72.6 %, DrawRatio: 45.2 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```

[0, 3] 8+0.08 4t
```
Score of Lynx-mt-early-static-eval-extra-checks-5750-win-x64 vs Lynx 5749 - main: 4066 - 4123 - 8411  [0.498] 16600
...      Lynx-mt-early-static-eval-extra-checks-5750-win-x64 playing White: 3389 - 668 - 4243  [0.664] 8300
...      Lynx-mt-early-static-eval-extra-checks-5750-win-x64 playing Black: 677 - 3455 - 4168  [0.333] 8300
...      White vs Black: 6844 - 1345 - 8411  [0.666] 16600
Elo difference: -1.2 +/- 3.7, LOS: 26.4 %, DrawRatio: 50.7 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```