### PR TITLE
🔍 Minor corrhist with king hashes

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -536,8 +536,8 @@ public static class Constants
     public const int NonPawnCorrHistoryHashSize = 16_384;
     public const int NonPawnCorrHistoryHashMask = NonPawnCorrHistoryHashSize - 1;
 
-    public const int NonPawnCorrHistorySize = 16_384;
-    public const int NonPawnCorrHistoryMask = NonPawnCorrHistorySize - 1;
+    public const int MinorCorrHistoryHashSize = 16_384;
+    public const int MinorCorrHistoryHashMask = MinorCorrHistoryHashSize - 1;
 
     public const int CorrectionHistoryScale = 256;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -82,6 +82,7 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_pawnCorrHistory);
         Array.Clear(_nonPawnCorrHistory);
+        Array.Clear(_minorCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -12,6 +12,8 @@ public readonly struct GameState
 
     public readonly ulong NonPawnBlackKey;
 
+    public readonly ulong MinorKey;
+
     public readonly int IncrementalEvalAccumulator;
 
     public readonly int IncrementalPhaseAccumulator;
@@ -29,6 +31,7 @@ public readonly struct GameState
         KingPawnKey = position.KingPawnUniqueIdentifier;
         NonPawnWhiteKey = position.NonPawnHash[(int)Side.White];
         NonPawnBlackKey = position.NonPawnHash[(int)Side.Black];
+        MinorKey = position.MinorHash;
 
         EnPassant = position.EnPassant;
         Castle = position.Castle;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -25,6 +25,8 @@ public class Position : IDisposable
 
     public ulong MinorHash { get; private set; }
 
+    public ulong MinorHash { get; private set; }
+
     /// <summary>
     /// Use <see cref="Piece"/> as index
     /// </summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -25,8 +25,6 @@ public class Position : IDisposable
 
     public ulong MinorHash { get; private set; }
 
-    public ulong MinorHash { get; private set; }
-
     /// <summary>
     /// Use <see cref="Piece"/> as index
     /// </summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -153,6 +153,16 @@ public sealed partial class Engine
 
         nonPawnNoSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnNoSTMCorrHistEntry, scaledBonus, weight);
 
+        // Minor correction history
+        var minorHash = position.MinorHash;
+        var minorIndex = minorHash & Constants.MinorCorrHistoryHashMask;
+
+        var minorCorrHistIndex = (2 * minorIndex) + side;
+        Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
+
+        ref var minorCorrHistEntry = ref _minorCorrHistory[minorCorrHistIndex];
+        minorCorrHistEntry = UpdateCorrectionHistory(minorCorrHistEntry, scaledBonus, weight);
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static int UpdateCorrectionHistory(int previousCorrectedScore, int scaledBonus, int weight)
@@ -212,8 +222,17 @@ public sealed partial class Engine
 
         var nonPawnNoSTMCorrHist = _nonPawnCorrHistory[nonPawnNoSTMCorrHistIndex];
 
+        // Minor correction history - Sirius author original idea
+        var minorHash = position.MinorHash;
+        var minorIndex = minorHash & Constants.MinorCorrHistoryHashMask;
+
+        var minorCorrHistIndex = (2 * minorIndex) + side;
+        Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
+
+        var minorCorrHist = _minorCorrHistory[minorCorrHistIndex];
+
         // Correction aggregation
-        var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist;
+        var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist + minorCorrHist;
         var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -114,13 +114,12 @@ public sealed partial class Engine
         var scaledBonus = evaluationDelta * Constants.CorrectionHistoryScale;
         var weight = 2 * Math.Min(16, depth + 1);
 
-        // Pawn correction history
-        var pawnHash = position.KingPawnUniqueIdentifier
-            ^ ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
+        var kingsHash = ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);
 
+        // Pawn correction history
+        var pawnHash = position.KingPawnUniqueIdentifier ^ kingsHash;   // Remove kings hash
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryHashMask;
-
         var pawnCorrHistIndex = (2 * pawnIndex) + side;
         Debug.Assert(pawnCorrHistIndex < (ulong)_pawnCorrHistory.Length);
 
@@ -154,9 +153,8 @@ public sealed partial class Engine
         nonPawnNoSTMCorrHistEntry = UpdateCorrectionHistory(nonPawnNoSTMCorrHistEntry, scaledBonus, weight);
 
         // Minor correction history
-        var minorHash = position.MinorHash;
+        var minorHash = position.MinorHash ^ kingsHash;     // Add kings hash
         var minorIndex = minorHash & Constants.MinorCorrHistoryHashMask;
-
         var minorCorrHistIndex = (2 * minorIndex) + side;
         Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
 
@@ -188,13 +186,12 @@ public sealed partial class Engine
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
 
-        // Pawn correction history
-        var pawnHash = position.KingPawnUniqueIdentifier
-            ^ ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
+        var kingsHash = ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);
 
+        // Pawn correction history
+        var pawnHash = position.KingPawnUniqueIdentifier ^ kingsHash;   // Remove kings hash
         var pawnIndex = pawnHash & Constants.PawnCorrHistoryHashMask;
-
         var pawnCorrHistIndex = (2 * pawnIndex) + side;
         Debug.Assert(pawnCorrHistIndex < (ulong)_pawnCorrHistory.Length);
 
@@ -223,9 +220,8 @@ public sealed partial class Engine
         var nonPawnNoSTMCorrHist = _nonPawnCorrHistory[nonPawnNoSTMCorrHistIndex];
 
         // Minor correction history - Sirius author original idea
-        var minorHash = position.MinorHash;
+        var minorHash = position.MinorHash ^ kingsHash;     // Add kings hash
         var minorIndex = minorHash & Constants.MinorCorrHistoryHashMask;
-
         var minorCorrHistIndex = (2 * minorIndex) + side;
         Debug.Assert(minorCorrHistIndex < (ulong)_minorCorrHistory.Length);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -54,6 +54,12 @@ public sealed partial class Engine
     private readonly int[] _nonPawnCorrHistory = GC.AllocateArray<int>(Constants.NonPawnCorrHistoryHashSize * 2 * 2, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.MinorCorrHistoryHashSize"/> x 2
+    /// Minor hash x side to move
+    /// </summary>
+    private readonly int[] _minorCorrHistory = GC.AllocateArray<int>(Constants.MinorCorrHistoryHashSize * 2, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -195,6 +195,33 @@ public static class ZobristTable
         return nonPawnSideHash;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong MinorHash(Position position)
+    {
+        ulong minorHash = 0;
+
+        for (int pieceIndex = (int)Piece.N; pieceIndex <= (int)Piece.B; ++pieceIndex)
+        {
+            var whiteBitboard = position.PieceBitBoards[pieceIndex];
+            while (whiteBitboard != default)
+            {
+                whiteBitboard = whiteBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                minorHash ^= PieceHash(pieceSquareIndex, pieceIndex);
+            }
+
+            var blackBitboard = position.PieceBitBoards[pieceIndex + 6];
+            while (blackBitboard != default)
+            {
+                blackBitboard = blackBitboard.WithoutLS1B(out var pieceSquareIndex);
+
+                minorHash ^= PieceHash(pieceSquareIndex, pieceIndex + 6);
+            }
+        }
+
+        return minorHash;
+    }
+
     /// <summary>
     /// Initializes Zobrist table (long[64][12])
     /// </summary>


### PR DESCRIPTION
Tried in #1700 with a different setup.

```
Test  | search/minor-corrhist-revival-with-king-hash
Elo   | 2.17 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | 63514: +17254 -16857 =29403
Penta | [1351, 7634, 13485, 7841, 1446]
https://openbench.lynx-chess.com/test/1653/
```