### PR TITLE
🔍 SE: triple extension (margin 100) II

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -402,6 +402,9 @@ public sealed class EngineSettings
     [SPSA<int>(0, 50, 5)]
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
+    [SPSA<int>(20, 70, 5)]
+    public int SE_TripleExtensions_Margin { get; set; } = 40;
+
     #endregion
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -421,7 +421,7 @@ public sealed class EngineSettings
     public int SE_DoubleExtensions_Max { get; set; } = 6;
 
     [SPSA<int>(25, 100, 5)]
-    public int SE_TripleExtensions_Margin { get; set; } = 75;
+    public int SE_TripleExtensions_Margin { get; set; } = 100;
 
     #endregion
 }

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -402,8 +402,8 @@ public sealed class EngineSettings
     [SPSA<int>(0, 50, 5)]
     public int SE_DoubleExtensions_Margin { get; set; } = 15;
 
-    [SPSA<int>(20, 70, 5)]
-    public int SE_TripleExtensions_Margin { get; set; } = 40;
+    [SPSA<int>(25, 100, 5)]
+    public int SE_TripleExtensions_Margin { get; set; } = 75;
 
     #endregion
 }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -438,15 +438,15 @@ public sealed partial class Engine
 
                     if (!pvNode && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max)
                     {
-                        // Double extension
-                        if (singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
-                        {
-                            ++singularDepthExtensions;
-                            ++stack.DoubleExtensions;
-                        }
                         // Triple extension
                         if (!isCapture
                             && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
+                        {
+                            singularDepthExtensions += 2;
+                            ++stack.DoubleExtensions;
+                        }
+                        // Double extension
+                        else if (singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
                         {
                             ++singularDepthExtensions;
                             ++stack.DoubleExtensions;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -435,6 +435,7 @@ public sealed partial class Engine
                         ++singularDepthExtensions;
                     }
 
+                    // Triple extension
                     if (!isCapture && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
                     {
                         ++singularDepthExtensions;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -434,6 +434,11 @@ public sealed partial class Engine
                     {
                         ++singularDepthExtensions;
                     }
+
+                    if (!isCapture && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
+                    {
+                        ++singularDepthExtensions;
+                    }
                 }
                 // Multicut
                 else if (singularScore >= beta)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -436,19 +436,21 @@ public sealed partial class Engine
                 {
                     ++singularDepthExtensions;
 
-                    // Double extension
-                    if (!pvNode
-                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta
-                        && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max)
+                    if (!pvNode && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max)
                     {
-                        ++singularDepthExtensions;
-                        ++stack.DoubleExtensions;
-                    }
-
-                    // Triple extension
-                    if (!isCapture && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
-                    {
-                        ++singularDepthExtensions;
+                        // Double extension
+                        if (singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta)
+                        {
+                            ++singularDepthExtensions;
+                            ++stack.DoubleExtensions;
+                        }
+                        // Triple extension
+                        if (!isCapture
+                            && singularScore + Configuration.EngineSettings.SE_TripleExtensions_Margin < singularBeta)
+                        {
+                            ++singularDepthExtensions;
+                            ++stack.DoubleExtensions;
+                        }
                     }
                 }
                 // Multicut


### PR DESCRIPTION
Alt. impl to https://github.com/lynx-chess/Lynx/pull/1794

```
Test  | search/se-triple-extensions-margin-100-2
Elo   | -0.00 +- 3.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.34 (-2.25, 2.89) [0.00, 3.00]
Games | 9150: +2111 -2111 =4928
Penta | [80, 1101, 2226, 1075, 93]
https://openbench.lynx-chess.com/test/1823/
```
