### PR TITLE
🔍 SPSA 2025-06-27

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -174,73 +174,73 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.93;
+    public double LMR_Base_Quiet { get; set; } = 0.57;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.31;
+    public double LMR_Base_Noisy { get; set; } = 0.29;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 2.97;
+    public double LMR_Divisor_Quiet { get; set; } = 3.38;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.76;
+    public double LMR_Divisor_Noisy { get; set; } = 2.42;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 155;
+    public int LMR_Improving { get; set; } = 76;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 83;
+    public int LMR_Cutnode { get; set; } = 58;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 86;
+    public int LMR_TTPV { get; set; } = 56;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 43;
+    public int LMR_TTCapture { get; set; } = 90;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 93;
+    public int LMR_PVNode { get; set; } = 45;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 27;
+    public int LMR_InCheck { get; set; } = 47;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 35;
+    public int LMR_Quiet { get; set; } = 42;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 1917;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2280;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 4744;
+    public int LMR_History_Divisor_Noisy { get; set; } = 5905;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 60;
+    public int LMR_DeeperBase { get; set; } = 50;
 
     [SPSA<int>(enabled: false)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -260,7 +260,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 114;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 97;
 
     [SPSA<int>(enabled: false)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
@@ -269,7 +269,7 @@ public sealed class EngineSettings
     public int AspirationWindow_Base { get; set; } = 9;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double AspirationWindow_Multiplier { get; set; } = 1.5;
+    public double AspirationWindow_Multiplier { get; set; } = 1.24;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -278,16 +278,16 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(10, 150, 10)]
-    public int ImprovingRate { get; set; } = 50;
+    public int ImprovingRate { get; set; } = 45;
 
     [SPSA<int>(enabled: false)]
     public int RFP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_Improving_Margin { get; set; } = 80;
+    public int RFP_Improving_Margin { get; set; } = 85;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_NotImproving_Margin { get; set; } = 100;
+    public int RFP_NotImproving_Margin { get; set; } = 104;
 
     [SPSA<double>(enabled: false)]
     public double RFP_ImprovingFactor { get; set; } = 0.75;
@@ -299,10 +299,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 83;
+    public int Razoring_Depth1Bonus { get; set; } = 103;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 186;
+    public int Razoring_NotDepth1Bonus { get; set; } = 199;
 
     [SPSA<int>(enabled: false)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -326,7 +326,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 117;
+    public int History_BestScoreBetaMargin { get; set; } = 116;
 
     [SPSA<int>(enabled: false)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -344,7 +344,7 @@ public sealed class EngineSettings
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -201;
+    public int HistoryPrunning_Margin { get; set; } = -738;
 
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -358,10 +358,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -42;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -37;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -89;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -98;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -379,25 +379,25 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 109;
+    public int CorrHistoryWeight_Pawn { get; set; } = 117;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 70;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 63;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 116;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 124;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 130;
+    public int CorrHistoryWeight_Minor { get; set; } = 136;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
@@ -415,7 +415,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 14;
+    public int SE_DoubleExtensions_Margin { get; set; } = 7;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;


### PR DESCRIPTION
After making some asp window and rfp <-> improving stuff tunable in #1785 and #1788 

![image](https://github.com/user-attachments/assets/3e202ce0-d301-4de9-ace8-ae01802e8a8f)


```
iterations: 2319 (109.78s per iter)
games: 18552 (13.72s per game)
LMR_Base_Quiet = 57(-36.265463) in [10, 200]
LMR_Base_Noisy = 29(-1.944820) in [10, 200]
LMR_Divisor_Quiet = 338(+40.83) in [100, 500]
LMR_Divisor_Noisy = 242(-33.880208) in [100, 500]
LMR_Improving = 76(-78.613963) in [25, 300]
LMR_Cutnode = 58(-25.348840) in [25, 300]
LMR_TTPV = 56(-30.006223) in [25, 300]
LMR_TTCapture = 90(+46.65) in [25, 300]
LMR_PVNode = 45(-48.211012) in [25, 300]
LMR_InCheck = 47(+19.65) in [25, 300]
LMR_Quiet = 42(+7.46) in [25, 300]
LMR_History_Divisor_Quiet = 2280(+362.74) in [1, 8192]
LMR_History_Divisor_Noisy = 5905(+1161.00) in [1, 8192]
LMR_DeeperBase = 50(-9.577192) in [20, 100]
NMP_StaticEvalBetaDivisor = 97(-17.242114) in [50, 350]
AspirationWindow_Multiplier = 124(-25.945255) in [100, 300]
ImprovingRate = 45(-4.915774) in [10, 150]
RFP_Improving_Margin = 85(+4.60) in [50, 150]
RFP_NotImproving_Margin = 104(+4.26) in [50, 150]
Razoring_Depth1Bonus = 103(+19.56) in [1, 300]
Razoring_NotDepth1Bonus = 199(+13.04) in [1, 300]
History_BestScoreBetaMargin = 116(-1.425412) in [0, 200]
FP_DepthScalingFactor = 85(-0.061653) in [1, 200]
FP_Margin = 102(+17.64) in [0, 500]
HistoryPrunning_Margin = -738(-537.321099) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -37(+4.80) in [-100, -10]
PVS_SEE_Threshold_Noisy = -98(-9.114106) in [-150, -50]
CorrHistoryWeight_Pawn = 117(+7.62) in [25, 200]
CorrHistoryWeight_NonPawnSTM = 63(-6.994369) in [25, 200]
CorrHistoryWeight_NonPawnNoSTM = 124(+7.65) in [25, 200]
CorrHistoryWeight_Minor = 136(+5.95) in [25, 200]
SE_DoubleExtensions_Margin = 7(-7.057605) in [0, 50]
```

```
Test  | spsa/27-6
Elo   | 15.90 +- 6.31 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.44 (-2.25, 2.89) [0.00, 3.00]
Games | 3674: +943 -775 =1956
Penta | [23, 390, 860, 524, 40]
https://openbench.lynx-chess.com/test/1829/
```