### PR TITLE
⚖️ Material scaling - 2.5% 

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -26,7 +26,7 @@ public static class EvaluationConstants
 
     public const int MaterialScalingTotal = 1024;
 
-    public const int MaterialScalingDiff = 50;
+    public const int MaterialScalingDiff = 100;
 
     public const int MaterialScalingBase = MaterialScalingTotal - MaterialScalingDiff;
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -1,5 +1,7 @@
 ﻿#pragma warning disable IDE1006 // Naming Styles
 
+using Lynx.Model;
+
 namespace Lynx;
 
 public static class EvaluationConstants
@@ -21,6 +23,27 @@ public static class EvaluationConstants
     ];
 
     public const int MaxPhase = 24;
+
+    public const int MaterialScalingTotal = 1024;
+
+    public const int MaterialScalingDiff = 50;
+
+    public const int MaterialScalingBase = MaterialScalingTotal - MaterialScalingDiff;
+
+    public static ReadOnlySpan<int> MaterialScalingPieceValues =>
+    [
+        0, 300, 300, 500, 900, 0,
+        0, 300, 300, 500, 900, 0,
+    ];
+
+    public static readonly int MaterialScaling_Total =
+        (16 * MaterialScalingPieceValues[(int)Piece.P])
+        + (4 * MaterialScalingPieceValues[(int)Piece.N])
+        + (4 * MaterialScalingPieceValues[(int)Piece.B])
+        + (4 * MaterialScalingPieceValues[(int)Piece.R])
+        + (2 * MaterialScalingPieceValues[(int)Piece.Q]);
+
+    public static readonly int MaterialScalingDivisor = MaterialScaling_Total / MaterialScalingDiff;
 
     /// <summary>
     /// 2 x <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -43,7 +43,7 @@ public static class EvaluationConstants
         + (4 * MaterialScalingPieceValues[(int)Piece.R])
         + (2 * MaterialScalingPieceValues[(int)Piece.Q]);
 
-    public static readonly int MaterialScalingDivisor = MaterialScaling_Total / MaterialScalingDiff;
+    public static readonly double MaterialScalingDivisor = (double)MaterialScaling_Total / MaterialScalingDiff;
 
     /// <summary>
     /// 2 x <see cref="Constants.AbsoluteMaxDepth"/> x <see cref="Constants.MaxNumberOfPossibleMovesInAPosition"/>

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -26,7 +26,7 @@ public static class EvaluationConstants
 
     public const int MaterialScalingTotal = 1024;
 
-    public const int MaterialScalingDiff = 100;
+    public const int MaterialScalingDiff = 25;
 
     public const int MaterialScalingBase = MaterialScalingTotal - MaterialScalingDiff;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1377,7 +1377,7 @@ public class Position : IDisposable
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
-        eval * (200 - movesWithoutCaptureOrPawnMove) / 200;
+        (int)(eval * (200 - movesWithoutCaptureOrPawnMove) / 200.0);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScaleEvalWithMaterialLeft(int eval)
@@ -1397,7 +1397,7 @@ public class Position : IDisposable
 
         var scale = MaterialScalingBase + (weigthedMaterialCount / MaterialScalingDivisor);
 
-        return eval * scale / MaterialScalingTotal;
+        return (int)(eval * scale / MaterialScalingTotal);
     }
 
     #endregion

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -976,6 +976,7 @@ public class Position : IDisposable
         // Endgame scaling with pawn count, formula yoinked from Sirius
         eval = (int)(eval * ((80 + (totalPawnsCount * 7)) / 128.0));
 
+        eval = ScaleEvalWithMaterialLeft(eval);
         eval = ScaleEvalWith50MovesDrawDistance(eval, movesWithoutCaptureOrPawnMove);
 
         eval = Math.Clamp(eval, MinStaticEval, MaxStaticEval);
@@ -1377,6 +1378,27 @@ public class Position : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int ScaleEvalWith50MovesDrawDistance(int eval, int movesWithoutCaptureOrPawnMove) =>
         eval * (200 - movesWithoutCaptureOrPawnMove) / 200;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal int ScaleEvalWithMaterialLeft(int eval)
+    {
+        //var pawnCount = (PieceBitBoards[(int)Piece.P] | PieceBitBoards[(int)Piece.p]).CountBits();
+        var knightCount = (PieceBitBoards[(int)Piece.N] | PieceBitBoards[(int)Piece.n]).CountBits();
+        var bishopCount = (PieceBitBoards[(int)Piece.B] | PieceBitBoards[(int)Piece.b]).CountBits();
+        var rookCount = (PieceBitBoards[(int)Piece.R] | PieceBitBoards[(int)Piece.r]).CountBits();
+        var queenCount = (PieceBitBoards[(int)Piece.Q] | PieceBitBoards[(int)Piece.q]).CountBits();
+
+        var weigthedMaterialCount =
+            //(pawnCount * MaterialScalingPieceValues[(int)Piece.P])
+            (knightCount * MaterialScalingPieceValues[(int)Piece.N])
+            + (bishopCount * MaterialScalingPieceValues[(int)Piece.B])
+            + (rookCount * MaterialScalingPieceValues[(int)Piece.R])
+            + (queenCount * MaterialScalingPieceValues[(int)Piece.Q]);
+
+        var scale = MaterialScalingBase + (weigthedMaterialCount / MaterialScalingDivisor);
+
+        return eval * scale / MaterialScalingTotal;
+    }
 
     #endregion
 


### PR DESCRIPTION
```
Test  | search/material-scaling-1-percentage-2.5
Elo   | -8.06 +- 5.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 6380: +1566 -1714 =3100
Penta | [151, 788, 1424, 712, 115]
https://openbench.lynx-chess.com/test/1549/
```