### PR TITLE
⚡ Pawn movegen: Improve branching on double pawn push

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -157,15 +157,19 @@ public static class MoveGenerator
                 else
                 {
                     movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
-                }
 
-                // Double pawn push
-                // Inside of the if because singlePush square cannot be occupied either
-                var doublePushSquare = sourceSquare + (2 * pawnPush);
-                if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare)
-                    && ((sourceRank == 2 && position.Side == Side.Black) || (sourceRank == 7 && position.Side == Side.White)))
-                {
-                    movePool[localIndex++] = MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece);
+                    // Double pawn push
+                    // Inside of the single pawn push if because singlePush square cannot be occupied either
+                    if ((sourceRank == 2 && position.Side == Side.Black)
+                        || (sourceRank == 7 && position.Side == Side.White))
+                    {
+                        var doublePushSquare = sourceSquare + (2 * pawnPush);
+
+                        if (!position.OccupancyBitBoards[2].GetBit(doublePushSquare))
+                        {
+                            movePool[localIndex++] = MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
```
Test  | perf/movegen-double-pawn-ush
Elo   | -0.31 +- 3.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 1.47 (-2.25, 2.89) [-5.00, 0.00]
Games | 17784: +4744 -4760 =8280
Penta | [323, 2081, 4106, 2053, 329]
https://openbench.lynx-chess.com/test/1508/
```