### PR TITLE
Bugfix/corrhist double correction reset scale

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -233,7 +233,7 @@ public sealed partial class Engine
 
         // Correction aggregation
         var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist + minorCorrHist;
-        var correctStaticEval = staticEvaluation + (correction / (Constants.CorrectionHistoryScale * 3));
+        var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -720,8 +720,6 @@ public sealed partial class Engine
 
         var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
 
-        staticEval = CorrectStaticEvaluation(position, staticEval);
-
         Game.UpdateStaticEvalInStack(ply, staticEval);
 
         int standPat =


### PR DESCRIPTION
Only removing the double correction:
```
Test  | bugfix/corrhist-double-correction
Elo   | -2.68 +- 6.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.27 (-2.25, 2.89) [-5.00, 0.00]
Games | 3762: +980 -1009 =1773
Penta | [70, 481, 804, 460, 66]
https://openbench.lynx-chess.com/test/1644/
```

Both changes:
```
Test  | bugfix/corrhist-double-correction-reset-scale
Elo   | 9.67 +- 6.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.54 (-2.25, 2.89) [-3.00, 1.00]
Games | 4814: +1352 -1218 =2244
Penta | [104, 513, 1047, 631, 112]
https://openbench.lynx-chess.com/test/1645/
```