### PR TITLE
⚡ Castling free squares using presaved bitboards

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -54,7 +54,8 @@ using static Lynx.TunableEvalParameters;
 //PieceSquareTables();
 //NewMasks();
 //DarkLightSquares();
-PawnIslands();
+//PawnIslands();
+CastlingBitBoards();
 
 #pragma warning disable IDE0059 // Unnecessary assignment of a value
 const string TrickyPosition = Constants.TrickyTestPositionFEN;
@@ -1233,4 +1234,12 @@ static void DarkLightSquares()
 static void PawnIslands()
 {
     PawnIslandsGenerator.GeneratePawnIslands();
+}
+
+static void CastlingBitBoards()
+{
+    Constants.WhiteShortCastleFreeSquares.Print();
+    Constants.WhiteLongCastleFreeSquares.Print();
+    Constants.BlackShortCastleFreeSquares.Print();
+    Constants.BlackLongCastleFreeSquares.Print();
 }

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -99,6 +99,57 @@ public static class Constants
     /// </summary>
     public const BitBoard NotABFiles = 0xFCFCFCFCFCFCFCFC;
 
+    /// <summary>8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 1 1 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteShortCastleFreeSquares = 0x6000000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 1 1 1 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteLongCastleFreeSquares = 0xe00000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 0 1 1 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackShortCastleFreeSquares = 0x60;
+
+    /// <summary>
+    /// 8   0 1 1 1 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackLongCastleFreeSquares = 0xe;
+
     public static readonly string[] Coordinates =
     [
         "a8", "b8", "c8", "d8", "e8", "f8", "g8", "h8",

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -99,7 +99,8 @@ public static class Constants
     /// </summary>
     public const BitBoard NotABFiles = 0xFCFCFCFCFCFCFCFC;
 
-    /// <summary>8   0 0 0 0 0 0 0 0
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
     /// 7   0 0 0 0 0 0 0 0
     /// 6   0 0 0 0 0 0 0 0
     /// 5   0 0 0 0 0 0 0 0

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -287,8 +287,7 @@ public static class MoveGenerator
 
                 if (!ise1Attacked
                     && (position.Castle & (int)CastlingRights.WK) != default
-                    && !occupancy.GetBit(BoardSquare.f1)
-                    && !occupancy.GetBit(BoardSquare.g1)
+                    && (occupancy & Constants.WhiteShortCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.f1, Side.Black)
                     && !position.IsSquareAttacked((int)BoardSquare.g1, Side.Black))
                 {
@@ -300,9 +299,7 @@ public static class MoveGenerator
 
                 if (!ise1Attacked
                     && (position.Castle & (int)CastlingRights.WQ) != default
-                    && !occupancy.GetBit(BoardSquare.d1)
-                    && !occupancy.GetBit(BoardSquare.c1)
-                    && !occupancy.GetBit(BoardSquare.b1)
+                    && (occupancy & Constants.WhiteLongCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.d1, Side.Black)
                     && !position.IsSquareAttacked((int)BoardSquare.c1, Side.Black))
                 {
@@ -318,8 +315,7 @@ public static class MoveGenerator
 
                 if ((!ise8Attacked
                     && (position.Castle & (int)CastlingRights.BK) != default)
-                    && !occupancy.GetBit(BoardSquare.f8)
-                    && !occupancy.GetBit(BoardSquare.g8)
+                    && (occupancy & Constants.BlackShortCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.f8, Side.White)
                     && !position.IsSquareAttacked((int)BoardSquare.g8, Side.White))
                 {
@@ -331,9 +327,7 @@ public static class MoveGenerator
 
                 if (!ise8Attacked
                     && (position.Castle & (int)CastlingRights.BQ) != default
-                    && !occupancy.GetBit(BoardSquare.d8)
-                    && !occupancy.GetBit(BoardSquare.c8)
-                    && !occupancy.GetBit(BoardSquare.b8)
+                    && (occupancy & Constants.BlackLongCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.d8, Side.White)
                     && !position.IsSquareAttacked((int)BoardSquare.c8, Side.White))
                 {
@@ -421,13 +415,13 @@ public static class MoveGenerator
         try
         {
 #endif
-        return IsAnyPawnMoveValid(position, offset)
-            || IsAnyPieceMoveValid((int)Piece.K + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
-            || IsAnyCastlingMoveValid(position);
+            return IsAnyPawnMoveValid(position, offset)
+                || IsAnyPieceMoveValid((int)Piece.K + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.B + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.N + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.R + offset, position)
+                || IsAnyCastlingMoveValid(position);
 #if DEBUG
         }
         catch (Exception e)
@@ -540,8 +534,7 @@ public static class MoveGenerator
 
                 if (!ise1Attacked
                     && (position.Castle & (int)CastlingRights.WK) != default
-                    && !occupancy.GetBit(BoardSquare.f1)
-                    && !occupancy.GetBit(BoardSquare.g1)
+                    && (occupancy & Constants.WhiteShortCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.f1, Side.Black)
                     && !position.IsSquareAttacked((int)BoardSquare.g1, Side.Black)
                     && IsValidMove(position, WhiteShortCastle))
@@ -551,9 +544,7 @@ public static class MoveGenerator
 
                 if (!ise1Attacked
                     && (position.Castle & (int)CastlingRights.WQ) != default
-                    && !occupancy.GetBit(BoardSquare.d1)
-                    && !occupancy.GetBit(BoardSquare.c1)
-                    && !occupancy.GetBit(BoardSquare.b1)
+                    && (occupancy & Constants.WhiteLongCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.d1, Side.Black)
                     && !position.IsSquareAttacked((int)BoardSquare.c1, Side.Black)
                     && IsValidMove(position, WhiteLongCastle))
@@ -567,8 +558,7 @@ public static class MoveGenerator
 
                 if (!ise8Attacked
                     && (position.Castle & (int)CastlingRights.BK) != default
-                    && !occupancy.GetBit(BoardSquare.f8)
-                    && !occupancy.GetBit(BoardSquare.g8)
+                    && (occupancy & Constants.BlackShortCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.f8, Side.White)
                     && !position.IsSquareAttacked((int)BoardSquare.g8, Side.White)
                     && IsValidMove(position, BlackShortCastle))
@@ -578,9 +568,7 @@ public static class MoveGenerator
 
                 if ((!ise8Attacked
                     && (position.Castle & (int)CastlingRights.BQ) != default)
-                    && !occupancy.GetBit(BoardSquare.d8)
-                    && !occupancy.GetBit(BoardSquare.c8)
-                    && !occupancy.GetBit(BoardSquare.b8)
+                    && (occupancy & Constants.BlackLongCastleFreeSquares) == 0
                     && !position.IsSquareAttacked((int)BoardSquare.d8, Side.White)
                     && !position.IsSquareAttacked((int)BoardSquare.c8, Side.White)
                     && IsValidMove(position, BlackLongCastle))


### PR DESCRIPTION
Use castling bitboards to check empty squares for castling movegen
```
Score of Lynx-perf-movegen-castling-freesquares-6549-win-x64 vs Lynx 6548 - main: 4662 - 4582 - 8507  [0.502] 17751
...      Lynx-perf-movegen-castling-freesquares-6549-win-x64 playing White: 3839 - 817 - 4220  [0.670] 8876
...      Lynx-perf-movegen-castling-freesquares-6549-win-x64 playing Black: 823 - 3765 - 4287  [0.334] 8875
...      White vs Black: 7604 - 1640 - 8507  [0.668] 17751
Elo difference: 1.6 +/- 3.7, LOS: 79.7 %, DrawRatio: 47.9 %
SPRT: llr 2.9 (100.3%), lbound -2.25, ubound 2.89 - H1 was accepted
```