### PR TITLE
🔍 History pruning: `break` -> `continue`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -368,7 +368,7 @@ public sealed partial class Engine
                     && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
                     && QuietHistory() < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                 {
-                    break;
+                    continue;
                 }
 
                 // 🔍 Futility Pruning (FP) - all quiet moves can be pruned


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -3.08 +/- 4.83, nElo: -4.92 +/- 7.72
LOS: 10.57 %, DrawRatio: 43.60 %, PairsRatio: 0.95
Games: 7780, Wins: 2022, Losses: 2091, Draws: 3667, Points: 3855.5 (49.56 %)
Ptnml(0-2): [149, 976, 1696, 933, 136], WL/DD Ratio: 0.93
LLR: -2.26 (-100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```