### PR TITLE
🔍 SE: don't do negative extensions on `pvNode`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -441,7 +441,7 @@ public sealed partial class Engine
                     return singularScore;
                 }
                 // Negative extension
-                else if (ttScore >= beta)
+                else if (!pvNode && ttScore >= beta)
                 {
                     --singularDepthExtensions;
                 }


### PR DESCRIPTION
```
Test  | search/se-no-negative-extensions-on-pvnode
Elo   | -0.14 +- 3.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.44 (-2.25, 2.89) [0.00, 3.00]
Games | 10178: +2363 -2367 =5448
Penta | [96, 1238, 2428, 1228, 99]
https://openbench.lynx-chess.com/test/1765/
```