### PR TITLE
🔍 Correction history: average

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -696,7 +696,7 @@ public sealed partial class Engine
                 || (ttElementType == NodeType.Beta && bestScore <= staticEval)
                 || (ttElementType == NodeType.Alpha && bestScore >= staticEval)))
             {
-                UpdateCorrectionHistory(position, bestScore - staticEval, depth);
+                UpdateCorrectionHistory(position, bestScore - ((staticEval + rawStaticEval) / 2), depth);
             }
 
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);


### PR DESCRIPTION
```
Score of Lynx-search-corrhist-avg-6353-win-x64 vs Lynx 6341 - main: 396 - 526 - 825  [0.463] 1747
...      Lynx-search-corrhist-avg-6353-win-x64 playing White: 327 - 99 - 447  [0.631] 873
...      Lynx-search-corrhist-avg-6353-win-x64 playing Black: 69 - 427 - 378  [0.295] 874
...      White vs Black: 754 - 168 - 825  [0.668] 1747
Elo difference: -25.9 +/- 11.8, LOS: 0.0 %, DrawRatio: 47.2 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```