### PR TITLE
🔍 Corrplexity: reduce less when `Math.Abs(corrected - diff)` is big (100 cp)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -211,6 +211,15 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval_Delta { get; set; } = 75;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Quiet { get; set; } = 100;
 
     /// <summary>

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -214,7 +214,7 @@ public sealed class EngineSettings
     public int LMR_CorrectedStaticEval { get; set; } = 100;
 
     [SPSA<int>(25, 300, 30)]
-    public int LMR_CorrectedStaticEval_Delta { get; set; } = 75;
+    public int LMR_CorrectedStaticEval_Delta { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -474,6 +474,11 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_InCheck;
                                 }
 
+                                if(Math.Abs(staticEval - rawStaticEval) > Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_CorrectedStaticEval;
+                                }
+
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // -= history/(maxHistory/2)

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -459,6 +459,22 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "lmr_correctedstaticeval":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_CorrectedStaticEval = value;
+                    }
+                    break;
+                }
+            case "lmr_correctedstaticeval_delta":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta = value;
+                    }
+                    break;
+                }
 
             case "nmp_mindepth":
                 {


### PR DESCRIPTION
```
Score of Lynx-search-corrplexity-2-6078-win-x64 vs Lynx 6073 - main: 17963 - 17796 - 34028  [0.501] 69787
...      Lynx-search-corrplexity-2-6078-win-x64 playing White: 14324 - 3582 - 16987  [0.654] 34893
...      Lynx-search-corrplexity-2-6078-win-x64 playing Black: 3639 - 14214 - 17041  [0.348] 34894
...      White vs Black: 28538 - 7221 - 34028  [0.653] 69787
Elo difference: 0.8 +/- 1.8, LOS: 81.1 %, DrawRatio: 48.8 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```