### PR TITLE
🧪 Remove non-pawn corrhist but apply the scale change

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -139,7 +139,7 @@ public sealed partial class Engine
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryMask;
         var correction = _pawnCorrHistory[(2 * pawnIndex) + (ulong)position.Side];
 
-        var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
+        var correctStaticEval = staticEvaluation + (correction / 3 * Constants.CorrectionHistoryScale);
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -139,7 +139,7 @@ public sealed partial class Engine
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryMask;
         var correction = _pawnCorrHistory[(2 * pawnIndex) + (ulong)position.Side];
 
-        var correctStaticEval = staticEvaluation + (correction / 3 * Constants.CorrectionHistoryScale);
+        var correctStaticEval = staticEvaluation + (correction / (3 * Constants.CorrectionHistoryScale));
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }


### PR DESCRIPTION
```
Test  | experiment/remove-nopawncorrehist-scale
Elo   | -5.72 +- 5.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.95 (-2.25, 2.89) [0.00, 3.00]
Games | 7598: +1938 -2063 =3597
Penta | [187, 955, 1587, 936, 134]
https://openbench.lynx-chess.com/test/1636/
```