### PR TITLE
🔍 SPSA continuation history

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -207,13 +207,13 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3107;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2997;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3451;
+    public int LMR_History_Divisor_Noisy { get; set; } = 3948;
 
     [SPSA<int>(20, 100, 8)]
     public int LMR_DeeperBase { get; set; } = 38;
@@ -302,7 +302,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -643;
+    public int HistoryPrunning_Margin { get; set; } = -517;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;


### PR DESCRIPTION
```
iterations: 606 (283.36s per iter)
games: 19392 (8.85s per game)
LMR_History_Divisor_Quiet = 2997(-563.396671) in [1, 8192]
LMR_History_Divisor_Noisy = 3948(+325.54) in [1, 8192]
HistoryPrunning_Margin = -517(+319.79) in [-8192, 0]
```

```
Test  | search/continuation-history-pruning-spsa-2
Elo   | -0.89 +- 3.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 13592: +3306 -3341 =6945
Penta | [182, 1670, 3119, 1651, 174]
https://openbench.lynx-chess.com/test/1479/
```