### PR TITLE
🔍 `depthExtension`: use for NMP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -264,7 +264,7 @@ public sealed partial class Engine
                     //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
 
                     var gameState = position.MakeNullMove();
-                    var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);
+                    var nmpScore = -NegaMax(depth - 1 + depthExtension - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);
                     position.UnMakeNullMove(gameState);
 
                     if (nmpScore >= beta)


### PR DESCRIPTION
```
Test  | search/depthExtensions-nmp
Elo   | -5.79 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 8816: +2263 -2410 =4143
Penta | [206, 1104, 1910, 1007, 181]
https://openbench.lynx-chess.com/test/1734/
```