### PR TITLE
🧹 History refactor II

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -49,32 +49,15 @@ public sealed partial class Engine
     /// [12][64][12]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int CaptureHistoryIndex(int piece, int targetSquare, int capturedPiece)
+    private ref int CaptureHistoryEntry(Move move)
     {
         const int pieceOffset = 64 * 12;
         const int targetSquareOffset = 12;
 
-        return (piece * pieceOffset)
-            + (targetSquare * targetSquareOffset)
-            + capturedPiece;
-    }
-
-    /// <summary>
-    /// [12][64][12][64][ContinuationHistoryPlyCount]
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ContinuationHistoryIndex(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
-    {
-        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
-
-        return (piece * pieceOffset)
-            + (targetSquare * targetSquareOffset)
-            + (previousMovePiece * previousMovePieceOffset)
-            + (previousMoveTargetSquare * previousMoveTargetSquareOffset)
-            + ply;
+        return ref _captureHistory[
+            (move.Piece() * pieceOffset)
+            + (move.TargetSquare() * targetSquareOffset)
+            + move.CapturedPiece()];
     }
 
     /// <summary>
@@ -99,15 +82,18 @@ public sealed partial class Engine
     }
 
     /// <summary>
-    /// [64][64]
+    /// [12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int CounterMoveIndex(int previousMoveSourceSquare, int previousMoveTargetSquare)
+    private ref Move CounterMove(int ply)
     {
         const int sourceSquareOffset = 64;
 
-        return (previousMoveSourceSquare * sourceSquareOffset)
-            + previousMoveTargetSquare;
+        var previousMove = Game.ReadMoveFromStack(ply);
+
+        return ref _counterMoves[
+            (previousMove.Piece() * sourceSquareOffset)
+            + previousMove.TargetSquare()];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -78,6 +78,27 @@ public sealed partial class Engine
     }
 
     /// <summary>
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int ContinuationHistoryEntry(int piece, int targetSquare, int ply)
+    {
+        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
+
+        var previousMove = Game.ReadMoveFromStack(ply);
+
+        return ref _continuationHistory[
+            (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset)
+            + (previousMove.Piece() * previousMovePieceOffset)
+            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
+            //+ 0];
+    }
+
+    /// <summary>
     /// [64][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -166,10 +166,6 @@ public sealed partial class Engine
             _quietHistory[piece][targetSquare],
             HistoryBonus[depth]);
 
-        int continuationHistoryIndex;
-        int previousMovePiece = -1;
-        int previousTargetSquare = -1;
-
         if (!isRoot)
         {
             // 🔍 Continuation history
@@ -177,14 +173,8 @@ public sealed partial class Engine
             var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
-            previousMovePiece = previousMove.Piece();
-            previousTargetSquare = previousMove.TargetSquare();
-
-            continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
-
-            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                _continuationHistory[continuationHistoryIndex],
-                HistoryBonus[depth]);
+            ref var continuationHistoryEntry = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
+            continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, HistoryBonus[depth]);
 
             //    var previousPreviousMove = Game.MoveStack[ply - 2];
             //    var previousPreviousMovePiece = previousPreviousMove.Piece();
@@ -213,11 +203,8 @@ public sealed partial class Engine
                 if (!isRoot)
                 {
                     // 🔍 Continuation history penalty / malus
-                    continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
-
-                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                        _continuationHistory[continuationHistoryIndex],
-                        -HistoryBonus[depth]);
+                    ref var continuationHistoryEntry = ref ContinuationHistoryEntry(visitedMovePiece, visitedMoveTargetSquare, ply - 1);
+                    continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, -HistoryBonus[depth]);
                 }
             }
         }
@@ -238,7 +225,8 @@ public sealed partial class Engine
             if (!isRoot && (depth >= Configuration.EngineSettings.CounterMoves_MinDepth || pvNode))
             {
                 // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
-                _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
+                _counterMoves[CounterMoveIndex(previousMove.Piece(), previousMove.TargetSquare())] = move;
             }
         }
     }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -167,19 +167,8 @@ public sealed partial class Engine
         {
             // 🔍 Continuation history
             // - Counter move history (continuation history, ply - 1)
-            var previousMove = Game.ReadMoveFromStack(ply - 1);
-            Debug.Assert(previousMove != 0);
-
             ref var continuationHistoryEntry = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
             continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, rawHistoryBonus);
-
-            //    var previousPreviousMove = Game.MoveStack[ply - 2];
-            //    var previousPreviousMovePiece = previousPreviousMove.Piece();
-            //    var previousPreviousMoveTargetSquare = previousPreviousMove.TargetSquare();
-
-            //    _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare] = ScoreHistoryMove(
-            //        _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare],
-            //        EvaluationConstants.HistoryBonus[depth]);
         }
 
         for (int i = 0; i < visitedMovesCounter - 1; ++i)
@@ -193,7 +182,6 @@ public sealed partial class Engine
 
                 // 🔍 Quiet history penalty / malus
                 // When a quiet move fails high, penalize previous visited quiet moves
-
                 ref var quietHistoryEntry = ref _quietHistory[visitedMovePiece][visitedMoveTargetSquare];
                 quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryBonus);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -268,7 +268,6 @@ public sealed partial class Engine
         int bestScore = EvaluationConstants.MinEval;
         Move? bestMove = null;
         bool isAnyMoveValid = false;
-        var previousMove = Game.ReadMoveFromStack(ply - 1);
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
         int visitedMovesCounter = 0;
@@ -294,7 +293,8 @@ public sealed partial class Engine
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
-                _quietHistory[move.Piece()][move.TargetSquare()] + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
+                _quietHistory[move.Piece()][move.TargetSquare()]
+                + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -424,7 +424,7 @@ public sealed partial class Engine
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // ~ history/(0.75 * maxHistory/2/)
-                                reduction -= _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())] / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
+                                reduction -= CaptureHistoryEntry(move) / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
                             }
                             else
                             {


### PR DESCRIPTION
```
Score of Lynx-search-hist-refactor-2-5807-win-x64 vs Lynx 5805 - main: 1890 - 1777 - 3284  [0.508] 6951
...      Lynx-search-hist-refactor-2-5807-win-x64 playing White: 1471 - 401 - 1605  [0.654] 3477
...      Lynx-search-hist-refactor-2-5807-win-x64 playing Black: 419 - 1376 - 1679  [0.362] 3474
...      White vs Black: 2847 - 820 - 3284  [0.646] 6951
Elo difference: 5.6 +/- 5.9, LOS: 96.9 %, DrawRatio: 47.2 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```