### PR TITLE
🔍 Improving: strictly greater

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -146,7 +146,7 @@ public sealed partial class Engine
             if (ply >= 2)
             {
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
-                improving = evalDiff >= 0;
+                improving = evalDiff > 0;
                 improvingRate = evalDiff / 50.0;
             }
 


### PR DESCRIPTION
```
Test  | search/improving-strictly-greater
Elo   | -4.79 +- 4.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 10882: +2818 -2968 =5096
Penta | [259, 1387, 2275, 1285, 235]
https://openbench.lynx-chess.com/test/1514/
```