### PR TITLE
🔍 Set `HalfMovesWithoutCaptureOrPawnMove` to 0 in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -753,13 +753,15 @@ public sealed partial class Engine
 
             // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castling moves
             Game.UpdateMoveinStack(ply, move);
-            // This is technically not correct for castling moves, but whatever
-            Game.HalfMovesWithoutCaptureOrPawnMove = 0;
+            var oldHalfMovesWithoutCaptureOrPawnMove = Game.HalfMovesWithoutCaptureOrPawnMove;
+            Game.HalfMovesWithoutCaptureOrPawnMove = 0; // Not exactly true for castling moves, but meh
 
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
+
             position.UnmakeMove(move, gameState);
+            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
 
             PrintMove(position, ply, move, score, isQuiescence: true);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -751,8 +751,10 @@ public sealed partial class Engine
 
             PrintPreMove(position, ply, move, isQuiescence: true);
 
-            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
+            // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castling moves
             Game.UpdateMoveinStack(ply, move);
+            // This is technically not correct for castling moves, but whatever
+            Game.HalfMovesWithoutCaptureOrPawnMove = 0;
 
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);


### PR DESCRIPTION
```
Test  | bugfix/reset-50mr-qsearch
Elo   | -0.84 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 32508: +8406 -8485 =15617
Penta | [669, 4040, 6926, 3939, 680]
https://openbench.lynx-chess.com/test/1548/
```