### PR TITLE
🔍 LMR: allow on first visited move when not root move

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -496,115 +496,114 @@ public sealed partial class Engine
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth
                 // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
-                if (visitedMovesCounter > 0)
+                int reduction = 0;
+
+                if (isNotGettingCheckmated)
                 {
-                    int reduction = 0;
+                    var isRootExtraReduction = isRoot ? 1 : 0;
 
-                    if (isNotGettingCheckmated)
+                    if (depth >= Configuration.EngineSettings.LMR_MinDepth
+                        && visitedMovesCounter >=
+                            (pvNode
+                                ? (Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV + isRootExtraReduction)
+                                : (Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV + isRootExtraReduction)))
                     {
-                        if (depth >= Configuration.EngineSettings.LMR_MinDepth
-                            && visitedMovesCounter >=
-                                (pvNode
-                                    ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
-                                    : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV))
+                        if (isCapture)
                         {
-                            if (isCapture)
-                            {
-                                reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter];
+                            reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter];
 
-                                reduction /= EvaluationConstants.LMRScaleFactor;
+                            reduction /= EvaluationConstants.LMRScaleFactor;
 
-                                // ~ history/(0.75 * maxHistory/2/)
-                                reduction -= CaptureHistoryEntry(move) / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
-                            }
-                            else
-                            {
-                                reduction = EvaluationConstants.LMRReductions[0][depth][visitedMovesCounter]
-                                    + Configuration.EngineSettings.LMR_Quiet;    // Quiet LMR
-
-                                if (!improving)
-                                {
-                                    reduction += Configuration.EngineSettings.LMR_Improving;
-                                }
-
-                                if (cutnode)
-                                {
-                                    reduction += Configuration.EngineSettings.LMR_Cutnode;
-                                }
-
-                                if (!ttPv)
-                                {
-                                    reduction += Configuration.EngineSettings.LMR_TTPV;
-                                }
-
-                                if (ttMoveIsCapture)    // Move isn't a capture but TT move is
-                                {
-                                    reduction += Configuration.EngineSettings.LMR_TTCapture;
-                                }
-
-                                if (pvNode)
-                                {
-                                    reduction -= Configuration.EngineSettings.LMR_PVNode;
-                                }
-
-                                if (position.IsInCheck())   // i.e. move gives check
-                                {
-                                    reduction -= Configuration.EngineSettings.LMR_InCheck;
-                                }
-
-                                reduction /= EvaluationConstants.LMRScaleFactor;
-
-                                // -= history/(maxHistory/2)
-
-                                reduction -= QuietHistory() / Configuration.EngineSettings.LMR_History_Divisor_Quiet;
-                            }
+                            // ~ history/(0.75 * maxHistory/2/)
+                            reduction -= CaptureHistoryEntry(move) / Configuration.EngineSettings.LMR_History_Divisor_Noisy;
                         }
-
-                        // 🔍 Static Exchange Evaluation (SEE) reduction
-                        // Bad captures are reduced more
-                        // Last attempt to move it inside of LMR conditions was https://github.com/lynx-chess/Lynx/pull/1589
-                        if (!isInCheck
-                            && moveScore < EvaluationConstants.PromotionMoveScoreValue
-                            && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
+                        else
                         {
-                            reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
-                        }
+                            reduction = EvaluationConstants.LMRReductions[0][depth][visitedMovesCounter]
+                                + Configuration.EngineSettings.LMR_Quiet;    // Quiet LMR
 
-                        // Don't allow LMR to drop into qsearch or increase the depth: min depth 1
-                        // (depth - 1) - depth + 2 = 1, min depth we want
-                        // newDepth - newDepth + 1 = 1, min depth we want
-                        reduction = Math.Max(0, Math.Min(reduction, newDepth - 1));
+                            if (!improving)
+                            {
+                                reduction += Configuration.EngineSettings.LMR_Improving;
+                            }
+
+                            if (cutnode)
+                            {
+                                reduction += Configuration.EngineSettings.LMR_Cutnode;
+                            }
+
+                            if (!ttPv)
+                            {
+                                reduction += Configuration.EngineSettings.LMR_TTPV;
+                            }
+
+                            if (ttMoveIsCapture)    // Move isn't a capture but TT move is
+                            {
+                                reduction += Configuration.EngineSettings.LMR_TTCapture;
+                            }
+
+                            if (pvNode)
+                            {
+                                reduction -= Configuration.EngineSettings.LMR_PVNode;
+                            }
+
+                            if (position.IsInCheck())   // i.e. move gives check
+                            {
+                                reduction -= Configuration.EngineSettings.LMR_InCheck;
+                            }
+
+                            reduction /= EvaluationConstants.LMRScaleFactor;
+
+                            // -= history/(maxHistory/2)
+
+                            reduction -= QuietHistory() / Configuration.EngineSettings.LMR_History_Divisor_Quiet;
+                        }
                     }
 
-                    var reducedDepth = newDepth - reduction;
-
-                    // Search with reduced depth and zero window
-                    score = -NegaMax(reducedDepth, ply + 1, -alpha - 1, -alpha, cutnode: true, cancellationToken);
-
-                    // 🔍 Principal Variation Search (PVS)
-                    if (score > alpha && newDepth > reducedDepth)
+                    // 🔍 Static Exchange Evaluation (SEE) reduction
+                    // Bad captures are reduced more
+                    // Last attempt to move it inside of LMR conditions was https://github.com/lynx-chess/Lynx/pull/1589
+                    if (!isInCheck
+                        && moveScore < EvaluationConstants.PromotionMoveScoreValue
+                        && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)
                     {
-                        // Optimistic search, validating that the rest of the moves are worse than bestmove.
-                        // It should produce more cutoffs and therefore be faster.
-                        // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+                        reduction += Configuration.EngineSettings.SEE_BadCaptureReduction;
+                    }
 
-                        var deeper = score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
-                        var shallower = score < bestScore + depth;
+                    // Don't allow LMR to drop into qsearch or increase the depth: min depth 1
+                    // (depth - 1) - depth + 2 = 1, min depth we want
+                    // newDepth - newDepth + 1 = 1, min depth we want
+                    reduction = Math.Max(0, Math.Min(reduction, newDepth - 1));
+                }
 
-                        if (deeper && !shallower && depth < Configuration.EngineSettings.MaxDepth)
-                        {
-                            ++newDepth;
-                        }
-                        else if (shallower && !deeper && newDepth > 1)
-                        {
-                            --newDepth;
-                        }
+                var reducedDepth = newDepth - reduction;
 
-                        if (newDepth > reducedDepth)
-                        {
-                            // Search with full depth but narrowed score bandwidth (zero-window search)
-                            score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
-                        }
+                // Search with reduced depth and zero window
+                score = -NegaMax(reducedDepth, ply + 1, -alpha - 1, -alpha, cutnode: true, cancellationToken);
+
+                // 🔍 Principal Variation Search (PVS)
+                if (score > alpha && newDepth > reducedDepth)
+                {
+                    // Optimistic search, validating that the rest of the moves are worse than bestmove.
+                    // It should produce more cutoffs and therefore be faster.
+                    // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
+
+                    var deeper = score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
+                    var shallower = score < bestScore + depth;
+
+                    if (deeper && !shallower && depth < Configuration.EngineSettings.MaxDepth)
+                    {
+                        ++newDepth;
+                    }
+                    else if (shallower && !deeper && newDepth > 1)
+                    {
+                        --newDepth;
+                    }
+
+                    if (newDepth > reducedDepth)
+                    {
+                        // Search with full depth but narrowed score bandwidth (zero-window search)
+                        score = -NegaMax(newDepth, ply + 1, -alpha - 1, -alpha, !cutnode, cancellationToken);
                     }
                 }
 


### PR DESCRIPTION
```
Test  | search/lmr-see-on-root
Elo   | -35.47 +- 10.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 1622: +333 -498 =791
Penta | [51, 245, 353, 142, 20]
https://openbench.lynx-chess.com/test/1795/
```