### PR TITLE
🔍 QSearch SEE pruning: don't prune on recaptures

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -705,6 +705,9 @@ public sealed partial class Engine
             return staticEval;
         }
 
+        Debug.Assert(ply > 0);
+        var previousMoveTargetSquare = Game.ReadMoveFromStack(ply - 1).TargetSquare();
+
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
         int bestScore = eval;
@@ -732,9 +735,12 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[moveIndex];
             var moveScore = moveScores[moveIndex];
+            bool isRecapture = previousMoveTargetSquare == move.TargetSquare();
 
             // 🔍 QSearch SEE pruning: pruning bad captures
-            if (moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            if (!isRecapture
+                && moveScore < EvaluationConstants.PromotionMoveScoreValue
+                && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
             {
                 continue;
             }


### PR DESCRIPTION
```
Score of Lynx-search-qsearch-isrecapture-5784-win-x64 vs Lynx 5781 - main: 1149 - 1265 - 2236  [0.488] 4650
...      Lynx-search-qsearch-isrecapture-5784-win-x64 playing White: 909 - 284 - 1132  [0.634] 2325
...      Lynx-search-qsearch-isrecapture-5784-win-x64 playing Black: 240 - 981 - 1104  [0.341] 2325
...      White vs Black: 1890 - 524 - 2236  [0.647] 4650
Elo difference: -8.7 +/- 7.2, LOS: 0.9 %, DrawRatio: 48.1 %
SPRT: llr -2.26 (-78.4%), lbound -2.25, ubound 2.89 - H0 was accepted
```