### PR TITLE
🔍 Don't stop search early on extra threads when mate is detected

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -309,26 +309,29 @@ public sealed partial class Engine
                 return false;
             }
 
-            var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
-            _logger.Info(
-                "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
-                _id, depth - 1, mate, bestScore, winningMateThreshold);
-
-            if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
+            if (IsMainEngine)
             {
-                if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
-                {
-                    _logger.Info("[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
-                        _id, _searchConstraints.SoftLimitTimeBound);
+                var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
+                _logger.Info(
+                    "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+                    _id, depth - 1, mate, bestScore, winningMateThreshold);
 
-                    return false;
+                if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
+                {
+                    if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
+                    {
+                        _logger.Info("[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
+                            _id, _searchConstraints.SoftLimitTimeBound);
+
+                        return false;
+                    }
+
+                    _logger.Info("[#{EngineId}] Could stop search, since mate is short enough",
+                        _id, _searchConstraints.SoftLimitTimeBound);
                 }
 
-                _logger.Info("[#{EngineId}] Could stop search, since mate is short enough",
-                    _id, _searchConstraints.SoftLimitTimeBound);
+                _logger.Info("[#{EngineId}] Search continues, hoping to find a faster mate", _id);
             }
-
-            _logger.Info("[#{EngineId}] Search continues, hoping to find a faster mate", _id);
         }
 
         if (depth >= Configuration.EngineSettings.MaxDepth)


### PR DESCRIPTION
We're basically doing this to avoid the logs TBF, but kinda makes sense as well

I don't really understand how this didn't pass, but whatever
```
Test  | mt/no-early-stop-extra-threads-on-mate
Elo   | -4.78 +- 4.13 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=64MB
LLR   | -2.27 (-2.25, 2.89) [-5.00, 0.00]
Games | 10688: +2615 -2762 =5311
Penta | [202, 1368, 2350, 1223, 201]
https://openbench.lynx-chess.com/test/1587/
```

