### PR TITLE
🔍 Add `alpha != beta - 1` condition for TT non-cutoffs extension condition

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -82,7 +82,8 @@ public sealed partial class Engine
                 {
                     return ttScore;
                 }
-                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
+                else if (depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth
+                    && alpha != beta - 1)
                 {
                     // Extension idea from Stormphrax
                     ++depth;

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -410,4 +410,23 @@ public class RegressionTest : BaseTest
 
         Assert.AreEqual(depth, result.Depth);
     }
+
+    [Test]
+    public void HighSeldepthAtDepth2()
+    {
+        var engine = GetEngine();
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        var result = engine.BestMove(new("go wtime 3000 btime 3000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        // It used to happen at the second repetition, info depth 2 seldepth 124
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+        Assert.Less(result.DepthReached, 3 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+    }
 }


### PR DESCRIPTION
Tweak https://github.com/lynx-chess/Lynx/pull/1342

```
Test  | bugfix/high-seldepth-extra-condition-2
Elo   | -4.65 +- 4.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.75 (-2.25, 2.89) [-3.00, 1.00]
Games | 8446: +2134 -2247 =4065
Penta | [184, 1074, 1802, 997, 166]
https://openbench.lynx-chess.com/test/1609/
```