### PR TITLE
⚡  QSearch prefetch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -754,6 +754,8 @@ public sealed partial class Engine
             // No need to check for threefold or 50 moves repetitions, since we're only searching captures, promotions, and castles
             Game.UpdateMoveinStack(ply, move);
 
+            _tt.PrefetchTTEntry(position);
+
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters


### PR DESCRIPTION
```
Test  | perf/qsearch-prefetch
Elo   | 0.54 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 149460: +39309 -39076 =71075
Penta | [2650, 17296, 34704, 17331, 2749]
https://openbench.lynx-chess.com/test/1550/
```

```
Test  | perf/qsearch-prefetch
Elo   | -0.32 +- 1.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 44092: +10384 -10424 =23284
Penta | [428, 4778, 11634, 4818, 388]
https://openbench.lynx-chess.com/test/1687/
```