### PR TITLE
🔍 SE: limit to when `doubleExtensions >= 10`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -405,6 +405,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;
 
+    [SPSA<int>(enabled: false)]
+    public int SE_DoubleExtensions_Max_Total { get; set; } = 10;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -415,7 +415,8 @@ public sealed partial class Engine
                 && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
                 && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
                 && ttElementType != NodeType.Alpha
-                && ply < 3 * depth)     // Preventing search explosions
+                && ply < 3 * depth     // Preventing search explosions
+                && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max_Total)
             {
                 position.UnmakeMove(move, gameState);
 


### PR DESCRIPTION
```
Test  | search/se-limit-extensions
Elo   | -0.87 +- 2.11 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.62 (-2.25, 2.89) [-3.00, 1.00]
Games | 28826: +6567 -6639 =15620
Penta | [237, 3141, 7678, 3171, 186]
https://openbench.lynx-chess.com/test/1814/
```