### PR TITLE
🔍 Remove corrhist `MaxRawBonus` clamp

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -156,7 +156,7 @@ public sealed partial class Engine
         static int UpdateCorrectionHistory(int previousCorrectedScore, int scaledBonus, int weight)
         {
             const int weightScale = 256;
-            var maxIncrement = Configuration.EngineSettings.CorrHistory_MaxRawBonus;
+            //var maxIncrement = Configuration.EngineSettings.CorrHistory_MaxRawBonus;
             var maxVal = Configuration.EngineSettings.CorrHistory_MaxValue;
 
             int weightedEval =
@@ -164,7 +164,7 @@ public sealed partial class Engine
                     + (scaledBonus * weight))
                 / weightScale;
 
-            weightedEval = Math.Clamp(weightedEval, previousCorrectedScore - maxIncrement, previousCorrectedScore + maxIncrement);
+            //weightedEval = Math.Clamp(weightedEval, previousCorrectedScore - maxIncrement, previousCorrectedScore + maxIncrement);
 
             return Math.Clamp(weightedEval, -maxVal, +maxVal);
         }


### PR DESCRIPTION
```
Test  | search/corrhist-remove-CorrHistory_MaxRawBonus-clamp-2
Elo   | -5.19 +- 4.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 9508: +2472 -2614 =4422
Penta | [215, 1206, 2024, 1124, 185]
https://openbench.lynx-chess.com/test/1637/
```

```
Test  | search/corrhist-remove-CorrHistory_MaxRawBonus-clamp-2
Elo   | -4.69 +- 11.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.29 (-2.25, 2.89) [0.00, 3.00]
Games | 1186: +268 -284 =634
Penta | [13, 142, 299, 126, 13]
https://openbench.lynx-chess.com/test/1630/
```