### PR TITLE
🔍 SE: limit double extensions: not after `doubleExtensions[ply] >= 3`

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -240,6 +240,9 @@ public sealed class Game : IDisposable
     public int UpdateStaticEvalInStack(int n, int value) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval = value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ReadDoubleExtensionsFromStack(int n) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].DoubleExtensions;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref PlyStackEntry Stack(int n) => ref _stack[n + EvaluationConstants.ContinuationHistoryPlyCount];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -4,6 +4,8 @@ public struct PlyStackEntry
 {
     public int StaticEval { get; set; }
 
+    public int DoubleExtensions { get; set; }
+
     public Move Move { get; set; }
 
     public PlyStackEntry()

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -136,6 +136,7 @@ public sealed partial class Engine
         int rawStaticEval, staticEval;
         int phase = int.MaxValue;
         ref var stack = ref Game.Stack(ply);
+        stack.DoubleExtensions = Game.ReadDoubleExtensionsFromStack(ply - 1);
 
         if (isInCheck)
         {
@@ -431,9 +432,11 @@ public sealed partial class Engine
 
                     // Double extension
                     if (!pvNode
-                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
+                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta
+                        && stack.DoubleExtensions < 5)
                     {
                         ++singularDepthExtensions;
+                        ++stack.DoubleExtensions;
                     }
                 }
                 // Multicut


### PR DESCRIPTION
#1764 reimpl
```
Score of Lynx-search-se-limit-double-extensions-2-6420-win-x64 vs Lynx 6418 - main: 803 - 882 - 1735  [0.488] 3420
...      Lynx-search-se-limit-double-extensions-2-6420-win-x64 playing White: 681 - 160 - 870  [0.652] 1711
...      Lynx-search-se-limit-double-extensions-2-6420-win-x64 playing Black: 122 - 722 - 865  [0.324] 1709
...      White vs Black: 1403 - 282 - 1735  [0.664] 3420
Elo difference: -8.0 +/- 8.2, LOS: 2.7 %, DrawRatio: 50.7 %
SPRT: llr -1.64 (-56.9%), lbound -2.25, ubound 2.89
```