### PR TITLE
🧹 Clear TT and invoke warm-up from `Searcher`

### DIFF
--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -3,7 +3,7 @@
     "EnableTuning": true
   },
   "EngineSettings": {
-    "TranspositionTableSize": 256
+    //"TranspositionTableSize": 256
   },
   "NLog": {
     "internalLogLevel": "Warn",

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -1,7 +1,6 @@
 using Lynx.Model;
 using Lynx.UCI.Commands.GUI;
 using NLog;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 
@@ -32,7 +31,7 @@ public sealed partial class Engine : IDisposable
     public Engine(ChannelWriter<object> engineWriter) : this(0, engineWriter, new()) { }
 
 #pragma warning disable RCS1163 // Unused parameter - used in Release mode
-    public Engine(int id, ChannelWriter<object> engineWriter, in TranspositionTable tt, bool warmup = false)
+    public Engine(int id, ChannelWriter<object> engineWriter, in TranspositionTable tt)
 #pragma warning restore RCS1163 // Unused parameter
     {
         _id = id;
@@ -51,28 +50,11 @@ public sealed partial class Engine : IDisposable
             _moveNodeCount[i] = new ulong[64];
         }
 
-#if !DEBUG
-        if (warmup)
-        {
-            // Temporary channel so that no output is generated
-            _engineWriter = Channel.CreateUnbounded<object>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false }).Writer;
-            WarmupEngine();
-
-            _engineWriter = engineWriter;
-
-            NewGame();
-        }
-#endif
-
         _logger.Info("Engine {0} initialized", _id);
     }
 
-#pragma warning disable S1144 // Unused private types or members should be removed - used in Release mode
-    private void WarmupEngine()
+    public void Warmup()
     {
-        _logger.Info("Warming up engine");
-        var sw = Stopwatch.StartNew();
-
         AdjustPosition(Constants.SuperLongPositionCommand);
 
         const string goWarmupCommand = "go depth 10";   // ~300 ms
@@ -81,16 +63,10 @@ public sealed partial class Engine : IDisposable
         BestMove(command);
 
         Bench(2);
-
-        sw.Stop();
-        _logger.Info("Warm-up finished in {0}ms", sw.ElapsedMilliseconds);
     }
-#pragma warning restore S1144 // Unused private types or members should be removed
 
     private void ResetEngine()
     {
-        _tt.Clear();
-
         // Clear histories
         for (int i = 0; i < 12; ++i)
         {

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -25,9 +25,6 @@ public readonly struct TranspositionTable
         _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
-    /// <summary>
-    /// Multithreaded clearing of the transposition table
-    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Clear()
     {

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -15,6 +15,8 @@ public readonly struct TranspositionTable
     public readonly int Size;
 #pragma warning restore CA1051 // Do not declare visible instance fields
 
+    public int Length => _tt.Length;
+
     public TranspositionTable()
     {
         Size = Configuration.EngineSettings.TranspositionTableSize;
@@ -23,6 +25,10 @@ public readonly struct TranspositionTable
         _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
     }
 
+    /// <summary>
+    /// Multithreaded clearing of the transposition table
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Clear()
     {
         Array.Clear(_tt);
@@ -213,6 +219,9 @@ public readonly struct TranspositionTable
 
         return items;
     }
+
+    [Obsolete("Only tests")]
+    internal ref TranspositionTableElement Get(int index) => ref _tt[index];
 
     [Conditional("DEBUG")]
     private void Stats()

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -35,6 +35,7 @@ public sealed class Searcher
     {
         InitializeStaticClasses();
 
+        _firstRun = true;
         _uciReader = uciReader;
         _engineWriter = engineWriter;
 
@@ -55,7 +56,6 @@ public sealed class Searcher
 #endif
 
         _ttWrapper.Clear();
-        _firstRun = true;
 
         ForceGCCollection();
     }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -29,6 +29,8 @@ public sealed class Searcher
 
     public string FEN => _mainEngine.Game.FEN;
 
+    private bool _firstRun;
+
     public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter)
     {
         InitializeStaticClasses();
@@ -53,6 +55,8 @@ public sealed class Searcher
 #endif
 
         _ttWrapper.Clear();
+        _firstRun = true;
+
         ForceGCCollection();
     }
 
@@ -500,7 +504,11 @@ public sealed class Searcher
             AllocateExtraEngines();
         }
 
-        _ttWrapper.Clear();
+        if (!_firstRun)
+        {
+            _ttWrapper.Clear();
+        }
+        _firstRun = false;
 
         ForceGCCollection();
     }

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -70,4 +70,39 @@ public class TranspositionTableTests
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }
+
+    [Test]
+    [Explicit]
+    [NonParallelizable]
+    [Category(Categories.LongRunning)]
+    public void ClearTT()
+    {
+        Configuration.EngineSettings.TranspositionTableSize = 31;
+        Configuration.EngineSettings.Threads = 7;
+
+        var tt = new TranspositionTable();
+
+        Assert.AreNotEqual(0, tt.Length % Configuration.EngineSettings.Threads, "We want to test the edge case where the last thread clears more items than the rest");
+
+        for(int index = 0; index < tt.Length; ++index)
+        {
+            ref var ttEntry = ref tt.Get(index);
+            ttEntry.Update(1, 2, 3, 4, NodeType.Exact, 5, 6);
+        }
+
+        tt.Clear();
+
+        for (int index = 0; index < tt.Length; ++index)
+        {
+            var ttEntry = tt.Get(index);
+
+            Assert.AreEqual(0, ttEntry.Score);
+            Assert.AreEqual(0, ttEntry.StaticEval);
+            Assert.AreEqual(0, ttEntry.Depth);
+            Assert.AreEqual(NodeType.Unknown, ttEntry.Type);
+            Assert.AreEqual(false, ttEntry.WasPv);
+            Assert.AreEqual(0, ttEntry.Move);
+            Assert.AreEqual(0, ttEntry.Key);
+        }
+    }
 }


### PR DESCRIPTION
Stop doing TT clearing inside of `Engine` and stop invoking warmup from its constructor: `Seacher` should control both directly.