### PR TITLE
🐛 Apply quiet history malus to last searched move

### DIFF
--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -172,7 +172,7 @@ public sealed partial class Engine
             continuationHistoryEntry = ScoreHistoryMove(continuationHistoryEntry, rawHistoryBonus);
         }
 
-        for (int i = 0; i < visitedMovesCounter - 1; ++i)
+        for (int i = 0; i < visitedMovesCounter; ++i)
         {
             var visitedMove = visitedMoves[i];
 


### PR DESCRIPTION
Heh, since the counter is incremented after the calls to `UpdateMoveOrderingHeuristicsOnQuietBetaCutoff`, no need to exclude the last move.

```
Test  | bugfix/quiet-history-malus-dont-exclude-last-move
Elo   | 12.89 +- 5.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 6096: +1694 -1468 =2934
Penta | [89, 675, 1345, 799, 140]
https://openbench.lynx-chess.com/test/1774/
```

The opposite in capture malus fails, as expected
```
Score of Lynx-bugfix-capture-history-malus-exclude-last-move-6371-win-x64 vs Lynx 6369 - main: 500 - 533 - 1057  [0.492] 2090
...      Lynx-bugfix-capture-history-malus-exclude-last-move-6371-win-x64 playing White: 405 - 92 - 548  [0.650] 1045
...      Lynx-bugfix-capture-history-malus-exclude-last-move-6371-win-x64 playing Black: 95 - 441 - 509  [0.334] 1045
...      White vs Black: 846 - 187 - 1057  [0.658] 2090
Elo difference: -5.5 +/- 10.5, LOS: 15.2 %, DrawRatio: 50.6 %
SPRT: llr -0.734 (-25.4%), lbound -2.25, ubound 2.89
```