### PR TITLE
🔍 SE: triple extension (margin 40)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -402,6 +402,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 50, 5)]
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
+    [SPSA<int>(20, 70, 5)]
+    public int SE_TripleExtensions_Margin { get; set; } = 40;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,6 +435,7 @@ public sealed partial class Engine
                         ++singularDepthExtensions;
                     }
 
+                    // Triple extension
                     if (!isCapture && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -434,6 +434,11 @@ public sealed partial class Engine
                     {
                         ++singularDepthExtensions;
                     }
+
+                    if (!isCapture && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
+                    {
+                        ++singularDepthExtensions;
+                    }
                 }
                 // Multicut
                 else if (singularScore >= beta)


### PR DESCRIPTION
```
Test  | search/se-triple-extensions-margin-40
Elo   | -1.44 +- 3.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.30 (-2.25, 2.89) [0.00, 3.00]
Games | 12832: +2982 -3035 =6815
Penta | [114, 1587, 3062, 1544, 109]
https://openbench.lynx-chess.com/test/1767/
```