### PR TITLE
🐛🧠 Fix illegal moves on fast `ponderhit`

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -499,7 +499,7 @@ public sealed partial class Engine
         var score = 0;
         ShortMove ttBestMove = default;
 
-        var position = Game.PositionBeforeLastSearch;
+        using var position = new Position(Game.PositionBeforeLastSearch);
         var ttEntry = _tt.ProbeHash(position, ply: 0);
 
         if (ttEntry.NodeType != NodeType.Unknown)


### PR DESCRIPTION
### Context

In the event that a depth 1 search isn't completed, an 'emergency move' is chosen.
In https://github.com/lynx-chess/Lynx/pull/1449 to new method of picking up this move was introduced, which was patched in https://github.com/lynx-chess/Lynx/pull/1452 to use `Game.PositionBeforeLastSearch`.

`Game.PositionBeforeLastSearch` is used to reset `Game.CurrentPosition` [right after a search](https://github.com/lynx-chess/Lynx/blob/f3d97c5c54cf322a38c08615fb7c4378e9a8b3e4/src/Lynx/Engine.cs#L152) and on [UCI `position` command parsing](https://github.com/lynx-chess/Lynx/blob/f3d97c5c54cf322a38c08615fb7c4378e9a8b3e4/src/Lynx/Model/Game.cs#L81).

Pondering/permanent brain is implemented as a double search in Lynx, and in the event of `ponderhit` there's no `position` command between both searches, so `Game.PositionBeforeLastSearch` isn't reset.

### Problem

Sooo.. when a 'too fast' `ponderhit` happens, so fast that no depth 1 search is completed:
- Search ends at depth 0, without best move.
- An 'emergency move' is chosen, which was modifying  `Game.PositionBeforeLastSearch` directly while checking for legality [here](https://github.com/lynx-chess/Lynx/blob/f3d97c5c54cf322a38c08615fb7c4378e9a8b3e4/src/Lynx/Search/IDDFS.cs#L538), but not reverting those changes.
- `Game.CurrentPosition` is 'reset' to that modified `Game.PositionBeforeLastSearch`
- Second search happens, resulting in illegal moves due to searching.. with the wrong side side to move, as if our emergency move was played by our opponent.

### Solution

Two alternatives:
- Working with a copy of `Game.PositionBeforeLastSearch` in `BestMoveRoot()` (fd42f7b64081b32b5ff977fe248666dfd5b61fe1)
- Making sure to unmake/undo our move there if we're working with the real one

The former implies extra allocations for copying the position, but is conceptually more correct (`PositionBeforeLastSearch` shouldn't ever be modified) and  _might_ be more resilient in the rare event of any exception happening during `BestMoveRoot` while pondering (when not pondering, any exception will prevent a best move from being generated, which will make the engine stall anyway since there's no second search).

Choosing the first one, at least for this bugfix