### PR TITLE
🔍 SE: negative extension

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -399,6 +399,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int SE_DepthMultiplier { get; set; } = 1;
 
+    [SPSA<int>(0, 50, 5)]
+    public int SE_DoubleExtensions_Margin { get; set; } = 25;
+
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -400,7 +400,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 25;
+    public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
     #endregion
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -423,16 +423,14 @@ public sealed partial class Engine
 
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
 
+                // Singular extension
                 if (singularScore < singularBeta)
                 {
+                    ++singularDepthExtensions;
+
                     // Double extension
                     if (!pvNode
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
-                    {
-                        singularDepthExtensions += 2;
-                    }
-                    // Singular extension
-                    else
                     {
                         ++singularDepthExtensions;
                     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,6 +435,11 @@ public sealed partial class Engine
                         ++singularDepthExtensions;
                     }
                 }
+                // Negative extension
+                else if (ttScore >= beta)
+                {
+                    --singularDepthExtensions;
+                }
 
                 gameState = position.MakeMove(move);
             }


### PR DESCRIPTION
```
Test  | search/se-negative-extensions
Elo   | 11.99 +- 5.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 6002: +1551 -1344 =3107
Penta | [59, 627, 1441, 796, 78]
https://openbench.lynx-chess.com/test/1749/
```