### PR TITLE
🐛 Add missing `ArrayPool<ulong>.Shared.Return` for `Position.NonPawnHash`

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1811,6 +1811,7 @@ public class Position : IDisposable
     {
         ArrayPool<BitBoard>.Shared.Return(PieceBitBoards, clearArray: true);
         ArrayPool<BitBoard>.Shared.Return(OccupancyBitBoards, clearArray: true);
+        ArrayPool<ulong>.Shared.Return(NonPawnHash, clearArray: true);
         // No need to clear, since we always have to initialize it to Piece.None after renting it anyway
 #pragma warning disable S3254 // Default parameter values should not be passed as arguments
         ArrayPool<int>.Shared.Return(Board, clearArray: false);


### PR DESCRIPTION
```
Test  | bugfix/missing-nonpawnhash-return
Elo   | 5.94 +- 8.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-10.00, 0.00]
Games | 2458: +664 -622 =1172
Penta | [45, 281, 538, 317, 48]
https://openbench.lynx-chess.com/test/1621/
```