### PR TITLE
⚡ Make `GameState` a `ref` (`readonly`) struct

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -2,7 +2,7 @@
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly struct GameState
+public readonly ref struct GameState
 {
     public readonly ulong ZobristKey;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -21,7 +21,7 @@ public class Position : IDisposable
 
     public ulong KingPawnUniqueIdentifier { get; private set; }
 
-    public ulong[] NonPawnHash { get; private set; }
+    public ulong[] NonPawnHash { get; }
 
     public ulong MinorHash { get; private set; }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -411,14 +411,6 @@ public sealed partial class Engine
             Game.AddToPositionHashHistory(position.UniqueIdentifier);
             Game.UpdateMoveinStack(ply, move);
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            void RevertMove()
-            {
-                Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
-                Game.RemoveFromPositionHashHistory();
-                position.UnmakeMove(move, gameState);
-            }
-
             int score = 0;
 
             if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition()))
@@ -563,7 +555,10 @@ public sealed partial class Engine
             }
 
             // After making a move
-            RevertMove();
+            Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
+            Game.RemoveFromPositionHashHistory();
+            position.UnmakeMove(move, gameState);
+
             if (isRoot)
             {
                 var nodesSpentInThisMove = _nodes - previousNodes;


### PR DESCRIPTION
```
Test  | perf/ref-readonly-gamestate
Elo   | -1.72 +- 2.16 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 39140: +10421 -10615 =18104
Penta | [809, 4591, 8911, 4503, 756]
https://openbench.lynx-chess.com/test/1641/
```