### PR TITLE
🧪 Move check extensions after SE

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -137,11 +137,6 @@ public sealed partial class Engine
         int phase = int.MaxValue;
         ref var stack = ref Game.Stack(ply);
 
-        if (isInCheck)
-        {
-            ++depthExtension;
-        }
-
         if (depth + depthExtension <= 0)
         {
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
@@ -448,6 +443,11 @@ public sealed partial class Engine
                 }
 
                 gameState = position.MakeMove(move);
+            }
+            // Check extensions
+            else if (isInCheck)
+            {
+                ++depthExtension;
             }
 
             var previousNodes = _nodes;


### PR DESCRIPTION
```
Test  | experiment/move-check-extensions-around
Elo   | -33.28 +- 14.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.36 (-2.25, 2.89) [0.00, 3.00]
Games | 1068: +254 -356 =458
Penta | [46, 143, 226, 105, 14]
https://openbench.lynx-chess.com/test/1800/
```