### PR TITLE
🧹 Unify indices used in `Game._gameStack`

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -21,7 +21,7 @@ public sealed class Game : IDisposable
     /// <summary>
     /// Indexed by ply
     /// </summary>
-    private readonly PlyStackEntry[] _gameStack;
+    private readonly PlyStackEntry[] _stack;
 
     private bool _disposedValue;
 
@@ -40,7 +40,7 @@ public sealed class Game : IDisposable
     public Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Span<Move> movePool)
     {
         _positionHashHistory = ArrayPool<ulong>.Shared.Rent(Constants.MaxNumberMovesInAGame);
-        _gameStack = ArrayPool<PlyStackEntry>.Shared.Rent(Constants.MaxNumberMovesInAGame);
+        _stack = ArrayPool<PlyStackEntry>.Shared.Rent(Constants.MaxNumberMovesInAGame + EvaluationConstants.ContinuationHistoryPlyCount);
 
         var parsedFen = FENParser.ParseFEN(fen);
         CurrentPosition = new Position(parsedFen);
@@ -228,19 +228,19 @@ public sealed class Game : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UpdateMoveinStack(int n, Move move) => _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount].Move = move;
+    public void UpdateMoveinStack(int n, Move move) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].Move = move;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public Move ReadMoveFromStack(int n) => _gameStack[n + EvaluationConstants.ContinuationHistoryPlyCount].Move;
+    public Move ReadMoveFromStack(int n) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].Move;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int ReadStaticEvalFromStack(int n) => _gameStack[n].StaticEval;
+    public int ReadStaticEvalFromStack(int n) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int UpdateStaticEvalInStack(int n, int value) => _gameStack[n].StaticEval = value;
+    public int UpdateStaticEvalInStack(int n, int value) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval = value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ref PlyStackEntry GameStack(int n) => ref _gameStack[n];
+    public ref PlyStackEntry GameStack(int n) => ref _stack[n + EvaluationConstants.ContinuationHistoryPlyCount];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int PositionHashHistoryLength() => _positionHashHistoryPointer;
@@ -258,7 +258,7 @@ public sealed class Game : IDisposable
 
     public void FreeResources()
     {
-        ArrayPool<PlyStackEntry>.Shared.Return(_gameStack, clearArray: true);
+        ArrayPool<PlyStackEntry>.Shared.Return(_stack, clearArray: true);
         ArrayPool<ulong>.Shared.Return(_positionHashHistory);
 
         CurrentPosition.FreeResources();


### PR DESCRIPTION
~~From the SPRT result, this might have unveiled a bug~~

```
Score of Lynx-refactor-gamestack-index-6128-win-x64 vs Lynx 6123 - main: 2158 - 2114 - 4015  [0.503] 8287
...      Lynx-refactor-gamestack-index-6128-win-x64 playing White: 1713 - 424 - 2007  [0.656] 4144
...      Lynx-refactor-gamestack-index-6128-win-x64 playing Black: 445 - 1690 - 2008  [0.350] 4143
...      White vs Black: 3403 - 869 - 4015  [0.653] 8287
Elo difference: 1.8 +/- 5.4, LOS: 75.0 %, DrawRatio: 48.4 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```