### PR TITLE
🔍 QSearch LMP

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -324,8 +324,6 @@ public sealed class EngineSettings
     [SPSA<int>(-150, -50, 10)]
     public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
 
-    public int QS_
-
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -274,6 +274,9 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
+    //[SPSA<int>(1, 5, 0.5)]
+    public int LMP_QSearch_MovesToTry { get; set; } = 2;
+
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     /// <summary>
@@ -320,6 +323,8 @@ public sealed class EngineSettings
 
     [SPSA<int>(-150, -50, 10)]
     public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
+
+    public int QS_
 
     #endregion
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -717,6 +717,7 @@ public sealed partial class Engine
             moveScores[i] = ScoreMoveQSearch(pseudoLegalMoves[i], ttBestMove);
         }
 
+        int visitedMovesCounter = 0;
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
@@ -732,6 +733,12 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[moveIndex];
             var moveScore = moveScores[moveIndex];
+
+            // 🔍 QSearch LMP: prune all moves once a number of them have been visited
+            if (visitedMovesCounter >= Configuration.EngineSettings.LMP_QSearch_MovesToTry)
+            {
+                break;
+            }
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
@@ -786,6 +793,8 @@ public sealed partial class Engine
                     nodeType = NodeType.Exact;
                 }
             }
+
+            ++visitedMovesCounter;
         }
 
         if (!isAnyCaptureValid

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -567,6 +567,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmp_qsearch_movestotry":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMP_QSearch_MovesToTry = value;
+                    }
+                    break;
+                }
             case "history_maxmovevalue":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
\>= 2
```
Score of Lynx-search-qsearch-lmp-5787-win-x64 vs Lynx 5781 - main: 11891 - 11828 - 22121  [0.501] 45840
...      Lynx-search-qsearch-lmp-5787-win-x64 playing White: 9357 - 2461 - 11102  [0.650] 22920
...      Lynx-search-qsearch-lmp-5787-win-x64 playing Black: 2534 - 9367 - 11019  [0.351] 22920
...      White vs Black: 18724 - 4995 - 22121  [0.650] 45840
Elo difference: 0.5 +/- 2.3, LOS: 65.9 %, DrawRatio: 48.3 %
SPRT: llr -2.25 (-77.9%), lbound -2.25, ubound 2.89 - H0 was accepted
```

40+0.4
```
Score of Lynx-search-qsearch-lmp-5787-win-x64 vs Lynx 5781 - main: 5444 - 5422 - 11854  [0.500] 22720
...      Lynx-search-qsearch-lmp-5787-win-x64 playing White: 4683 - 771 - 5906  [0.672] 11360
...      Lynx-search-qsearch-lmp-5787-win-x64 playing Black: 761 - 4651 - 5948  [0.329] 11360
...      White vs Black: 9334 - 1532 - 11854  [0.672] 22720
Elo difference: 0.3 +/- 3.1, LOS: 58.4 %, DrawRatio: 52.2 %
SPRT: llr -1.37 (-47.5%), lbound -2.25, ubound 2.89
```

\>= 3
```
Score of Lynx-search-qsearch-lmp-5787-win-x64-mod vs Lynx 5781 - main: 2853 - 2944 - 5166  [0.496] 10963
...      Lynx-search-qsearch-lmp-5787-win-x64-mod playing White: 2238 - 647 - 2598  [0.645] 5483
...      Lynx-search-qsearch-lmp-5787-win-x64-mod playing Black: 615 - 2297 - 2568  [0.347] 5480
...      White vs Black: 4535 - 1262 - 5166  [0.649] 10963
Elo difference: -2.9 +/- 4.7, LOS: 11.6 %, DrawRatio: 47.1 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```