### PR TITLE
🔍 SE: limit `ply < 2 * depth` and no mate scores

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,6 +67,8 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
+    private readonly int[] _doubleExtensions = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
+
     /// <summary>
     /// <see cref="Constants.KingPawnHashSize"/>
     /// </summary>
@@ -96,6 +98,7 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
+        Array.Clear(_doubleExtensions);
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_moveNodeCount[i]);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,8 +67,6 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
-    private readonly int[] _doubleExtensions = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
-
     /// <summary>
     /// <see cref="Constants.KingPawnHashSize"/>
     /// </summary>
@@ -98,7 +96,6 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
-        Array.Clear(_doubleExtensions);
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_moveNodeCount[i]);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -413,7 +413,8 @@ public sealed partial class Engine
                 && depth >= Configuration.EngineSettings.SE_MinDepth
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && ttElementType != NodeType.Alpha)
+                && ttElementType != NodeType.Alpha
+                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 
@@ -433,6 +434,7 @@ public sealed partial class Engine
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;
+                        ++_doubleExtensions[ply];
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -412,7 +412,7 @@ public sealed partial class Engine
                 isBestMove      // Ensures !isRoot and TT hit (otherwise there wouldn't be a TT move)
                 && depth >= Configuration.EngineSettings.SE_MinDepth
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
-                //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
+                && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
                 && ply < 2 * depth)     // Preventing search explosions
             {
@@ -434,7 +434,6 @@ public sealed partial class Engine
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;
-                        ++_doubleExtensions[ply];
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -414,7 +414,7 @@ public sealed partial class Engine
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
-                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
+                && ply < 2 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 


### PR DESCRIPTION
8+0.08
```
Score of Lynx-search-se-limit-half-depth-no-matescores-6397-win-x64 vs Lynx 6374 - main: 2219 - 2117 - 4302  [0.506] 8638
...      Lynx-search-se-limit-half-depth-no-matescores-6397-win-x64 playing White: 1833 - 371 - 2116  [0.669] 4320
...      Lynx-search-se-limit-half-depth-no-matescores-6397-win-x64 playing Black: 386 - 1746 - 2186  [0.343] 4318
...      White vs Black: 3579 - 757 - 4302  [0.663] 8638
Elo difference: 4.1 +/- 5.2, LOS: 93.9 %, DrawRatio: 49.8 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Test  | search/se-limit-half-depth-no-matescores
Elo   | -3.90 +- 3.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [-3.00, 1.00]
Games | 11392: +2533 -2661 =6198
Penta | [104, 1432, 2745, 1318, 97]
https://openbench.lynx-chess.com/test/1792/
```