### PR TITLE
🔍 Add ply & depth condition for TT non-cutoffs extension condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,8 @@ public sealed partial class Engine
                 {
                     return ttScore;
                 }
-                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
+                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth
+                    && ply < depth * 2) // Extra condition suggested by Sirius author
                 {
                     // Extension idea from Stormphrax
                     ++depth;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -83,7 +83,7 @@ public sealed partial class Engine
                     return ttScore;
                 }
                 else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth
-                    && ply < depth * 2) // Extra condition suggested by Sirius author
+                    && ply < depth * 4) // Extra condition suggested by Sirius author
                 {
                     // Extension idea from Stormphrax
                     ++depth;

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -410,4 +410,23 @@ public class RegressionTest : BaseTest
 
         Assert.AreEqual(depth, result.Depth);
     }
+
+    [Test]
+    public void HighSeldepthAtDepth2()
+    {
+        var engine = GetEngine();
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        var result = engine.BestMove(new("go wtime 3000 btime 3000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        // It used to happen at the second repetition, info depth 2 seldepth 124
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+    }
 }

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -417,10 +417,10 @@ public class RegressionTest : BaseTest
         var engine = GetEngine();
 
         engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        var result = engine.BestMove(new("go wtime 3000 btime 3000 winc 3000 binc 3000"));
+        var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
         Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
 
-        // It used to happen at the second repetition, info depth 2 seldepth 124
+        // It used to happen at the second repetition, info depth 2 seldepth 127
         engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
         result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
         Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
@@ -428,5 +428,24 @@ public class RegressionTest : BaseTest
         engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
         result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
         Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+    }
+
+    [Test]
+    public void HighSeldepthAtDepth2_FixedDepth()
+    {
+        var engine = GetEngine();
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        // It used to happen at the second repetition, info depth 2 seldepth 127
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go depth 3"));
+        Assert.Less(result.DepthReached, 16, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go depth 3"));
+        Assert.Less(result.DepthReached, 16, $"depth {result.Depth}, seldepth {result.DepthReached}");
     }
 }


### PR DESCRIPTION
Tweak https://github.com/lynx-chess/Lynx/pull/1342

ply < depth * 2
```
Test  | bugfix/high-seldepth-extra-condition
Elo   | -3.97 +- 3.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 13290: +3424 -3576 =6290
Penta | [263, 1748, 2802, 1542, 290]
https://openbench.lynx-chess.com/test/1606/
```

ply < depth * 4
```
Test  | bugfix/high-seldepth-extra-condition
Elo   | -0.56 +- 1.12 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=64MB
LLR   | 0.41 (-2.25, 2.89) [-3.00, 1.00]
Games | 137864: +34130 -34351 =69383
Penta | [2205, 17048, 30686, 16749, 2244]
https://openbench.lynx-chess.com/test/1608/
```

Removing the extension idea (#1672) is worse than this workaround