### PR TITLE
⚡ Don't add king PSQT values to incremental evaluator

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -193,6 +193,8 @@ public class Position : IDisposable
             piece == (int)Piece.N || piece == (int)Piece.n
             || piece == (int)Piece.B || piece == (int)Piece.b;
 
+        bool isKingMove = false;
+
         if (piece == (int)Piece.P || piece == (int)Piece.p)
         {
             _kingPawnUniqueIdentifier ^= sourcePieceHash;       // We remove pawn from start square
@@ -219,6 +221,7 @@ public class Position : IDisposable
 
             if (piece == (int)Piece.K || piece == (int)Piece.k)
             {
+                isKingMove = true;
                 // King (and castling) moves require calculating king buckets twice and recalculating all related parameters, so skipping incremental eval for those cases for now
                 // No need to check for move.IsCastle(), see CastlingMovesAreKingMoves test
                 _isIncrementalEval = false;
@@ -248,11 +251,14 @@ public class Position : IDisposable
                 (sameSideBucket, opposideSideBucket) = (opposideSideBucket, sameSideBucket);
             }
 
-            _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, piece, sourceSquare);
-            _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, piece, sourceSquare);
+            if (!isKingMove)
+            {
+                _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, piece, sourceSquare);
+                _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, piece, sourceSquare);
 
-            _incrementalEvalAccumulator += PSQT(0, sameSideBucket, newPiece, targetSquare);
-            _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, newPiece, targetSquare);
+                _incrementalEvalAccumulator += PSQT(0, sameSideBucket, newPiece, targetSquare);
+                _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, newPiece, targetSquare);
+            }
 
             _incrementalPhaseAccumulator += extraPhaseIfIncremental;
 


### PR DESCRIPTION
Hopefully the extra branch makes up for not doing the PSQT accesses.


8+0.08, [-5, 0]
```
Score of Lynx-perf-no-king-psqts-incremental-evaluator-6453-win-x64 vs Lynx 6451 - main: 6012 - 6081 - 11736  [0.499] 23829
...      Lynx-perf-no-king-psqts-incremental-evaluator-6453-win-x64 playing White: 4964 - 1032 - 5920  [0.665] 11916
...      Lynx-perf-no-king-psqts-incremental-evaluator-6453-win-x64 playing Black: 1048 - 5049 - 5816  [0.332] 11913
...      White vs Black: 10013 - 2080 - 11736  [0.666] 23829
Elo difference: -1.0 +/- 3.1, LOS: 26.5 %, DrawRatio: 49.3 %
SPRT: llr 2.91 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```