### PR TITLE
🔍 QSearch LMP with `!inCheck` guard

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -324,8 +324,6 @@ public sealed class EngineSettings
     [SPSA<int>(-150, -50, 10)]
     public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
 
-    public int QS_
-
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -274,6 +274,9 @@ public sealed class EngineSettings
     //[SPSA<int>(0, 10, 0.5)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
+    //[SPSA<int>(1, 5, 0.5)]
+    public int LMP_QSearch_MovesToTry { get; set; } = 2;
+
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     /// <summary>
@@ -320,6 +323,8 @@ public sealed class EngineSettings
 
     [SPSA<int>(-150, -50, 10)]
     public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
+
+    public int QS_
 
     #endregion
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -717,6 +717,7 @@ public sealed partial class Engine
             moveScores[i] = ScoreMoveQSearch(pseudoLegalMoves[i], ttBestMove);
         }
 
+        int visitedMovesCounter = 0;
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
@@ -732,6 +733,12 @@ public sealed partial class Engine
 
             var move = pseudoLegalMoves[moveIndex];
             var moveScore = moveScores[moveIndex];
+
+            // 🔍 QSearch LMP: prune all moves once a number of them have been visited
+            if (visitedMovesCounter >= Configuration.EngineSettings.LMP_QSearch_MovesToTry)
+            {
+                break;
+            }
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
@@ -786,6 +793,8 @@ public sealed partial class Engine
                     nodeType = NodeType.Exact;
                 }
             }
+
+            ++visitedMovesCounter;
         }
 
         if (!isAnyCaptureValid

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -735,7 +735,7 @@ public sealed partial class Engine
             var moveScore = moveScores[moveIndex];
 
             // 🔍 QSearch LMP: prune all moves once a number of them have been visited
-            if (visitedMovesCounter >= Configuration.EngineSettings.LMP_QSearch_MovesToTry)
+            if (!isInCheck && visitedMovesCounter >= Configuration.EngineSettings.LMP_QSearch_MovesToTry)
             {
                 break;
             }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -567,6 +567,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmp_qsearch_movestotry":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMP_QSearch_MovesToTry = value;
+                    }
+                    break;
+                }
             case "history_maxmovevalue":
                 {
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))


### PR DESCRIPTION
#1582 without guard

```
Score of Lynx-search-qsearch-lmp-incheck-guard-5788-win-x64 vs Lynx 5781 - main: 1590 - 1701 - 2947  [0.491] 6238
...      Lynx-search-qsearch-lmp-incheck-guard-5788-win-x64 playing White: 1237 - 358 - 1523  [0.641] 3118
...      Lynx-search-qsearch-lmp-incheck-guard-5788-win-x64 playing Black: 353 - 1343 - 1424  [0.341] 3120
...      White vs Black: 2580 - 711 - 2947  [0.650] 6238
Elo difference: -6.2 +/- 6.3, LOS: 2.7 %, DrawRatio: 47.2 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```