### PR TITLE
🔍202-04-09 - including Fail-low TTPV LMR

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -214,6 +214,12 @@ public sealed class EngineSettings
     public int LMR_Quiet { get; set; } = 100;
 
     /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_FailLowTTPV { get; set; } = 100;
+
+    /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -160,79 +160,79 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.85;
+    public double LMR_Base_Quiet { get; set; } = 0.56;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.52;
+    public double LMR_Base_Noisy { get; set; } = 0.43;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.70;
+    public double LMR_Divisor_Quiet { get; set; } = 2.20;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.67;
+    public double LMR_Divisor_Noisy { get; set; } = 2.58;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 75;
+    public int LMR_Improving { get; set; } = 124;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 141;
+    public int LMR_Cutnode { get; set; } = 86;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 82;
+    public int LMR_TTPV { get; set; } = 98;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 100;
+    public int LMR_TTCapture { get; set; } = 31;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 60;
+    public int LMR_PVNode { get; set; } = 112;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 79;
+    public int LMR_InCheck { get; set; } = 95;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 100;
+    public int LMR_Quiet { get; set; } = 137;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_FailLowTTPV { get; set; } = 100;
+    public int LMR_FailLowTTPV { get; set; } = 109;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3107;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2074;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3451;
+    public int LMR_History_Divisor_Noisy { get; set; } = 4003;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 38;
+    public int LMR_DeeperBase { get; set; } = 31;
 
     //[SPSA<int>(1, 10, 1)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -252,13 +252,13 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 113;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 107;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 10;
+    public int AspirationWindow_Base { get; set; } = 11;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -276,10 +276,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 104;
+    public int Razoring_Depth1Bonus { get; set; } = 143;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 190;
+    public int Razoring_NotDepth1Bonus { get; set; } = 213;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -300,7 +300,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 86;
+    public int History_BestScoreBetaMargin { get; set; } = 93;
 
     //[SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -309,16 +309,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 105;
+    public int FP_DepthScalingFactor { get; set; } = 112;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 108;
+    public int FP_Margin { get; set; } = 119;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -643;
+    public int HistoryPrunning_Margin { get; set; } = -362;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -332,10 +332,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -42;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -40;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -123;
 
     #endregion
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -446,6 +446,11 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_TTPV;
                                 }
 
+                                if (ttHit && ttPv && ttScore <= alpha)   // From Stormphrax
+                                {
+                                    reduction += Configuration.EngineSettings.LMR_FailLowTTPV;
+                                }
+
                                 if (ttMoveIsCapture)    // Move isn't a capture but TT move is
                                 {
                                     reduction += Configuration.EngineSettings.LMR_TTCapture;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -457,6 +457,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_faillowttpv":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_FailLowTTPV = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
```
iterations: 377 (281.34s per iter)
games: 12064 (8.79s per game)
LMR_Base_Quiet = 56(-28.593158) in [10, 200]
LMR_Base_Noisy = 43(-8.774680) in [10, 200]
LMR_Divisor_Quiet = 220(-49.522265) in [100, 500]
LMR_Divisor_Noisy = 258(-8.552130) in [100, 500]
LMR_Improving = 124(+49.27) in [25, 300]
LMR_Cutnode = 86(-55.303285) in [25, 300]
LMR_TTPV = 98(+16.27) in [25, 300]
LMR_TTCapture = 31(-68.586166) in [25, 300]
LMR_PVNode = 112(+51.65) in [25, 300]
LMR_InCheck = 95(+15.59) in [25, 300]
LMR_Quiet = 137(+36.65) in [25, 300]
LMR_FailLowTTPV = 109(+8.66) in [25, 300]
LMR_History_Divisor_Quiet = 2074(-1032.789284) in [1, 8192]
LMR_History_Divisor_Noisy = 4003(+551.96) in [1, 8192]
LMR_DeeperBase = 31(-6.735039) in [20, 100]
NMP_StaticEvalBetaDivisor = 107(-6.177814) in [50, 350]
AspirationWindow_Base = 11(+1.25) in [5, 30]
Razoring_Depth1Bonus = 143(+39.10) in [1, 300]
Razoring_NotDepth1Bonus = 213(+23.01) in [1, 300]
History_BestScoreBetaMargin = 93(+7.42) in [0, 200]
FP_DepthScalingFactor = 112(+7.18) in [1, 200]
FP_Margin = 119(+11.11) in [0, 500]
HistoryPrunning_Margin = -362(+280.63) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -40(+2.21) in [-100, -10]
PVS_SEE_Threshold_Noisy = -123(-6.190299) in [-150, -50]
```

![image](https://github.com/user-attachments/assets/af289006-aa8c-4257-947e-db2c0efef901)

```
Test  | spsa/lmr-faillow-ttpv-9-4
Elo   | -0.75 +- 3.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.77 (-2.25, 2.89) [0.00, 3.00]
Games | 11090: +2637 -2661 =5792
Penta | [128, 1376, 2572, 1330, 139]
https://openbench.lynx-chess.com/test/1583/
```
