### PR TITLE
Introduce development versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         (Get-Content $input_path) -Replace $regex, '${{ github.event.inputs.new_engine_version }}' | Out-File $input_path
 
     - name: Publish ${{ matrix.runtime-identifier }} version
-      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true /p:DeterministicBuild=true -o artifacts/${{ matrix.runtime-identifier }}
+      run: dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:Optimized=true /p:DeterministicBuild=true /p:ReleaseBuild=true -o artifacts/${{ matrix.runtime-identifier }}
 
     - name: Upload Lynx-${{ matrix.runtime-identifier }} artifact
       if: github.event.inputs.new_engine_version != ''
@@ -113,7 +113,7 @@ jobs:
 
     - name: Deterministic build
       if: matrix.runtime-identifier == 'linux-x64'
-      run: dotnet clean -c Release && dotnet build -c Release /p:DeterministicBuild=true
+      run: dotnet clean -c Release && dotnet build -c Release /p:DeterministicBuild=true /p:ReleaseBuild=true
 
     - name: Pack NuGet package
       if: matrix.runtime-identifier == 'linux-x64'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,10 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ReleaseBuild)' == 'true'">
+    <DefineConstants>LYNX_RELEASE</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup>
     <NoWarn>$(NoWarn),1591,S101,S104,S103,S107,S109,S125,S1067,S1135,S1659,S2148,S3903,S4041,S1133,IDE0290,RCS1090,CA1031,CA1045,CA1062,CA1505,CA1724,CA1815,CA1819,CA2007,VSTHRD200,IDE0290</NoWarn>
   </PropertyGroup>

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test:
 	dotnet test -c Release & dotnet test -c Release --filter "TestCategory=LongRunning" & dotnet test -c Release --filter "TestCategory=Perft"
 
 publish:
-	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:DeterministicBuild=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
+	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
 
 run:
 	dotnet run --project src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME}

--- a/src/Lynx/UCI/Commands/Engine/IdCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/IdCommand.cs
@@ -21,11 +21,22 @@ public sealed class IdCommand : IEngineBaseCommand
 
     public static string GetLynxVersion()
     {
-        return
-            Assembly.GetAssembly(typeof(IdCommand))
-                !.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
-                ?.InformationalVersion?.Split('+')[0]
-                ?? "Unknown";
+        var fullVersion = Assembly.GetAssembly(typeof(IdCommand))
+            !.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+
+        var parts = fullVersion?.Split('+');
+
+#if LYNX_RELEASE
+        return parts?[0] ?? "Unknown";
+#else
+        return parts?.Length switch
+        {
+            >= 2 => $"{parts[0]}-dev-{parts[1][..Math.Min(7, parts[1].Length)]}",
+            1 => parts[0],
+            _ => "Unknown"
+        };
+#endif
     }
 
     public static string NameString => $"id name {EngineName} {GetLynxVersion()}";


### PR DESCRIPTION
Introduce development versioning (enabled by default)

- `make` -> `Lynx <current_version>-dev-<commith_hash>`, i.e. `Lynx 1.9.1-dev-955dce1`
- GH CI builds -> `Lynx <current_version>-<branch>-<run_number>-dev-<commit_hash>`, i.e. `Lynx 1.9.1-main-5932-dev-955dce1`
- GH Release builds -> `Lynx <new_version>`, i.e. `Lynx 1.9.1`

GH CI builds is combined with the recent  #1621