### PR TITLE
🔍 SE: cutnode double negative extension

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -440,10 +440,14 @@ public sealed partial class Engine
                 {
                     return singularScore;
                 }
+                else if (cutnode)
+                {
+                    singularDepthExtensions = -2;
+                }
                 // Negative extension
                 else if (ttScore >= beta)
                 {
-                    --singularDepthExtensions;
+                    singularDepthExtensions = -1;
                 }
 
                 gameState = position.MakeMove(move);


### PR DESCRIPTION
```
Test  | search/se-cutnode
Elo   | 0.05 +- 4.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.27 (-2.25, 2.89) [0.00, 3.00]
Games | 7676: +1748 -1747 =4181
Penta | [66, 911, 1888, 902, 71]
https://openbench.lynx-chess.com/test/1790/
```