### PR TITLE
🔍 SE: double extension (margin 25)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -399,6 +399,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int SE_DepthMultiplier { get; set; } = 1;
 
+    [SPSA<int>(0, 50, 5)]
+    public int SE_DoubleExtensions_Margin { get; set; } = 25;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -423,16 +423,14 @@ public sealed partial class Engine
 
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
 
+                // Singular extension
                 if (singularScore < singularBeta)
                 {
+                    ++singularDepthExtensions;
+
                     // Double extension
                     if (!pvNode
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
-                    {
-                        singularDepthExtensions += 2;
-                    }
-                    // Singular extension
-                    else
                     {
                         ++singularDepthExtensions;
                     }


### PR DESCRIPTION
```
Test  | search/se-double-extensions-margin-25
Elo   | 3.85 +- 8.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.29 (-2.25, 2.89) [0.00, 3.00]
Games | 2258: +536 -511 =1211
Penta | [23, 268, 517, 303, 18]
https://openbench.lynx-chess.com/test/1746/
```