### PR TITLE
🔍 Continuation history: follow-up history III

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -174,7 +174,11 @@ public static class EvaluationConstants
 
     #endregion
 
-    public const int ContinuationHistoryPlyCount = 1;
+    public const int ContinuationHistoryPlyCount = 2;
+
+    public const int CounterMoveHistoryIndex = 0;
+
+    public const int FollowUpMoveHistoryIndex = 1;
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -49,32 +49,15 @@ public sealed partial class Engine
     /// [12][64][12]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int CaptureHistoryIndex(int piece, int targetSquare, int capturedPiece)
+    private ref int CaptureHistoryEntry(Move move)
     {
         const int pieceOffset = 64 * 12;
         const int targetSquareOffset = 12;
 
-        return (piece * pieceOffset)
-            + (targetSquare * targetSquareOffset)
-            + capturedPiece;
-    }
-
-    /// <summary>
-    /// [12][64][12][64][ContinuationHistoryPlyCount]
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ContinuationHistoryIndex(int piece, int targetSquare, int previousMovePiece, int previousMoveTargetSquare, int ply)
-    {
-        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
-        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
-
-        return (piece * pieceOffset)
-            + (targetSquare * targetSquareOffset)
-            + (previousMovePiece * previousMovePieceOffset)
-            + (previousMoveTargetSquare * previousMoveTargetSquareOffset)
-            + ply;
+        return ref _captureHistory[
+            (move.Piece() * pieceOffset)
+            + (move.TargetSquare() * targetSquareOffset)
+            + move.CapturedPiece()];
     }
 
     /// <summary>
@@ -99,15 +82,18 @@ public sealed partial class Engine
     }
 
     /// <summary>
-    /// [64][64]
+    /// [12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int CounterMoveIndex(int previousMoveSourceSquare, int previousMoveTargetSquare)
+    private ref Move CounterMove(int ply)
     {
         const int sourceSquareOffset = 64;
 
-        return (previousMoveSourceSquare * sourceSquareOffset)
-            + previousMoveTargetSquare;
+        var previousMove = Game.ReadMoveFromStack(ply);
+
+        return ref _counterMoves[
+            (previousMove.Piece() * sourceSquareOffset)
+            + previousMove.TargetSquare()];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -78,6 +78,27 @@ public sealed partial class Engine
     }
 
     /// <summary>
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int ContinuationHistoryEntry(int piece, int targetSquare, int ply)
+    {
+        const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMovePieceOffset = 64 * EvaluationConstants.ContinuationHistoryPlyCount;
+        const int previousMoveTargetSquareOffset = EvaluationConstants.ContinuationHistoryPlyCount;
+
+        var previousMove = Game.ReadMoveFromStack(ply);
+
+        return ref _continuationHistory[
+            (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset)
+            + (previousMove.Piece() * previousMovePieceOffset)
+            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
+            //+ 0];
+    }
+
+    /// <summary>
     /// [64][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -64,7 +64,21 @@ public sealed partial class Engine
     /// [12][64][12][64][ContinuationHistoryPlyCount]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref int ContinuationHistoryEntry(int piece, int targetSquare, int ply)
+    private ref int CounterMoveHistoryEntry(int piece, int targetSquare, int ply)
+        => ref ContinuationHistoryEntry(piece, targetSquare, ply - 1, EvaluationConstants.CounterMoveHistoryIndex);
+
+    /// <summary>
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int FollowUpHistoryEntry(int piece, int targetSquare, int ply)
+        => ref ContinuationHistoryEntry(piece, targetSquare, ply - 2, EvaluationConstants.FollowUpMoveHistoryIndex);
+
+    /// <summary>
+    /// [12][64][12][64][ContinuationHistoryPlyCount]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int ContinuationHistoryEntry(int piece, int targetSquare, int ply, int continuationHistoryIndex)
     {
         const int pieceOffset = 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
         const int targetSquareOffset = 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount;
@@ -77,8 +91,8 @@ public sealed partial class Engine
             (piece * pieceOffset)
             + (targetSquare * targetSquareOffset)
             + (previousMove.Piece() * previousMovePieceOffset)
-            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
-            //+ 0];
+            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)
+            + continuationHistoryIndex];
     }
 
     /// <summary>

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -166,10 +166,6 @@ public sealed partial class Engine
             _quietHistory[piece][targetSquare],
             HistoryBonus[depth]);
 
-        int continuationHistoryIndex;
-        int previousMovePiece = -1;
-        int previousTargetSquare = -1;
-
         if (!isRoot)
         {
             // 🔍 Continuation history
@@ -177,14 +173,8 @@ public sealed partial class Engine
             var previousMove = Game.ReadMoveFromStack(ply - 1);
             Debug.Assert(previousMove != 0);
 
-            previousMovePiece = previousMove.Piece();
-            previousTargetSquare = previousMove.TargetSquare();
-
-            continuationHistoryIndex = ContinuationHistoryIndex(piece, targetSquare, previousMovePiece, previousTargetSquare, 0);
-
-            _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                _continuationHistory[continuationHistoryIndex],
-                HistoryBonus[depth]);
+            ref var continuationHistoryEntry = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
+            continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, HistoryBonus[depth]);
 
             //    var previousPreviousMove = Game.MoveStack[ply - 2];
             //    var previousPreviousMovePiece = previousPreviousMove.Piece();
@@ -213,11 +203,8 @@ public sealed partial class Engine
                 if (!isRoot)
                 {
                     // 🔍 Continuation history penalty / malus
-                    continuationHistoryIndex = ContinuationHistoryIndex(visitedMovePiece, visitedMoveTargetSquare, previousMovePiece, previousTargetSquare, 0);
-
-                    _continuationHistory[continuationHistoryIndex] = ScoreHistoryMove(
-                        _continuationHistory[continuationHistoryIndex],
-                        -HistoryBonus[depth]);
+                    ref var continuationHistoryEntry = ref ContinuationHistoryEntry(visitedMovePiece, visitedMoveTargetSquare, ply - 1);
+                    continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, -HistoryBonus[depth]);
                 }
             }
         }
@@ -238,7 +225,8 @@ public sealed partial class Engine
             if (!isRoot && (depth >= Configuration.EngineSettings.CounterMoves_MinDepth || pvNode))
             {
                 // 🔍 Countermoves - fails to fix the bug and remove killer moves condition, see  https://github.com/lynx-chess/Lynx/pull/944
-                _counterMoves[CounterMoveIndex(previousMovePiece, previousTargetSquare)] = move;
+                var previousMove = Game.ReadMoveFromStack(ply - 1);
+                _counterMoves[CounterMoveIndex(previousMove.Piece(), previousMove.TargetSquare())] = move;
             }
         }
     }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -167,19 +167,8 @@ public sealed partial class Engine
         {
             // 🔍 Continuation history
             // - Counter move history (continuation history, ply - 1)
-            var previousMove = Game.ReadMoveFromStack(ply - 1);
-            Debug.Assert(previousMove != 0);
-
             ref var continuationHistoryEntry = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
             continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, rawHistoryBonus);
-
-            //    var previousPreviousMove = Game.MoveStack[ply - 2];
-            //    var previousPreviousMovePiece = previousPreviousMove.Piece();
-            //    var previousPreviousMoveTargetSquare = previousPreviousMove.TargetSquare();
-
-            //    _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare] = ScoreHistoryMove(
-            //        _continuationHistory[piece][targetSquare][1][previousPreviousMovePiece][previousPreviousMoveTargetSquare],
-            //        EvaluationConstants.HistoryBonus[depth]);
         }
 
         for (int i = 0; i < visitedMovesCounter - 1; ++i)
@@ -193,7 +182,6 @@ public sealed partial class Engine
 
                 // 🔍 Quiet history penalty / malus
                 // When a quiet move fails high, penalize previous visited quiet moves
-
                 ref var quietHistoryEntry = ref _quietHistory[visitedMovePiece][visitedMoveTargetSquare];
                 quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryBonus);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -268,7 +268,6 @@ public sealed partial class Engine
         int bestScore = EvaluationConstants.MinEval;
         Move? bestMove = null;
         bool isAnyMoveValid = false;
-        var previousMove = Game.ReadMoveFromStack(ply - 1);
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
         int visitedMovesCounter = 0;
@@ -294,7 +293,8 @@ public sealed partial class Engine
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
-                _quietHistory[move.Piece()][move.TargetSquare()] + _continuationHistory[ContinuationHistoryIndex(move.Piece(), move.TargetSquare(), previousMove.Piece(), previousMove.TargetSquare(), 0)];
+                _quietHistory[move.Piece()][move.TargetSquare()]
+                + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -424,7 +424,7 @@ public sealed partial class Engine
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // ~ history/(0.75 * maxHistory/2/)
-                                reduction -= _captureHistory[CaptureHistoryIndex(move.Piece(), move.TargetSquare(), move.CapturedPiece())] / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
+                                reduction -= CaptureHistoryEntry(move) / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
                             }
                             else
                             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -294,7 +294,8 @@ public sealed partial class Engine
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
                 _quietHistory[move.Piece()][move.TargetSquare()]
-                + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
+                + CounterMoveHistoryEntry(move.Piece(), move.TargetSquare(), ply)
+                + FollowUpHistoryEntry(move.Piece(), move.TargetSquare(), ply);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;


### PR DESCRIPTION
30+0.3

Same as #1587, a bit worse than the original attempt #1148 
```
Score of Lynx-search-followup-history-refactor-5808-win-x64 vs Lynx-search-hist-refactor-2-5807-win-x64: 1245 - 1347 - 2820  [0.491] 5412
...      Lynx-search-followup-history-refactor-5808-win-x64 playing White: 1072 - 204 - 1430  [0.660] 2706
...      Lynx-search-followup-history-refactor-5808-win-x64 playing Black: 173 - 1143 - 1390  [0.321] 2706
...      White vs Black: 2215 - 377 - 2820  [0.670] 5412
Elo difference: -6.5 +/- 6.4, LOS: 2.3 %, DrawRatio: 52.1 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```