### PR TITLE
🧠 Tweak skipping second search

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -144,7 +144,7 @@ public sealed class EngineSettings
 
     public int PonderHitMinTimeToContinueSearch { get; set; } = 100;
 
-    public int PonderHitMinDepthToStopSearch { get; set; } = 15;
+    public int PonderHitMinDepthToStopSearch { get; set; } = 5;
 
     #endregion
 


### PR DESCRIPTION
`PonderHitMinDepthToStopSearch` 10 -> 5 (same as original test in #1609)
```
Finished game 10090 (Lynx 5878 - main vs Lynx-ponder-tweak-skipsecondsearch-5879-win-x64): 1/2-1/2 {Draw by 3-fold repetition}
Score of Lynx-ponder-tweak-skipsecondsearch-5879-win-x64 vs Lynx 5878 - main: 2577 - 2553 - 4960  [0.501] 10090
...      Lynx-ponder-tweak-skipsecondsearch-5879-win-x64 playing White: 2081 - 507 - 2457  [0.656] 5045
...      Lynx-ponder-tweak-skipsecondsearch-5879-win-x64 playing Black: 496 - 2046 - 2503  [0.346] 5045
...      White vs Black: 4127 - 1003 - 4960  [0.655] 10090
Elo difference: 0.8 +/- 4.8, LOS: 63.1 %, DrawRatio: 49.2 %
SPRT: llr -0.332 (-11.5%), lbound -2.25, ubound 2.89
```