### PR TITLE
🔍 When TT cutoff conditions apply to PV nodes, reduce depth

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -72,15 +72,21 @@ public sealed partial class Engine
             ttEntryHasBestMove = ttBestMove != default;
 
             // TT cutoffs
-            if (!pvNode
-                && ttHit
+            if (ttHit
                 && ttDepth >= depth)
             {
                 if (ttElementType == NodeType.Exact
                     || (ttElementType == NodeType.Alpha && ttScore <= alpha)
                     || (ttElementType == NodeType.Beta && ttScore >= beta))
                 {
-                    return ttScore;
+                    if (pvNode)
+                    {
+                        --depth;
+                    }
+                    else
+                    {
+                        return ttScore;
+                    }
                 }
                 else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
                 {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -78,7 +78,8 @@ public sealed partial class Engine
                     || (ttElementType == NodeType.Alpha && ttScore <= alpha)
                     || (ttElementType == NodeType.Beta && ttScore >= beta))
                 {
-                    // in PV nodes, instead of the cutoff we reduce the depth
+                    // In PV nodes, instead of the cutoff we reduce the depth
+                    // Suggested by Calvin author, originally from Motor
                     if (pvNode)
                     {
                         --depth;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -88,7 +88,7 @@ public sealed partial class Engine
                         return ttScore;
                     }
                 }
-                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
+                else if (!pvNode && depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
                 {
                     // Extension idea from Stormphrax
                     ++depth;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -72,13 +72,13 @@ public sealed partial class Engine
             ttEntryHasBestMove = ttBestMove != default;
 
             // TT cutoffs
-            if (ttHit
-                && ttDepth >= depth)
+            if (ttHit && ttDepth >= depth)
             {
                 if (ttElementType == NodeType.Exact
                     || (ttElementType == NodeType.Alpha && ttScore <= alpha)
                     || (ttElementType == NodeType.Beta && ttScore >= beta))
                 {
+                    // in PV nodes, instead of the cutoff we reduce the depth
                     if (pvNode)
                     {
                         --depth;


### PR DESCRIPTION
```
Score of Lynx-search-ttprune-pvnode-reduction-6027-win-x64 vs Lynx 6005 - main: 6313 - 6318 - 11819  [0.500] 24450
...      Lynx-search-ttprune-pvnode-reduction-6027-win-x64 playing White: 4997 - 1301 - 5927  [0.651] 12225
...      Lynx-search-ttprune-pvnode-reduction-6027-win-x64 playing Black: 1316 - 5017 - 5892  [0.349] 12225
...      White vs Black: 10014 - 2617 - 11819  [0.651] 24450
Elo difference: -0.1 +/- 3.1, LOS: 48.2 %, DrawRatio: 48.3 %
SPRT: llr -1.85 (-63.9%), lbound -2.25, ubound 2.89
```

Pending LTC