### PR TITLE
🐛🧠 Fix time losses on fast `ponderhit`

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -137,14 +137,21 @@ public sealed class Searcher
             // Pondering
             _logger.Debug("Pondering");
 
-            var searchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+            SearchResult? searchResult = null;
 
-            if (searchResult is not null)
+            // This check takes care of early ponderhits that may have cancelled the ct
+            // before it was reset in OnGoCommand and therefore stay undetected
+            if (!_isPonderHit)
             {
-                // Final info command
-                _engineWriter.TryWrite(searchResult);
+                searchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
 
-                // We don't print bestmove command when ponder + ponderhit though
+                if (searchResult is not null)
+                {
+                    // Final info command
+                    _engineWriter.TryWrite(searchResult);
+
+                    // We don't print bestmove command when ponder + ponderhit though
+                }
             }
 
             // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
@@ -185,6 +192,11 @@ public sealed class Searcher
 
     private async Task MultiThreadedSearch(GoCommand goCommand)
     {
+        // Basic lazy SMP implementation
+        // Extra engines run in "go infinite" mode and their purpose is to populate the TT
+        // Not UCI output is produced by them nor their search results are taken into account
+        var extraEnginesSearchConstraints = SearchConstraints.InfiniteSearchConstraint;
+
         var searchConstraints = TimeManager.CalculateTimeManagement(_mainEngine.Game, goCommand);
         var isPondering = Configuration.EngineSettings.IsPonder && goCommand.Ponder;
 
@@ -200,14 +212,9 @@ public sealed class Searcher
             var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-            // Basic lazy SMP implementation
-            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
-            // Not UCI output is produced by them nor their search results are taken into account
-            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
-
             var tasks = _extraEngines
                 .Select(engine =>
-                    Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
                 .ToArray();
 
 #if MULTITHREAD_DEBUG
@@ -255,60 +262,62 @@ public sealed class Searcher
             // Pondering
             _logger.Debug("Pondering");
 
-#if MULTITHREAD_DEBUG
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            var lastElapsed = sw.ElapsedMilliseconds;
-#endif
+            SearchResult? finalSearchResult = null;
 
-            // Basic lazy SMP implementation
-            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
-            // Not UCI output is produced by them nor their search results are taken into account
-            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
-
-            var tasks = _extraEngines
-                .Select(engine =>
-                    Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
-                .ToArray();
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-            lastElapsed = sw.ElapsedMilliseconds;
-#endif
-
-            SearchResult? finalSearchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-            lastElapsed = sw.ElapsedMilliseconds;
-#endif
-
-            await _absoluteSearchCancellationTokenSource.CancelAsync();
-
-            // We wait just for the node count, so there's room for improvement here with thread voting
-            // and other strategies that take other thread results into account
-            var extraResults = await Task.WhenAll(tasks);
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-#endif
-
-            if (finalSearchResult is not null)
+            // This check takes care of early ponderhits that may have cancelled the ct
+            // before it was reset in OnGoCommand and therefore stay undetected
+            if (!_isPonderHit)
             {
-                foreach (var extraResult in extraResults)
-                {
-                    finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
-                }
-
-                finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
-
 #if MULTITHREAD_DEBUG
-                _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-                // Final info command
-                _engineWriter.TryWrite(finalSearchResult);
+                var tasks = _extraEngines
+                    .Select(engine =>
+                        Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    .ToArray();
 
-                // We don't print bestmove command when ponder + ponderhit though
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                finalSearchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                await _absoluteSearchCancellationTokenSource.CancelAsync();
+
+                // We wait just for the node count, so there's room for improvement here with thread voting
+                // and other strategies that take other thread results into account
+                var extraResults = await Task.WhenAll(tasks);
+
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                if (finalSearchResult is not null)
+                {
+                    foreach (var extraResult in extraResults)
+                    {
+                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                    }
+
+                    finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+
+#if MULTITHREAD_DEBUG
+                    _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                    // Final info command
+                    _engineWriter.TryWrite(finalSearchResult);
+
+                    // We don't print bestmove command when ponder + ponderhit though
+                }
             }
 
             // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
@@ -333,9 +342,10 @@ public sealed class Searcher
                     _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
                 }
 
-                tasks = [.. _extraEngines
+                var tasks = _extraEngines
                     .Select(engine =>
-                        Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))];
+                        Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    .ToArray();
 
 #if MULTITHREAD_DEBUG
                 _logger.Debug("End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
@@ -353,7 +363,7 @@ public sealed class Searcher
 
                 // We wait just for the node count, so there's room for improvement here with thread voting
                 // and other strategies that take other thread results into account
-                extraResults = await Task.WhenAll(tasks);
+                var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
                 _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);


### PR DESCRIPTION
#### Context

`go` command (aka 'search) and `ponderhit` are processed in different threads. `ponderhit` is processed in the UCI listener thread, and `go` is processed in the search thread, after going through a `Channel`

There's a `CancellationToken` responsible for cancelling searches in case of `stop`, `ponderhit`, hard time bound (time management), etc.

That `CancellationToken` gets reset at the beginning of every search if it has been used/cancelled before.

#### Problem
- On a fast `ponderhit` (i.e. opponent move is in time trouble, or they move immediately if there's only one legal move available):
- `ponderhit` command may get processed before the `go` command, specially taking into account in which thread is each of them processed and how `go` command needs to 'go through the Channel'.
  `CancellationToken` is cancelled during this processing
- `go` command is processed, clearing the `CancellationToken` and starting the pondering search
- GUI times the engine out and sends a `stop` command
- The engine stops searching, sees the `ponderhit` and starts the time-constrained search
- When the engine stops that second search and sends a final `bestmove` command, the GUI starts a new game

#### Solution

- Short term, making sure that there's no `ponderhit` right before starting the search should be enough to cover most of these cases
- Long term, this race condition isn't great and still exists after applying the previous solution, so probably `CancellationToken`s should be initialized at some other point (i.e. `Searcher` constructor and end of search?).

This PR applies the short term solution.

```
Score of Lynx-bugfix-ponder-timelosses-5862-win-x64 vs Lynx 5846 - main: 723 - 562 - 1275  [0.531] 2560
...      Lynx-bugfix-ponder-timelosses-5862-win-x64 playing White: 552 - 101 - 627  [0.676] 1280
...      Lynx-bugfix-ponder-timelosses-5862-win-x64 playing Black: 171 - 461 - 648  [0.387] 1280
...      White vs Black: 1013 - 272 - 1275  [0.645] 2560
Elo difference: 21.9 +/- 9.5, LOS: 100.0 %, DrawRatio: 49.8 %
SPRT: llr 2.59 (89.7%), lbound -2.25, ubound 2.89
```