### PR TITLE
🔍 Nonpawn correction history - poor man's implementation w/ key = zobrist key ^ pawns key

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -528,12 +528,13 @@ public static class Constants
     /// 262_144 * Marshal.SizeOf<PawnTableElement>() / 1024 = 4MB
     /// </summary>
     public const int KingPawnHashSize = 262_144;
-
     public const int KingPawnHashMask = KingPawnHashSize - 1;
 
     public const int PawnCorrHistorySize = 16_384;
-
     public const int PawnCorrHistoryMask = PawnCorrHistorySize - 1;
+
+    public const int NonPawnCorrHistorySize = 16_384;
+    public const int NonPawnCorrHistoryMask = PawnCorrHistorySize - 1;
 
     public const int CorrectionHistoryScale = 256;
 }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -81,6 +81,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_pawnEvalTable);
 
         Array.Clear(_pawnCorrHistory);
+        Array.Clear(_nonPawnCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,9 +42,15 @@ public sealed partial class Engine
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
     /// <summary>
-    /// <see cref="Constants.PawnCorrHistorySize"/> * 2
+    /// <see cref="Constants.PawnCorrHistorySize"/> x 2
     /// </summary>
     private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistorySize * 2, pinned: true);
+
+    /// <summary>
+    /// <see cref="Constants.PawnCorrHistorySize"/> x 2 (x *2)
+    /// hash x side to move x piece hash side
+    /// </summary>
+    private readonly int[] _nonPawnCorrHistory = GC.AllocateArray<int>(Constants.NonPawnCorrHistorySize * 2 /**2*/, pinned: true);
 
     /// <summary>
     /// 12 x 64

--- a/tests/Lynx.Test/ConstantsTest.cs
+++ b/tests/Lynx.Test/ConstantsTest.cs
@@ -168,5 +168,6 @@ public class ConstantsTest
     {
         Assert.True(int.IsPow2(KingPawnHashSize));
         Assert.True(int.IsPow2(PawnCorrHistorySize));
+        Assert.True(int.IsPow2(NonPawnCorrHistorySize));
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f9b2ddc3-a1f3-4388-b61d-fb058b221176)
