### PR TITLE
🔍 Update 50 moves rule in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,7 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 
 namespace Lynx;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Lynx;
 
@@ -745,17 +746,24 @@ public sealed partial class Engine
                 continue;
             }
 
+            // Before making a move
+            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
+            var oldHalfMovesWithoutCaptureOrPawnMove = Game.HalfMovesWithoutCaptureOrPawnMove;
+            _ = Game.Update50movesRule(move, move.IsCapture());
+            //Game.AddToPositionHashHistory(position.UniqueIdentifier);
+            Game.UpdateMoveinStack(ply, move);
+
             ++_nodes;
             isAnyCaptureValid = true;
 
             PrintPreMove(position, ply, move, isQuiescence: true);
 
-            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
-            Game.UpdateMoveinStack(ply, move);
-
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
+
+            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+            //Game.RemoveFromPositionHashHistory();
             position.UnmakeMove(move, gameState);
 
             PrintMove(position, ply, move, score, isQuiescence: true);


### PR DESCRIPTION
```
Test  | search/qsearch-update-50mr
Elo   | -1.22 +- 2.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 27110: +7212 -7307 =12591
Penta | [619, 3334, 5712, 3303, 587]
https://openbench.lynx-chess.com/test/1522/
```