### PR TITLE
🔍 SE;  if extensions are negative, set `cutnode` to true

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -446,6 +446,11 @@ public sealed partial class Engine
                     --singularDepthExtensions;
                 }
 
+                if (singularDepthExtensions < 0)
+                {
+                    cutnode = true;
+                }
+
                 gameState = position.MakeMove(move);
             }
 


### PR DESCRIPTION
```
Test  | search/se-negativeextensions-cutnode
Elo   | -0.37 +- 3.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.60 (-2.25, 2.89) [0.00, 3.00]
Games | 11152: +2563 -2575 =6014
Penta | [106, 1384, 2626, 1336, 124]
https://openbench.lynx-chess.com/test/1768/
```