### PR TITLE
🔍 SE: Multicut limit `singularScore` not mate/mated score

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -436,7 +436,7 @@ public sealed partial class Engine
                     }
                 }
                 // Multicut
-                else if (singularScore >= beta)
+                else if (singularScore >= beta && singularScore < Math.Abs(EvaluationConstants.PositiveCheckmateDetectionLimit))
                 {
                     return singularScore;
                 }


### PR DESCRIPTION
```
Test  | search/se-multicut-no-matescores
Elo   | 0.87 +- 2.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 36074: +9275 -9185 =17614
Penta | [589, 4241, 8288, 4329, 590]
https://openbench.lynx-chess.com/test/1782/
```