### PR TITLE
🔍 Pawn correction history / corrhist

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -331,6 +331,16 @@ public sealed class EngineSettings
     [SPSA<int>(-150, -50, 10)]
     public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
 
+    /// <summary>
+    /// Initial value same as <see cref="History_MaxMoveValue"/>
+    /// </summary>
+    public int CorrHistory_MaxValue { get; set; } = 8_192;
+
+    /// <summary>
+    /// Initial value same as <see cref="History_MaxMoveRawBonus"/>
+    /// </summary>
+    public int CorrHistory_MaxRawBonus { get; set; } = 1_896;
+
     #endregion
 }
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -530,6 +530,12 @@ public static class Constants
     public const int KingPawnHashSize = 262_144;
 
     public const int KingPawnHashMask = KingPawnHashSize - 1;
+
+    public const int PawnCorrHistorySize = 16_384;
+
+    public const int PawnCorrHistoryMask = PawnCorrHistorySize - 1;
+
+    public const int CorrectionHistoryScale = 256;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -80,6 +80,8 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_pawnEvalTable);
 
+        Array.Clear(_pawnCorrHistory);
+
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -19,7 +19,8 @@ public class Position : IDisposable
 
     public ulong UniqueIdentifier { get; private set; }
 
-    private ulong _kingPawnUniqueIdentifier;
+    // TODO rename: CamelCase
+    public ulong _kingPawnUniqueIdentifier { get; private set; }
 
     /// <summary>
     /// Use <see cref="Piece"/> as index

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -129,7 +129,7 @@ public sealed partial class Engine
         var correction = _pawnCorrHistory[position._kingPawnUniqueIdentifier & Constants.PawnCorrHistoryMask];
         var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
 
-        return Math.Clamp(correctStaticEval, EvaluationConstants.MinEval, EvaluationConstants.MaxStaticEval);
+        return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -1,4 +1,5 @@
 ﻿using Lynx.Model;
+using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -102,7 +103,7 @@ public sealed partial class Engine
         var scaledBonus = evaluationDelta * Constants.CorrectionHistoryScale;
         var weight = 2 * Math.Min(16, depth + 1);
 
-        ref var pawnCorrHistEntry = ref _pawnCorrHistory[position._kingPawnUniqueIdentifier & Constants.PawnCorrHistoryMask];
+        ref var pawnCorrHistEntry = ref _pawnCorrHistory[(2 * (int)(position._kingPawnUniqueIdentifier & Constants.PawnCorrHistoryMask)) + (int)position.Side];
         pawnCorrHistEntry = UpdateCorrectionHistory(pawnCorrHistEntry, scaledBonus, weight);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -126,7 +127,7 @@ public sealed partial class Engine
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int CorrectStaticEvaluation(Position position, int staticEvaluation)
     {
-        var correction = _pawnCorrHistory[position._kingPawnUniqueIdentifier & Constants.PawnCorrHistoryMask];
+        var correction = _pawnCorrHistory[(2 * (int)(position._kingPawnUniqueIdentifier & Constants.PawnCorrHistoryMask)) + (int)position.Side];
         var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -1,5 +1,4 @@
 ﻿using Lynx.Model;
-using Microsoft.Extensions.Options;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -34,14 +34,17 @@ public sealed partial class Engine
     private readonly int[] _captureHistory = GC.AllocateArray<int>(12 * 64 * 12, pinned: true);
 
     /// <summary>
-    /// 12 x 64 x 12 x 64 x ContinuationHistoryPlyCount
+    /// 12 x 64 x 12 x 64 x <see cref="EvaluationConstants.ContinuationHistoryPlyCount"/>
     /// piece x target square x last piece x last target square x plies back
     /// ply 0 -> Continuation move history
     /// ply 1 -> Follow-up move history
     /// </summary>
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
-    private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistorySize, pinned: true);
+    /// <summary>
+    /// <see cref="Constants.PawnCorrHistorySize"/> * 2
+    /// </summary>
+    private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistorySize * 2, pinned: true);
 
     /// <summary>
     /// 12 x 64

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -41,6 +41,8 @@ public sealed partial class Engine
     /// </summary>
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
+    private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistorySize, pinned: true);
+
     /// <summary>
     /// 12 x 64
     /// piece x target square

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -142,11 +142,13 @@ public sealed partial class Engine
                 Debug.Assert(ttStaticEval != int.MinValue);
 
                 staticEval = ttStaticEval;
+                staticEval = CorrectStaticEvaluation(position, staticEval);
                 phase = position.Phase();
             }
             else
             {
                 (staticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
+                staticEval = CorrectStaticEvaluation(position, staticEval);
                 _tt.SaveStaticEval(position, staticEval, ttPv);
             }
 
@@ -611,6 +613,15 @@ public sealed partial class Engine
             staticEval = bestScore;
         }
 
+        if (!(isInCheck
+            || bestMove?.IsCapture() == true
+            || bestMove?.IsPromotion() == true
+            || (ttElementType == NodeType.Beta && bestScore <= staticEval)
+            || (ttElementType == NodeType.Alpha && bestScore >= staticEval)))
+        {
+            UpdateCorrectionHistory(position, bestScore - staticEval, depth);
+        }
+
         _tt.RecordHash(position, staticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
 
         return bestScore;
@@ -683,8 +694,11 @@ public sealed partial class Engine
         var staticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         Debug.Assert(staticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
 
+        staticEval = CorrectStaticEvaluation(position, staticEval);
+
         Game.UpdateStaticEvalInStack(ply, staticEval);
 
+        // TODO rename to standPat
         int eval =
             (ttNodeType == NodeType.Exact
                 || (ttNodeType == NodeType.Alpha && ttScore < staticEval)

--- a/tests/Lynx.Test/ConstantsTest.cs
+++ b/tests/Lynx.Test/ConstantsTest.cs
@@ -162,4 +162,11 @@ public class ConstantsTest
     {
         Assert.Less(Constants.MaxNumberMovesInAGame, 1024 * 1024, "We'd need to customize ArrayPool due to desired array size requirements");
     }
+
+    [Test]
+    public void PowerOfTwo()
+    {
+        Assert.True(int.IsPow2(KingPawnHashSize));
+        Assert.True(int.IsPow2(PawnCorrHistorySize));
+    }
 }


### PR DESCRIPTION
```
Test  | search/pawn-corrhist-3-stm
Elo   | 11.35 +- 5.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | 7502: +2107 -1862 =3533
Penta | [164, 808, 1592, 993, 194]
https://openbench.lynx-chess.com/test/1596/
```