### PR TITLE
⚡ Use copy-make whenever the move is reverted immediately

### DIFF
--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -400,11 +400,10 @@ public static class MoveExtensions
             .Where(m =>
             {
                 // If any illegal moves exist with the same simple representation there's no need to disambiguate
-                var gameState = position.MakeMove(m);
-                var isLegal = position.WasProduceByAValidMove();
-                position.UnmakeMove(m, gameState);
+                using var newPosition = new Position(position);
+                _ = newPosition.MakeMove(m);
 
-                return isLegal;
+                return newPosition.WasProduceByAValidMove();
             })
             .ToArray();
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -648,11 +648,9 @@ public static class MoveGenerator
         }
 #endif
 
-        var gameState = position.MakeMove(move);
+        using var newPosition = new Position(position);
+        _ = newPosition.MakeMove(move);
 
-        bool result = position.WasProduceByAValidMove();
-        position.UnmakeMove(move, gameState);
-
-        return result;
+        return newPosition.WasProduceByAValidMove();
     }
 }

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -41,13 +41,17 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                bool validMove;
+                using (var newPosition = new Position(position))
+                {
+                    _ = newPosition.MakeMove(move);
+                    validMove = newPosition.WasProduceByAValidMove();
+                }
 
-                if (position.WasProduceByAValidMove())
+                if (validMove)
                 {
                     nodes = PerftRecursiveImpl(position, depth - 1, nodes);
                 }
-                position.UnmakeMove(move, state);
             }
 
             return nodes;
@@ -64,17 +68,20 @@ public static class Perft
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
             foreach (var move in MoveGenerator.GenerateAllMoves(position, moves))
             {
-                var state = position.MakeMove(move);
+                bool validMove;
+                using (var newPosition = new Position(position))
+                {
+                    _ = newPosition.MakeMove(move);
+                    validMove = newPosition.WasProduceByAValidMove();
+                }
 
-                if (position.WasProduceByAValidMove())
+                if (validMove)
                 {
                     var accumulatedNodes = nodes;
                     nodes = PerftRecursiveImpl(position, depth - 1, nodes);
 
                     write($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
                 }
-
-                position.UnmakeMove(move, state);
             }
 
             write(string.Empty);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -412,13 +412,13 @@ public sealed partial class Engine
             if (doSE)
             {
                 // Check if the move is legal - TODO replace this with IsLegal() check
-                var seGameState = position.MakeMove(move);
-                var validMove = position.WasProduceByAValidMove();
-                position.UnmakeMove(move, seGameState);
-
-                if (!validMove)
+                using (var newPosition = new Position(position))
                 {
-                    continue;
+                    _ = newPosition.MakeMove(move);
+                    if (!newPosition.WasProduceByAValidMove())
+                    {
+                        continue;
+                    }
                 }
 
                 var verificationDepth = (depth - 1) / 2;    // TODO tune?


### PR DESCRIPTION
```
Score of Lynx-refactor-se-6390-win-x64 vs Lynx 6374 - main: 116 - 155 - 239  [0.462] 510
...      Lynx-refactor-se-6390-win-x64 playing White: 97 - 25 - 133  [0.641] 255
...      Lynx-refactor-se-6390-win-x64 playing Black: 19 - 130 - 106  [0.282] 255
...      White vs Black: 227 - 44 - 239  [0.679] 510
Elo difference: -26.6 +/- 22.0, LOS: 0.9 %, DrawRatio: 46.9 %
SPRT: llr -0.673 (-23.3%), lbound -2.25, ubound 2.89
Started game 518 of 100000 (Lynx 6374 - main vs Lynx-refactor-se-6390-win-x64)
```