### PR TITLE
🧠 On `ponderhit` adapt soft limit to opponent's time

### DIFF
--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -123,6 +123,26 @@ public static class TimeManager
         return newSoftTimeLimit;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int PonderHitSoftLimit(int originalSoftLimit, GoCommand goCommand, SearchResult? ponderingSearchResult, bool isWhite)
+    {
+        int ourTimeLeft = goCommand.WhiteTime;
+        int opponentTimeLeft = goCommand.BlackTime;
+
+        if (!isWhite)
+        {
+            (ourTimeLeft, opponentTimeLeft) = (opponentTimeLeft, ourTimeLeft);
+        }
+
+        var timeAdvantage = ourTimeLeft / opponentTimeLeft;
+
+        // Our time 2, opponent's time 1 -> time advantage 2 -> we use twice the time, to catch up
+        // Our time 1, opponent's time 2 -> time advantagee 0.5 -> we use half of the time
+        var newSoftLimit = originalSoftLimit * timeAdvantage;
+
+        return newSoftLimit;
+    }
+
     /// <summary>
     /// Implementation based on Stash's
     /// When new score is higher than old score (negative <paramref name="scoreDelta"/>),


### PR DESCRIPTION
```
Score of Lynx-ponder-tm-opponent-time-5855-win-x64 vs Lynx 5846 - main: 1626 - 1574 - 2220  [0.505] 5420
...      Lynx-ponder-tm-opponent-time-5855-win-x64 playing White: 1115 - 433 - 1162  [0.626] 2710
...      Lynx-ponder-tm-opponent-time-5855-win-x64 playing Black: 511 - 1141 - 1058  [0.384] 2710
...      White vs Black: 2256 - 944 - 2220  [0.621] 5420
Elo difference: 3.3 +/- 7.1, LOS: 82.1 %, DrawRatio: 41.0 %
SPRT: llr 0.418 (14.5%), lbound -2.25, ubound 2.89
```

Stopped, will need to be retested after fixing illegal moves and timeouts.