### PR TITLE
🔍 Include 50mr counter in Zobrist key - only when probing/saving TT, full moves 30 - 5

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -371,6 +371,9 @@ public sealed class EngineSettings
     [SPSA<int>(25, 200, 15)]
     public int CorrHistoryWeight_Minor { get; set; } = 127;
 
+    //[SPSA<int>(5, 25, 5)]
+    public int TT_50MR_Step { get; set; } = 10;
+
     #endregion
 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -552,7 +552,7 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
 
         using var position = new Position(Game.PositionBeforeLastSearch);
-        var ttEntry = _tt.ProbeHash(position, ply: 0);
+        var ttEntry = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0);
 
         if (ttEntry.NodeType != NodeType.Unknown)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -68,7 +68,7 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, ply);
+            (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
 
             // ttScore shouldn't be used, since it'll be 0 for default structs
             ttHit = ttElementType != NodeType.Unknown && ttElementType != NodeType.None;
@@ -153,7 +153,7 @@ public sealed partial class Engine
             }
 
             var finalPositionEvaluation = Position.EvaluateFinalPosition(ply, isInCheck);
-            _tt.RecordHash(position, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
+            _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
             return finalPositionEvaluation;
         }
         else if (!pvNode)
@@ -169,7 +169,7 @@ public sealed partial class Engine
             else
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
-                _tt.SaveStaticEval(position, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
             }
 
@@ -284,7 +284,7 @@ public sealed partial class Engine
 
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
             }
         }
 
@@ -433,7 +433,11 @@ public sealed partial class Engine
             }
             else
             {
-                _tt.PrefetchTTEntry(position);
+                var nextHalfMovesCounter = (move.IsCapture() || move.Piece() == (int)Piece.P || move.Piece() == (int)Piece.p)
+                    ? 0
+                    : Game.HalfMovesWithoutCaptureOrPawnMove + 1;
+
+                _tt.PrefetchTTEntry(position, nextHalfMovesCounter);
 
                 bool isCutNode = !pvNode && !cutnode;   // Linter 'simplification' of pvNode ? false : !cutnode
 
@@ -647,7 +651,7 @@ public sealed partial class Engine
             UpdateCorrectionHistory(position, bestScore - staticEval, depth);
         }
 
-        _tt.RecordHash(position, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
+        _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
 
         return bestScore;
     }
@@ -691,7 +695,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, ply);
+        var ttProbeResult = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
         var ttHit = ttNodeType != NodeType.Unknown && ttNodeType != NodeType.None;
@@ -737,7 +741,7 @@ public sealed partial class Engine
         {
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
             }
 
             // Standing pat beta-cutoff (updating alpha after this check)
@@ -856,7 +860,7 @@ public sealed partial class Engine
             staticEval = bestScore;
         }
 
-        _tt.RecordHash(position, rawStaticEval, 0, ply, bestScore, nodeType, ttPv, bestMove);
+        _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, 0, ply, bestScore, nodeType, ttPv, bestMove);
 
         return bestScore;
     }


### PR DESCRIPTION
Revival of the previous attempts, but just using the 50mr when probing/recording to TT and not for draw detection

- https://github.com/lynx-chess/Lynx/pull/1539
- https://github.com/lynx-chess/Lynx/pull/1542
- https://github.com/lynx-chess/Lynx/pull/1544

```
Test  | search/zobrist-50mr-step-5-from-30
Elo   | -1.06 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 29066: +7737 -7826 =13503
Penta | [658, 3578, 6156, 3477, 664]
https://openbench.lynx-chess.com/test/1680/
```