### PR TITLE
🔍 Noisy FP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -314,49 +314,62 @@ public sealed partial class Engine
             if (visitedMovesCounter > 0
                 && !pvNode
                 && !isInCheck
-                && isNotGettingCheckmated
-                && moveScore < EvaluationConstants.PromotionMoveScoreValue) // Quiet or bad capture
+                && isNotGettingCheckmated)
             {
-                // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
-                // after searching the first few given by the move ordering algorithm
-                if (moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1))) // Based on formula suggested by Antares
+                // Quiet or bad capture
+                if (moveScore < EvaluationConstants.PromotionMoveScoreValue)
                 {
-                    break;
-                }
-
-                // 🔍 History pruning -  all quiet moves can be pruned
-                // once we find one with a history score too low
-                if (!isCapture
-                    && moveScore < EvaluationConstants.CounterMoveValue
-                    && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
-                    && QuietHistory() < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
-                {
-                    break;
-                }
-
-                // 🔍 Futility Pruning (FP) - all quiet moves can be pruned
-                // once it's considered that they don't have potential to raise alpha
-                if (depth <= Configuration.EngineSettings.FP_MaxDepth
-                    && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
-                {
-                    break;
-                }
-
-                // 🔍 PVS SEE pruning
-                if (isCapture)
-                {
-                    var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Noisy * depth * depth;
-
-                    if (!SEE.IsGoodCapture(position, move, threshold))
+                    // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
+                    // after searching the first few given by the move ordering algorithm
+                    if (moveIndex >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1))) // Based on formula suggested by Antares
                     {
-                        continue;
+                        break;
+                    }
+
+                    // 🔍 History pruning -  all quiet moves can be pruned
+                    // once we find one with a history score too low
+                    if (!isCapture
+                        && moveScore < EvaluationConstants.CounterMoveValue
+                        && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
+                        && QuietHistory() < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
+                    {
+                        break;
+                    }
+
+                    // 🔍 Futility Pruning (FP) - all quiet moves can be pruned
+                    // once it's considered that they don't have potential to raise alpha
+                    if (depth <= Configuration.EngineSettings.FP_MaxDepth
+                        && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
+                    {
+                        break;
+                    }
+
+                    // 🔍 PVS SEE pruning
+                    if (isCapture)
+                    {
+                        var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Noisy * depth * depth;
+
+                        if (!SEE.IsGoodCapture(position, move, threshold))
+                        {
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Quiet * depth;
+
+                        if (!SEE.HasPositiveScore(position, move, threshold))
+                        {
+                            continue;
+                        }
                     }
                 }
                 else
                 {
-                    var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Quiet * depth;
-
-                    if (!SEE.HasPositiveScore(position, move, threshold))
+                    // 🔍 Noisy Futility Pruning (FP) - current noisy move can be pruned
+                    // once it's considered that they don't have potential to raise alpha
+                    if (depth <= Configuration.EngineSettings.FP_MaxDepth
+                        && staticEval + Configuration.EngineSettings.FP_Margin + (Configuration.EngineSettings.FP_DepthScalingFactor * depth) <= alpha)
                     {
                         continue;
                     }


### PR DESCRIPTION
Skip current move. even if noisy, if it doesn't fit FP conditions.
Same values as quiet FP

```
Score of Lynx-search-noisy-fp-6012-win-x64 vs Lynx 6005 - main: 985 - 1105 - 1895  [0.485] 3985
...      Lynx-search-noisy-fp-6012-win-x64 playing White: 776 - 253 - 963  [0.631] 1992
...      Lynx-search-noisy-fp-6012-win-x64 playing Black: 209 - 852 - 932  [0.339] 1993
...      White vs Black: 1628 - 462 - 1895  [0.646] 3985
Elo difference: -10.5 +/- 7.8, LOS: 0.4 %, DrawRatio: 47.6 %
SPRT: llr -2.26 (-78.2%), lbound -2.25, ubound 2.89 - H0 was accepted
```