### PR TITLE
🔍 History bonus formula: try Quanticade's

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -57,7 +57,7 @@ public static class EvaluationConstants
 
             HistoryBonus[searchDepth] = Math.Min(
                 Configuration.EngineSettings.History_MaxMoveRawBonus,
-                (4 * searchDepth * searchDepth) + (120 * searchDepth) - 120);   // Sirius, originally from Berserk
+                (16 * searchDepth * searchDepth) + (32 * searchDepth) + 16);   // Quanticade
         }
     }
 


### PR DESCRIPTION
```
Score of Lynx-search-history-bonus-formula-5913-win-x64 vs Lynx 5912 - main: 5794 - 5832 - 10897  [0.499] 22523
...      Lynx-search-history-bonus-formula-5913-win-x64 playing White: 4608 - 1278 - 5376  [0.648] 11262
...      Lynx-search-history-bonus-formula-5913-win-x64 playing Black: 1186 - 4554 - 5521  [0.350] 11261
...      White vs Black: 9162 - 2464 - 10897  [0.649] 22523
Elo difference: -0.6 +/- 3.3, LOS: 36.2 %, DrawRatio: 48.4 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```