### PR TITLE
🔍 Post-LMR contHist update - score >= beta

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -605,6 +605,15 @@ public sealed partial class Engine
                             // Search with full depth but narrowed score bandwidth (zero-window search)
                             score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
                         }
+
+                        // 🔍 Post-LMR continuation history update
+                        var rawHistoryBonus = EvaluationConstants.HistoryBonus[depth];
+                        var historyBonus = score > alpha
+                            ? rawHistoryBonus
+                            : -rawHistoryBonus;
+
+                        ref var contHist = ref ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
+                        contHist = ScoreHistoryMove(contHist, historyBonus);
                     }
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -608,7 +608,7 @@ public sealed partial class Engine
 
                         // 🔍 Post-LMR continuation history update
                         var rawHistoryBonus = EvaluationConstants.HistoryBonus[depth];
-                        var historyBonus = score > alpha
+                        var historyBonus = score >= beta
                             ? rawHistoryBonus
                             : -rawHistoryBonus;
 


### PR DESCRIPTION
Cancelled (thanks, Windows updates 😡)
```
Score of Lynx-search-post-lmr-conthist-update-2-6361-win-x64 vs Lynx 6355 - main: 14196 - 13983 - 28211  [0.502] 56390
...      Lynx-search-post-lmr-conthist-update-2-6361-win-x64 playing White: 11645 - 2406 - 14144  [0.664] 28195
...      Lynx-search-post-lmr-conthist-update-2-6361-win-x64 playing Black: 2551 - 11577 - 14067  [0.340] 28195
...      White vs Black: 23222 - 4957 - 28211  [0.662] 56390
Elo difference: 1.3 +/- 2.0, LOS: 89.8 %, DrawRatio: 50.0 %
SPRT: llr -0.526 (-18.2%), lbound -2.25, ubound 2.89
```

```
Test  | search/post-lmr-conthist-update-2
Elo   | -2.32 +- 6.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.05 (-2.25, 2.89) [0.00, 5.00]
Games | 3738: +811 -836 =2091
Penta | [29, 441, 953, 418, 28]
https://openbench.lynx-chess.com/test/1773/
```