### PR TITLE
🔍 QSearch SEE pruning, include quiets

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -732,8 +732,8 @@ public sealed partial class Engine
             var move = pseudoLegalMoves[moveIndex];
             var moveScore = moveScores[moveIndex];
 
-            // 🔍 QSearch SEE pruning: pruning bad captures
-            if (moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+            // 🔍 QSearch SEE pruning: pruning bad captures and quiets (castling?)
+            if (moveScore < EvaluationConstants.PromotionMoveScoreValue)
             {
                 continue;
             }


### PR DESCRIPTION
```
Test  | search/qsearch-bad-capture-pruning-include-quiets
Elo   | -4.00 +- 4.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 11738: +3052 -3187 =5499
Penta | [252, 1489, 2505, 1388, 235]
https://openbench.lynx-chess.com/test/1523/
```