### PR TITLE
🔍 TT cutoffs: only allow if `ttScore <= alpha` or cutnode II

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -74,7 +74,8 @@ public sealed partial class Engine
             // TT cutoffs
             if (!pvNode
                 && ttHit
-                && ttDepth >= depth)
+                && ttDepth >= depth
+                && (ttScore <= alpha || cutnode))
             {
                 if (ttElementType == NodeType.Exact
                     || (ttElementType == NodeType.Alpha && ttScore <= alpha)


### PR DESCRIPTION
#1238 again, trying to mitigate bug related to #1342 

```
Test  | search/tt-cutoffs-cutnode-alpha-2
Elo   | -2.78 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 15856: +4094 -4221 =7541
Penta | [329, 2002, 3415, 1831, 351]
https://openbench.lynx-chess.com/test/1610/
```