### PR TITLE
🐛 Shallower: use `newDepth`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -544,7 +544,7 @@ public sealed partial class Engine
                         {
                             ++newDepth;
                         }
-                        else if (shallower && !deeper && depth > 1)
+                        else if (shallower && !deeper && newDepth > 1)
                         {
                             --newDepth;
                         }


### PR DESCRIPTION
```
Test  | search/shallower-newdepth
Elo   | 0.21 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 66036: +17762 -17723 =30551
Penta | [1315, 7660, 15007, 7743, 1293]
https://openbench.lynx-chess.com/test/1705/
```