### PR TITLE
🔍 SE: limit `ply <3 * depth` and no mate scores

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,6 +67,8 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
+    private readonly int[] _doubleExtensions = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
+
     /// <summary>
     /// <see cref="Constants.KingPawnHashSize"/>
     /// </summary>
@@ -96,6 +98,7 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
+        Array.Clear(_doubleExtensions);
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_moveNodeCount[i]);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -67,8 +67,6 @@ public sealed partial class Engine
 
     private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
-    private readonly int[] _doubleExtensions = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
-
     /// <summary>
     /// <see cref="Constants.KingPawnHashSize"/>
     /// </summary>
@@ -98,7 +96,6 @@ public sealed partial class Engine
 
         Array.Clear(_pVTable);
         Array.Clear(_maxDepthReached);
-        Array.Clear(_doubleExtensions);
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_moveNodeCount[i]);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -414,7 +414,7 @@ public sealed partial class Engine
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
-                && ply < 2 * depth)     // Preventing search explosions
+                && ply < 3 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -413,7 +413,8 @@ public sealed partial class Engine
                 && depth >= Configuration.EngineSettings.SE_MinDepth
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && ttElementType != NodeType.Alpha)
+                && ttElementType != NodeType.Alpha
+                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 
@@ -433,6 +434,7 @@ public sealed partial class Engine
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;
+                        ++_doubleExtensions[ply];
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -412,7 +412,7 @@ public sealed partial class Engine
                 isBestMove      // Ensures !isRoot and TT hit (otherwise there wouldn't be a TT move)
                 && depth >= Configuration.EngineSettings.SE_MinDepth
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
-                //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
+                && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
                 && ply < 2 * depth)     // Preventing search explosions
             {
@@ -434,7 +434,6 @@ public sealed partial class Engine
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;
-                        ++_doubleExtensions[ply];
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -414,7 +414,7 @@ public sealed partial class Engine
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 //&& Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
-                && 2 * _doubleExtensions[ply] < depth)     // Preventing search explosions
+                && ply < 2 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 


### PR DESCRIPTION
Still not solving the problems detected in CI though.

8+0.08
```
Score of Lynx-search-se-limit-onethird-depth-no-matescores-6399-win-x64 vs Lynx 6374 - main: 2924 - 2864 - 5762  [0.503] 11550
...      Lynx-search-se-limit-onethird-depth-no-matescores-6399-win-x64 playing White: 2412 - 492 - 2872  [0.666] 5776
...      Lynx-search-se-limit-onethird-depth-no-matescores-6399-win-x64 playing Black: 512 - 2372 - 2890  [0.339] 5774
...      White vs Black: 4784 - 1004 - 5762  [0.664] 11550
Elo difference: 1.8 +/- 4.5, LOS: 78.5 %, DrawRatio: 49.9 %
SPRT: llr 2.14 (74.1%), lbound -2.25, ubound 2.89
```

40+0.4
```
Test  | search/se-limit-onethird-depth-no-matescores
Elo   | 2.21 +- 2.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 17598: +4134 -4022 =9442
Penta | [137, 2075, 4288, 2137, 162]
https://openbench.lynx-chess.com/test/1794/
```