### PR TITLE
🟰 Use lowest absolute mate score result, highest depth result or same depth but better score result

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -334,8 +334,9 @@ public sealed class Searcher
                             totalNodes += extraResult.Nodes;
 
                             if (extraResult.BestMove != default
-                                && ((extraResult.Depth > finalSearchResult.Depth && finalSearchResult.Mate == default)
-                                    || (extraResult.Depth == finalSearchResult.Depth && extraResult.Score > finalSearchResult.Score)))
+                                && (Math.Abs(extraResult.Mate) < Math.Abs(finalSearchResult.Mate)
+                                    || (extraResult.Depth > finalSearchResult.Depth && extraResult.Mate == finalSearchResult.Mate)
+                                    || (extraResult.Depth == finalSearchResult.Depth && (extraResult.Score > finalSearchResult.Score))))
                             {
                                 finalSearchResult = extraResult;
                             }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -323,11 +323,26 @@ public sealed class Searcher
 
                 if (finalSearchResult is not null)
                 {
+                    var totalNodes = finalSearchResult.Nodes;
+                    var totalTime = finalSearchResult.Time;
+
                     foreach (var extraResult in extraResults)
                     {
-                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                        if (extraResult is not null)
+                        {
+                            finalSearchResult.Nodes += extraResult.Nodes;
+                            totalNodes += extraResult.Nodes;
+
+                            if (extraResult.BestMove != default
+                                && extraResult.Depth >= finalSearchResult.Depth
+                                && extraResult.Score >= finalSearchResult.Score)
+                            {
+                                finalSearchResult = extraResult;
+                            }
+                        }
                     }
 
+                    finalSearchResult.Nodes = totalNodes;
                     finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -334,8 +334,8 @@ public sealed class Searcher
                             totalNodes += extraResult.Nodes;
 
                             if (extraResult.BestMove != default
-                                && extraResult.Depth >= finalSearchResult.Depth
-                                && extraResult.Score >= finalSearchResult.Score)
+                                && ((extraResult.Depth > finalSearchResult.Depth && finalSearchResult.Mate == default)
+                                    || (extraResult.Depth == finalSearchResult.Depth && extraResult.Score > finalSearchResult.Score)))
                             {
                                 finalSearchResult = extraResult;
                             }


### PR DESCRIPTION
```
Test  | mt/use-highest-mate-or-highees-depth-result-or-same-depth-if-bestscore
Elo   | -1.45 +- 6.24 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | -0.40 (-2.25, 2.89) [0.00, 3.00]
Games | 4072: +971 -988 =2113
Penta | [53, 489, 971, 468, 55]
https://openbench.lynx-chess.com/test/1576/
```