### PR TITLE
🔍 Update capture history in Qsearch as if in depth 1

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -775,7 +775,7 @@ public sealed partial class Engine
 
                     if (move.IsCapture())
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(2, visitedMoves, visitedMovesCounter, move);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(1, visitedMoves, visitedMovesCounter, move);
                     }
 
                     nodeType = NodeType.Beta;


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1605

```
Test  | search/qsearch-capthis-update
Elo   | -2.93 +- 4.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.44 (-2.25, 2.89) [0.00, 3.00]
Games | 9734: +2598 -2680 =4456
Penta | [249, 1197, 2027, 1175, 219]
https://openbench.lynx-chess.com/test/1531/
```