### PR TITLE
🧹 Refactor `ContinuationHistory` ,abstracting array usage

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -78,6 +78,27 @@ public sealed partial class Engine
     }
 
     /// <summary>
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int ContinuationHistoryEntry(int piece, int targetSquare, int ply)
+    {
+        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
+
+        var previousMove = Game.ReadMoveFromStack(ply);
+
+        return ref _continuationHistory[
+            (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset)
+            + (previousMove.Piece() * previousMovePieceOffset)
+            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
+            //+ 0];
+    }
+
+    /// <summary>
     /// [64][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -166,10 +166,6 @@ public sealed partial class Engine
             _quietHistory[piece][targetSquare],
             HistoryBonus[depth]);
 
-        int continuationHistoryIndex;
-        int previousMovePiece = -1;
-        int previousTargetSquare = -1;
-
         if (!isRoot)
         {
             // 🔍 Continuation history
@@ -177,14 +173,8 @@ public sealed partial class Engine
             var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
-            previousMovePiece = previousMove.Piece();
-            previousTargetSquare = previousMove.TargetSquare();
-
-            continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
-
-            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                _continuationHistory[continuationHistoryIndex],
-                HistoryBonus[depth]);
+            ref var continuationHistoryEntry = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
+            continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, HistoryBonus[depth]);
 
             //    var previousPreviousMove = Game.MoveStack[ply - 2];
             //    var previousPreviousMovePiece = previousPreviousMove.Piece();
@@ -213,11 +203,8 @@ public sealed partial class Engine
                 if (!isRoot)
                 {
                     // 🔍 Continuation history penalty / malus
-                    continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
-
-                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                        _continuationHistory[continuationHistoryIndex],
-                        -HistoryBonus[depth]);
+                    ref var continuationHistoryEntry = ref ContinuationHistoryEntry(visitedMovePiece, visitedMoveTargetSquare, ply - 1);
+                    continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, -HistoryBonus[depth]);
                 }
             }
         }
@@ -238,7 +225,8 @@ public sealed partial class Engine
             if (!isRoot && (depth >= Configuration.EngineSettings.CounterMoves_MinDepth || pvNode))
             {
                 // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
-                _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
+                _counterMoves[CounterMoveIndex(previousMove.Piece(), previousMove.TargetSquare())] = move;
             }
         }
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -268,7 +268,6 @@ public sealed partial class Engine
         int bestScore = EvaluationConstants.MinEval;
         Move? bestMove = null;
         bool isAnyMoveValid = false;
-        var previousMove = Game.ReadMoveFromStack(ply - 1);
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
         int visitedMovesCounter = 0;
@@ -294,7 +293,8 @@ public sealed partial class Engine
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
-                _quietHistory[move.Piece()][move.TargetSquare()] + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
+                _quietHistory[move.Piece()][move.TargetSquare()]
+                + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;


### PR DESCRIPTION
```
Score of Lynx-search-conthis-refactor-5803-win-x64 vs Lynx 5802 - main: 5385 - 5548 - 9901  [0.496] 20834
...      Lynx-search-conthis-refactor-5803-win-x64 playing White: 4250 - 1228 - 4940  [0.645] 10418
...      Lynx-search-conthis-refactor-5803-win-x64 playing Black: 1135 - 4320 - 4961  [0.347] 10416
...      White vs Black: 8570 - 2363 - 9901  [0.649] 20834
Elo difference: -2.7 +/- 3.4, LOS: 6.0 %, DrawRatio: 47.5 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```