### PR TITLE
🐛🧠 [cherry-pick] Fix time losses on fast `ponderhit`

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -137,14 +137,21 @@ public sealed class Searcher
             // Pondering
             _logger.Debug("Pondering");
 
-            var searchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+            SearchResult? searchResult = null;
 
-            if (searchResult is not null)
+            // This check takes care of early ponderhits that may have cancelled the ct
+            // before it was reset in OnGoCommand and therefore stay undetected
+            if (!_isPonderHit)
             {
-                // Final info command
-                _engineWriter.TryWrite(searchResult);
+                searchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
 
-                // We don't print bestmove command when ponder + ponderhit though
+                if (searchResult is not null)
+                {
+                    // Final info command
+                    _engineWriter.TryWrite(searchResult);
+
+                    // We don't print bestmove command when ponder + ponderhit though
+                }
             }
 
             // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
@@ -185,6 +192,11 @@ public sealed class Searcher
 
     private async Task MultiThreadedSearch(GoCommand goCommand)
     {
+        // Basic lazy SMP implementation
+        // Extra engines run in "go infinite" mode and their purpose is to populate the TT
+        // Not UCI output is produced by them nor their search results are taken into account
+        var extraEnginesSearchConstraints = SearchConstraints.InfiniteSearchConstraint;
+
         var searchConstraints = TimeManager.CalculateTimeManagement(_mainEngine.Game, goCommand);
         var isPondering = Configuration.EngineSettings.IsPonder && goCommand.Ponder;
 
@@ -200,14 +212,9 @@ public sealed class Searcher
             var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-            // Basic lazy SMP implementation
-            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
-            // Not UCI output is produced by them nor their search results are taken into account
-            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
-
             var tasks = _extraEngines
                 .Select(engine =>
-                    Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
                 .ToArray();
 
 #if MULTITHREAD_DEBUG
@@ -255,60 +262,62 @@ public sealed class Searcher
             // Pondering
             _logger.Debug("Pondering");
 
-#if MULTITHREAD_DEBUG
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-            var lastElapsed = sw.ElapsedMilliseconds;
-#endif
+            SearchResult? finalSearchResult = null;
 
-            // Basic lazy SMP implementation
-            // Extra engines run in "go infinite" mode and their purpose is to populate the TT
-            // Not UCI output is produced by them nor their search results are taken into account
-            var extraEnginesSearchConstraint = SearchConstraints.InfiniteSearchConstraint;
-
-            var tasks = _extraEngines
-                .Select(engine =>
-                    Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
-                .ToArray();
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-            lastElapsed = sw.ElapsedMilliseconds;
-#endif
-
-            SearchResult? finalSearchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-            lastElapsed = sw.ElapsedMilliseconds;
-#endif
-
-            await _absoluteSearchCancellationTokenSource.CancelAsync();
-
-            // We wait just for the node count, so there's room for improvement here with thread voting
-            // and other strategies that take other thread results into account
-            var extraResults = await Task.WhenAll(tasks);
-
-#if MULTITHREAD_DEBUG
-            _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
-#endif
-
-            if (finalSearchResult is not null)
+            // This check takes care of early ponderhits that may have cancelled the ct
+            // before it was reset in OnGoCommand and therefore stay undetected
+            if (!_isPonderHit)
             {
-                foreach (var extraResult in extraResults)
-                {
-                    finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
-                }
-
-                finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
-
 #if MULTITHREAD_DEBUG
-                _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                var lastElapsed = sw.ElapsedMilliseconds;
 #endif
 
-                // Final info command
-                _engineWriter.TryWrite(finalSearchResult);
+                var tasks = _extraEngines
+                    .Select(engine =>
+                        Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                    .ToArray();
 
-                // We don't print bestmove command when ponder + ponderhit though
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of extra searches prep, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                finalSearchResult = _mainEngine.Search(in searchConstraints, isPondering: true, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
+
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of main search, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+                lastElapsed = sw.ElapsedMilliseconds;
+#endif
+
+                await _absoluteSearchCancellationTokenSource.CancelAsync();
+
+                // We wait just for the node count, so there's room for improvement here with thread voting
+                // and other strategies that take other thread results into account
+                var extraResults = await Task.WhenAll(tasks);
+
+#if MULTITHREAD_DEBUG
+                _logger.Debug("[Pondering] End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                if (finalSearchResult is not null)
+                {
+                    foreach (var extraResult in extraResults)
+                    {
+                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                    }
+
+                    finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+
+#if MULTITHREAD_DEBUG
+                    _logger.Debug("[Pondering] End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
+#endif
+
+                    // Final info command
+                    _engineWriter.TryWrite(finalSearchResult);
+
+                    // We don't print bestmove command when ponder + ponderhit though
+                }
             }
 
             // Avoiding the scenario where search finishes early (i.e. mate detected, max depth reached) and results comes
@@ -333,9 +342,9 @@ public sealed class Searcher
                     _searchCancellationTokenSource.CancelAfter(searchConstraints.HardLimitTimeBound);
                 }
 
-                tasks = _extraEngines
+                var tasks = _extraEngines
                     .Select(engine =>
-                        Task.Run(() => engine.Search(in extraEnginesSearchConstraint, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
+                        Task.Run(() => engine.Search(in extraEnginesSearchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None)))
                     .ToArray();
 
 #if MULTITHREAD_DEBUG
@@ -354,7 +363,7 @@ public sealed class Searcher
 
                 // We wait just for the node count, so there's room for improvement here with thread voting
                 // and other strategies that take other thread results into account
-                extraResults = await Task.WhenAll(tasks);
+                var extraResults = await Task.WhenAll(tasks);
 
 #if MULTITHREAD_DEBUG
                 _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);


### PR DESCRIPTION
_d1a55de9f3ba1af82c8ab28a2ec9d2d36d667369 cherry-pick_ (#1613)

----

#### Context

`go` command (aka 'search) and `ponderhit` are processed in different threads. `ponderhit` is processed in the UCI listener thread, and `go` is processed in the search thread, after going through a `Channel`

There's a `CancellationToken` responsible for cancelling searches in case of `stop`, `ponderhit`, hard time bound (time management), etc.

That `CancellationToken` gets reset at the beginning of every search if it has been used/cancelled before.

#### Problem
- On a fast `ponderhit` (i.e. opponent move is in time trouble, or they move immediately if there's only one legal move available):
- `ponderhit` command may get processed before the `go` command, specially taking into account in which thread is each of them processed and how `go` command needs to 'go through the Channel'. `CancellationToken` is cancelled during this processing
- `go` command is processed, clearing the `CancellationToken` and starting the pondering search
- GUI times the engine out and sends a `stop` command
- The engine stops searching, sees the `ponderhit` and starts the time-constrained search
- When the engine stops that second search and sends a final `bestmove` command, the GUI starts a new game

#### Solution

- Short term, making sure that there's no `ponderhit` right before starting the search should be enough to cover most of these cases
- Long term, this race condition isn't great and still exists after applying the previous solution, so probably `CancellationToken`s should be initialized at some other point (i.e. `Searcher` constructor and end of search?).

This PR applies the short term solution.

----

8+0.08, 1t, balanced book
```
Score of Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 vs Lynx-release-v1.9.1-5860-win-x64: 614 - 568 - 1818  [0.508] 3000
...      Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 playing White: 364 - 241 - 895  [0.541] 1500
...      Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 playing Black: 250 - 327 - 923  [0.474] 1500
...      White vs Black: 691 - 491 - 1818  [0.533] 3000
Elo difference: 5.3 +/- 7.8, LOS: 91.0 %, DrawRatio: 60.6 %
SPRT: llr 0 (0.0%), lbound -inf, ubound inf

Player: Lynx-cp-bugfix-ponder-timelosses-5864-win-x64
   "Draw by 3-fold repetition": 1397
   "Draw by fifty moves rule": 19
   "Draw by insufficient mating material": 370
   "Draw by stalemate": 16
   "Draw by timeout": 16
   "Loss: Black loses on time": 8
   "Loss: Black mates": 236
   "Loss: White loses on time": 5
   "Loss: White mates": 319
   "Win: Black loses on time": 31
   "Win: Black mates": 213
   "Win: White loses on time": 37
   "Win: White mates": 333
Player: Lynx-release-v1.9.1-5860-win-x64
   "Draw by 3-fold repetition": 1397
   "Draw by fifty moves rule": 19
   "Draw by insufficient mating material": 370
   "Draw by stalemate": 16
   "Draw by timeout": 16
   "Loss: Black loses on time": 31
   "Loss: Black mates": 213
   "Loss: White loses on time": 37
   "Loss: White mates": 333
   "Win: Black loses on time": 8
   "Win: Black mates": 236
   "Win: White loses on time": 5
   "Win: White mates": 319
```

8+0.08, 2t, unbalanced book
```
Score of Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 vs Lynx-release-v1.9.1-5860-win-x64: 824 - 659 - 1467  [0.528] 2950
...      Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 playing White: 643 - 114 - 718  [0.679] 1475
...      Lynx-cp-bugfix-ponder-timelosses-5864-win-x64 playing Black: 181 - 545 - 749  [0.377] 1475
...      White vs Black: 1188 - 295 - 1467  [0.651] 2950
Elo difference: 19.5 +/- 8.9, LOS: 100.0 %, DrawRatio: 49.7 %
SPRT: llr 2.63 (90.8%), lbound -2.25, ubound 2.89
```