### PR TITLE
🔍 Improving: set to true if `staticEval >= beta` by a margin of 100

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -390,6 +390,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Step { get; set; } = 10;
 
+    [SPSA<int>(50, 150, 10)]
+    public int Improving_BetaMargin { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int SE_MinDepth { get; set; } = 7;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -179,6 +179,8 @@ public sealed partial class Engine
                 improvingRate = evalDiff / 50.0;
             }
 
+            improving |= staticEval >= beta + Configuration.EngineSettings.Improving_BetaMargin;
+
             // From smol.cs
             // ttEvaluation can be used as a better positional evaluation:
             // If the score is outside what the current bounds are, but it did match flag and depth,


### PR DESCRIPTION
```
Score of Lynx-search-improving-beta-6360-win-x64 vs Lynx 6355 - main: 5843 - 5872 - 11769  [0.499] 23484
...      Lynx-search-improving-beta-6360-win-x64 playing White: 4776 - 1090 - 5876  [0.657] 11742
...      Lynx-search-improving-beta-6360-win-x64 playing Black: 1067 - 4782 - 5893  [0.342] 11742
...      White vs Black: 9558 - 2157 - 11769  [0.658] 23484
Elo difference: -0.4 +/- 3.1, LOS: 39.4 %, DrawRatio: 50.1 %
SPRT: llr -2.26 (-78.1%), lbound -2.25, ubound 2.89 - H0 was accepted
```