### PR TITLE
🧠 On `ponderhit` settle for initial search when time is low and a min depth is reached

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,6 +142,10 @@ public sealed class EngineSettings
 
     public int SoftTimeBoundLimitOnMate { get; set; } = 1_000;
 
+    public int PonderHitMinTimeToContinueSearch { get; set; } = 100;
+
+    public int PonderHitMinDepthToStopSearch { get; set; } = 5;
+
     #endregion
 
     #region Search

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -144,7 +144,7 @@ public sealed class EngineSettings
 
     public int PonderHitMinTimeToContinueSearch { get; set; } = 100;
 
-    public int PonderHitMinDepthToStopSearch { get; set; } = 5;
+    public int PonderHitMinDepthToStopSearch { get; set; } = 15;
 
     #endregion
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -165,8 +165,8 @@ public sealed class Searcher
                 _absoluteSearchCancellationTokenSource = new();
 
                 if (searchResult is null
-                    || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch
-                    || searchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch)
+                    || searchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch
+                    || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch)
                 {
                     _logger.Debug("Ponder hit - restarting search now with time constraints");
 
@@ -340,8 +340,8 @@ public sealed class Searcher
                 _absoluteSearchCancellationTokenSource = new();
 
                 if (finalSearchResult is null
-                    || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch
-                    || finalSearchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch)
+                    || finalSearchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch
+                    || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch)
                 {
                     _logger.Debug("Ponder hit - restarting search now with time constraints");
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -346,8 +346,8 @@ public sealed class Searcher
                     _logger.Debug("Ponder hit - restarting search now with time constraints");
 
 #if MULTITHREAD_DEBUG
-                sw = System.Diagnostics.Stopwatch.StartNew();
-                lastElapsed = sw.ElapsedMilliseconds;
+                    sw = System.Diagnostics.Stopwatch.StartNew();
+                    lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                     if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
@@ -361,15 +361,15 @@ public sealed class Searcher
                         .ToArray();
 
 #if MULTITHREAD_DEBUG
-                _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-                lastElapsed = sw.ElapsedMilliseconds;
+                    _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                    lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                     finalSearchResult = _mainEngine.Search(in searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, _searchCancellationTokenSource.Token);
 
 #if MULTITHREAD_DEBUG
-                _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-                lastElapsed = sw.ElapsedMilliseconds;
+                    _logger.Debug("End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                    lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
                     await _absoluteSearchCancellationTokenSource.CancelAsync();
@@ -379,7 +379,7 @@ public sealed class Searcher
                     var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
-                _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                    _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                     if (finalSearchResult is not null)
@@ -392,7 +392,7 @@ public sealed class Searcher
                         finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG
-                    _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                        _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
                         // Final info command

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -179,7 +179,9 @@ public sealed class Searcher
                 }
                 else
                 {
-                    _logger.Info("Ponder hit - settling for initial pondering search result due to low hard limit: {HardLimitTimeBound}ms (depth: {Depth})", searchConstraints.HardLimitTimeBound, searchResult.Depth);
+                    _logger.Info("Ponder hit - settling for initial pondering search result due to low hard limit: " +
+                        "{HardLimitTimeBound}ms (< {MinTime}ms), depth: {Depth} (>= {MaxDepth})",
+                        searchConstraints.HardLimitTimeBound, Configuration.EngineSettings.PonderHitMinTimeToContinueSearch, searchResult.Depth, Configuration.EngineSettings.PonderHitMinDepthToStopSearch);
                 }
 
                 if (searchResult is not null)
@@ -401,7 +403,9 @@ public sealed class Searcher
                 }
                 else
                 {
-                    _logger.Info("Ponder hit - settling for initial pondering search result due to low hard limit: {HardLimitTimeBound}ms (depth: {Depth})", searchConstraints.HardLimitTimeBound, finalSearchResult.Depth);
+                    _logger.Info("Ponder hit - settling for initial pondering search result due to low hard limit: " +
+                        "{HardLimitTimeBound}ms (< {MinTime}ms), depth: {Depth} (>= {MaxDepth})",
+                        searchConstraints.HardLimitTimeBound, Configuration.EngineSettings.PonderHitMinTimeToContinueSearch, finalSearchResult.Depth, Configuration.EngineSettings.PonderHitMinDepthToStopSearch);
 
                     // Final info command
                     _engineWriter.TryWrite(finalSearchResult);

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -155,13 +155,13 @@ public sealed class Searcher
             {
                 // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
                 _absoluteSearchCancellationTokenSource.Dispose();
+                _absoluteSearchCancellationTokenSource = new();
 
                 if (searchResult is null
                     || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch
                     || searchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch)
                 {
                     _logger.Debug("Ponder hit - restarting search now with time constraints");
-                    _absoluteSearchCancellationTokenSource = new();
 
                     if (searchConstraints.HardLimitTimeBound != SearchConstraints.DefaultHardLimitTimeBound)
                     {
@@ -328,13 +328,13 @@ public sealed class Searcher
             {
                 // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
                 _absoluteSearchCancellationTokenSource.Dispose();
+                _absoluteSearchCancellationTokenSource = new();
 
                 if (finalSearchResult is null
                     || searchConstraints.HardLimitTimeBound >= Configuration.EngineSettings.PonderHitMinTimeToContinueSearch
                     || finalSearchResult.Depth < Configuration.EngineSettings.PonderHitMinDepthToStopSearch)
                 {
                     _logger.Debug("Ponder hit - restarting search now with time constraints");
-                    _absoluteSearchCancellationTokenSource = new();
 
 #if MULTITHREAD_DEBUG
                 sw = System.Diagnostics.Stopwatch.StartNew();

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -301,6 +301,30 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "softtimeboundlimitonmate":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.SoftTimeBoundLimitOnMate = value;
+                    }
+                    break;
+                }
+            case "ponderhitmintimetocontinuesearch":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.PonderHitMinTimeToContinueSearch = value;
+                    }
+                    break;
+                }
+            case "ponderhitmindepthtostopsearch":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.PonderHitMinDepthToStopSearch = value;
+                    }
+                    break;
+                }
             #endregion
 
             #region Search tuning


### PR DESCRIPTION
`PonderHitMinDepthToStopSearch = 15`, `PonderHitMinTimeToContinueSearch = 100`

```
Score of Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 vs Lynx 5866 - main: 1217 - 1029 - 2210  [0.521] 4456
...      Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 playing White: 983 - 178 - 1067  [0.681] 2228
...      Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 playing Black: 234 - 851 - 1143  [0.362] 2228
...      White vs Black: 1834 - 412 - 2210  [0.660] 4456
Elo difference: 14.7 +/- 7.2, LOS: 100.0 %, DrawRatio: 49.6 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted

Player: Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64
   "Draw by timeout": 6
   "Loss: Black loses on time": 5
   "Loss: White loses on time": 7
   "Win: Black loses on time": 22
   "Win: White loses on time": 12
```

`PonderHitMinDepthToStopSearch = 5`, `PonderHitMinTimeToContinueSearch = 50`

```
Score of Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 vs Lynx 5866 - main: 478 - 469 - 993  [0.502] 1940
...      Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 playing White: 396 - 82 - 493  [0.662] 971
...      Lynx-ponder-timeouts-settle-for-initial-search-5871-win-x64 playing Black: 82 - 387 - 500  [0.343] 969
...      White vs Black: 783 - 164 - 993  [0.660] 1940
Elo difference: 1.6 +/- 10.8, LOS: 61.5 %, DrawRatio: 51.2 %
SPRT: llr 0.0109 (0.4%), lbound -2.25, ubound 2.89
```

----

Earlier stuff, using `PonderHitMinDepthToStopSearch = 5`,  `PonderHitMinTimeToContinueSearch = 100`

Initial run, before #1614 and therefore with too many time losses around:

```
Score of Lynx-ponder-timeouts-settle-for-initial-search-5857-win-x64 vs Lynx 5846 - main: 511 - 308 - 553  [0.574] 1372
...      Lynx-ponder-timeouts-settle-for-initial-search-5857-win-x64 playing White: 363 - 56 - 267  [0.724] 686
...      Lynx-ponder-timeouts-settle-for-initial-search-5857-win-x64 playing Black: 148 - 252 - 286  [0.424] 686
...      White vs Black: 615 - 204 - 553  [0.650] 1372
Elo difference: 51.8 +/- 14.2, LOS: 100.0 %, DrawRatio: 40.3 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted

Player: Lynx-ponder-timeouts-settle-for-initial-search-5857-win-x64
   "Draw by 3-fold repetition": 351
   "Draw by adjudication": 112
   "Draw by fifty moves rule": 2
   "Draw by insufficient mating material": 81
   "Draw by stalemate": 4
   "Draw by timeout": 3
   "Loss: Black loses on time": 34
   "Loss: Black mates": 1
   "Loss: Black wins by adjudication": 35
   "Loss: White loses on time": 20
   "Loss: White mates": 3
   "Loss: White wins by adjudication": 215
   "No result": 3
   "Win: Black loses on time": 116
   "Win: Black wins by adjudication": 36
   "Win: White loses on time": 112
   "Win: White mates": 3
   "Win: White wins by adjudication": 244
Player: Lynx 5846 - main
   "Draw by 3-fold repetition": 351
   "Draw by adjudication": 112
   "Draw by fifty moves rule": 2
   "Draw by insufficient mating material": 81
   "Draw by stalemate": 4
   "Draw by timeout": 3
   "Loss: Black loses on time": 116
   "Loss: Black wins by adjudication": 36
   "Loss: White loses on time": 112
   "Loss: White mates": 3
   "Loss: White wins by adjudication": 244
   "No result": 3
   "Win: Black loses on time": 34
   "Win: Black mates": 1
   "Win: Black wins by adjudication": 35
   "Win: White loses on time": 20
   "Win: White mates": 3
   "Win: White wins by adjudication": 215
Finished match
```