### PR TITLE
🪵 Don't log extra threads mate detection regarding early exit 

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -309,26 +309,29 @@ public sealed partial class Engine
                 return false;
             }
 
-            var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
-            _logger.Info(
-                "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
-                _id, depth - 1, mate, bestScore, winningMateThreshold);
-
-            if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
+            if (IsMainEngine)
             {
-                if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
-                {
-                    _logger.Info("[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
-                        _id, _searchConstraints.SoftLimitTimeBound);
+                var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
+                _logger.Info(
+                    "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+                    _id, depth - 1, mate, bestScore, winningMateThreshold);
 
-                    return false;
+                if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
+                {
+                    if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
+                    {
+                        _logger.Info("[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
+                            _id, _searchConstraints.SoftLimitTimeBound);
+
+                        return false;
+                    }
+
+                    _logger.Info("[#{EngineId}] Could stop search, since mate is short enough",
+                        _id, _searchConstraints.SoftLimitTimeBound);
                 }
 
-                _logger.Info("[#{EngineId}] Could stop search, since mate is short enough",
-                    _id, _searchConstraints.SoftLimitTimeBound);
+                _logger.Info("[#{EngineId}] Search continues, hoping to find a faster mate", _id);
             }
-
-            _logger.Info("[#{EngineId}] Search continues, hoping to find a faster mate", _id);
         }
 
         if (depth >= Configuration.EngineSettings.MaxDepth)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -250,8 +250,14 @@ public sealed partial class Engine
         }
         catch (OperationCanceledException)
         {
-            // Here we want Info for main thread and Debug for extre threads
-            var higherLogLevel = LogLevel.FromOrdinal(logLevel.Ordinal + 1);
+            // One degree higher than log level, but can't add 1 to Off
+            var higherLogLevel = IsMainEngine
+                ? LogLevel.Info
+#if MULTITHREAD_DEBUG
+                : LogLevel.Debug;
+#else
+                : LogLevel.Off;
+#endif
 
 #pragma warning disable S6667 // Logging in a catch clause should pass the caught exception as a parameter - expected exception we want to ignore
             _logger.Log(higherLogLevel,


### PR DESCRIPTION
#1651 surprisingly failed, so here's a more complex approach that just modifies the logging