### PR TITLE
Don't defer Threads and Hash update until 'ucinewgame'

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -36,12 +36,13 @@ public readonly struct TranspositionTable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Clear()
     {
-        _logger.Debug("Clearing TT");
+        var threadCount = Configuration.EngineSettings.Threads;
+
+        _logger.Debug("Zeroing TT using {ThreadCount} thread(s)", threadCount);
         var sw = Stopwatch.StartNew();
 
         var tt = _tt;
         var ttLength = tt.Length;
-        var threadCount = Configuration.EngineSettings.Threads;
         var sizePerThread = ttLength / threadCount;
 
         // Instead of just doing Array.Clear(_tt):

--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -128,10 +128,10 @@ public sealed class OptionCommand : IEngineBaseCommand
             "option name UCI_Opponent type string",
             $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.EngineAuthor}, see https://github.com/lynx-chess/Lynx",
             $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL}",
-            $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min {Constants.AbsoluteMinTTSize} max {Constants.AbsoluteMaxTTSize}",
-            $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
             $"option name Threads type spin default {Configuration.EngineSettings.Threads} min 1 max {Constants.MaxThreadCount}",
+            $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min {Constants.AbsoluteMinTTSize} max {Constants.AbsoluteMaxTTSize}",
             $"option name Ponder type check default {Configuration.EngineSettings.IsPonder}",
+            $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
             .. Configuration.GeneralSettings.EnableTuning ? SPSAAttributeHelpers.GenerateOptionStrings() : []
         ];
 

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -211,6 +211,7 @@ public sealed class UCIHandler
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.Hash = value;
+                        _searcher.UpdateHash();
                     }
                     break;
                 }
@@ -255,6 +256,7 @@ public sealed class UCIHandler
                     if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
                     {
                         Configuration.EngineSettings.Threads = value;
+                        _searcher.UpdateThreads();
                     }
                     break;
 #pragma warning restore S1066 // Collapsible "if" statements should be merged


### PR DESCRIPTION
There's no UCI `isready` after `ucinewgame`, so these 2 initializations currently take time from the engine's first search.
That explains why _sometimes_ the first STC game ends up in a loss on time.

```
Test  | stop-deferring-hash-threads-update-until-ucinewgame
Elo   | -1.49 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [-10.00, 0.00]
Games | 13990: +3608 -3668 =6714
Penta | [247, 1691, 3178, 1633, 246]
https://openbench.lynx-chess.com/test/1590/
```