### PR TITLE
🔍 Improving: set to true if `staticEval >= beta` by a margin of 200

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -390,6 +390,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Step { get; set; } = 10;
 
+    [SPSA<int>(50, 150, 10)]
+    public int Improving_BetaMargin { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int SE_MinDepth { get; set; } = 7;
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -391,7 +391,7 @@ public sealed class EngineSettings
     public int TT_50MR_Step { get; set; } = 10;
 
     [SPSA<int>(50, 150, 10)]
-    public int Improving_BetaMargin { get; set; } = 100;
+    public int Improving_BetaMargin { get; set; } = 200;
 
     [SPSA<int>(enabled: false)]
     public int SE_MinDepth { get; set; } = 7;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -179,6 +179,8 @@ public sealed partial class Engine
                 improvingRate = evalDiff / 50.0;
             }
 
+            improving |= staticEval >= beta + Configuration.EngineSettings.Improving_BetaMargin;
+
             // From smol.cs
             // ttEvaluation can be used as a better positional evaluation:
             // If the score is outside what the current bounds are, but it did match flag and depth,


### PR DESCRIPTION
See for 100: https://github.com/lynx-chess/Lynx/pull/1749

8+0.08, cancelled due to running with non-reg bounds
```
Score of Lynx-search-post-lmr-history-reduction-6407-win-x64 vs Lynx 6374 - main: 6263 - 6310 - 11937  [0.499] 24510
...      Lynx-search-post-lmr-history-reduction-6407-win-x64 playing White: 5133 - 1124 - 5998  [0.664] 12255
...      Lynx-search-post-lmr-history-reduction-6407-win-x64 playing Black: 1130 - 5186 - 5939  [0.335] 12255
...      White vs Black: 10319 - 2254 - 11937  [0.665] 24510
Elo difference: -0.7 +/- 3.1, LOS: 33.8 %, DrawRatio: 48.7 %
SPRT: llr 0.529 (18.3%), lbound -2.25, ubound 2.89
```

```
Score of Lynx-search-improving-beta-200-6417-win-x64 vs Lynx 6411 - main: 5738 - 5757 - 11765  [0.500] 23260
...      Lynx-search-improving-beta-200-6417-win-x64 playing White: 4740 - 1011 - 5879  [0.660] 11630
...      Lynx-search-improving-beta-200-6417-win-x64 playing Black: 998 - 4746 - 5886  [0.339] 11630
...      White vs Black: 9486 - 2009 - 11765  [0.661] 23260
Elo difference: -0.3 +/- 3.1, LOS: 43.0 %, DrawRatio: 50.6 %
SPRT: llr -2.09 (-72.2%), lbound -2.25, ubound 2.89
```