### PR TITLE
🐛 Makefile:  Use either `PROCESSOR_ARCHITEW6432` or `PROCESSOR_ARCHITECTURE` to detect windows arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ RUNTIME=
 OUTPUT_DIR=artifacts/Lynx/
 
 ifeq ($(OS),Windows_NT)
-	ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
 		RUNTIME=win-x64
 	else ifeq ($(PROCESSOR_ARCHITECTURE),ARM64)
 		RUNTIME=win-arm64

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ OUTPUT_DIR=artifacts/Lynx/
 ifeq ($(OS),Windows_NT)
 	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
 		RUNTIME=win-x64
+	else ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
+		RUNTIME=win-x64
+	else ifeq ($(PROCESSOR_ARCHITEW6432),ARM64)
+		RUNTIME=win-arm64
 	else ifeq ($(PROCESSOR_ARCHITECTURE),ARM64)
 		RUNTIME=win-arm64
 	else


### PR DESCRIPTION
Locally (W11 machine):
```bash
makefile:8: PROCESSOR_ARCHITEW6432: AMD64
makefile:9: PROCESSOR_ARCHITECTURE: x86
```

GH actions `windows-latest`:

```bash
Makefile:8: PROCESSOR_ARCHITEW6432:
Makefile:9: PROCESSOR_ARCHITECTURE: AMD64
```

```
Operating System
  Microsoft Windows Server 2022
  10.0.20[3](https://github.com/lynx-chess/Lynx/actions/runs/15837229447/job/44643179815#step:1:3)48
  Datacenter
Runner Image
  Image: windows-2022
  Version: 2025061[7](https://github.com/lynx-chess/Lynx/actions/runs/15837229447/job/44643179815#step:1:8).1.0
  Included Software: https://github.com/actions/runner-images/blob/win22/20250617.1/images/windows/Windows2022-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/win22%2F20250617.1
```

----


BTW, ARM:
```bash
Makefile:8: PROCESSOR_ARCHITEW6432:
Makefile:9: PROCESSOR_ARCHITECTURE: AMD64
```

```
Operating System
  Microsoft Windows 11
  10.0.226[3](https://github.com/lynx-chess/Lynx/actions/runs/15837229447/job/44643179791#step:1:3)1
  Enterprise
Runner Image
  Image: windows-11
  Version: 0.0.3
  Included Software: https://github.com/actions/runner-images/blob/win11/0.0/images/windows/Windows11-Arm-Readme.md
  Image Release: https://github.com/actions/runner-images/releases/tag/win11F0.0
```

Maybe due to emulation underneath?