### PR TITLE
🧪 Threats + 'side' threats `GameState` saving impact - in `GameState`

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -32,6 +32,9 @@ public readonly struct GameState
     public readonly BitBoard WhiteKingAttacks;
     public readonly BitBoard BlackKingAttacks;
 
+    public readonly BitBoard WhiteAttacks;
+    public readonly BitBoard BlackAttacks;
+
     public readonly int IncrementalEvalAccumulator;
 
     public readonly int IncrementalPhaseAccumulator;
@@ -66,6 +69,9 @@ public readonly struct GameState
         BlackRookAttacks = attacks[(int)Piece.r];
         BlackQueenAttacks = attacks[(int)Piece.q];
         BlackKingAttacks = attacks[(int)Piece.k];
+
+        WhiteAttacks = position._attacksBySide[(int)Side.White];
+        BlackAttacks = position._attacksBySide[(int)Side.Black];
 
         EnPassant = position.EnPassant;
         Castle = position.Castle;

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -14,6 +14,24 @@ public readonly struct GameState
 
     public readonly ulong MinorKey;
 
+    public readonly BitBoard WhitePawnAttacks;
+    public readonly BitBoard BlackPawnAttacks;
+
+    public readonly BitBoard WhiteKnightAttacks;
+    public readonly BitBoard BlackKnightAttacks;
+
+    public readonly BitBoard WhiteBishopAttacks;
+    public readonly BitBoard BlackBishopAttacks;
+
+    public readonly BitBoard WhiteRookAttacks;
+    public readonly BitBoard BlackRookAttacks;
+
+    public readonly BitBoard WhiteQueenAttacks;
+    public readonly BitBoard BlackQueenAttacks;
+
+    public readonly BitBoard WhiteKingAttacks;
+    public readonly BitBoard BlackKingAttacks;
+
     public readonly int IncrementalEvalAccumulator;
 
     public readonly int IncrementalPhaseAccumulator;
@@ -32,6 +50,22 @@ public readonly struct GameState
         NonPawnWhiteKey = position.NonPawnHash[(int)Side.White];
         NonPawnBlackKey = position.NonPawnHash[(int)Side.Black];
         MinorKey = position.MinorHash;
+
+        var attacks = position._attacks;
+
+        WhitePawnAttacks = attacks[(int)Piece.P];
+        WhiteKnightAttacks = attacks[(int)Piece.N];
+        WhiteBishopAttacks = attacks[(int)Piece.B];
+        WhiteRookAttacks = attacks[(int)Piece.R];
+        WhiteQueenAttacks = attacks[(int)Piece.Q];
+        WhiteKingAttacks = attacks[(int)Piece.K];
+
+        BlackPawnAttacks = attacks[(int)Piece.p];
+        BlackKnightAttacks = attacks[(int)Piece.n];
+        BlackBishopAttacks = attacks[(int)Piece.b];
+        BlackRookAttacks = attacks[(int)Piece.r];
+        BlackQueenAttacks = attacks[(int)Piece.q];
+        BlackKingAttacks = attacks[(int)Piece.k];
 
         EnPassant = position.EnPassant;
         Castle = position.Castle;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -124,13 +124,13 @@ public class Position : IDisposable
         _nonPawnHash[(int)Side.Black] = position._nonPawnHash[(int)Side.Black];
 
         _pieceBitBoards = ArrayPool<BitBoard>.Shared.Rent(12);
-        Array.Copy(position._pieceBitBoards, _pieceBitBoards, position._pieceBitBoards.Length);
+        Array.Copy(position._pieceBitBoards, _pieceBitBoards, 12);
 
         _occupancyBitBoards = ArrayPool<BitBoard>.Shared.Rent(3);
-        Array.Copy(position._occupancyBitBoards, _occupancyBitBoards, position._occupancyBitBoards.Length);
+        Array.Copy(position._occupancyBitBoards, _occupancyBitBoards, 3);
 
         _board = ArrayPool<int>.Shared.Rent(64);
-        Array.Copy(position._board, _board, position._board.Length);
+        Array.Copy(position._board, _board, 64);
 
         _side = position._side;
         _castle = position._castle;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -479,7 +479,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnmakeMove(Move move, GameState gameState)
+    public void UnmakeMove(Move move, in GameState gameState)
     {
         var oppositeSide = (int)_side;
         var side = Utils.OppositeSide(oppositeSide);

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -25,8 +25,10 @@ public class Position : IDisposable
     private readonly ulong[] _pieceBitBoards;
     private readonly ulong[] _occupancyBitBoards;
     private readonly int[] _board;
-    private byte _castle;
 
+    internal readonly BitBoard[] _attacks;
+
+    private byte _castle;
     private BoardSquare _enPassant;
     private Side _side;
 
@@ -89,6 +91,8 @@ public class Position : IDisposable
         _pieceBitBoards = parsedFEN._pieceBitBoards;
         _occupancyBitBoards = parsedFEN._occupancyBitBoards;
         _board = parsedFEN._board;
+        _attacks = ArrayPool<ulong>.Shared.Rent(12);
+
         _side = parsedFEN.Side;
         _castle = parsedFEN._castle;
         _enPassant = parsedFEN._enPassant;
@@ -132,6 +136,9 @@ public class Position : IDisposable
         _board = ArrayPool<int>.Shared.Rent(64);
         Array.Copy(position._board, _board, 64);
 
+        _attacks = ArrayPool<BitBoard>.Shared.Rent(12);
+        Array.Copy(position._attacks, _attacks, 12);
+
         _side = position._side;
         _castle = position._castle;
         _enPassant = position._enPassant;
@@ -152,6 +159,8 @@ public class Position : IDisposable
         Debug.Assert(ZobristTable.MinorHash(this) == _minorHash);
 
         var gameState = new GameState(this);
+
+        Array.Clear(_attacks);
 
         var oldSide = (int)_side;
         var offset = Utils.PieceOffset(oldSide);
@@ -566,6 +575,20 @@ public class Position : IDisposable
         _nonPawnHash[(int)Side.White] = gameState.NonPawnWhiteKey;
         _nonPawnHash[(int)Side.Black] = gameState.NonPawnBlackKey;
 
+        _attacks[(int)Piece.P] = gameState.WhitePawnAttacks;
+        _attacks[(int)Piece.N] = gameState.WhiteKnightAttacks;
+        _attacks[(int)Piece.B] = gameState.WhiteBishopAttacks;
+        _attacks[(int)Piece.R] = gameState.WhiteRookAttacks;
+        _attacks[(int)Piece.Q] = gameState.WhiteQueenAttacks;
+        _attacks[(int)Piece.K] = gameState.WhiteKingAttacks;
+
+        _attacks[(int)Piece.p] = gameState.BlackPawnAttacks;
+        _attacks[(int)Piece.n] = gameState.BlackKnightAttacks ;
+        _attacks[(int)Piece.b] = gameState.BlackBishopAttacks ;
+        _attacks[(int)Piece.r] = gameState.BlackRookAttacks ;
+        _attacks[(int)Piece.q] = gameState.BlackQueenAttacks ;
+        _attacks[(int)Piece.k] = gameState.BlackKingAttacks;
+
         _incrementalEvalAccumulator = gameState.IncrementalEvalAccumulator;
         _incrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;
         _isIncrementalEval = gameState.IsIncrementalEval;
@@ -672,6 +695,9 @@ public class Position : IDisposable
 
         BitBoard whitePawnAttacks = whitePawns.ShiftUpRight() | whitePawns.ShiftUpLeft();
         BitBoard blackPawnAttacks = blackPawns.ShiftDownRight() | blackPawns.ShiftDownLeft();
+
+        _attacks[(int)Piece.P] = whitePawnAttacks;
+        _attacks[(int)Piece.p] = blackPawnAttacks;
 
         var whiteKing = _pieceBitBoards[(int)Piece.K].GetLS1BIndex();
         var blackKing = _pieceBitBoards[(int)Piece.k].GetLS1BIndex();
@@ -1164,6 +1190,7 @@ public class Position : IDisposable
 
         var occupancy = _occupancyBitBoards[(int)Side.Both];
         var attacks = Attacks.RookAttacks(squareIndex, occupancy);
+        _attacks[(int)Piece.R + Utils.PieceOffset(pieceSide)] |= attacks;
 
         // Mobility
         var attacksCount =
@@ -1215,6 +1242,7 @@ public class Position : IDisposable
         //var oppositeQueensIndex = (int)Piece.q - offset;
 
         var attacks = Attacks.KnightAttacks[squareIndex];
+        _attacks[(int)Piece.N + Utils.PieceOffset(pieceSide)] |= attacks;
 
         // Mobility
         var attacksCount =
@@ -1247,6 +1275,7 @@ public class Position : IDisposable
 
         var occupancy = _occupancyBitBoards[(int)Side.Both];
         var attacks = Attacks.BishopAttacks(squareIndex, occupancy);
+        _attacks[(int)Piece.B + offset] |= attacks;
 
         // Mobility
         var attacksCount =
@@ -1301,6 +1330,7 @@ public class Position : IDisposable
     {
         var occupancy = _occupancyBitBoards[(int)Side.Both];
         var attacks = Attacks.QueenAttacks(squareIndex, occupancy);
+        _attacks[(int)Piece.Q + Utils.PieceOffset(pieceSide)] |= attacks;
 
         // Mobility
         var attacksCount =
@@ -1322,6 +1352,9 @@ public class Position : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal int KingAdditionalEvaluation(int squareIndex, int pieceSide, BitBoard enemyPawnAttacks)
     {
+        var attacks = Attacks.KingAttacks[squareIndex];
+        _attacks[(int)Piece.K + Utils.PieceOffset(pieceSide)] |= attacks;
+
         // Virtual mobility (as if Queen)
         var attacksCount =
             (Attacks.QueenAttacks(squareIndex, _occupancyBitBoards[(int)Side.Both])

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -404,7 +404,7 @@ public sealed partial class Engine
 
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -484,7 +484,7 @@ public sealed partial class Engine
             {
                 Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
                 Game.RemoveFromPositionHashHistory();
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
             }
 
             int score = 0;
@@ -887,7 +887,7 @@ public sealed partial class Engine
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -903,7 +903,7 @@ public sealed partial class Engine
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMove(move, in gameState);
 
             PrintMove(position, ply, move, score, isQuiescence: true);
 


### PR DESCRIPTION
#1805 + in GameState due to its size (> 80) (#1690)

8+0.08
```
Score of Lynx 6526 - main vs Lynx-eval-threats-base-attacksbyside-gamestate-in-6529-win-x64: 557 - 439 - 918  [0.531] 1914
...      Lynx 6526 - main playing White: 455 - 74 - 429  [0.699] 958
...      Lynx 6526 - main playing Black: 102 - 365 - 489  [0.362] 956
...      White vs Black: 820 - 176 - 918  [0.668] 1914
Elo difference: 21.4 +/- 11.2, LOS: 100.0 %, DrawRatio: 48.0 %
SPRT: llr 2.9 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```

40+0.4
```
Score of Lynx 6526 - main vs Lynx-eval-threats-base-attacksbyside-gamestate-in-6529-win-x64: 903 - 783 - 1910  [0.517] 3596
...      Lynx 6526 - main playing White: 812 - 67 - 920  [0.707] 1799
...      Lynx 6526 - main playing Black: 91 - 716 - 990  [0.326] 1797
...      White vs Black: 1528 - 158 - 1910  [0.690] 3596
Elo difference: 11.6 +/- 7.8, LOS: 99.8 %, DrawRatio: 53.1 %
SPRT: llr 2.89 (100.1%), lbound -2.25, ubound 2.89 - H1 was accepted
```