### PR TITLE
⚡ Reduce nlog allocations

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -137,9 +137,12 @@ public sealed partial class Engine
                     alpha = Math.Clamp(lastSearchResult.Score - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
                     beta = Math.Clamp(lastSearchResult.Score + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
 
-                    _logger.Log(logLevel,
-                    "[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
-                    _id, depth, alpha, beta, lastSearchResult.Score, _nodes);
+                    if (_logger.IsEnabled(logLevel))
+                    {
+                        _logger.Log(logLevel,
+                            "[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
+                            _id, depth, alpha, beta, lastSearchResult.Score, _nodes);
+                    }
 
                     Debug.Assert(
                         lastSearchResult.Mate == 0
@@ -151,9 +154,12 @@ public sealed partial class Engine
                         var depthToSearch = depth - failHighReduction;
                         Debug.Assert(depthToSearch > 0);
 
-                        _logger.Log(logLevel,
+                        if (_logger.IsEnabled(logLevel))
+                        {
+                            _logger.Log(logLevel,
                             "[#{EngineId}] Asp-win depth {Depth} ({DepthWithoutReduction} - {Reduction}), window {Window}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
                             _id, depthToSearch, depth, failHighReduction, window, alpha, beta, bestScore, _nodes);
+                        }
 
                         bestScore = NegaMax(depth: depthToSearch, ply: 0, alpha, beta, cutnode: false, cancellationToken);
                         Debug.Assert(bestScore > EvaluationConstants.MinEval && bestScore < EvaluationConstants.MaxEval);
@@ -259,11 +265,14 @@ public sealed partial class Engine
                 : LogLevel.Off;
 #endif
 
+            if (_logger.IsEnabled(logLevel))
+            {
 #pragma warning disable S6667 // Logging in a catch clause should pass the caught exception as a parameter - expected exception we want to ignore
-            _logger.Log(higherLogLevel,
-            "[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
-            _id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
+                _logger.Log(higherLogLevel,
+                    "[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
+                    _id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
 #pragma warning restore S6667 // Logging in a catch clause should pass the caught exception as a parameter.
+            }
 
             for (int i = 0; i < lastSearchResult?.Moves.Length; ++i)
             {
@@ -324,34 +333,50 @@ public sealed partial class Engine
             }
 
             var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
-            _logger.Log(logLevel,
-                "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
-                _id, depth - 1, mate, bestScore, winningMateThreshold);
+
+            if (_logger.IsEnabled(logLevel))
+            {
+                _logger.Log(logLevel,
+                    "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+                    _id, depth - 1, mate, bestScore, winningMateThreshold);
+            }
 
             if (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold)
             {
                 if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
                 {
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
-                        _id, _searchConstraints.SoftLimitTimeBound);
+                    if (_logger.IsEnabled(logLevel))
+                    {
+                        _logger.Log(logLevel,
+                            "[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
+                            _id, _searchConstraints.SoftLimitTimeBound);
+                    }
 
                     return false;
                 }
 
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Could stop search, since mate is short enough",
-                    _id, _searchConstraints.SoftLimitTimeBound);
+                if (_logger.IsEnabled(logLevel))
+                {
+                    _logger.Log(logLevel,
+                        "[#{EngineId}] Could stop search, since mate is short enough",
+                        _id, _searchConstraints.SoftLimitTimeBound);
+                }
             }
 
-            _logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
+            if (_logger.IsEnabled(logLevel))
+            {
+                _logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
+            }
         }
 
         if (depth >= Configuration.EngineSettings.MaxDepth)
         {
-            _logger.Log(logLevel,
-                "[#{EngineId}] Max depth reached: {MaxDepth}",
-                _id, Configuration.EngineSettings.MaxDepth);
+            if (_logger.IsEnabled(logLevel))
+            {
+                _logger.Log(logLevel,
+                    "[#{EngineId}] Max depth reached: {MaxDepth}",
+                    _id, Configuration.EngineSettings.MaxDepth);
+            }
 
             return false;
         }
@@ -363,9 +388,12 @@ public sealed partial class Engine
 
             if (!shouldContinue)
             {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
-                    _id, depth - 1);
+                if (_logger.IsEnabled(logLevel))
+                {
+                    _logger.Log(logLevel,
+                        "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
+                        _id, depth - 1);
+                }
             }
 
             return shouldContinue;
@@ -378,15 +406,21 @@ public sealed partial class Engine
             var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
             var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
 
-            _logger.Log(logLevel,
-                "[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
-                _id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+            if (_logger.IsEnabled(logLevel))
+            {
+                _logger.Log(logLevel,
+                    "[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
+                    _id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+            }
 
             if (elapsedMilliseconds > scaledSoftLimitTimeBound)
             {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
-                    _id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
+                if (_logger.IsEnabled(logLevel))
+                {
+                    _logger.Log(logLevel,
+                        "[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
+                        _id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
+                }
 
                 return false;
             }


### PR DESCRIPTION
Check `Logger.IsEnabled(logLevel)` before invoking Logger methods with many parameters, since they allocate an array

```
Test  | perf/nlog-allocations
Elo   | -2.92 +- 3.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [-3.00, 1.00]
Games | 18584: +4804 -4960 =8820
Penta | [341, 2245, 4264, 2113, 329]
https://openbench.lynx-chess.com/test/1591/
```

8t
```
Test  | perf/nlog-allocations
Elo   | 0.06 +- 2.48 (95%)
SPRT  | 6.0+0.06s Threads=8 Hash=256MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | 26822: +6580 -6575 =13667
Penta | [385, 3249, 6132, 3266, 379]
https://openbench.lynx-chess.com/test/1593/
```