### PR TITLE
🧪 Threats + `GameState` saving impact

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -14,6 +14,24 @@ public readonly struct GameState
 
     public readonly ulong MinorKey;
 
+    public readonly BitBoard WhitePawnAttacks;
+    public readonly BitBoard BlackPawnAttacks;
+
+    public readonly BitBoard WhiteKnightAttacks;
+    public readonly BitBoard BlackKnightAttacks;
+
+    public readonly BitBoard WhiteBishopAttacks;
+    public readonly BitBoard BlackBishopAttacks;
+
+    public readonly BitBoard WhiteRookAttacks;
+    public readonly BitBoard BlackRookAttacks;
+
+    public readonly BitBoard WhiteQueenAttacks;
+    public readonly BitBoard BlackQueenAttacks;
+
+    public readonly BitBoard WhiteKingAttacks;
+    public readonly BitBoard BlackKingAttacks;
+
     public readonly int IncrementalEvalAccumulator;
 
     public readonly int IncrementalPhaseAccumulator;
@@ -32,6 +50,22 @@ public readonly struct GameState
         NonPawnWhiteKey = position.NonPawnHash[(int)Side.White];
         NonPawnBlackKey = position.NonPawnHash[(int)Side.Black];
         MinorKey = position.MinorHash;
+
+        var attacks = position._attacks;
+
+        WhitePawnAttacks = attacks[(int)Piece.P];
+        WhiteKnightAttacks = attacks[(int)Piece.N];
+        WhiteBishopAttacks = attacks[(int)Piece.B];
+        WhiteRookAttacks = attacks[(int)Piece.R];
+        WhiteQueenAttacks = attacks[(int)Piece.Q];
+        WhiteKingAttacks = attacks[(int)Piece.K];
+
+        BlackPawnAttacks = attacks[(int)Piece.p];
+        BlackKnightAttacks = attacks[(int)Piece.n];
+        BlackBishopAttacks = attacks[(int)Piece.b];
+        BlackRookAttacks = attacks[(int)Piece.r];
+        BlackQueenAttacks = attacks[(int)Piece.q];
+        BlackKingAttacks = attacks[(int)Piece.k];
 
         EnPassant = position.EnPassant;
         Castle = position.Castle;


### PR DESCRIPTION
8+0.08
```
Score of Lynx 6520 - main vs Lynx-eval-threats-base-6521-win-x64: 665 - 542 - 1064  [0.527] 2271
...      Lynx 6520 - main playing White: 539 - 96 - 502  [0.695] 1137
...      Lynx 6520 - main playing Black: 126 - 446 - 562  [0.359] 1134
...      White vs Black: 985 - 222 - 1064  [0.668] 2271
Elo difference: 18.8 +/- 10.4, LOS: 100.0 %, DrawRatio: 46.9 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx 6520 - main vs Lynx-eval-threats-base-6521-win-x64: 132 - 108 - 240  [0.525] 480
...      Lynx 6520 - main playing White: 123 - 9 - 108  [0.738] 240
...      Lynx 6520 - main playing Black: 9 - 99 - 132  [0.313] 240
...      White vs Black: 222 - 18 - 240  [0.713] 480
Elo difference: 17.4 +/- 22.0, LOS: 93.9 %, DrawRatio: 50.0 %
SPRT: llr 0.592 (20.5%), lbound -2.25, ubound 2.89
```