### PR TITLE
🔍 QSearch: improve alpha before beta cutoff

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -8,7 +8,7 @@ namespace Lynx;
 public sealed partial class Engine
 {
     private readonly Stopwatch _stopWatch = new();
-    private readonly Move[] _pVTable = GC.AllocateArray<Move>(Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1) / 2, pinned: true);
+    private readonly Move[] _pVTable = GC.AllocateArray<Move>(Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1 + Constants.ArrayDepthMargin) / 2, pinned: true);
 
     /// <summary>
     /// 2 x (<see cref="Configuration.EngineSettings.MaxDepth"/> + <see cref="Constants.ArrayDepthMargin"/>)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -764,15 +764,6 @@ public sealed partial class Engine
             {
                 bestScore = score;
 
-                // Beta-cutoff
-                if (score >= beta)
-                {
-                    PrintMessage($"Pruning: {move} is enough to discard this line");
-
-                    nodeType = NodeType.Beta;
-                    break;
-                }
-
                 // Improving alpha
                 if (score > alpha)
                 {
@@ -783,6 +774,15 @@ public sealed partial class Engine
                     CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
 
                     nodeType = NodeType.Exact;
+                }
+
+                // Beta-cutoff
+                if (score >= beta)
+                {
+                    PrintMessage($"Pruning: {move} is enough to discard this line");
+
+                    nodeType = NodeType.Beta;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
As seen in #1050 and #1046
```
Test  | search/qsearch-beta-cutoff-order
Elo   | -16.48 +- 7.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 3376: +836 -996 =1544
Penta | [98, 431, 751, 349, 59]
https://openbench.lynx-chess.com/test/1530/
```