### PR TITLE
🟰 Thread voting impl II

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -334,8 +334,9 @@ public sealed class Searcher
                             totalNodes += extraResult.Nodes;
 
                             if (extraResult.BestMove != default
-                                && ((extraResult.Depth > finalSearchResult.Depth && finalSearchResult.Mate == default)
-                                    || (extraResult.Depth == finalSearchResult.Depth && extraResult.Score > finalSearchResult.Score)))
+                                && (Math.Abs(extraResult.Mate) < Math.Abs(finalSearchResult.Mate)
+                                    || (extraResult.Depth > finalSearchResult.Depth && extraResult.Mate == finalSearchResult.Mate)
+                                    || (extraResult.Depth == finalSearchResult.Depth && (extraResult.Score > finalSearchResult.Score))))
                             {
                                 finalSearchResult = extraResult;
                             }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -323,11 +323,26 @@ public sealed class Searcher
 
                 if (finalSearchResult is not null)
                 {
+                    var totalNodes = finalSearchResult.Nodes;
+                    var totalTime = finalSearchResult.Time;
+
                     foreach (var extraResult in extraResults)
                     {
-                        finalSearchResult.Nodes += extraResult?.Nodes ?? 0;
+                        if (extraResult is not null)
+                        {
+                            finalSearchResult.Nodes += extraResult.Nodes;
+                            totalNodes += extraResult.Nodes;
+
+                            if (extraResult.BestMove != default
+                                && extraResult.Depth >= finalSearchResult.Depth
+                                && extraResult.Score >= finalSearchResult.Score)
+                            {
+                                finalSearchResult = extraResult;
+                            }
+                        }
                     }
 
+                    finalSearchResult.Nodes = totalNodes;
                     finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 
 #if MULTITHREAD_DEBUG

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -2,7 +2,6 @@ using Lynx.Model;
 using Lynx.UCI.Commands.Engine;
 using Lynx.UCI.Commands.GUI;
 using NLog;
-using System.Runtime.ConstrainedExecution;
 using System.Threading.Channels;
 
 namespace Lynx;

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -334,8 +334,8 @@ public sealed class Searcher
                             totalNodes += extraResult.Nodes;
 
                             if (extraResult.BestMove != default
-                                && extraResult.Depth >= finalSearchResult.Depth
-                                && extraResult.Score >= finalSearchResult.Score)
+                                && ((extraResult.Depth > finalSearchResult.Depth && finalSearchResult.Mate == default)
+                                    || (extraResult.Depth == finalSearchResult.Depth && extraResult.Score > finalSearchResult.Score)))
                             {
                                 finalSearchResult = extraResult;
                             }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -348,7 +348,7 @@ public sealed class Searcher
                                 }
                                 else if (                                               // Mate detected in main thread:
                                     extraResult.Mate < finalSearchResult.Mate               // Faster +Mate, or slower -Mate
-                                    || extraResult.Depth > finalSearchResult.Depth)         // Higher depth
+                                        || extraResult.Depth > finalSearchResult.Depth)     // Higher depth
                                 {
                                     finalSearchResult = extraResult;
                                 }


### PR DESCRIPTION
#1644 re-worked

2t
```
Score of Lynx-mt-thread-voting-2-5946-win-x64 vs Lynx 5940 - main: 180 - 199 - 451  [0.489] 830
...      Lynx-mt-thread-voting-2-5946-win-x64 playing White: 153 - 34 - 228  [0.643] 415
...      Lynx-mt-thread-voting-2-5946-win-x64 playing Black: 27 - 165 - 223  [0.334] 415
...      White vs Black: 318 - 61 - 451  [0.655] 830
Elo difference: -8.0 +/- 16.0, LOS: 16.5 %, DrawRatio: 54.3 %
SPRT: llr -0.427 (-14.8%), lbound -2.25, ubound 2.89
```

4t

```
Test  | mt/thread-voting-2
Elo   | 1.50 +- 9.27 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | 0.05 (-2.25, 2.89) [0.00, 3.00]
Games | 1856: +451 -443 =962
Penta | [21, 226, 430, 226, 25]
https://openbench.lynx-chess.com/test/1580/
```