### PR TITLE
🔍 Continuation history: follow-up history II

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -174,7 +174,11 @@ public static class EvaluationConstants
 
     #endregion
 
-    public const int ContinuationHistoryPlyCount = 1;
+    public const int ContinuationHistoryPlyCount = 2;
+
+    public const int CounterMoveHistoryIndex = 0;
+
+    public const int FollowUpMoveHistoryIndex = 1;
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -1,6 +1,5 @@
 ﻿using NLog;
 using System.Buffers;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Lynx.Model;
@@ -235,13 +234,13 @@ public sealed class Game : IDisposable
     public Move ReadMoveFromStack(int n) => _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount].Move;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int ReadStaticEvalFromStack(int n) => _gameStack[n].StaticEval;
+    public int ReadStaticEvalFromStack(int n) => _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int UpdateStaticEvalInStack(int n, int value) => _gameStack[n].StaticEval = value;
+    public int UpdateStaticEvalInStack(int n, int value) => _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval = value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref PlyStackEntry GameStack(int n) => ref _gameStack[n];
+    public ref PlyStackEntry GameStack(int n) => ref _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int PositionHashHistoryLength() => _positionHashHistoryPointer;

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -207,7 +207,7 @@ public sealed partial class Engine
                 rawHistoryBonus);
 
             // - Follow-up history (continuation history, ply - 2)
-            if (ply > 2)
+            if (ply >= 2)
             {
                 var previousPreviousMove = Game.ReadMoveFromStack(ply - 2);
                 Debug.Assert(previousPreviousMove != 0);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -269,6 +269,7 @@ public sealed partial class Engine
         Move? bestMove = null;
         bool isAnyMoveValid = false;
         var previousMove = Game.ReadMoveFromStack(ply - 1);
+        var previousPreviousMove = Game.ReadMoveFromStack(ply - 2);
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
         int visitedMovesCounter = 0;
@@ -294,7 +295,9 @@ public sealed partial class Engine
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
-                _quietHistory[move.Piece()][move.TargetSquare()] + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
+                _quietHistory[move.Piece()][move.TargetSquare()]
+                + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), EvaluationConstants.CounterMoveHistoryIndex)]
+                + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousPreviousMove.Piece(), previousPreviousMove.TargetSquare(), EvaluationConstants.FollowUpMoveHistoryIndex)];
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;


### PR DESCRIPTION
Tried in https://github.com/lynx-chess/Lynx/pull/1148

```
Test  | search/followup-history
Elo   | -6.42 +- 4.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 8010: +2055 -2203 =3752
Penta | [197, 1008, 1698, 950, 152]
https://openbench.lynx-chess.com/test/1519/
```