### PR TITLE
🔍 SE: return alpha when no moves but verifying SE

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -668,10 +668,17 @@ public sealed partial class Engine
         {
             Debug.Assert(bestMove is null);
 
-            bestScore = Position.EvaluateFinalPosition(ply, isInCheck);
+            if (isVerifyingSE)
+            {
+                bestScore = alpha;
+            }
+            else
+            {
+                bestScore = Position.EvaluateFinalPosition(ply, isInCheck);
 
-            nodeType = NodeType.Exact;
-            staticEval = bestScore;
+                nodeType = NodeType.Exact;
+                staticEval = bestScore;
+            }
         }
 
         if (!isVerifyingSE)


### PR DESCRIPTION
```
Test  | search/se-nomoves-return-alpha
Elo   | 0.04 +- 2.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.68 (-2.25, 2.89) [0.00, 3.00]
Games | 19152: +4547 -4545 =10060
Penta | [150, 2062, 5143, 2078, 143]
https://openbench.lynx-chess.com/test/1740/
```