### PR TITLE
🔍 LMR: only do noisy on `!ttpv` nodes

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -417,7 +417,7 @@ public sealed partial class Engine
                                     ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
                                     : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV))
                         {
-                            if (isCapture)
+                            if (isCapture && !ttPv) // !ttPv idea from Clover
                             {
                                 reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter];
 


### PR DESCRIPTION
```
Score of Lynx-search-nosiry-lmr-nottpv-5929-win-x64 vs Lynx 5912 - main: 761 - 796 - 1383  [0.494] 2940
...      Lynx-search-nosiry-lmr-nottpv-5929-win-x64 playing White: 574 - 193 - 703  [0.630] 1470
...      Lynx-search-nosiry-lmr-nottpv-5929-win-x64 playing Black: 187 - 603 - 680  [0.359] 1470
...      White vs Black: 1177 - 380 - 1383  [0.636] 2940
Elo difference: -4.1 +/- 9.1, LOS: 18.8 %, DrawRatio: 47.0 %
SPRT: llr -0.778 (-26.9%), lbound -2.25, ubound 2.89
```