### PR TITLE
🟰 Use highest depth result, or same depth if best score

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -323,11 +323,26 @@ public sealed class Searcher
 
                 if (finalSearchResult is not null)
                 {
+                    var totalNodes = finalSearchResult.Nodes;
+                    var totalTime = finalSearchResult.Time;
+
                     foreach (var extraResult in extraResults)
                     {
-                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                        if (extraResult is not null)
+                        {
+                            finalSearchResult.Nodes += extraResult.Nodes;
+                            totalNodes += extraResult.Nodes;
+
+                            if (extraResult.BestMove != default
+                                && extraResult.Depth >= finalSearchResult.Depth
+                                && extraResult.Score >= finalSearchResult.Score)
+                            {
+                                finalSearchResult = extraResult;
+                            }
+                        }
                     }
 
+                    finalSearchResult.Nodes = totalNodes;
                     finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -334,8 +334,8 @@ public sealed class Searcher
                             totalNodes += extraResult.Nodes;
 
                             if (extraResult.BestMove != default
-                                && extraResult.Depth >= finalSearchResult.Depth
-                                && extraResult.Score >= finalSearchResult.Score)
+                                && ((extraResult.Depth > finalSearchResult.Depth && finalSearchResult.Mate == default)
+                                    || (extraResult.Depth == finalSearchResult.Depth && extraResult.Score > finalSearchResult.Score)))
                             {
                                 finalSearchResult = extraResult;
                             }


### PR DESCRIPTION
Precursor: https://github.com/lynx-chess/Lynx/pull/1637

```
Test  | mt/use-highest-depth-result-or-same-depth-if-bestscore
Elo   | -2.58 +- 7.62 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | -0.40 (-2.25, 2.89) [0.00, 3.00]
Games | 2692: +662 -682 =1348
Penta | [29, 343, 626, 315, 33]
https://openbench.lynx-chess.com/test/1573/
```