### PR TITLE
🔍 LMR: penalize root moves requiring more visited moves

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -496,17 +496,19 @@ public sealed partial class Engine
 
                 // 🔍 Late Move Reduction (LMR) - search with reduced depth
                 // Impl. based on Ciekce (Stormphrax) and Martin (Motor) advice, and Stormphrax & Akimbo implementations
-                if (visitedMovesCounter > 0)
+                if (visitedMovesCounter >= 1)
                 {
                     int reduction = 0;
 
                     if (isNotGettingCheckmated)
                     {
+                        var isRootExtraReduction = isRoot ? 2 : 0;
+
                         if (depth >= Configuration.EngineSettings.LMR_MinDepth
                             && visitedMovesCounter >=
                                 (pvNode
-                                    ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV
-                                    : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV))
+                                    ? Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_PV + isRootExtraReduction
+                                    : Configuration.EngineSettings.LMR_MinFullDepthSearchedMoves_NonPV + isRootExtraReduction))
                         {
                             if (isCapture)
                             {


### PR DESCRIPTION
8+0.08
```
Test  | search/lmr-tarnished-idea
Elo   | 1.43 +- 1.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | 152048: +39737 -39113 =73198
Penta | [2798, 18308, 33251, 18806, 2861]
https://openbench.lynx-chess.com/test/1796/
```

40+0.4 - non-ref
```
Test  | search/lmr-tarnished-idea
Elo   | 4.36 +- 3.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 10128: +2405 -2278 =5445
Penta | [90, 1198, 2382, 1283, 111]
https://openbench.lynx-chess.com/test/1799/
```