### PR TITLE
🔍 Use TT static eval as static eval (instead of TT score)

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -129,12 +129,12 @@ public static class EvaluationConstants
     /// <summary>
     /// Max static eval. It doesn't include checkmate values and it's below <see cref="PositiveCheckmateDetectionLimit"/>
     /// </summary>
-    public const int MaxStaticEval = PositiveCheckmateDetectionLimit - 1;
+    public const int MaxStaticEval = PositiveCheckmateDetectionLimit - 1000;
 
     /// <summary>
     /// Min static eval. It doesn't include checkmate values and it's above <see cref="NegativeCheckmateDetectionLimit"/>
     /// </summary>
-    public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1;
+    public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1000;
 
     /// <summary>
     /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,9 +155,9 @@ public sealed partial class Engine
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
+            if (ttHit && ttElementType != (ttStaticEval > staticEval ? NodeType.Alpha : NodeType.Beta))
             {
-                staticEval = ttScore;
+                staticEval = ttStaticEval;
             }
 
             bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -123,7 +123,9 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
+            staticEval = Math.Clamp(finalPositionEvaluation, EvaluationConstants.MinStaticEval , EvaluationConstants.MaxStaticEval);
+
+            _tt.RecordHash(position, staticEval, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
             return finalPositionEvaluation;
         }
         else if (!pvNode)
@@ -599,7 +601,7 @@ public sealed partial class Engine
             bestScore = Position.EvaluateFinalPosition(ply, isInCheck);
 
             nodeType = NodeType.Exact;
-            staticEval = bestScore;
+            staticEval = Math.Clamp(bestScore, EvaluationConstants.MinStaticEval , EvaluationConstants.MaxStaticEval);;
         }
 
         _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
@@ -796,7 +798,7 @@ public sealed partial class Engine
             bestScore = Position.EvaluateFinalPosition(ply, position.IsInCheck());
 
             nodeType = NodeType.Exact;
-            staticEval = bestScore;
+            staticEval = Math.Clamp(bestScore, EvaluationConstants.MinStaticEval , EvaluationConstants.MaxStaticEval);
         }
 
         _tt.RecordHash(position, staticEval, 0, ply, bestScore, nodeType, ttPv, bestMove);


### PR DESCRIPTION
[Use tt staticeval instead](https://github.com/lynx-chess/Lynx/commit/3849e5c918892a2dbe35dfb678663b43888c49a1)
[0, 3]
```
Score of Lynx-experiment-use-ttstaticeval-as-staticeval-5915-win-x64 vs Lynx 5912 - main: 6310 - 6347 - 11055  [0.499] 23712
...      Lynx-experiment-use-ttstaticeval-as-staticeval-5915-win-x64 playing White: 4800 - 1374 - 5682  [0.644] 11856
...      Lynx-experiment-use-ttstaticeval-as-staticeval-5915-win-x64 playing Black: 1510 - 4973 - 5373  [0.354] 11856
...      White vs Black: 9773 - 2884 - 11055  [0.645] 23712
Elo difference: -0.5 +/- 3.2, LOS: 37.1 %, DrawRatio: 46.6 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```

[When final position, clamp the score to [MinStaticEval, MaxStaticEval]](https://github.com/lynx-chess/Lynx/commit/1edb03c06215b84644829dd5838fa86277d1ce16)

```
Test  | experiment/use-ttstaticeval-as-staticeval
Elo   | -4.73 +- 7.48 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | -0.70 (-2.25, 2.89) [-3.00, 1.00]
Games | 3156: +772 -815 =1569
Penta | [61, 394, 694, 385, 44]
https://openbench.lynx-chess.com/test/1566/
```