### PR TITLE
🔍RFP: max depth 7 -> 9

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -267,7 +267,7 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     //[SPSA<int>(1, 10, 0.5)]
-    public int RFP_MaxDepth { get; set; } = 7;
+    public int RFP_MaxDepth { get; set; } = 9;
 
     //[SPSA<int>(1, 300, 15)]
     //public int RFP_DepthScalingFactor { get; set; } = 55;


### PR DESCRIPTION
```
Test  | search/rfp-maxdepth-9
Elo   | -0.23 +- 1.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 47628: +11507 -11539 =24582
Penta | [572, 5765, 11163, 5751, 563]
https://openbench.lynx-chess.com/test/1665/
```