### PR TITLE
🔍 SPSA: 2025-06-23

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -174,73 +174,73 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.79;
+    public double LMR_Base_Quiet { get; set; } = 0.93;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.38;
+    public double LMR_Base_Noisy { get; set; } = 0.31;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.71;
+    public double LMR_Divisor_Quiet { get; set; } = 2.97;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.84;
+    public double LMR_Divisor_Noisy { get; set; } = 2.76;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 107;
+    public int LMR_Improving { get; set; } = 155;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 100;
+    public int LMR_Cutnode { get; set; } = 83;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 113;
+    public int LMR_TTPV { get; set; } = 86;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 68;
+    public int LMR_TTCapture { get; set; } = 43;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 89;
+    public int LMR_PVNode { get; set; } = 93;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 51;
+    public int LMR_InCheck { get; set; } = 27;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 70;
+    public int LMR_Quiet { get; set; } = 35;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 2687;
+    public int LMR_History_Divisor_Quiet { get; set; } = 1917;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 3816;
+    public int LMR_History_Divisor_Noisy { get; set; } = 4744;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 52;
+    public int LMR_DeeperBase { get; set; } = 60;
 
     [SPSA<int>(enabled: false)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -260,7 +260,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 104;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 114;
 
     [SPSA<int>(enabled: false)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
@@ -284,10 +284,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 67;
+    public int Razoring_Depth1Bonus { get; set; } = 83;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 196;
+    public int Razoring_NotDepth1Bonus { get; set; } = 186;
 
     [SPSA<int>(enabled: false)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -311,7 +311,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 116;
+    public int History_BestScoreBetaMargin { get; set; } = 117;
 
     [SPSA<int>(enabled: false)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -320,16 +320,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 92;
+    public int FP_DepthScalingFactor { get; set; } = 85;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 102;
+    public int FP_Margin { get; set; } = 84;
 
     [SPSA<int>(enabled: false)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -113;
+    public int HistoryPrunning_Margin { get; set; } = -201;
 
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -343,10 +343,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -40;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -42;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -107;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -89;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -364,25 +364,25 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 117;
+    public int CorrHistoryWeight_Pawn { get; set; } = 109;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 96;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 70;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 100;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 116;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 127;
+    public int CorrHistoryWeight_Minor { get; set; } = 130;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
@@ -400,7 +400,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 15;
+    public int SE_DoubleExtensions_Margin { get; set; } = 14;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;


### PR DESCRIPTION
20+0.2, 8 games per pair, 7.5k iter
<details>

<Summary>Params</Summary>

```json
{
   "t":7432,
   "spsa_params":{
      "a":1.0,
      "c":1.0,
      "A":65,
      "alpha":0.601,
      "gamma":0.102
   },
   "uci_params":[
      {
         "name":"LMR_Base_Quiet",
         "value":93.11520787468808,
         "min_value":10,
         "max_value":200,
         "step":20
      },
      {
         "name":"LMR_Base_Noisy",
         "value":31.247206129170625,
         "min_value":10,
         "max_value":200,
         "step":20
      },
      {
         "name":"LMR_Divisor_Quiet",
         "value":297.23888640118514,
         "min_value":100,
         "max_value":500,
         "step":20
      },
      {
         "name":"LMR_Divisor_Noisy",
         "value":276.2830109257367,
         "min_value":100,
         "max_value":500,
         "step":20
      },
      {
         "name":"LMR_Improving",
         "value":154.927944710586,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_Cutnode",
         "value":82.61830640142972,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_TTPV",
         "value":86.29229704405148,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_TTCapture",
         "value":43.40061898651575,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_PVNode",
         "value":93.41309860569945,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_InCheck",
         "value":26.809307672561285,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_Quiet",
         "value":35.0679254452846,
         "min_value":25,
         "max_value":300,
         "step":30
      },
      {
         "name":"LMR_History_Divisor_Quiet",
         "value":1916.6870075907452,
         "min_value":1,
         "max_value":8192,
         "step":512
      },
      {
         "name":"LMR_History_Divisor_Noisy",
         "value":4744.433634239459,
         "min_value":1,
         "max_value":8192,
         "step":512
      },
      {
         "name":"LMR_DeeperBase",
         "value":59.71431467128732,
         "min_value":20,
         "max_value":100,
         "step":8
      },
      {
         "name":"NMP_StaticEvalBetaDivisor",
         "value":113.80779873322864,
         "min_value":50,
         "max_value":350,
         "step":15
      },
      {
         "name":"Razoring_Depth1Bonus",
         "value":83.2144894493248,
         "min_value":1,
         "max_value":300,
         "step":15
      },
      {
         "name":"Razoring_NotDepth1Bonus",
         "value":186.3163164342352,
         "min_value":1,
         "max_value":300,
         "step":15
      },
      {
         "name":"History_BestScoreBetaMargin",
         "value":117.13737862104476,
         "min_value":0,
         "max_value":200,
         "step":10
      },
      {
         "name":"FP_DepthScalingFactor",
         "value":85.47183804094958,
         "min_value":1,
         "max_value":200,
         "step":10
      },
      {
         "name":"FP_Margin",
         "value":83.61577137982624,
         "min_value":0,
         "max_value":500,
         "step":25
      },
      {
         "name":"HistoryPrunning_Margin",
         "value":-200.92589078870293,
         "min_value":-8192,
         "max_value":0,
         "step":512
      },
      {
         "name":"PVS_SEE_Threshold_Quiet",
         "value":-42.28243686047398,
         "min_value":-100,
         "max_value":-10,
         "step":10
      },
      {
         "name":"PVS_SEE_Threshold_Noisy",
         "value":-88.67255602043012,
         "min_value":-150,
         "max_value":-50,
         "step":10
      },
      {
         "name":"CorrHistoryWeight_Pawn",
         "value":109.29245229038311,
         "min_value":25,
         "max_value":200,
         "step":15
      },
      {
         "name":"CorrHistoryWeight_NonPawnSTM",
         "value":69.71429687755749,
         "min_value":25,
         "max_value":200,
         "step":15
      },
      {
         "name":"CorrHistoryWeight_NonPawnNoSTM",
         "value":116.4437523140716,
         "min_value":25,
         "max_value":200,
         "step":15
      },
      {
         "name":"CorrHistoryWeight_Minor",
         "value":129.78198451877887,
         "min_value":25,
         "max_value":200,
         "step":15
      },
      {
         "name":"SE_DoubleExtensions_Margin",
         "value":13.525397065380218,
         "min_value":0,
         "max_value":50,
         "step":5
      }
   ]
}
```
</details>

![image](https://github.com/user-attachments/assets/234c5d22-f143-46e3-a0e5-421b38bd615d)

```
Score of Lynx-spsa-23-6-6456-win-x64 vs Lynx 6451 - main: 1607 - 1424 - 3519  [0.514] 6550
...      Lynx-spsa-23-6-6456-win-x64 playing White: 1433 - 131 - 1711  [0.699] 3275
...      Lynx-spsa-23-6-6456-win-x64 playing Black: 174 - 1293 - 1808  [0.329] 3275
...      White vs Black: 2726 - 305 - 3519  [0.685] 6550
Elo difference: 9.7 +/- 5.7, LOS: 100.0 %, DrawRatio: 53.7 %
SPRT: llr 2.89 (100.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```