### PR TITLE
🔍 Add missing eval correction in PVnodes

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -258,8 +258,9 @@ public sealed partial class Engine
         }
         else
         {
-            staticEval = rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
-            // TODO correct static eval
+            rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
+            staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+
             if (!ttHit)
             {
                 _tt.SaveStaticEval(position, rawStaticEval, ttPv);


### PR DESCRIPTION
```
Score of Lynx-search-corrhist-pvnodes-6055-win-x64 vs Lynx 6054 - main: 2685 - 2624 - 5001  [0.503] 10310
...      Lynx-search-corrhist-pvnodes-6055-win-x64 playing White: 2152 - 508 - 2495  [0.659] 5155
...      Lynx-search-corrhist-pvnodes-6055-win-x64 playing Black: 533 - 2116 - 2506  [0.346] 5155
...      White vs Black: 4268 - 1041 - 5001  [0.656] 10310
Elo difference: 2.1 +/- 4.8, LOS: 79.9 %, DrawRatio: 48.5 %
SPRT: llr 2.03 (70.1%), lbound -2.25, ubound 2.89
```