### PR TITLE
🟰 Use highest deph result, but only if score is better than the current one

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -323,11 +323,26 @@ public sealed class Searcher
 
                 if (finalSearchResult is not null)
                 {
+                    var totalNodes = finalSearchResult.Nodes;
+                    var totalTime = finalSearchResult.Time;
+
                     foreach (var extraResult in extraResults)
                     {
-                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                        if (extraResult is not null)
+                        {
+                            finalSearchResult.Nodes += extraResult.Nodes;
+                            totalNodes += extraResult.Nodes;
+
+                            if (extraResult.BestMove != default
+                                && extraResult.Depth >= finalSearchResult.Depth
+                                && extraResult.Score >= finalSearchResult.Score)
+                            {
+                                finalSearchResult = extraResult;
+                            }
+                        }
                     }
 
+                    finalSearchResult.Nodes = totalNodes;
                     finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG


### PR DESCRIPTION
Precursor: https://github.com/lynx-chess/Lynx/pull/1637, best attempt: #1638 
```
Test  | mt/use-highest-depth-result-if-bestscore
Elo   | 0.26 +- 8.04 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | -0.07 (-2.25, 2.89) [0.00, 3.00]
Games | 2630: +643 -641 =1346
Penta | [36, 333, 578, 329, 39]
https://openbench.lynx-chess.com/test/1572/
```