### PR TITLE
🔍 SE: low depth extension II

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -420,6 +420,12 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;
 
+    [SPSA<int>(enabled: false)]
+    public int SE_LowDepthExtensions_MaxDepth { get; set; } = 7;
+
+    [SPSA<int>(10, 60, 5)]
+    public int SE_LowDepthExtensions_Margin { get; set; } = 30;
+
     #endregion
 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -458,6 +458,14 @@ public sealed partial class Engine
 
                 gameState = position.MakeMove(move);
             }
+            // Low depth extensions
+            else if (!isInCheck
+                && depth <= Configuration.EngineSettings.SE_LowDepthExtensions_MaxDepth
+                && staticEval <= alpha - Configuration.EngineSettings.SE_LowDepthExtensions_Margin
+                && ttElementType == NodeType.Beta)
+            {
+                singularDepthExtensions = 1;
+            }
 
             var previousNodes = _nodes;
             visitedMoves[visitedMovesCounter] = move;


### PR DESCRIPTION
Alt impl to #1796 

```
Test  | search/se-lowdepth-extensions-2
Elo   | -7.46 +- 4.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 5960: +1309 -1437 =3214
Penta | [52, 758, 1468, 670, 32]
https://openbench.lynx-chess.com/test/1825/
```