### PR TITLE
🔍 Corrhist weights + SPSA 2024-05-05

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -351,25 +351,25 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 100;
+    public int CorrHistoryWeight_Pawn { get; set; } = 115;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 100;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 91;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 100;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 94;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 100;
+    public int CorrHistoryWeight_Minor { get; set; } = 105;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -166,73 +166,73 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.85;
+    public double LMR_Base_Quiet { get; set; } = 0.79;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.52;
+    public double LMR_Base_Noisy { get; set; } = 0.38;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.70;
+    public double LMR_Divisor_Quiet { get; set; } = 2.71;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.67;
+    public double LMR_Divisor_Noisy { get; set; } = 2.84;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 75;
+    public int LMR_Improving { get; set; } = 107;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 141;
+    public int LMR_Cutnode { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 82;
+    public int LMR_TTPV { get; set; } = 113;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 100;
+    public int LMR_TTCapture { get; set; } = 68;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 60;
+    public int LMR_PVNode { get; set; } = 89;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 79;
+    public int LMR_InCheck { get; set; } = 51;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 100;
+    public int LMR_Quiet { get; set; } = 70;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3107;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2687;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3451;
+    public int LMR_History_Divisor_Noisy { get; set; } = 3816;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 38;
+    public int LMR_DeeperBase { get; set; } = 52;
 
     //[SPSA<int>(1, 10, 1)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -252,13 +252,13 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 113;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 104;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
 
     [SPSA<int>(5, 30, 1)]
-    public int AspirationWindow_Base { get; set; } = 10;
+    public int AspirationWindow_Base { get; set; } = 9;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -276,10 +276,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 104;
+    public int Razoring_Depth1Bonus { get; set; } = 67;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 190;
+    public int Razoring_NotDepth1Bonus { get; set; } = 196;
 
     //[SPSA<int>(1, 10, 0.5)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -300,7 +300,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 86;
+    public int History_BestScoreBetaMargin { get; set; } = 116;
 
     //[SPSA<int>(0, 6, 0.5)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -309,16 +309,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 105;
+    public int FP_DepthScalingFactor { get; set; } = 92;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 108;
+    public int FP_Margin { get; set; } = 102;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -643;
+    public int HistoryPrunning_Margin { get; set; } = -113;
 
     //[SPSA<int>(0, 10, 0.5)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -332,10 +332,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -42;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -40;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -117;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -107;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -351,25 +351,25 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 115;
+    public int CorrHistoryWeight_Pawn { get; set; } = 117;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 91;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 96;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 94;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 105;
+    public int CorrHistoryWeight_Minor { get; set; } = 127;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -347,6 +347,30 @@ public sealed class EngineSettings
     /// </summary>
     public int CorrHistory_MaxRawBonus { get; set; } = 1_896;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 200, 15)]
+    public int CorrHistoryWeight_Pawn { get; set; } = 100;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 200, 15)]
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 100;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 200, 15)]
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 100;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 200, 15)]
+    public int CorrHistoryWeight_Minor { get; set; } = 100;
+
     #endregion
 }
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -539,8 +539,6 @@ public static class Constants
     public const int MinorCorrHistoryHashSize = 16_384;
     public const int MinorCorrHistoryHashMask = MinorCorrHistoryHashSize - 1;
 
-    public const int CorrectionHistoryScale = 256;
-
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -34,6 +34,10 @@ public static class EvaluationConstants
 
     public const int LMRScaleFactor = 100;
 
+    public const int CorrectionHistoryScale = 256;
+
+    public const int CorrHistScaleFactor = 100;
+
     static EvaluationConstants()
     {
         var quietReductions = LMRReductions[0] = new int[Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin][];

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -111,7 +111,7 @@ public sealed partial class Engine
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
 
-        var scaledBonus = evaluationDelta * Constants.CorrectionHistoryScale;
+        var scaledBonus = evaluationDelta * EvaluationConstants.CorrectionHistoryScale;
         var weight = 2 * Math.Min(16, depth + 1);
 
         var kingsHash = ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
@@ -228,8 +228,11 @@ public sealed partial class Engine
         var minorCorrHist = _minorCorrHistory[minorCorrHistIndex];
 
         // Correction aggregation
-        var correction = pawnCorrHist + nonPawnSTMCorrHist + nonPawnNoSTMCorrHist + minorCorrHist;
-        var correctStaticEval = staticEvaluation + (correction / Constants.CorrectionHistoryScale);
+        var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
+            + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
+            + (nonPawnNoSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnNoSTM)
+            + (minorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Minor);
+        var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
     }

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -715,6 +715,56 @@ public sealed class UCIHandler
                     break;
                 }
 
+            case "corrhistory_maxvalue":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistory_MaxValue = value;
+                    }
+                    break;
+                }
+            case "corrhistory_maxrawbonus":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistory_MaxRawBonus = value;
+                    }
+                    break;
+                }
+
+            case "corrhistoryweight_pawn":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistoryWeight_Pawn = value;
+                    }
+                    break;
+                }
+            case "corrhistoryweight_nonpawnstm":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM = value;
+                    }
+                    break;
+                }
+            case "corrhistoryweight_nonpawnnostm":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistoryWeight_NonPawnNoSTM = value;
+                    }
+                    break;
+                }
+            case "corrhistoryweight_minor":
+                {
+                    if (length > 4 && int.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.CorrHistoryWeight_Minor = value;
+                    }
+                    break;
+                }
+
             #endregion
 
             default:
@@ -803,7 +853,7 @@ public sealed class UCIHandler
                 $"Avx512BW = {Avx512BW.IsSupported}",
             ];
 
-            foreach(var instructionSet in intrinsics)
+            foreach (var instructionSet in intrinsics)
             {
                 await _engineToUci.Writer.WriteAsync($"\t- {instructionSet}");
             }


### PR DESCRIPTION
Tuned values:
```
iterations: 6839 (98.31s per iter)
games: 54712 (12.29s per game)
LMR_Base_Quiet = 79(-5.992415) in [10, 200]
LMR_Base_Noisy = 38(-13.588942) in [10, 200]
LMR_Divisor_Quiet = 271(+1.07) in [100, 500]
LMR_Divisor_Noisy = 284(+17.31) in [100, 500]
LMR_Improving = 107(+31.96) in [25, 300]
LMR_Cutnode = 100(-40.672839) in [25, 300]
LMR_TTPV = 113(+31.38) in [25, 300]
LMR_TTCapture = 68(-32.470931) in [25, 300]
LMR_PVNode = 89(+28.63) in [25, 300]
LMR_InCheck = 51(-28.184378) in [25, 300]
LMR_Quiet = 70(-29.578029) in [25, 300]
LMR_History_Divisor_Quiet = 2687(-420.097750) in [1, 8192]
LMR_History_Divisor_Noisy = 3816(+365.16) in [1, 8192]
LMR_DeeperBase = 52(+13.82) in [20, 100]
NMP_StaticEvalBetaDivisor = 104(-9.195943) in [50, 350]
AspirationWindow_Base = 9(-0.777279) in [5, 30]
Razoring_Depth1Bonus = 67(-37.267101) in [1, 300]
Razoring_NotDepth1Bonus = 196(+6.11) in [1, 300]
History_BestScoreBetaMargin = 116(+29.87) in [0, 200]
FP_DepthScalingFactor = 92(-12.925428) in [1, 200]
FP_Margin = 102(-5.787613) in [0, 500]
HistoryPrunning_Margin = -113(+529.53) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -40(+1.75) in [-100, -10]
PVS_SEE_Threshold_Noisy = -107(+9.72) in [-150, -50]
CorrHistoryWeight_Pawn = 117(+17.27) in [25, 200]
CorrHistoryWeight_NonPawnSTM = 96(-3.703512) in [25, 200]
CorrHistoryWeight_NonPawnNoSTM = 100(+0.41) in [25, 200]
CorrHistoryWeight_Minor = 127(+27.21) in [25, 200]
```

![image](https://github.com/user-attachments/assets/19e01c0a-d133-4341-ab96-73de2bb88820)


```
Test  | spsa/5-5
Elo   | 9.91 +- 4.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 7576: +1930 -1714 =3932
Penta | [82, 829, 1783, 979, 115]
https://openbench.lynx-chess.com/test/1667/
```