### PR TITLE
🔍 Update 50 moves rule in QSearch II

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -95,7 +95,7 @@ public sealed class Game : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Update50movesRule(Move moveToPlay, bool isCapture)
     {
-        if (isCapture)
+        if (isCapture || moveToPlay.IsCastle())
         {
             if (HalfMovesWithoutCaptureOrPawnMove < 100)
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,7 +1,6 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-using System.Text.RegularExpressions;
 
 namespace Lynx;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,7 @@
 ﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 
 namespace Lynx;
 
@@ -745,17 +746,24 @@ public sealed partial class Engine
                 continue;
             }
 
+            // Before making a move
+            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
+            var oldHalfMovesWithoutCaptureOrPawnMove = Game.HalfMovesWithoutCaptureOrPawnMove;
+            _ = Game.Update50movesRule(move, move.IsCapture());
+            //Game.AddToPositionHashHistory(position.UniqueIdentifier);
+            Game.UpdateMoveinStack(ply, move);
+
             ++_nodes;
             isAnyCaptureValid = true;
 
             PrintPreMove(position, ply, move, isQuiescence: true);
 
-            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
-            Game.UpdateMoveinStack(ply, move);
-
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
+
+            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+            //Game.RemoveFromPositionHashHistory();
             position.UnmakeMove(move, gameState);
 
             PrintMove(position, ply, move, score, isQuiescence: true);


### PR DESCRIPTION
Followup of https://github.com/lynx-chess/Lynx/pull/1597
```
Test  | search/qsearch-update-50mr-2
Elo   | -4.92 +- 4.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 10026: +2588 -2730 =4708
Penta | [250, 1231, 2141, 1193, 198]
https://openbench.lynx-chess.com/test/1529/
```