### PR TITLE
🔍 LMR: not while in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -510,7 +510,7 @@ public sealed partial class Engine
                 {
                     int reduction = 0;
 
-                    if (isNotGettingCheckmated)
+                    if (isNotGettingCheckmated && !isInCheck)
                     {
                         var isRootExtraReduction = isRoot ? 2 : 0;
 


### PR DESCRIPTION
```
Test  | search/lmr-not-incheck
Elo   | -7.71 +- 9.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.70 (-2.25, 2.89) [0.00, 3.00]
Games | 2072: +530 -576 =966
Penta | [45, 269, 448, 235, 39]
https://openbench.lynx-chess.com/test/1828/
```