### PR TITLE
🟰 Thread voting impl III

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <!--<DefineConstants>MULTITHREAD_DEBUG</DefineConstants>-->
+    <DefineConstants>MULTITHREAD_DEBUG</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
-    <DefineConstants>MULTITHREAD_DEBUG</DefineConstants>
+    <!--<DefineConstants>MULTITHREAD_DEBUG</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -373,7 +373,7 @@ public sealed class Searcher
 #endif
 
         var totalNodes = finalSearchResult?.Nodes ?? 0;
-        var totalTime = finalSearchResult?.Time ?? 0;
+        var finalTime = finalSearchResult?.Time ?? 0;
 
         await foreach (var task in Task.WhenEach(tasks))
         {
@@ -382,11 +382,11 @@ public sealed class Searcher
             if (extraResult is not null)
             {
                 totalNodes += extraResult.Nodes;
-                totalTime += extraResult.Time;
 
                 if (finalSearchResult is null)
                 {
                     finalSearchResult = extraResult;
+                    finalTime = extraResult.Time;
                     continue;
                 }
 
@@ -430,7 +430,7 @@ public sealed class Searcher
         if (finalSearchResult is not null)
         {
             finalSearchResult.Nodes = totalNodes;
-            finalSearchResult.Time = totalTime;
+            finalSearchResult.Time = finalTime;
 
             finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -403,6 +403,7 @@ public sealed class Searcher
                     var previousDepth = finalSearchResult.Depth;
                     var previousScore = finalSearchResult.Score;
                     var previousMate = finalSearchResult.Mate;
+                    var previousBestMove = finalSearchResult.BestMove;
 #endif
 
                     finalSearchResult = finalSearchResult.Mate switch
@@ -439,9 +440,10 @@ public sealed class Searcher
 #if MULTITHREAD_DEBUG
                     if (previousEngineId != finalSearchResult.EngineId)
                     {
-                        _logger.Warn("[MT] Engine {EngineId1} result (Depth {Depth1}, score {Score1}, mate {Mate1}) replaced with engine {EngineId2} one (Depth {Depth2}, score {Score2}, mate {Mate2})",
-                            previousEngineId, previousDepth, previousScore, previousMate,
-                            finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.Score, finalSearchResult.Mate);
+                        _logger.Warn("[MT] Engine {EngineId1} result (Depth {Depth1}, best move {BestMove1}, score {Score1}, mate {Mate1}) -> {EngineId2} result (Depth {Depth2}, best move {BestMove2}, score {Score2}, mate {Mate2}) | {FEN}",
+                            previousEngineId, previousDepth, previousBestMove, previousScore, previousMate,
+                            finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.BestMove, finalSearchResult.Score, finalSearchResult.Mate,
+                            _mainEngine.Game.PositionBeforeLastSearch.FEN(_mainEngine.Game.HalfMovesWithoutCaptureOrPawnMove));
                     }
 #endif
                 }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -439,7 +439,7 @@ public sealed class Searcher
 #if MULTITHREAD_DEBUG
                     if (previousEngineId != finalSearchResult.EngineId)
                     {
-                        _logger.Info("[MT] Engine {EngineId1} result (Depth {Depth1}, score {Score1}, mate {Mate1}) replaced with engine {EngineId2} one (Depth {Depth2}, score {Score2}, mate {Mate2})",
+                        _logger.Warn("[MT] Engine {EngineId1} result (Depth {Depth1}, score {Score1}, mate {Mate1}) replaced with engine {EngineId2} one (Depth {Depth2}, score {Score2}, mate {Mate2})",
                             previousEngineId, previousDepth, previousScore, previousMate,
                             finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.Score, finalSearchResult.Mate);
                     }
@@ -634,7 +634,8 @@ public sealed class Searcher
             {
                 _extraEngines[i] = new Engine(i + 2,
 #if MULTITHREAD_DEBUG
-                    _engineWriter,
+                    //_engineWriter,
+                    SilentChannelWriter<object>.Instance,
 #else
                     SilentChannelWriter<object>.Instance,
 #endif

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -440,7 +440,7 @@ public sealed class Searcher
 #if MULTITHREAD_DEBUG
                     if (previousEngineId != finalSearchResult.EngineId)
                     {
-                        _logger.Warn("[MT] #{EngineId1} (Depth {Depth1}, {BestMove1}, cp {Score1}, mate {Mate1}) -> #{EngineId2} result (Depth {Depth2}, {BestMove2}, cp {Score2}, mate {Mate2}) | {FEN}",
+                        _logger.Info("[MT] #{EngineId1} (Depth {Depth1}, {BestMove1}, cp {Score1}, mate {Mate1}) -> #{EngineId2} result (Depth {Depth2}, {BestMove2}, cp {Score2}, mate {Mate2}) | {FEN}",
                             previousEngineId, previousDepth, previousBestMove.UCIStringMemoized(), previousScore, previousMate,
                             finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.BestMove.UCIStringMemoized(), finalSearchResult.Score, finalSearchResult.Mate,
                             _mainEngine.Game.PositionBeforeLastSearch.FEN(_mainEngine.Game.HalfMovesWithoutCaptureOrPawnMove));
@@ -636,8 +636,7 @@ public sealed class Searcher
             {
                 _extraEngines[i] = new Engine(i + 2,
 #if MULTITHREAD_DEBUG
-                    //_engineWriter,
-                    SilentChannelWriter<object>.Instance,
+                    _engineWriter,
 #else
                     SilentChannelWriter<object>.Instance,
 #endif

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -372,14 +372,65 @@ public sealed class Searcher
                     _logger.Debug("End of extra searches, {0} ms", sw.ElapsedMilliseconds - lastElapsed);
 #endif
 
+        var totalNodes = finalSearchResult?.Nodes ?? 0;
+        var totalTime = finalSearchResult?.Time ?? 0;
+
+        await foreach (var task in Task.WhenEach(tasks))
+        {
+            var extraResult = await task;
+
+            if (extraResult is not null)
+            {
+                totalNodes += extraResult.Nodes;
+                totalTime += extraResult.Time;
+
+                if (finalSearchResult is null)
+                {
+                    finalSearchResult = extraResult;
+                    continue;
+                }
+
+                // Thread voting, original impl sligtly corrected based on by Heimdall's (based on Berserk's)
+                if (extraResult.BestMove != default)
+                {
+                    finalSearchResult = finalSearchResult.Mate switch
+                    {
+                        0                                                                       // No mate detected in main thread:
+                            when                                                                //      Extra thread:
+                                extraResult.Mate > 0                                            //          Mate
+                                    || extraResult.Depth > finalSearchResult.Depth              //          ||  Higher depth
+                                    || (extraResult.Depth == finalSearchResult.Depth            //          ||  Same depth, better score
+                                        && extraResult.Score > finalSearchResult.Score)
+
+                                => extraResult,
+                        > 0                                                                     // Mating in main thread:
+                            when                                                                //      Extra thread:
+                                extraResult.Mate > 0                                            //          Still mating
+                                    && (extraResult.Mate < finalSearchResult.Mate               //          &&  [But faster (shorter mate)
+                                        || (extraResult.Mate == finalSearchResult.Mate          //              || Same mating distance, but higher depth]
+                                            && extraResult.Depth > finalSearchResult.Depth))
+
+                                => extraResult,
+
+                        < 0                                                                     // Mated in main thread:
+                            when                                                                //      Extra thread:
+                                extraResult.Depth > finalSearchResult.Depth                     //          Higher depth
+                                    || (extraResult.Depth == finalSearchResult.Depth            //          || Same depth
+                                        && (extraResult.Mate >= 0                               //              && [But mating or at least not mated any more
+                                            || extraResult.Mate < finalSearchResult.Mate))      //                  || Still mated, but longer mate]
+
+                                => extraResult,
+
+                        _ => finalSearchResult
+                    };
+                }
+            }
+        }
+
         if (finalSearchResult is not null)
         {
-            // We wait just for the node count, so there's room for improvement here with thread voting
-            // and other strategies that take other thread results into account
-            await foreach (var extraResult in Task.WhenEach(tasks))
-            {
-                finalSearchResult.Nodes += (await extraResult)?.Nodes ?? 0;
-            }
+            finalSearchResult.Nodes = totalNodes;
+            finalSearchResult.Time = totalTime;
 
             finalSearchResult.NodesPerSecond = Utils.CalculateNps(finalSearchResult.Nodes, 0.001 * finalSearchResult.Time);
 

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -440,9 +440,9 @@ public sealed class Searcher
 #if MULTITHREAD_DEBUG
                     if (previousEngineId != finalSearchResult.EngineId)
                     {
-                        _logger.Warn("[MT] Engine {EngineId1} result (Depth {Depth1}, best move {BestMove1}, score {Score1}, mate {Mate1}) -> {EngineId2} result (Depth {Depth2}, best move {BestMove2}, score {Score2}, mate {Mate2}) | {FEN}",
-                            previousEngineId, previousDepth, previousBestMove, previousScore, previousMate,
-                            finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.BestMove, finalSearchResult.Score, finalSearchResult.Mate,
+                        _logger.Warn("[MT] #{EngineId1} (Depth {Depth1}, {BestMove1}, cp {Score1}, mate {Mate1}) -> #{EngineId2} result (Depth {Depth2}, {BestMove2}, cp {Score2}, mate {Mate2}) | {FEN}",
+                            previousEngineId, previousDepth, previousBestMove.UCIStringMemoized(), previousScore, previousMate,
+                            finalSearchResult.EngineId, finalSearchResult.Depth, finalSearchResult.BestMove.UCIStringMemoized(), finalSearchResult.Score, finalSearchResult.Mate,
                             _mainEngine.Game.PositionBeforeLastSearch.FEN(_mainEngine.Game.HalfMovesWithoutCaptureOrPawnMove));
                     }
 #endif


### PR DESCRIPTION
```
Test  | mt/thread-voting-revival-1
Elo   | 1.97 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=4 Hash=128MB
LLR   | 0.59 (-2.25, 2.89) [0.00, 3.00]
Games | 13260: +3228 -3153 =6879
Penta | [192, 1559, 3040, 1660, 179]
https://openbench.lynx-chess.com/test/1582/
```

```
32t, 250 20+0.2 games | +57 -53 =140
```

```
34t, 1030 40+0.4 games |  +244 -201 =585
```