### PR TITLE
⚡ Avoid `GameState` struct copies

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -482,7 +482,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnmakeMove(Move move, GameState gameState)
+    public void UnmakeMove(Move move, in GameState gameState)
     {
         var oppositeSide = (int)Side;
         var side = Utils.OppositeSide(oppositeSide);
@@ -604,7 +604,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnMakeNullMove(GameState gameState)
+    public void UnMakeNullMove(in GameState gameState)
     {
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -267,7 +267,7 @@ public sealed partial class Engine
 
                     var gameState = position.MakeNullMove();
                     var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);
-                    position.UnMakeNullMove(gameState);
+                    position.UnMakeNullMove(in gameState);
 
                     if (nmpScore >= beta)
                     {
@@ -393,7 +393,7 @@ public sealed partial class Engine
 
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -416,7 +416,7 @@ public sealed partial class Engine
             {
                 Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
                 Game.RemoveFromPositionHashHistory();
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
             }
 
             int score = 0;
@@ -799,7 +799,7 @@ public sealed partial class Engine
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -814,7 +814,7 @@ public sealed partial class Engine
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMove(move, in gameState);
 
             PrintMove(position, ply, move, score, isQuiescence: true);
 


### PR DESCRIPTION
Linter doesn't recommend it yet, being the threshold 80 bytes

```
Test  | perf/in-gamestate
Elo   | -1.74 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 37472: +9776 -9964 =17732
Penta | [702, 4424, 8655, 4270, 685]
https://openbench.lynx-chess.com/test/1624/
```