### PR TITLE
🔍 Corrplexity inverted: reduce more when `Math.Abs(corrected - diff)` is small

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,6 +211,15 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval_Delta { get; set; } = 75;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Quiet { get; set; } = 100;
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -474,6 +474,11 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_InCheck;
                                 }
 
+                                if(Math.Abs(staticEval - rawStaticEval) > Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_CorrectedStaticEval;
+                                }
+
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // -= history/(maxHistory/2)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -474,9 +474,10 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_InCheck;
                                 }
 
-                                if(Math.Abs(staticEval - rawStaticEval) > Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta)
+                                // 'Correplexity'
+                                if(Math.Abs(staticEval - rawStaticEval) <= Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta)
                                 {
-                                    reduction -= Configuration.EngineSettings.LMR_CorrectedStaticEval;
+                                    reduction += Configuration.EngineSettings.LMR_CorrectedStaticEval;
                                 }
 
                                 reduction /= EvaluationConstants.LMRScaleFactor;

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -459,6 +459,22 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_correctedstaticeval":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_CorrectedStaticEval = value;
+                    }
+                    break;
+                }
+            case "lmr_correctedstaticeval_delta":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
```
Score of Lynx-search-corrplexity-inverted-6081-win-x64 vs Lynx 6080 - main: 597 - 689 - 1214  [0.482] 2500
...      Lynx-search-corrplexity-inverted-6081-win-x64 playing White: 465 - 157 - 628  [0.623] 1250
...      Lynx-search-corrplexity-inverted-6081-win-x64 playing Black: 132 - 532 - 586  [0.340] 1250
...      White vs Black: 997 - 289 - 1214  [0.642] 2500
Elo difference: -12.8 +/- 9.8, LOS: 0.5 %, DrawRatio: 48.6 %
SPRT: llr -1.73 (-59.8%), lbound -2.25, ubound 2.89
```