### PR TITLE
🔍 History: dont penalize alpha raisers

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -685,7 +685,8 @@ public sealed partial class Engine
                 }
             }
 
-            //if (!isBestMove)
+            // Don't penalize alpha raisers - idea by Obsidian author
+            if (!isBestMove)
             {
                 if (isCapture)
                 {
@@ -935,7 +936,8 @@ public sealed partial class Engine
                 }
             }
 
-            //if (!isBestMove)
+            // Don't penalize alpha raisers - idea by Obsidian author
+            if (!isBestMove)
             {
                 if (move.IsCapture())
                 {


### PR DESCRIPTION
```
Score of Lynx-search-history-dont-penalize-alpha-raisers-6376-win-x64 vs Lynx 6374 - main: 2224 - 2317 - 4478  [0.495] 9019
...      Lynx-search-history-dont-penalize-alpha-raisers-6376-win-x64 playing White: 1814 - 424 - 2271  [0.654] 4509
...      Lynx-search-history-dont-penalize-alpha-raisers-6376-win-x64 playing Black: 410 - 1893 - 2207  [0.336] 4510
...      White vs Black: 3707 - 834 - 4478  [0.659] 9019
Elo difference: -3.6 +/- 5.1, LOS: 8.4 %, DrawRatio: 49.7 %
SPRT: llr -2.26 (-78.3%), lbound -2.25, ubound 2.89 - H0 was accepted
```