### PR TITLE
🔍 Post-LMR contHist update - score > alpha

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -605,6 +605,15 @@ public sealed partial class Engine
                             // Search with full depth but narrowed score bandwidth (zero-window search)
                             score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
                         }
+
+                        // 🔍 Post-LMR continuation history update
+                        var rawHistoryBonus = EvaluationConstants.HistoryBonus[depth];
+                        var historyBonus = score > alpha
+                            ? rawHistoryBonus
+                            : -rawHistoryBonus;
+
+                        ref var contHist = ref ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
+                        contHist = ScoreHistoryMove(contHist, historyBonus);
                     }
                 }
 


### PR DESCRIPTION
See also #1741 

8+0.08
```
Score of Lynx-search-post-lmr-conthist-update-1-6362-win-x64 vs Lynx 6355 - main: 25410 - 24818 - 49772  [0.503] 100000
...      Lynx-search-post-lmr-conthist-update-1-6362-win-x64 playing White: 20944 - 4310 - 24746  [0.666] 50000
...      Lynx-search-post-lmr-conthist-update-1-6362-win-x64 playing Black: 4466 - 20508 - 25026  [0.340] 50000
...      White vs Black: 41452 - 8776 - 49772  [0.663] 100000
Elo difference: 2.1 +/- 1.5, LOS: 99.6 %, DrawRatio: 49.8 %
SPRT: llr 2.76 (95.3%), lbound -2.25, ubound 2.89
```

40+0.4 non-reg
```
Test  | search/post-lmr-conthist-update-1
Elo   | 6.33 +- 5.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 5106: +1198 -1105 =2803
Penta | [40, 571, 1252, 636, 54]
https://openbench.lynx-chess.com/test/1798/
```