### PR TITLE
⚖️ Allow positions with >8 pawns

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1264,7 +1264,10 @@ public class Position : IDisposable
                 ? Constants.DarkSquaresBitBoard
                 : Constants.LightSquaresBitBoard);
 
-        packedBonus += BadBishop_SameColorPawnsPenalty[sameColorPawns.CountBits()];
+        // Allowing playing positions with > 8 pawns
+        var sameColorPawnsCount = sameColorPawns.CountBits() % 9;
+
+        packedBonus += BadBishop_SameColorPawnsPenalty[sameColorPawnsCount];
 
         // Blocked central pawns
         var sameSideCentralPawns = sameSidePawns & Constants.CentralFiles;


### PR DESCRIPTION
[-5, 0]
```
Score of Lynx-eval-more-than-8-pawns-6532-win-x64 vs Lynx 6526 - main: 3232 - 3214 - 5819  [0.501] 12265
...      Lynx-eval-more-than-8-pawns-6532-win-x64 playing White: 2671 - 525 - 2937  [0.675] 6133
...      Lynx-eval-more-than-8-pawns-6532-win-x64 playing Black: 561 - 2689 - 2882  [0.326] 6132
...      White vs Black: 5360 - 1086 - 5819  [0.674] 12265
Elo difference: 0.5 +/- 4.5, LOS: 58.9 %, DrawRatio: 47.4 %
SPRT: llr 2.91 (100.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```