### PR TITLE
🐛 Fix LMR clamping

### DIFF
--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -162,9 +162,17 @@ public sealed partial class Engine
         var piece = move.Piece();
         var targetSquare = move.TargetSquare();
 
+        try
+        {
+
         _quietHistory[piece][targetSquare] = ScoreHistoryMove(
             _quietHistory[piece][targetSquare],
             HistoryBonus[depth]);
+        }
+        catch(Exception e)
+        {
+            ;
+        }
 
         int continuationHistoryIndex;
         int previousMovePiece = -1;

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -162,17 +162,9 @@ public sealed partial class Engine
         var piece = move.Piece();
         var targetSquare = move.TargetSquare();
 
-        try
-        {
-
         _quietHistory[piece][targetSquare] = ScoreHistoryMove(
             _quietHistory[piece][targetSquare],
             HistoryBonus[depth]);
-        }
-        catch(Exception e)
-        {
-            ;
-        }
 
         int continuationHistoryIndex;
         int previousMovePiece = -1;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -465,10 +465,6 @@ public sealed partial class Engine
                                 // -= history/(maxHistory/2)
 
                                 reduction -= QuietHistory() / Configuration.EngineSettings.LMR_History_Divisor_Quiet;
-
-                                // Don't allow LMR to drop into qsearch or increase the depth
-                                // depth - 1 - depth +2 = 1, min depth we want
-                                reduction = Math.Clamp(reduction, 0, depth - 2);
                             }
                         }
 
@@ -481,11 +477,11 @@ public sealed partial class Engine
                             && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
                         {
                             reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
-                            reduction = Math.Clamp(reduction, 0, depth - 1);
                         }
                     }
 
-                    var reducedDepth = newDepth - reduction;
+                    // Don't allow LMR to drop into qsearch or increase the depth
+                    var reducedDepth = Math.Clamp(newDepth - reduction, 0, newDepth);
 
                     // Search with reduced depth and zero window
                     score = -NegaMax(reducedDepth, ply + 1, -alpha - 1, -alpha, cutnode: true, cancellationToken);


### PR DESCRIPTION
<details>

<Summary>logs</Summary>

Before
```bash
position fen r1n1n1b1/1P1P1P1P/1N1N1N2/2RnQrRq/2pKp3/3BNQbQ/k7/4Bq2 w - - 0 1
go infinite
info depth 1 seldepth 25 multipv 1 score cp 2137 nodes 3971741 nps 1663075 time 2388 pv b7a8q a2b3
info depth 2 seldepth 27 multipv 1 score cp 2395 nodes 10760832 nps 1694950 time 6349 pv b7a8q c8a7 a8a7 a2b3
info depth 3 seldepth 27 multipv 1 score cp 2686 nodes 12085284 nps 1715932 time 7043 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 f3f1 g3e5 c4e5
info depth 4 seldepth 27 multipv 1 score mate 4 nodes 12229632 nps 1715437 time 7129 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 5 seldepth 27 multipv 1 score mate 4 nodes 12230219 nps 1715427 time 7130 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 6 seldepth 27 multipv 1 score mate 4 nodes 12230781 nps 1715437 time 7130 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 7 seldepth 27 multipv 1 score mate 4 nodes 12232352 nps 1715381 time 7131 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 8 seldepth 27 multipv 1 score mate 4 nodes 12235678 nps 1715231 time 7134 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 9 seldepth 27 multipv 1 score mate 4 nodes 12236595 nps 1715222 time 7134 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 10 seldepth 27 multipv 1 score mate 4 nodes 12239145 nps 1715166 time 7136 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 11 seldepth 27 multipv 1 score mate 4 nodes 12246186 nps 1715048 time 7140 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 12 seldepth 27 multipv 1 score mate 4 nodes 12250875 nps 1714861 time 7144 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 13 seldepth 27 multipv 1 score mate 4 nodes 12261005 nps 1714678 time 7151 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 14 seldepth 27 multipv 1 score mate 4 nodes 12270388 nps 1714530 time 7157 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 15 seldepth 27 multipv 1 score mate 4 nodes 12286064 nps 1714073 time 7168 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 16 seldepth 27 multipv 1 score mate 4 nodes 12298455 nps 1713958 time 7175 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 17 seldepth 27 multipv 1 score mate 4 nodes 12308024 nps 1713832 time 7182 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 18 seldepth 27 multipv 1 score mate 4 nodes 12343815 nps 1713487 time 7204 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 19 seldepth 27 multipv 1 score mate 4 nodes 12369755 nps 1712831 time 7222 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 20 seldepth 27 multipv 1 score mate 4 nodes 12451059 nps 1712408 time 7271 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 21 seldepth 27 multipv 1 score mate 4 nodes 12506023 nps 1711813 time 7306 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 22 seldepth 27 multipv 1 score mate 4 nodes 12655287 nps 1711452 time 7394 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 23 seldepth 27 multipv 1 score mate 4 nodes 12759525 nps 1712507 time 7451 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 24 seldepth 27 multipv 1 score mate 4 nodes 12982559 nps 1713218 time 7578 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 25 seldepth 27 multipv 1 score mate 4 nodes 13176488 nps 1714062 time 7687 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 26 seldepth 27 multipv 1 score mate 4 nodes 13510757 nps 1716793 time 7870 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 27 seldepth 27 multipv 1 score mate 4 nodes 13757963 nps 1719446 time 8001 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 28 seldepth 27 multipv 1 score mate 4 nodes 14300978 nps 1722741 time 8301 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 29 seldepth 27 multipv 1 score mate 4 nodes 15003862 nps 1733005 time 8658 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 30 seldepth 27 multipv 1 score mate 4 nodes 15339284 nps 1737873 time 8826 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 30 seldepth 27 multipv 1 score mate 4 nodes 15426821 nps 1733536 time 8899 hashfull 364 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
bestmove b7a8q ponder c8a7
21:47:03 | [ERROR] [#1] Depth 31: unexpected error ocurred during the search of position "r1n1n1b1/1P1P1P1P/1N1N1N2/2RnQrRq/2pKp3/3BNQbQ/k7/4Bq2 w - - 0 1", best move will be returned
 System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 583
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 491
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 491
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 491
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 491
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 491
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove) in C:\dev\personal\Lynx\src\Lynx\Search\NegaMax.cs:line 525
   at Lynx.Engine.IDDFS(Boolean isPondering, CancellationToken cancellationToken) in C:\dev\personal\Lynx\src\Lynx\Search\IDDFS.cs:line 148
```


After:
```
position fen r1n1n1b1/1P1P1P1P/1N1N1N2/2RnQrRq/2pKp3/3BNQbQ/k7/4Bq2 w - - 0 1
go infinite
info depth 1 seldepth 25 multipv 1 score cp 2137 nodes 3971741 nps 646748 time 6141 pv b7a8q a2b3
info depth 2 seldepth 27 multipv 1 score cp 2395 nodes 10760832 nps 664138 time 16203 pv b7a8q c8a7 a8a7 a2b3
info depth 3 seldepth 27 multipv 1 score cp 2686 nodes 12085284 nps 659304 time 18330 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 f3f1 g3e5 c4e5
info depth 4 seldepth 27 multipv 1 score mate 4 nodes 12229632 nps 658685 time 18567 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 5 seldepth 27 multipv 1 score mate 4 nodes 12230219 nps 658672 time 18568 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 6 seldepth 27 multipv 1 score mate 4 nodes 12230781 nps 658662 time 18569 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 7 seldepth 27 multipv 1 score mate 4 nodes 12232352 nps 658614 time 18573 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 8 seldepth 27 multipv 1 score mate 4 nodes 12235678 nps 658497 time 18581 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 9 seldepth 27 multipv 1 score mate 4 nodes 12236596 nps 658473 time 18583 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 10 seldepth 27 multipv 1 score mate 4 nodes 12239146 nps 658397 time 18589 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 11 seldepth 27 multipv 1 score mate 4 nodes 12246187 nps 658225 time 18605 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 12 seldepth 27 multipv 1 score mate 4 nodes 12250876 nps 658123 time 18615 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 13 seldepth 27 multipv 1 score mate 4 nodes 12261006 nps 658044 time 18633 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 14 seldepth 27 multipv 1 score mate 4 nodes 12270389 nps 657866 time 18652 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 15 seldepth 27 multipv 1 score mate 4 nodes 12285755 nps 657693 time 18680 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 16 seldepth 27 multipv 1 score mate 4 nodes 12297880 nps 657641 time 18700 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 17 seldepth 27 multipv 1 score mate 4 nodes 12307933 nps 657403 time 18722 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 18 seldepth 27 multipv 1 score mate 4 nodes 12343672 nps 656671 time 18797 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 19 seldepth 27 multipv 1 score mate 4 nodes 12368036 nps 656474 time 18840 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 20 seldepth 27 multipv 1 score mate 4 nodes 12447607 nps 655371 time 18993 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 21 seldepth 27 multipv 1 score mate 4 nodes 12498148 nps 654191 time 19105 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 22 seldepth 27 multipv 1 score mate 4 nodes 12649561 nps 652179 time 19396 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 23 seldepth 27 multipv 1 score mate 4 nodes 12747673 nps 650937 time 19584 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 24 seldepth 27 multipv 1 score mate 4 nodes 12975215 nps 650251 time 19954 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 25 seldepth 27 multipv 1 score mate 4 nodes 13160174 nps 648930 time 20280 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 26 seldepth 27 multipv 1 score mate 4 nodes 13490729 nps 646897 time 20855 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 27 seldepth 27 multipv 1 score mate 4 nodes 13747428 nps 646765 time 21256 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 28 seldepth 27 multipv 1 score mate 4 nodes 14194485 nps 644839 time 22012 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 29 seldepth 27 multipv 1 score mate 4 nodes 14888789 nps 644956 time 23085 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 30 seldepth 27 multipv 1 score mate 4 nodes 15229246 nps 644175 time 23641 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 31 seldepth 27 multipv 1 score mate 4 nodes 16154749 nps 644576 time 25063 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
info depth 32 seldepth 30 multipv 1 score mate 4 nodes 26533719 nps 554800 time 47826 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
 stop
info depth 32 seldepth 33 multipv 1 score mate 4 nodes 81766180 nps 540339 time 151324 hashfull 915 pv b7a8q c8a7 a8a7 a2b2 b6c4 b2b3 a7a3
bestmove b7a8q ponder c8a7
```

</details>

```
Test  | bugfix/lmr-clamping
Elo   | -1.29 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 70634: +18861 -19123 =32650
Penta | [1657, 8642, 14913, 8516, 1589]
https://openbench.lynx-chess.com/test/1516/
```