### PR TITLE
🔍 LMR: invert `pvnode` condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -451,9 +451,9 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_TTCapture;
                                 }
 
-                                if (pvNode)
+                                if (!pvNode)
                                 {
-                                    reduction -= Configuration.EngineSettings.LMR_PVNode;
+                                    reduction += Configuration.EngineSettings.LMR_PVNode;
                                 }
 
                                 if (position.IsInCheck())   // i.e. move gives check


### PR DESCRIPTION
```
Score of Lynx-search-lmr-invert-pvnode-condition-5930-win-x64 vs Lynx 5912 - main: 960 - 1084 - 1752  [0.484] 3796
...      Lynx-search-lmr-invert-pvnode-condition-5930-win-x64 playing White: 742 - 277 - 879  [0.622] 1898
...      Lynx-search-lmr-invert-pvnode-condition-5930-win-x64 playing Black: 218 - 807 - 873  [0.345] 1898
...      White vs Black: 1549 - 495 - 1752  [0.639] 3796
Elo difference: -11.4 +/- 8.1, LOS: 0.3 %, DrawRatio: 46.2 %
SPRT: llr -2.25 (-78.0%), lbound -2.25, ubound 2.89 - H0 was accepted
```