### PR TITLE
🔍 SE: limit `ply < 2 * depth`

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,6 +67,8 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
+    private readonly int[] _doubleExtensions = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
+
     /// <summary>
     /// <see cref="Constants.KingPawnHashSize"/>
     /// </summary>
@@ -96,6 +98,7 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
+        Array.Clear(_doubleExtensions);
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_moveNodeCount[i]);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -413,7 +413,8 @@ public sealed partial class Engine
                 && depth >= Configuration.EngineSettings.SE_MinDepth
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && ttElementType != NodeType.Alpha)
+                && ttElementType != NodeType.Alpha
+                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 
@@ -433,6 +434,7 @@ public sealed partial class Engine
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;
+                        ++_doubleExtensions[ply];
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -414,7 +414,7 @@ public sealed partial class Engine
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
-                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
+                && ply < 2 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 


### PR DESCRIPTION
```
Test  | search/se-limit-half-depth-2
Elo   | -5.19 +- 6.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.03 (-2.25, 2.89) [-3.00, 1.00]
Games | 3748: +819 -875 =2054
Penta | [33, 482, 899, 428, 32]
https://openbench.lynx-chess.com/test/1781/
```

Superseded by #1768 