### PR TITLE
🔍 LMR: allow on first visited move when not root move II

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -500,7 +500,7 @@ public sealed partial class Engine
 
                 if (isNotGettingCheckmated)
                 {
-                    var isRootExtraReduction = isRoot ? 1 : 0;
+                    var isRootExtraReduction = isRoot ? 2 : 0;
 
                     if (depth >= Configuration.EngineSettings.LMR_MinDepth
                         && visitedMovesCounter >=


### PR DESCRIPTION
```
Score of Lynx-search-lmr-on-root-2-6403-win-x64 vs Lynx 6374 - main: 145 - 181 - 384  [0.475] 710
...      Lynx-search-lmr-on-root-2-6403-win-x64 playing White: 120 - 35 - 200  [0.620] 355
...      Lynx-search-lmr-on-root-2-6403-win-x64 playing Black: 25 - 146 - 184  [0.330] 355
...      White vs Black: 266 - 60 - 384  [0.645] 710
Elo difference: -17.6 +/- 17.3, LOS: 2.3 %, DrawRatio: 54.1 %
SPRT: llr -0.854 (-29.6%), lbound -2.25, ubound 2.89
```