### PR TITLE
👁️ Add option to estimate multithreaded-search NPS

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -14,7 +14,7 @@
     "UseOnlineTablebaseInRootPositions": false, // Experimental, requires network connection
     "ShowWDL": false,
     "IsPonder": false,
-    "EstimateMultithreadedSearchNPS":  true
+    "EstimateMultithreadedSearchNPS": true
   },
 
   // Logging settings

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -13,7 +13,8 @@
     "TranspositionTableSize": 256,
     "UseOnlineTablebaseInRootPositions": false, // Experimental, requires network connection
     "ShowWDL": false,
-    "IsPonder": false
+    "IsPonder": false,
+    "EstimateMultithreadedSearchNPS":  true
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -109,6 +109,12 @@ public sealed class EngineSettings
 
     public bool IsPonder { get; set; }
 
+    /// <summary>
+    /// Real NPS aren't calculated until the last search command.
+    /// This option enables the report of an NPS estimation by the main thread
+    /// </summary>
+    public bool EstimateMultithreadedSearchNPS { get; set; }
+
     public double SPSA_OB_R_end { get; set; } = 0.02;
 
     #region Time management

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -64,7 +64,7 @@ public sealed class SearchResult
 
         var nps = NodesPerSecond;
 
-        if (HashfullPermill != -1   // Not last info command
+        if (HashfullPermill == -1   // Not last info command
             && Configuration.EngineSettings.EstimateMultithreadedSearchNPS)
         {
             nps *= (ulong)Configuration.EngineSettings.Threads;

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -67,7 +67,11 @@ public sealed class SearchResult
         if (HashfullPermill == -1   // Not last info command
             && Configuration.EngineSettings.EstimateMultithreadedSearchNPS)
         {
+            // Estimate total nps
             nps *= (ulong)Configuration.EngineSettings.Threads;
+
+            // Remove the 5 less significative digits to hint that this is an estimate
+            nps = nps / 100_000 * 100_000;
         }
 
         sb.Append(InfoCommand.Id)

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -71,7 +71,8 @@ public sealed class SearchResult
             nps *= (ulong)Configuration.EngineSettings.Threads;
 
             // Remove the 5 less significative digits to hint that this is an estimate
-            nps = nps / 100_000 * 100_000;
+            const int k = 100_000;
+            nps = nps / k * k;
         }
 
         sb.Append(InfoCommand.Id)

--- a/src/Lynx/Model/SearchResult.cs
+++ b/src/Lynx/Model/SearchResult.cs
@@ -62,13 +62,21 @@ public sealed class SearchResult
         sb.Append("[#").Append(EngineId).Append("] ");
 #endif
 
+        var nps = NodesPerSecond;
+
+        if (HashfullPermill != -1   // Not last info command
+            && Configuration.EngineSettings.EstimateMultithreadedSearchNPS)
+        {
+            nps *= (ulong)Configuration.EngineSettings.Threads;
+        }
+
         sb.Append(InfoCommand.Id)
           .Append(" depth ").Append(Depth)
           .Append(" seldepth ").Append(DepthReached)
           .Append(" multipv 1")
           .Append(" score ").Append(Mate == default ? "cp " + Lynx.WDL.NormalizeScore(Score) : "mate " + Mate)
           .Append(" nodes ").Append(Nodes)
-          .Append(" nps ").Append(NodesPerSecond)
+          .Append(" nps ").Append(nps)
           .Append(" time ").Append(Time);
 
         if (HashfullPermill != -1)

--- a/tests/Lynx.Test/ConfigurationTest.cs
+++ b/tests/Lynx.Test/ConfigurationTest.cs
@@ -41,7 +41,8 @@ public class ConfigurationTest
         {
             foreach (var property in reflectionProperties)
             {
-                if (property.PropertyType == typeof(int[]))
+                if (property.PropertyType == typeof(int[])
+                    || property.Name == "EstimateMultithreadedSearchNPS")
                 {
                     continue;
                 }


### PR DESCRIPTION
In current impl only last UCI `info` command takes into account multithreaded search and therefore the nps from all threads.
This PR adds an option to estimate the total NPS for the intermediate `info` commands.

With this impl relying on hashfull population, it's possible that the last `info` command from the main thread contains hashfull, due to the 'final search result' generation reusing the last search result object, and its hashfull being populated before the .ToString() is invoked

```
info depth 24 seldepth 28 multipv 1 score cp 35 nodes 140327 nps 11700000 time 72 pv e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 f2f3 g6g5 f4e5 c7c6 g3g4 f5g6
info depth 25 seldepth 31 multipv 1 score cp 35 nodes 177897 nps 11000000 time 96 pv e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 f2f3 g6g5 f4e5 c7c6 g3g4 f5g6 h2h4 f6d7
info depth 26 seldepth 31 multipv 1 score cp 35 nodes 218050 nps 10200000 time 127 pv e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 f2f3 g6g5 f4e5 c7c6 g3g4 f5g6 h2h4
info depth 27 seldepth 33 multipv 1 score cp 28 nodes 433887 nps 9800000 time 264 pv e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 c3b5 g6g5 f4e5 f6g4 e5g7 g8g7 d1d2 g4f6 b5c3 c7c6 h2h4 g5g4 f2f3 h6h5 f3g4 h5g4
info depth 28 seldepth 33 multipv 1 score cp 30 nodes 603237 nps 9700000 time 371 pv e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 f2f3 g6g5 f4e5 c7c6 g3g4 f5g6 h2h4 f6d7 e5d6 g7f8
info depth 29 seldepth 36 multipv 1 score cp 59 nodes 3020310 nps 1467273 time 2058 hashfull 698 pv e1c1 a7a6 b5e2 c6b4 a2a3 f5c2 d1e1 c2b3 a3b4 g6g5 f4g5 h6g5 h2h4 g5h4 g3h4 a6a5 b4b5 a5a4 h4h5 a4a3 h5h6 a3a2 c3a2 a8a2 h6g7 g8g7
info depth 32 seldepth 41 multipv 1 score cp 29 nodes 18075948 nps 8783259 time 2058 hashfull 698 pv f3e5 e8g8 e1c1 a7a6 e5c6 a6b5 c6b8 f8b8 a2a3 b8c8 f2f3 g6g5 f4e5 c7c6 g3g4 f5g6 h2h4 f6d7 e5g7 g8g7 c3e2 g5h4 h1h4 a8a4
bestmove f3e5 ponder e8g8
```

However, the final `info` command comes immediately after it with the real NPS, so it shouldn't be a problem.