### PR TITLE
⚡ Use `array.AsSpan().Clear()` for small arrays

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -166,8 +166,8 @@ public class Position : IDisposable
 
         var gameState = new GameState(this);
 
-        Array.Clear(_attacks);
-        Array.Clear(_attacksBySide);
+        _attacks.AsSpan().Clear();
+        _attacksBySide.AsSpan().Clear();
 
         var oldSide = (int)_side;
         var offset = Utils.PieceOffset(oldSide);
@@ -481,8 +481,8 @@ public class Position : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void UnmakeMove(Move move, GameState gameState)
     {
-        Array.Clear(_attacks);
-        Array.Clear(_attacksBySide);
+        _attacks.AsSpan().Clear();
+        _attacksBySide.AsSpan().Clear();
 
         var oppositeSide = (int)_side;
         var side = Utils.OppositeSide(oppositeSide);


### PR DESCRIPTION
```
Test  | perf/array-asspan-clear
Elo   | 3.71 +- 3.77 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [-3.00, 1.00]
Games | 13220: +3770 -3629 =5821
Penta | [279, 1480, 2963, 1597, 291]
https://openbench.lynx-chess.com/test/1855/
```