### PR TITLE
🔍 Pawn history II

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -530,6 +530,10 @@ public static class Constants
     public const int KingPawnHashSize = 262_144;
 
     public const int KingPawnHashMask = KingPawnHashSize - 1;
+
+    public const int PawnHistorySize = 16_384;
+
+    public const int PawnHistoryMask = PawnHistorySize - 1;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -100,6 +100,7 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_captureHistory);
         Array.Clear(_continuationHistory);
+        Array.Clear(_pawnHistory);
         Array.Clear(_counterMoves);
 
         Array.Clear(_pawnEvalTable);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -78,7 +78,24 @@ public sealed partial class Engine
             + (targetSquare * targetSquareOffset)
             + (previousMove.Piece() * previousMovePieceOffset)
             + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
-            //+ 0];
+        //+ 0];
+    }
+
+    /// <summary>
+    /// [<see cref="Constants.PawnHistorySize"/>][12][64]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int PawnHistoryEntry(ulong pawnKey, int piece, int targetSquare)
+    {
+        const int pawnKeyOffset = 12 * 64;
+        const int pieceOffset = 64;
+
+        var keyIndex = (int)(pawnKey & Constants.PawnHistoryMask);
+
+        return ref _pawnHistory[
+            (keyIndex * pawnKeyOffset)
+            + (piece * pieceOffset)
+            + targetSquare];
     }
 
     /// <summary>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -41,6 +41,12 @@ public sealed partial class Engine
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.PawnHistorySize"/> x 12 x 64
+    /// pawn key x piece x target square
+    /// </summary>
+    private readonly int[] _pawnHistory = GC.AllocateArray<int>(Constants.PawnHistorySize * 12 * 64, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>
@@ -519,7 +525,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, position.KingPawnUniqueIdentifier, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -9,10 +9,11 @@ namespace Lynx;
 public sealed partial class Engine
 {
     /// <summary>
-    /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
+    /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>,
+    /// <see cref="_killerMoves"/>, <see cref="_counterMoves"/>, <see cref="_quietHistory"/>, <see cref="_continuationHistory"/> and <see cref="_pawnEvalTable"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int ply, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int ply, ulong pawnKey, ShortMove bestMoveTTCandidate = default)
     {
         if ((ShortMove)move == bestMoveTTCandidate)
         {
@@ -83,18 +84,26 @@ public sealed partial class Engine
             }
 
             // Counter move history
+            var piece = move.Piece();
+            var targetSquare = move.TargetSquare();
             return BaseMoveScore
-                + _quietHistory[move.Piece()][move.TargetSquare()]
-                + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
+                + _quietHistory[piece][targetSquare]
+                + PawnHistoryEntry(pawnKey, piece, targetSquare)
+                + ContinuationHistoryEntry(piece, targetSquare, ply - 1);
         }
+
+        var movePiece = move.Piece();
+        var moveTargetSquare = move.TargetSquare();
 
         // History move or 0 if not found
         return BaseMoveScore
-            + _quietHistory[move.Piece()][move.TargetSquare()];
+            + _quietHistory[movePiece][moveTargetSquare]
+            + PawnHistoryEntry(pawnKey, movePiece, moveTargetSquare);
     }
 
     /// <summary>
-    /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
+    /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>
+    /// and <see cref="_captureHistory"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int ScoreMoveQSearch(Move move, ShortMove bestMoveTTCandidate = default)
@@ -152,7 +161,7 @@ public sealed partial class Engine
     /// Quiet history, contination history, killers and counter moves
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot, bool pvNode)
+    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(Position position, int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot, bool pvNode)
     {
         var piece = move.Piece();
         var targetSquare = move.TargetSquare();
@@ -163,6 +172,10 @@ public sealed partial class Engine
 
         ref var quietHistoryEntry = ref _quietHistory[piece][targetSquare];
         quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, rawHistoryBonus);
+
+        // 🔍 Pawn history
+        ref var pawnHistoryEntry = ref PawnHistoryEntry(position.KingPawnUniqueIdentifier, piece, targetSquare);
+        pawnHistoryEntry = ScoreHistoryMove(pawnHistoryEntry, rawHistoryBonus);
 
         if (!isRoot)
         {
@@ -185,6 +198,10 @@ public sealed partial class Engine
                 // When a quiet move fails high, penalize previous visited quiet moves
                 quietHistoryEntry = ref _quietHistory[visitedMovePiece][visitedMoveTargetSquare];
                 quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryBonus);
+
+                // 🔍 Pawn history penalty / malus
+                pawnHistoryEntry = ref PawnHistoryEntry(position.KingPawnUniqueIdentifier, piece, targetSquare);
+                pawnHistoryEntry = ScoreHistoryMove(pawnHistoryEntry, rawHistoryBonus);
 
                 if (!isRoot)
                 {


### PR DESCRIPTION
First attempt: #1455 

```
Test  | search/pawn-history-2
Elo   | -6.84 +- 5.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 7516: +1912 -2060 =3544
Penta | [174, 971, 1596, 863, 154]
https://openbench.lynx-chess.com/test/1552/
```