### PR TITLE
🔍 SE: multicut with `singularScore`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -436,9 +436,9 @@ public sealed partial class Engine
                     }
                 }
                 // Multicut
-                else if (singularBeta >= beta)
+                else if (singularScore >= beta)
                 {
-                    return singularBeta;
+                    return singularScore;
                 }
                 // Negative extension
                 else if (ttScore >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,6 +435,11 @@ public sealed partial class Engine
                         ++singularDepthExtensions;
                     }
                 }
+                // Multicut
+                else if (singularBeta >= beta)
+                {
+                    return singularBeta;
+                }
                 // Negative extension
                 else if (ttScore >= beta)
                 {


### PR DESCRIPTION
As seen in Alexandria.

```
Test  | search/se-multicut-singularScore
Elo   | 6.21 +- 3.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 12250: +2909 -2690 =6651
Penta | [118, 1352, 2973, 1557, 125]
https://openbench.lynx-chess.com/test/1759/
```