### PR TITLE
🟰 Use highest depth result

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -359,12 +359,22 @@ public sealed class Searcher
 
                 if (finalSearchResult is not null)
                 {
+                    var totalNodes = finalSearchResult.Nodes;
+                    var totalTime = finalSearchResult.Time;
+
                     foreach (var extraResult in extraResults)
                     {
-                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                        totalNodes += extraResult?.Nodes ?? 0;
+
+                        if (extraResult?.Depth > finalSearchResult.Depth
+                            && extraResult.BestMove != 0)
+                        {
+                            finalSearchResult = extraResult;
+                        }
                     }
 
-                    finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
+                    finalSearchResult.Nodes = totalNodes;
+                    finalSearchResult.NodesPerSecond = Utils.CalculateNps(totalNodes, 0.001 * totalTime);
 
 #if MULTITHREAD_DEBUG
                     _logger.Debug("End of multithread calculations, {0} ms", sw.ElapsedMilliseconds - lastElapsed);


### PR DESCRIPTION
```
Test  | mt/use-highest-depth-result
Elo   | 1.14 +- 1.19 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | 0.98 (-2.25, 2.89) [0.00, 3.00]
Games | 132244: +35232 -34797 =62215
Penta | [2627, 15909, 28691, 16192, 2703]
https://openbench.lynx-chess.com/test/1233/
```