### PR TITLE
🔍 SE: double negative extension (margin 60)

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -402,6 +402,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 50, 5)]
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
+    [SPSA<int>(25, 10, 5)]
+    public int SE_DoubleNegativeExtensons_Margin { get; set; } = 60;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -439,6 +439,12 @@ public sealed partial class Engine
                 else if (ttScore >= beta)
                 {
                     --singularDepthExtensions;
+
+                    // Double negative extension
+                    if (ttScore + Configuration.EngineSettings.SE_DoubleNegativeExtensons_Margin >= beta)
+                    {
+                        --singularDepthExtensions;
+                    }
                 }
 
                 gameState = position.MakeMove(move);


### PR DESCRIPTION
```
Test  | search/se-double-negative-extension
Elo   | -3.45 +- 3.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 11888: +2698 -2816 =6374
Penta | [119, 1467, 2869, 1391, 98]
https://openbench.lynx-chess.com/test/1810/
```