### PR TITLE
🔍 Razoring: increae max depth 3

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -257,7 +257,7 @@ public sealed class EngineSettings
     //public int RFP_DepthScalingFactor { get; set; } = 55;
 
     //[SPSA<int>(1, 10, 0.5)]
-    public int Razoring_MaxDepth { get; set; } = 2;
+    public int Razoring_MaxDepth { get; set; } = 3;
 
     [SPSA<int>(1, 300, 15)]
     public int Razoring_Depth1Bonus { get; set; } = 104;


### PR DESCRIPTION
```
Score of Lynx-search-razoring-max-depth-3-5840-win-x64 vs Lynx 5835 - main: 1951 - 2054 - 3680  [0.493] 7685
...      Lynx-search-razoring-max-depth-3-5840-win-x64 playing White: 1518 - 427 - 1897  [0.642] 3842
...      Lynx-search-razoring-max-depth-3-5840-win-x64 playing Black: 433 - 1627 - 1783  [0.345] 3843
...      White vs Black: 3145 - 860 - 3680  [0.649] 7685
Elo difference: -4.7 +/- 5.6, LOS: 5.2 %, DrawRatio: 47.9 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```