### PR TITLE
🔍 Minor correction history / corrhist - w/ king hashes

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -536,6 +536,9 @@ public static class Constants
     public const int NonPawnCorrHistorySize = 16_384;
     public const int NonPawnCorrHistoryMask = NonPawnCorrHistorySize - 1;
 
+    public const int MinorCorrHistorySize = 16_384;
+    public const int MinorCorrHistoryMask = MinorCorrHistorySize - 1;
+
     public const int CorrectionHistoryScale = 256;
 
     public const string NumberWithSignFormat = "+#;-#;0";

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -82,6 +82,7 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_pawnCorrHistory);
         Array.Clear(_nonPawnCorrHistory);
+        Array.Clear(_minorCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,8 +1,10 @@
-﻿namespace Lynx.Model;
+﻿using System.Buffers;
+
+namespace Lynx.Model;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly struct GameState
+public readonly struct GameState : IDisposable
 {
     public readonly ulong ZobristKey;
 
@@ -11,6 +13,12 @@ public readonly struct GameState
     public readonly ulong NonPawnWhiteKey;
 
     public readonly ulong NonPawnBlackKey;
+
+    #region PieceKeys
+
+    public readonly ulong[] PieceKey;
+
+    #endregion
 
     public readonly int IncremetalEvalAccumulator;
 
@@ -22,18 +30,26 @@ public readonly struct GameState
 
     public readonly bool IsIncrementalEval;
 
-    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey,
+    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey, ulong[] pieceKey,
         int incrementalEvalAccumulator, int incrementalPhaseAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
         KingPawnKey = kingPawnKey;
         NonPawnWhiteKey = nonPawnWhiteKey;
         NonPawnBlackKey = nonPawnBlackKey;
+        PieceKey = ArrayPool<ulong>.Shared.Rent(12);
+        Array.Copy(pieceKey, PieceKey, 12);
+
         IncremetalEvalAccumulator = incrementalEvalAccumulator;
         IncrementalPhaseAccumulator = incrementalPhaseAccumulator;
         EnPassant = enpassant;
         Castle = castle;
         IsIncrementalEval = isIncrementalEval;
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<BitBoard>.Shared.Return(PieceKey, clearArray: true);
     }
 }
 

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,10 +1,8 @@
-﻿using System.Buffers;
-
-namespace Lynx.Model;
+﻿namespace Lynx.Model;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly struct GameState : IDisposable
+public readonly struct GameState
 {
     public readonly ulong ZobristKey;
 
@@ -16,7 +14,13 @@ public readonly struct GameState : IDisposable
 
     #region PieceKeys
 
-    public readonly ulong[] PieceKey;
+    public readonly ulong KnightWhiteKey;
+
+    public readonly ulong KnightBlackKey;
+
+    public readonly ulong BishopWhiteKey;
+
+    public readonly ulong BishopBlackKey;
 
     #endregion
 
@@ -30,26 +34,23 @@ public readonly struct GameState : IDisposable
 
     public readonly bool IsIncrementalEval;
 
-    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey, ulong[] pieceKey,
+    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey, ulong knightWhiteKey, ulong knightBlackKey, ulong bishopWhiteKey, ulong bishopBlackKey,
         int incrementalEvalAccumulator, int incrementalPhaseAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
         KingPawnKey = kingPawnKey;
         NonPawnWhiteKey = nonPawnWhiteKey;
         NonPawnBlackKey = nonPawnBlackKey;
-        PieceKey = ArrayPool<ulong>.Shared.Rent(12);
-        Array.Copy(pieceKey, PieceKey, 12);
+        KnightWhiteKey = knightWhiteKey;
+        KnightBlackKey = knightBlackKey;
+        BishopWhiteKey = bishopWhiteKey;
+        BishopBlackKey = bishopBlackKey;
 
         IncremetalEvalAccumulator = incrementalEvalAccumulator;
         IncrementalPhaseAccumulator = incrementalPhaseAccumulator;
         EnPassant = enpassant;
         Castle = castle;
         IsIncrementalEval = isIncrementalEval;
-    }
-
-    public void Dispose()
-    {
-        ArrayPool<BitBoard>.Shared.Return(PieceKey, clearArray: true);
     }
 }
 

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -22,6 +22,10 @@ public readonly struct GameState
 
     public readonly ulong BishopBlackKey;
 
+    public readonly ulong KingWhiteKey;
+
+    public readonly ulong KingBlackKey;
+
     #endregion
 
     public readonly int IncremetalEvalAccumulator;
@@ -34,7 +38,7 @@ public readonly struct GameState
 
     public readonly bool IsIncrementalEval;
 
-    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey, ulong knightWhiteKey, ulong knightBlackKey, ulong bishopWhiteKey, ulong bishopBlackKey,
+    public GameState(ulong zobristKey, ulong kingPawnKey, ulong nonPawnWhiteKey, ulong nonPawnBlackKey, ulong knightWhiteKey, ulong knightBlackKey, ulong bishopWhiteKey, ulong bishopBlackKey, ulong kingWhiteKey, ulong kingBlackKey,
         int incrementalEvalAccumulator, int incrementalPhaseAccumulator, BoardSquare enpassant, byte castle, bool isIncrementalEval)
     {
         ZobristKey = zobristKey;
@@ -45,6 +49,8 @@ public readonly struct GameState
         KnightBlackKey = knightBlackKey;
         BishopWhiteKey = bishopWhiteKey;
         BishopBlackKey = bishopBlackKey;
+        KingWhiteKey = kingWhiteKey;
+        KingBlackKey = kingBlackKey;
 
         IncremetalEvalAccumulator = incrementalEvalAccumulator;
         IncrementalPhaseAccumulator = incrementalPhaseAccumulator;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -127,6 +127,12 @@ public class Position : IDisposable
         _incrementalPhaseAccumulator = position._incrementalPhaseAccumulator;
     }
 
+    public ulong MinorHash =>
+        PieceUniqueIdentifiers[(int)Piece.N]
+        ^ PieceUniqueIdentifiers[(int)Piece.B]
+        ^ PieceUniqueIdentifiers[(int)Piece.n]
+        ^ PieceUniqueIdentifiers[(int)Piece.b];
+
     #region Move making
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -150,6 +156,8 @@ public class Position : IDisposable
         Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
         Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
         Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
+
+        Debug.Assert(ZobristTable.MinorHash(this) == MinorHash);
 #endif
         // No need to make copies of value type, and reference ones are copied inside of the constructor
         var gameState = new GameState(UniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black], PieceUniqueIdentifiers,

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -131,7 +131,9 @@ public class Position : IDisposable
         PieceUniqueIdentifiers[(int)Piece.N]
         ^ PieceUniqueIdentifiers[(int)Piece.B]
         ^ PieceUniqueIdentifiers[(int)Piece.n]
-        ^ PieceUniqueIdentifiers[(int)Piece.b];
+        ^ PieceUniqueIdentifiers[(int)Piece.b]
+        ^ PieceUniqueIdentifiers[(int)Piece.K]
+        ^ PieceUniqueIdentifiers[(int)Piece.k];
 
     #region Move making
 
@@ -150,18 +152,18 @@ public class Position : IDisposable
         Debug.Assert(arr[(int)Piece.B] == PieceUniqueIdentifiers[(int)Piece.B]);
         //Debug.Assert(arr[(int)Piece.R] == PieceUniqueIdentifiers[(int)Piece.R]);
         //Debug.Assert(arr[(int)Piece.Q] == PieceUniqueIdentifiers[(int)Piece.Q]);
-        //Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
+        Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
         Debug.Assert(arr[(int)Piece.n] == PieceUniqueIdentifiers[(int)Piece.n]);
         Debug.Assert(arr[(int)Piece.b] == PieceUniqueIdentifiers[(int)Piece.b]);
         //Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
         //Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
-        //Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
+        Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
 
         Debug.Assert(ZobristTable.MinorHash(this) == MinorHash);
 #endif
         // No need to make copies of value type, and reference ones are copied inside of the constructor
         var gameState = new GameState(UniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black],
-            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b],
+            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b], PieceUniqueIdentifiers[(int)Piece.K], PieceUniqueIdentifiers[(int)Piece.k],
             _incrementalEvalAccumulator, _incrementalPhaseAccumulator, EnPassant, Castle, _isIncrementalEval);
 
         var oldSide = (int)Side;
@@ -634,6 +636,8 @@ public class Position : IDisposable
         PieceUniqueIdentifiers[(int)Piece.n] = gameState.KnightBlackKey;
         PieceUniqueIdentifiers[(int)Piece.B] = gameState.BishopWhiteKey;
         PieceUniqueIdentifiers[(int)Piece.b] = gameState.BishopBlackKey;
+        PieceUniqueIdentifiers[(int)Piece.K] = gameState.KingWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.k] = gameState.KingBlackKey;
 
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _incrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;
@@ -653,7 +657,7 @@ public class Position : IDisposable
             ^ ZobristTable.EnPassantHash((int)oldEnPassant);
 
         return new GameState(oldUniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black],
-            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b],
+            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b], PieceUniqueIdentifiers[(int)Piece.K], PieceUniqueIdentifiers[(int)Piece.k],
             _incrementalEvalAccumulator, _incrementalPhaseAccumulator, oldEnPassant, byte.MaxValue, _isIncrementalEval);
     }
 
@@ -671,6 +675,8 @@ public class Position : IDisposable
         PieceUniqueIdentifiers[(int)Piece.n] = gameState.KnightBlackKey;
         PieceUniqueIdentifiers[(int)Piece.B] = gameState.BishopWhiteKey;
         PieceUniqueIdentifiers[(int)Piece.b] = gameState.BishopBlackKey;
+        PieceUniqueIdentifiers[(int)Piece.K] = gameState.KingWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.k] = gameState.KingBlackKey;
 
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _incrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -148,19 +148,20 @@ public class Position : IDisposable
 
         Debug.Assert(arr[(int)Piece.N] == PieceUniqueIdentifiers[(int)Piece.N]);
         Debug.Assert(arr[(int)Piece.B] == PieceUniqueIdentifiers[(int)Piece.B]);
-        Debug.Assert(arr[(int)Piece.R] == PieceUniqueIdentifiers[(int)Piece.R]);
-        Debug.Assert(arr[(int)Piece.Q] == PieceUniqueIdentifiers[(int)Piece.Q]);
-        Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
+        //Debug.Assert(arr[(int)Piece.R] == PieceUniqueIdentifiers[(int)Piece.R]);
+        //Debug.Assert(arr[(int)Piece.Q] == PieceUniqueIdentifiers[(int)Piece.Q]);
+        //Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
         Debug.Assert(arr[(int)Piece.n] == PieceUniqueIdentifiers[(int)Piece.n]);
         Debug.Assert(arr[(int)Piece.b] == PieceUniqueIdentifiers[(int)Piece.b]);
-        Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
-        Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
-        Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
+        //Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
+        //Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
+        //Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
 
         Debug.Assert(ZobristTable.MinorHash(this) == MinorHash);
 #endif
         // No need to make copies of value type, and reference ones are copied inside of the constructor
-        var gameState = new GameState(UniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black], PieceUniqueIdentifiers,
+        var gameState = new GameState(UniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black],
+            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b],
             _incrementalEvalAccumulator, _incrementalPhaseAccumulator, EnPassant, Castle, _isIncrementalEval);
 
         var oldSide = (int)Side;
@@ -511,14 +512,14 @@ public class Position : IDisposable
 
         Debug.Assert(arr[(int)Piece.N] == PieceUniqueIdentifiers[(int)Piece.N]);
         Debug.Assert(arr[(int)Piece.B] == PieceUniqueIdentifiers[(int)Piece.B]);
-        Debug.Assert(arr[(int)Piece.R] == PieceUniqueIdentifiers[(int)Piece.R]);
-        Debug.Assert(arr[(int)Piece.Q] == PieceUniqueIdentifiers[(int)Piece.Q]);
-        Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
+        //Debug.Assert(arr[(int)Piece.R] == PieceUniqueIdentifiers[(int)Piece.R]);
+        //Debug.Assert(arr[(int)Piece.Q] == PieceUniqueIdentifiers[(int)Piece.Q]);
+        //Debug.Assert(arr[(int)Piece.K] == PieceUniqueIdentifiers[(int)Piece.K]);
         Debug.Assert(arr[(int)Piece.n] == PieceUniqueIdentifiers[(int)Piece.n]);
         Debug.Assert(arr[(int)Piece.b] == PieceUniqueIdentifiers[(int)Piece.b]);
-        Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
-        Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
-        Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
+        //Debug.Assert(arr[(int)Piece.r] == PieceUniqueIdentifiers[(int)Piece.r]);
+        //Debug.Assert(arr[(int)Piece.q] == PieceUniqueIdentifiers[(int)Piece.q]);
+        //Debug.Assert(arr[(int)Piece.k] == PieceUniqueIdentifiers[(int)Piece.k]);
 #endif
 
         // KingPawn hash assert won't work due to PassedPawnBonusNoEnemiesAheadBonus
@@ -624,11 +625,16 @@ public class Position : IDisposable
         // Updating saved values
         Castle = gameState.Castle;
         EnPassant = gameState.EnPassant;
+
         UniqueIdentifier = gameState.ZobristKey;
         KingPawnUniqueIdentifier = gameState.KingPawnKey;
         NonPawnHash[(int)Side.White] = gameState.NonPawnWhiteKey;
         NonPawnHash[(int)Side.Black] = gameState.NonPawnBlackKey;
-        Array.Copy(gameState.PieceKey, PieceUniqueIdentifiers, 12);
+        PieceUniqueIdentifiers[(int)Piece.N] = gameState.KnightWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.n] = gameState.KnightBlackKey;
+        PieceUniqueIdentifiers[(int)Piece.B] = gameState.BishopWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.b] = gameState.BishopBlackKey;
+
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _incrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;
         _isIncrementalEval = gameState.IsIncrementalEval;
@@ -646,7 +652,8 @@ public class Position : IDisposable
             ZobristTable.SideHash()
             ^ ZobristTable.EnPassantHash((int)oldEnPassant);
 
-        return new GameState(oldUniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black], PieceUniqueIdentifiers,
+        return new GameState(oldUniqueIdentifier, KingPawnUniqueIdentifier, NonPawnHash[(int)Side.White], NonPawnHash[(int)Side.Black],
+            PieceUniqueIdentifiers[(int)Piece.N], PieceUniqueIdentifiers[(int)Piece.n], PieceUniqueIdentifiers[(int)Piece.B], PieceUniqueIdentifiers[(int)Piece.b],
             _incrementalEvalAccumulator, _incrementalPhaseAccumulator, oldEnPassant, byte.MaxValue, _isIncrementalEval);
     }
 
@@ -655,10 +662,16 @@ public class Position : IDisposable
     {
         Side = (Side)Utils.OppositeSide(Side);
         EnPassant = gameState.EnPassant;
+
         UniqueIdentifier = gameState.ZobristKey;
         KingPawnUniqueIdentifier = gameState.KingPawnKey;
         NonPawnHash[(int)Side.White] = gameState.NonPawnWhiteKey;
         NonPawnHash[(int)Side.Black] = gameState.NonPawnBlackKey;
+        PieceUniqueIdentifiers[(int)Piece.N] = gameState.KnightWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.n] = gameState.KnightBlackKey;
+        PieceUniqueIdentifiers[(int)Piece.B] = gameState.BishopWhiteKey;
+        PieceUniqueIdentifiers[(int)Piece.b] = gameState.BishopBlackKey;
+
         _incrementalEvalAccumulator = gameState.IncremetalEvalAccumulator;
         _incrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;
         _isIncrementalEval = gameState.IsIncrementalEval;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -320,7 +320,7 @@ public class Position : IDisposable
 
                         UniqueIdentifier ^= hashChange;
                         NonPawnHash[oldSide] ^= hashChange;
-                        PieceUniqueIdentifiers[rookIndex] ^= hashChange;
+                        //PieceUniqueIdentifiers[rookIndex] ^= hashChange;
 
                         _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, rookIndex, rookSourceSquare);
                         _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, rookIndex, rookSourceSquare);
@@ -349,7 +349,7 @@ public class Position : IDisposable
 
                         UniqueIdentifier ^= hashChange;
                         NonPawnHash[oldSide] ^= hashChange;
-                        PieceUniqueIdentifiers[rookIndex] ^= hashChange;
+                        //PieceUniqueIdentifiers[rookIndex] ^= hashChange;
 
                         _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, rookIndex, rookSourceSquare);
                         _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, rookIndex, rookSourceSquare);
@@ -445,7 +445,7 @@ public class Position : IDisposable
 
                         UniqueIdentifier ^= hashChange;
                         NonPawnHash[oldSide] ^= hashChange;
-                        PieceUniqueIdentifiers[rookIndex] ^= hashChange;
+                        //PieceUniqueIdentifiers[rookIndex] ^= hashChange;
 
                         break;
                     }
@@ -468,7 +468,7 @@ public class Position : IDisposable
 
                         UniqueIdentifier ^= hashChange;
                         NonPawnHash[oldSide] ^= hashChange;
-                        PieceUniqueIdentifiers[rookIndex] ^= hashChange;
+                        //PieceUniqueIdentifiers[rookIndex] ^= hashChange;
 
                         break;
                     }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -114,6 +114,7 @@ public sealed partial class Engine
         var scaledBonus = evaluationDelta * Constants.CorrectionHistoryScale;
         var weight = 2 * Math.Min(16, depth + 1);
 
+        // Pawn correction history
         var pawnHash = position.KingPawnUniqueIdentifier
             ^ ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);
@@ -124,9 +125,9 @@ public sealed partial class Engine
         Debug.Assert(pawnCorrHistIndex < (ulong)_pawnCorrHistory.Length);
 
         ref var pawnCorrHistEntry = ref _pawnCorrHistory[pawnCorrHistIndex];
-
         pawnCorrHistEntry = UpdateCorrectionHistory(pawnCorrHistEntry, scaledBonus, weight);
 
+        // Non-pawn correction history - side to move
         var nonPawnSTMIndex = position.NonPawnHash[side] & Constants.NonPawnCorrHistoryMask;
 
         var nonPawnCorrHistSTMIndex =
@@ -137,9 +138,9 @@ public sealed partial class Engine
         Debug.Assert(nonPawnCorrHistSTMIndex < (ulong)_nonPawnCorrHistory.Length);
 
         ref var nonPawnSTMCorrHistEntry = ref _nonPawnCorrHistory[nonPawnCorrHistSTMIndex];
-
         nonPawnSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnSTMCorrHistEntry, scaledBonus, weight);
 
+        // Non-pawn correction history - not side to move
         var nonPawnNoSTMIndex = position.NonPawnHash[oppositeSide] & Constants.NonPawnCorrHistoryMask;
 
         var nonPawnNoSTMCorrHistIndex = (nonPawnNoSTMIndex * 2 * 2)
@@ -152,6 +153,17 @@ public sealed partial class Engine
 
         nonPawnNoSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnNoSTMCorrHistEntry, scaledBonus, weight);
 
+        // Minor correction history
+        var minorHash = position.MinorHash;
+        var minorIndex = minorHash & Constants.MinorCorrHistoryMask;
+
+        var minorCorrHistIndex = (2 * minorIndex) + side;
+        Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
+
+        ref var minorCorrHistEntry = ref _minorCorrHistory[minorCorrHistIndex];
+        minorCorrHistEntry = UpdateCorrectionHistory(minorCorrHistEntry, scaledBonus, weight);
+
+        // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int UpdateCorrectionHistory(int previousCorrectedScore, int scaledBonus, int weight)
         {
@@ -176,6 +188,7 @@ public sealed partial class Engine
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
 
+        // Pawn correction history
         var pawnHash = position.KingPawnUniqueIdentifier
             ^ ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);
@@ -187,6 +200,7 @@ public sealed partial class Engine
 
         var pawnCorrHist = _pawnCorrHistory[pawnCorrHistIndex];
 
+        // Non-pawn correction history - side to move
         var nonPawnSTMoveIndex = position.NonPawnHash[side] & Constants.NonPawnCorrHistoryMask;
 
         var nonPawnSTMoveCorrHistIndex = (nonPawnSTMoveIndex * 2 * 2)
@@ -197,6 +211,7 @@ public sealed partial class Engine
 
         var nonPawnSTMCorrHist = _nonPawnCorrHistory[nonPawnSTMoveCorrHistIndex];
 
+        // Non-pawn correction history - not side to move
         var nonPawnNoSTMIndex = position.NonPawnHash[oppositeSide] & Constants.NonPawnCorrHistoryMask;
 
         var nonPawnNoSTMCorrHistIndex = (nonPawnNoSTMIndex * 2 * 2)
@@ -207,8 +222,17 @@ public sealed partial class Engine
 
         var nonPawnNoSTMCorrHist = _nonPawnCorrHistory[nonPawnNoSTMCorrHistIndex];
 
-        var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist;
-        var correctStaticEval = staticEvaluation + (correction / (Constants.CorrectionHistoryScale * 3));
+        // Minor correction history
+        var minorHash = position.MinorHash;
+        var minorIndex = minorHash & Constants.MinorCorrHistoryMask;
+
+        var minorCorrHistIndex = (2 * minorIndex) + side;
+        Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
+
+        var minorCorrHist = _minorCorrHistory[minorCorrHistIndex];
+
+        var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist + minorCorrHist;
+        var correctStaticEval = staticEvaluation + (correction / (Constants.CorrectionHistoryScale * 4));
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -54,6 +54,12 @@ public sealed partial class Engine
     private readonly int[] _nonPawnCorrHistory = GC.AllocateArray<int>(Constants.NonPawnCorrHistorySize * 2 * 2, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.PawnCorrHistorySize"/> x 2
+    /// Pawn hash x side to move
+    /// </summary>
+    private readonly int[] _minorCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistorySize * 2, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -265,7 +265,7 @@ public sealed partial class Engine
                     //    depth,
                     //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
-                    using var gameState = position.MakeNullMove();
+                    var gameState = position.MakeNullMove();
                     var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);
                     position.UnMakeNullMove(gameState);
 
@@ -796,7 +796,7 @@ public sealed partial class Engine
                 continue;
             }
 
-            using var gameState = position.MakeMove(move);
+            var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
                 position.UnmakeMove(move, gameState);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -265,7 +265,7 @@ public sealed partial class Engine
                     //    depth,
                     //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
-                    var gameState = position.MakeNullMove();
+                    using var gameState = position.MakeNullMove();
                     var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);
                     position.UnMakeNullMove(gameState);
 
@@ -796,7 +796,7 @@ public sealed partial class Engine
                 continue;
             }
 
-            var gameState = position.MakeMove(move);
+            using var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
                 position.UnmakeMove(move, gameState);

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -193,6 +193,56 @@ public static class ZobristTable
         return nonPawnSideHash;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong MinorHash(Position position)
+    {
+        ulong minorHash = 0;
+
+        for (int pieceIndex = (int)Piece.N; pieceIndex <= (int)Piece.B; ++pieceIndex)
+        {
+            var whiteBitboard = position.PieceBitBoards[pieceIndex];
+            while (whiteBitboard != default)
+            {
+                whiteBitboard = whiteBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                minorHash ^= PieceHash(pieceSquareIndex, pieceIndex);
+            }
+
+            var blackBitboard = position.PieceBitBoards[pieceIndex + 6];
+            while (blackBitboard != default)
+            {
+                blackBitboard = blackBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                minorHash ^= PieceHash(pieceSquareIndex, pieceIndex + 6);
+            }
+        }
+
+        return minorHash;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void PieceUniqueIdentifiers(Position position, Span<ulong> pieceIdentifiers)
+    {
+        for (int pieceIndex = (int)Piece.N; pieceIndex <= (int)Piece.K; ++pieceIndex)
+        {
+            var whiteBitboard = position.PieceBitBoards[pieceIndex];
+            while (whiteBitboard != default)
+            {
+                whiteBitboard = whiteBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                pieceIdentifiers[pieceIndex] ^= PieceHash(pieceSquareIndex, pieceIndex);
+            }
+
+            var blackBitboard = position.PieceBitBoards[pieceIndex + 6];
+            while (blackBitboard != default)
+            {
+                blackBitboard = blackBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                pieceIdentifiers[pieceIndex + 6] ^= PieceHash(pieceSquareIndex, pieceIndex + 6);
+            }
+        }
+    }
+
     /// <summary>
     /// Initializes Zobrist table (long[64][12])
     /// </summary>

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -217,6 +217,12 @@ public static class ZobristTable
             }
         }
 
+        var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();
+        minorHash ^= PieceHash(whiteKing, (int)Piece.K);
+
+        var blackKing = position.PieceBitBoards[(int)Piece.k].GetLS1BIndex();
+        minorHash ^= PieceHash(blackKing, (int)Piece.k);
+
         return minorHash;
     }
 


### PR DESCRIPTION
```
Test  | search/minor-corrhist-3-king-hashes
Elo   | -16.64 +- 7.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 3218: +746 -900 =1572
Penta | [77, 418, 742, 326, 46]
https://openbench.lynx-chess.com/test/1632/
```