### PR TITLE
🔍 LMR: quiet

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -204,6 +204,12 @@ public sealed class EngineSettings
     public int LMR_InCheck { get; set; } = 79;
 
     /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_Quiet { get; set; } = 100;
+
+    /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -428,7 +428,8 @@ public sealed partial class Engine
                             }
                             else
                             {
-                                reduction = EvaluationConstants.LMRReductions[0][depth][visitedMovesCounter];
+                                reduction = EvaluationConstants.LMRReductions[0][depth][visitedMovesCounter]
+                                    + 1;    // Quiet LMR
 
                                 if (!improving)
                                 {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -429,7 +429,7 @@ public sealed partial class Engine
                             else
                             {
                                 reduction = EvaluationConstants.LMRReductions[0][depth][visitedMovesCounter]
-                                    + 1;    // Quiet LMR
+                                    + Configuration.EngineSettings.LMR_Quiet;    // Quiet LMR
 
                                 if (!improving)
                                 {

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -425,6 +425,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_quiet":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_Quiet = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
Our quiet formula sucks I guess, but I'll take it.

```
Test  | search/LMR-quiet
Elo   | 5.09 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | 18484: +5090 -4819 =8575
Penta | [385, 2150, 3961, 2301, 445]
https://openbench.lynx-chess.com/test/1535/
``` 