### PR TITLE
⚡  Check pawns and knights first in InCheck method

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1468,11 +1468,11 @@ public class Position : IDisposable
 
         // I tried to order them from most to least likely - not tested
         return
-            IsSquareAttackedByRooks(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var rookAttacks)
-            || IsSquareAttackedByBishops(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var bishopAttacks)
-            || IsSquareAttackedByQueens(oppositeSideOffset, bishopAttacks, rookAttacks)
+            IsSquareAttackedByPawns(kingSquare, oppositeSideInt, oppositeSideOffset)
             || IsSquareAttackedByKnights(kingSquare, oppositeSideOffset)
-            || IsSquareAttackedByPawns(kingSquare, oppositeSideInt, oppositeSideOffset);
+            || IsSquareAttackedByRooks(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var rookAttacks)
+            || IsSquareAttackedByBishops(kingSquare, oppositeSideOffset, bothSidesOccupancy, out var bishopAttacks)
+            || IsSquareAttackedByQueens(oppositeSideOffset, bishopAttacks, rookAttacks);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Test  | perf/isincheck-pawnsfirst
Elo   | -1.03 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 28998: +7812 -7898 =13288
Penta | [623, 3385, 6555, 3327, 609]
https://openbench.lynx-chess.com/test/1462/
```