### PR TITLE
🔍 Restrict LMP, HP and FP to non-captures (bad captures allowed before)

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -309,7 +309,7 @@ public sealed partial class Engine
                 && !pvNode
                 && !isInCheck
                 && isNotGettingCheckmated
-                && moveScore < EvaluationConstants.PromotionMoveScoreValue) // Quiet move
+                && moveScore < EvaluationConstants.BadCaptureMoveBaseScoreValue) // Quiet move
             {
                 // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                 // after searching the first few given by the move ordering algorithm
@@ -322,8 +322,7 @@ public sealed partial class Engine
 
                 // 🔍 History pruning -  all quiet moves can be pruned
                 // once we find one with a history score too low
-                if (!isCapture
-                    && moveScore < EvaluationConstants.CounterMoveValue
+                if (moveScore < EvaluationConstants.CounterMoveValue
                     && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
                     && _quietHistory[move.Piece()][move.TargetSquare()] < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                 {


### PR DESCRIPTION
```
Test  | search/fail-no-pruning-no-bad-captures
Elo   | -0.72 +- 2.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 35148: +9540 -9613 =15995
Penta | [843, 4331, 7308, 4240, 852]
https://openbench.lynx-chess.com/test/1419/
```