### PR TITLE
🧪 Stop using tt score as static eval

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -150,16 +150,6 @@ public sealed partial class Engine
                 improvingRate = evalDiff / 50.0;
             }
 
-            // From smol.cs
-            // ttEvaluation can be used as a better positional evaluation:
-            // If the score is outside what the current bounds are, but it did match flag and depth,
-            // then we can trust that this score is more accurate than the current static evaluation,
-            // and we can update our static evaluation for better accuracy in pruning
-            if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
-            {
-                staticEval = ttScore;
-            }
-
             bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
             // Fail-high pruning (moves with high scores) - prune more when improving


### PR DESCRIPTION
```
Score of Lynx-experiment-stop-using-ttscore-as-staticeval-5914-win-x64 vs Lynx 5912 - main: 854 - 969 - 1834  [0.484] 3657
...      Lynx-experiment-stop-using-ttscore-as-staticeval-5914-win-x64 playing White: 681 - 212 - 935  [0.628] 1828
...      Lynx-experiment-stop-using-ttscore-as-staticeval-5914-win-x64 playing Black: 173 - 757 - 899  [0.340] 1829
...      White vs Black: 1438 - 385 - 1834  [0.644] 3657
Elo difference: -10.9 +/- 7.9, LOS: 0.4 %, DrawRatio: 50.2 %
SPRT: llr -2.27 (-78.5%), lbound -2.25, ubound 2.89 - H0 was accepted
```