### PR TITLE
🐛 `IndexOutOfRange` due to `depth = -1`

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -54,10 +54,13 @@ public sealed partial class Engine
         const int pieceOffset = 64 * 12;
         const int targetSquareOffset = 12;
 
-        return ref _captureHistory[
-            (move.Piece() * pieceOffset)
+        var index = (move.Piece() * pieceOffset)
             + (move.TargetSquare() * targetSquareOffset)
-            + move.CapturedPiece()];
+            + move.CapturedPiece();
+
+        Debug.Assert(index < _captureHistory.Length);
+
+        return ref _captureHistory[index];
     }
 
     /// <summary>
@@ -73,11 +76,14 @@ public sealed partial class Engine
 
         var previousMove = Game.ReadMoveFromStack(ply);
 
-        return ref _continuationHistory[
-            (piece * pieceOffset)
+        var index = (piece * pieceOffset)
             + (targetSquare * targetSquareOffset)
             + (previousMove.Piece() * previousMovePieceOffset)
-            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset)];
+            + (previousMove.TargetSquare() * previousMoveTargetSquareOffset);
+
+        Debug.Assert(index < _continuationHistory.Length);
+
+        return ref _continuationHistory[index];
         //+ 0];
     }
 
@@ -91,9 +97,12 @@ public sealed partial class Engine
 
         var previousMove = Game.ReadMoveFromStack(ply);
 
-        return ref _counterMoves[
-            (previousMove.Piece() * sourceSquareOffset)
-            + previousMove.TargetSquare()];
+        var index = (previousMove.Piece() * sourceSquareOffset)
+            + previousMove.TargetSquare();
+
+        Debug.Assert(index < _counterMoves.Length);
+
+        return ref _counterMoves[index];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -110,25 +119,36 @@ public sealed partial class Engine
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);
 
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryMask;
-        ref var pawnCorrHistEntry = ref _pawnCorrHistory[(2 * pawnIndex) + side];
+
+        var pawnCorrHistIndex = (2 * pawnIndex) + side;
+        Debug.Assert(pawnCorrHistIndex < (ulong)_pawnCorrHistory.Length);
+
+        ref var pawnCorrHistEntry = ref _pawnCorrHistory[pawnCorrHistIndex];
 
         pawnCorrHistEntry = UpdateCorrectionHistory(pawnCorrHistEntry, scaledBonus, weight);
 
         var nonPawnSTMIndex = position.NonPawnHash[side] & Constants.NonPawnCorrHistoryMask;
 
-        ref var nonPawnSTMCorrHistEntry = ref _nonPawnCorrHistory[
+        var nonPawnCorrHistSTMIndex =
             (nonPawnSTMIndex * 2 * 2)
             + (side * 2)
-            + side];
+            + side;
+
+        Debug.Assert(nonPawnCorrHistSTMIndex < (ulong)_nonPawnCorrHistory.Length);
+
+        ref var nonPawnSTMCorrHistEntry = ref _nonPawnCorrHistory[nonPawnCorrHistSTMIndex];
 
         nonPawnSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnSTMCorrHistEntry, scaledBonus, weight);
 
         var nonPawnNoSTMIndex = position.NonPawnHash[oppositeSide] & Constants.NonPawnCorrHistoryMask;
 
-        ref var nonPawnNoSTMCorrHistEntry = ref _nonPawnCorrHistory[
-            (nonPawnNoSTMIndex * 2 * 2)
+        var nonPawnNoSTMCorrHistIndex = (nonPawnNoSTMIndex * 2 * 2)
             + (side * 2)
-            + (ulong)oppositeSide];
+            + (ulong)oppositeSide;
+
+        Debug.Assert(nonPawnNoSTMCorrHistIndex < (ulong)_nonPawnCorrHistory.Length);
+
+        ref var nonPawnNoSTMCorrHistEntry = ref _nonPawnCorrHistory[nonPawnNoSTMCorrHistIndex];
 
         nonPawnNoSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnNoSTMCorrHistEntry, scaledBonus, weight);
 
@@ -162,21 +182,30 @@ public sealed partial class Engine
 
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryMask;
 
-        var pawnCorrHist = _pawnCorrHistory[(2 * pawnIndex) + side];
+        var pawnCorrHistIndex = (2 * pawnIndex) + side;
+        Debug.Assert(pawnCorrHistIndex < (ulong)_pawnCorrHistory.Length);
+
+        var pawnCorrHist = _pawnCorrHistory[pawnCorrHistIndex];
 
         var nonPawnSTMoveIndex = position.NonPawnHash[side] & Constants.NonPawnCorrHistoryMask;
 
-        var nonPawnSTMCorrHist = _nonPawnCorrHistory[
-            (nonPawnSTMoveIndex * 2 * 2)
+        var nonPawnSTMoveCorrHistIndex = (nonPawnSTMoveIndex * 2 * 2)
             + (side * 2)
-            + side];
+            + side;
+
+        Debug.Assert(nonPawnSTMoveCorrHistIndex < (ulong)_nonPawnCorrHistory.Length);
+
+        var nonPawnSTMCorrHist = _nonPawnCorrHistory[nonPawnSTMoveCorrHistIndex];
 
         var nonPawnNoSTMIndex = position.NonPawnHash[oppositeSide] & Constants.NonPawnCorrHistoryMask;
 
-        var nonPawnNoSTMCorrHist = _nonPawnCorrHistory[
-            (nonPawnNoSTMIndex * 2 * 2)
+        var nonPawnNoSTMCorrHistIndex = (nonPawnNoSTMIndex * 2 * 2)
             + (side * 2)
-            + (ulong)oppositeSide];
+            + (ulong)oppositeSide;
+
+        Debug.Assert(nonPawnNoSTMCorrHistIndex < (ulong)_nonPawnCorrHistory.Length);
+
+        var nonPawnNoSTMCorrHist = _nonPawnCorrHistory[nonPawnNoSTMCorrHistIndex];
 
         var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist;
         var correctStaticEval = staticEvaluation + (correction / (Constants.CorrectionHistoryScale * 3));

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,6 @@
-﻿using Lynx.Model;
+﻿#pragma warning disable S1192 // String literals should not be duplicated - it's assertion message strings
+
+using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
@@ -19,6 +21,8 @@ public sealed partial class Engine
     private int NegaMax(int depth, int ply, int alpha, int beta, bool cutnode, CancellationToken cancellationToken, bool parentWasNullMove = false)
     {
         var position = Game.CurrentPosition;
+
+        Debug.Assert(depth >= 0 || !position.IsInCheck(), "Assertion failed", "Current check extension impl won't work otherwise");
 
         // Prevents runtime failure in case depth is increased due to check extension, since we're using ply when calculating pvTable index,
         if (ply >= Configuration.EngineSettings.MaxDepth)
@@ -78,20 +82,22 @@ public sealed partial class Engine
                     || (ttElementType == NodeType.Alpha && ttScore <= alpha)
                     || (ttElementType == NodeType.Beta && ttScore >= beta))
                 {
+                    if (!pvNode)
+                    {
+                        return ttScore;
+                    }
+
                     // In PV nodes, instead of the cutoff we reduce the depth
                     // Suggested by Calvin author, originally from Motor
-                    if (pvNode)
+                    // I had to add the not-in-check guard
+                    if (!position.IsInCheck())
                     {
                         --depth;
 
-                        if (depth <= 0 && !position.IsInCheck())
+                        if (depth <= 0)
                         {
                             return QuiescenceSearch(ply, alpha, beta, pvNode, cancellationToken);
                         }
-                    }
-                    else
-                    {
-                        return ttScore;
                     }
                 }
                 else if (!pvNode && depth <= Configuration.EngineSettings.TTHit_NoCutoffExtension_MaxDepth)
@@ -278,6 +284,8 @@ public sealed partial class Engine
                 _tt.SaveStaticEval(position, rawStaticEval, ttPv);
             }
         }
+
+        Debug.Assert(depth >= 0, "Assertion failed", "QSearch should have been triggered");
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -410,4 +410,13 @@ public class RegressionTest : BaseTest
 
         Assert.AreEqual(depth, result.Depth);
     }
+
+    [TestCase("8/1p1k3b/p1n1pp2/P1B4p/BPP2p2/5P2/3K2PP/8 b - c3 1 1", 30)]
+    public void NegativeDepth(string fen, int depth)
+    {
+        var engine = GetEngine();
+        engine.AdjustPosition($"position fen {fen}");
+
+        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+    }
 }


### PR DESCRIPTION
#1668 caused illegal moves due to provoking the situation of being depth < 0 and `inCheck`, which triggers check extensions but keeps depth < 0, ending up trying to access `HistoryBonus[-1]`

[-5, 0]

```
Score of Lynx-bugfix-indexoutofrange-6088-win-x64 vs Lynx 6086 - main: 1721 - 1680 - 3189  [0.503] 6590
...      Lynx-bugfix-indexoutofrange-6088-win-x64 playing White: 1345 - 373 - 1578  [0.647] 3296
...      Lynx-bugfix-indexoutofrange-6088-win-x64 playing Black: 376 - 1307 - 1611  [0.359] 3294
...      White vs Black: 2652 - 749 - 3189  [0.644] 6590
Elo difference: 2.2 +/- 6.0, LOS: 75.9 %, DrawRatio: 48.4 %
SPRT: llr 2.47 (85.3%), lbound -2.25, ubound 2.89
```