### PR TITLE
🔍 LMR: fail-low TTPV 

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -214,6 +214,12 @@ public sealed class EngineSettings
     public int LMR_Quiet { get; set; } = 100;
 
     /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_FailLowTTPV { get; set; } = 100;
+
+    /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -446,6 +446,11 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_TTPV;
                                 }
 
+                                if (ttHit && ttPv && ttScore <= alpha)   // From Stormphrax
+                                {
+                                    reduction += Configuration.EngineSettings.LMR_FailLowTTPV;
+                                }
+
                                 if (ttMoveIsCapture)    // Move isn't a capture but TT move is
                                 {
                                     reduction += Configuration.EngineSettings.LMR_TTCapture;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -457,6 +457,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_faillowttpv":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_FailLowTTPV = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
```
Test  | search/lmr-faillow-ttpv
Elo   | 0.36 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 97070: +25525 -25424 =46121
Penta | [2016, 11850, 20714, 11927, 2028]
https://openbench.lynx-chess.com/test/1574/
```