### PR TITLE
🔍 SE: before legality check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -393,14 +393,6 @@ public sealed partial class Engine
                 }
             }
 
-            var gameState = position.MakeMove(move);
-
-            if (!position.WasProduceByAValidMove())
-            {
-                position.UnmakeMove(move, gameState);
-                continue;
-            }
-
             int singular = 0;
 
             // 🔍 Singular extensions (SE) - extend TT move when it looks better than every other move
@@ -415,8 +407,6 @@ public sealed partial class Engine
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha)
             {
-                position.UnmakeMove(move, gameState);
-
                 var verificationDepth = (depth + depthExtension - 1) / 2;    // TODO tune?
                 var singularBeta = ttScore - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
@@ -426,8 +416,14 @@ public sealed partial class Engine
                 {
                     ++singular;
                 }
+            }
 
-                gameState = position.MakeMove(move);
+            var gameState = position.MakeMove(move);
+
+            if (!position.WasProduceByAValidMove())
+            {
+                position.UnmakeMove(move, gameState);
+                continue;
             }
 
             var previousNodes = _nodes;


### PR DESCRIPTION
Looks like a gain, but searching illegal positions can explode in unexpected ways, i.e. higher hash collisions 

```
Test  | search/se-no-legality-check
Elo   | 2.09 +- 2.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.89 (-2.25, 2.89) [0.00, 3.00]
Games | 32602: +7843 -7647 =17112
Penta | [300, 3521, 8477, 3689, 314]
https://openbench.lynx-chess.com/test/1738/
```