### PR TITLE
🔍 NMP: SF epic simplfiication: `7 + depth / 3`, no static eval diff

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -249,7 +249,7 @@ public sealed class EngineSettings
     public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(enabled: false)]
-    public int NMP_BaseDepthReduction { get; set; } = 2;
+    public int NMP_BaseDepthReduction { get; set; } = 7;
 
 #pragma warning disable CA1805 // Do not initialize unnecessarily
     [SPSA<int>(enabled: false)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,16 +252,7 @@ public sealed partial class Engine
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                     && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
                 {
-                    var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
-                        + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
-                        + Math.Min(
-                            Configuration.EngineSettings.NMP_StaticEvalBetaMaxReduction,
-                            staticEvalBetaDiff / Configuration.EngineSettings.NMP_StaticEvalBetaDivisor);
-
-                    // TODO more advanced adaptative reduction, similar to what Ethereal and Stormphrax are doing
-                    //var nmpReduction = Math.Min(
-                    //    depth,
-                    //    3 + (depth / 3) + Math.Min((staticEval - beta) / 200, 3));
+                    var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction + (depth / Configuration.EngineSettings.NMP_DepthDivisor);
 
                     var gameState = position.MakeNullMove();
                     var nmpScore = -NegaMax(depth - 1 - nmpReduction, ply + 1, -beta, -beta + 1, !cutnode, cancellationToken, parentWasNullMove: true);


### PR DESCRIPTION
```
Score of Lynx-search-nmp-epic-sf-simplification-6391-win-x64 vs Lynx 6374 - main: 233 - 330 - 517  [0.455] 1080
...      Lynx-search-nmp-epic-sf-simplification-6391-win-x64 playing White: 199 - 70 - 271  [0.619] 540
...      Lynx-search-nmp-epic-sf-simplification-6391-win-x64 playing Black: 34 - 260 - 246  [0.291] 540
...      White vs Black: 459 - 104 - 517  [0.664] 1080
Elo difference: -31.3 +/- 15.0, LOS: 0.0 %, DrawRatio: 47.9 %
SPRT: llr -1.7 (-58.8%), lbound -2.25, ubound 2.89
```