### PR TITLE
🔍 Corrhist: half weight: `Math.Min(16, depth + 1)`

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -112,7 +112,7 @@ public sealed partial class Engine
         var oppositeSide = Utils.OppositeSide((int)side);
 
         var scaledBonus = evaluationDelta * Constants.CorrectionHistoryScale;
-        var weight = 2 * Math.Min(16, depth + 1);
+        var weight = Math.Min(16, depth + 1);
 
         var pawnHash = position.KingPawnUniqueIdentifier
             ^ ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)


### PR DESCRIPTION
Results are good in a way: there's elo in this tweak

```
Test  | search/corrhist-half-weight
Elo   | -11.43 +- 6.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 4834: +1181 -1340 =2313
Penta | [135, 623, 1020, 544, 95]
https://openbench.lynx-chess.com/test/1652/
```