### PR TITLE
🔍 SE: limit double extensions: not after `doubleExtensions[ply] >= 6`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -402,6 +402,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 50, 5)]
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
+    [SPSA<int>(enabled: false)]
+    public int SE_DoubleExtensions_Max { get; set; } = 10;
+
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -403,7 +403,7 @@ public sealed class EngineSettings
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
     [SPSA<int>(enabled: false)]
-    public int SE_DoubleExtensions_Max { get; set; } = 10;
+    public int SE_DoubleExtensions_Max { get; set; } = 6;
 
     #endregion
 }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -240,6 +240,9 @@ public sealed class Game : IDisposable
     public int UpdateStaticEvalInStack(int n, int value) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].StaticEval = value;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ReadDoubleExtensionsFromStack(int n) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].DoubleExtensions;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ref PlyStackEntry Stack(int n) => ref _stack[n + EvaluationConstants.ContinuationHistoryPlyCount];
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -4,6 +4,8 @@ public struct PlyStackEntry
 {
     public int StaticEval { get; set; }
 
+    public int DoubleExtensions { get; set; }
+
     public Move Move { get; set; }
 
     public PlyStackEntry()

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -136,6 +136,7 @@ public sealed partial class Engine
         int rawStaticEval, staticEval;
         int phase = int.MaxValue;
         ref var stack = ref Game.Stack(ply);
+        stack.DoubleExtensions = Game.ReadDoubleExtensionsFromStack(ply - 1);
 
         if (isInCheck)
         {
@@ -431,9 +432,11 @@ public sealed partial class Engine
 
                     // Double extension
                     if (!pvNode
-                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
+                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta
+                        && stack.DoubleExtensions < 5)
                     {
                         ++singularDepthExtensions;
+                        ++stack.DoubleExtensions;
                     }
                 }
                 // Multicut

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -433,7 +433,7 @@ public sealed partial class Engine
                     // Double extension
                     if (!pvNode
                         && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta
-                        && stack.DoubleExtensions < 5)
+                        && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max)
                     {
                         ++singularDepthExtensions;
                         ++stack.DoubleExtensions;


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1764 reimpl, #1776 with bigger constant

```
Test  | search/se-limit-double-extensions-2-6
Elo   | 1.23 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 26612: +6206 -6112 =14294
Penta | [209, 2968, 6831, 3116, 182]
https://openbench.lynx-chess.com/test/1804/
```

Same `bench`

`bench 16`: 14167953 (main) vs 14187644