### PR TITLE
Double max supported moves per game to 1024

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -321,7 +321,7 @@ public static class Constants
     /// </summary>
     public const int MaxNumberOfPossibleMovesInAPosition = 250;
 
-    public const int MaxNumberMovesInAGame = 1024;
+    public const int MaxNumberMovesInAGame = 2048;
 
     public static readonly int SideLimit = Enum.GetValues<Piece>().Length / 2;
 

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -40,7 +40,6 @@ public sealed class Game : IDisposable
 
     public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool)
     {
-        Debug.Assert(Constants.MaxNumberMovesInAGame <= 1024, "Assert fail", "Need to customized ArrayPool due to desired array size requirements");
         _positionHashHistory = ArrayPool<ulong>.Shared.Rent(Constants.MaxNumberMovesInAGame);
         _gameStack = ArrayPool<PlyStackEntry>.Shared.Rent(Constants.MaxNumberMovesInAGame);
 

--- a/tests/Lynx.Test/ConstantsTest.cs
+++ b/tests/Lynx.Test/ConstantsTest.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+using System.Buffers;
 using System.Collections.Frozen;
 using static Lynx.Constants;
 
@@ -154,5 +155,11 @@ public class ConstantsTest
         {
             Assert.AreEqual((sq >> 3) + 1, 8 - Constants.Rank[sq]);
         }
+    }
+
+    [Test]
+    public void MaxNumberMovesInAGame()
+    {
+        Assert.Less(Constants.MaxNumberMovesInAGame, 1024 * 1024, "We'd need to customize ArrayPool due to desired array size requirements");
     }
 }


### PR DESCRIPTION
```
Score of Lynx-refactor-bump-max-moves-5793-win-x64 vs Lynx 5790 - main: 4189 - 4203 - 7959  [0.500] 16351
...      Lynx-refactor-bump-max-moves-5793-win-x64 playing White: 3315 - 871 - 3989  [0.649] 8175
...      Lynx-refactor-bump-max-moves-5793-win-x64 playing Black: 874 - 3332 - 3970  [0.350] 8176
...      White vs Black: 6647 - 1745 - 7959  [0.650] 16351
Elo difference: -0.3 +/- 3.8, LOS: 43.9 %, DrawRatio: 48.7 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```