### PR TITLE
🧪 Multi-array TT

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1043,7 +1043,7 @@ static void TranspositionTableMethod()
     static void TesSize(int size)
     {
         Console.WriteLine("Hash: {0} MB", size);
-        var length = TranspositionTable.CalculateLength(size);
+        var length = (int)TranspositionTable.CalculateLength(size);
 
         var lengthMb = length / 1024 / 1024;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -309,7 +309,7 @@ public static class Constants
         13, 15, 15, 15, 12, 15, 15, 14
     ];
 
-    public static int AbsoluteMaxTTSize => (int)((ulong)Array.MaxLength * TranspositionTableElement.Size / (1024 * 1024));
+    public static int AbsoluteMaxTTSize => 524_288; // 4TB RAM, not bad
 
     public const int AbsoluteMinTTSize = 1;
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -270,7 +270,7 @@ public readonly struct TranspositionTable
         return score;
     }
 
-¡   [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private readonly ulong PopulatedItemsCount()
     {
         ulong items = 0;
@@ -321,7 +321,7 @@ public readonly struct TranspositionTable
                 if (_tt[i][j].Key != default)
                 {
                     var entry = _tt[i][j];
-                    Console.WriteLine($"{i}: Key = {entry.Key}, Depth: {entry.Depth}, Score: entry.Score}, Move: {(entry.Move != 0 ? ((Move)entry.Move).UCIString() : " - ")} {_tt[i].Type}");
+                    Console.WriteLine($"{i}: Key = {entry.Key}, Depth: {entry.Depth}, Score: {entry.Score}, Move: {(entry.Move != 0 ? ((Move)entry.Move).UCIString() : " - ")} {entry.Type}");
                 }
             }
         }

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -92,6 +92,8 @@ public readonly struct TranspositionTable
         if (Sse.IsSupported)
         {
             (var ttIndex, var entryIndex) = CalculateTTIndexes(position.UniqueIdentifier);
+            Debug.Assert(ttIndex < _ttArrayCount);
+            Debug.Assert(entryIndex < Array.MaxLength);
 
             unsafe
             {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -23,8 +23,8 @@ public sealed partial class Engine
         // Prevents runtime failure in case depth is increased due to check extension, since we're using ply when calculating pvTable index,
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
-            _logger.Debug("[#{EngineId}] Max depth {Depth} reached",
-                _id, Configuration.EngineSettings.MaxDepth);
+            _logger.Debug("[#{EngineId}] Max depth {Depth} reached while searching position {FEN}",
+                _id, Configuration.EngineSettings.MaxDepth, position.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
 
             return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         }
@@ -627,8 +627,8 @@ public sealed partial class Engine
 
         if (ply >= Configuration.EngineSettings.MaxDepth)
         {
-            _logger.Debug("[#{EngineId}] Max depth {Depth} reached in qsearch",
-                _id, Configuration.EngineSettings.MaxDepth);
+            _logger.Debug("[#{EngineId}] Max depth {Depth} reached in qsearch while searching position {FEN}",
+                _id, Configuration.EngineSettings.MaxDepth, position.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
 
             return position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         }

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -82,9 +82,9 @@ public class TranspositionTableTests
 
         var tt = new TranspositionTable();
 
-        Assert.AreNotEqual(0, tt.Length % Configuration.EngineSettings.Threads, "We want to test the edge case where the last thread clears more items than the rest");
+        Assert.AreNotEqual(0, (int)tt.Length % Configuration.EngineSettings.Threads, "We want to test the edge case where the last thread clears more items than the rest");
 
-        for(int index = 0; index < tt.Length; ++index)
+        for(int index = 0; index < (int)tt.Length; ++index)
         {
             ref var ttEntry = ref tt.Get(index);
             ttEntry.Update(1, 2, 3, 4, NodeType.Exact, 5, 6);
@@ -92,7 +92,7 @@ public class TranspositionTableTests
 
         tt.Clear();
 
-        for (int index = 0; index < tt.Length; ++index)
+        for (int index = 0; index < (int)tt.Length; ++index)
         {
             var ttEntry = tt.Get(index);
 


### PR DESCRIPTION
Non-reg using sizes that fit in one array (aka simply testing the impact of the double array access)
```
Score of Lynx-experiment-multiarray-tt-5985-win-x64 vs Lynx-logging-aspwindows-5986-win-x64: 5011 - 5074 - 9535  [0.498] 19620
...      Lynx-experiment-multiarray-tt-5985-win-x64 playing White: 3887 - 1072 - 4851  [0.643] 9810
...      Lynx-experiment-multiarray-tt-5985-win-x64 playing Black: 1124 - 4002 - 4684  [0.353] 9810
...      White vs Black: 7889 - 2196 - 9535  [0.645] 19620
Elo difference: -1.1 +/- 3.5, LOS: 26.5 %, DrawRatio: 48.6 %
SPRT: llr -0.146 (-5.1%), lbound -2.25, ubound 2.89
```

Non-reg distributing the items in 13 arrays (256GB TCEC ram / ~20GB current max TT size):
```
```

[0, 3] doubling TT size LTC
```
```