### PR TITLE
⚡  Make `GameState` a ref struct

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly struct GameState
+public readonly ref struct GameState
 {
     public readonly ulong ZobristKey;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -482,7 +482,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnmakeMove(Move move, GameState gameState)
+    public void UnmakeMove(Move move, in GameState gameState)
     {
         var oppositeSide = (int)Side;
         var side = Utils.OppositeSide(oppositeSide);
@@ -604,7 +604,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnMakeNullMove(GameState gameState)
+    public void UnMakeNullMove(in GameState gameState)
     {
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;


### PR DESCRIPTION
FML

```
Test  | perf/ref-gamestate
Elo   | -1.15 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 78360: +20343 -20602 =37415
Penta | [1408, 9202, 18178, 9025, 1367]
https://openbench.lynx-chess.com/test/1622/
```