### PR TITLE
🧹 Refactor threats to minimize code duplication

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1420,7 +1420,7 @@ public class Position : IDisposable
         }
     }
 
-    private static int[][] DefendedThreatsBonus =>
+    private static readonly int[][] _defendedThreatsBonus =
     [
         [],
         KnightThreatsBonus_Defended,
@@ -1430,7 +1430,7 @@ public class Position : IDisposable
         KingThreatsBonus_Defended
     ];
 
-    private static int[][] UndefendedThreatsBonus =>
+    private static readonly int[][] _undefendedThreatsBonus =
     [
         [],
         KnightThreatsBonus,
@@ -1465,7 +1465,7 @@ public class Position : IDisposable
                 defended = defended.WithoutLS1B(out var square);
                 var attackedPiece = Board[square];
 
-                packedBonus += DefendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
+                packedBonus += _defendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
             }
 
             var undefended = threats[i] & ~defendedSquares;
@@ -1474,7 +1474,7 @@ public class Position : IDisposable
                 undefended = undefended.WithoutLS1B(out var square);
                 var attackedPiece = Board[square];
 
-                packedBonus += UndefendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
+                packedBonus += _undefendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
             }
         }
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1420,116 +1420,62 @@ public class Position : IDisposable
         }
     }
 
+    private static int[][] DefendedThreatsBonus =>
+    [
+        [],
+        KnightThreatsBonus_Defended,
+        BishopThreatsBonus_Defended,
+        RookThreatsBonus_Defended,
+        QueenThreatsBonus_Defended,
+        KingThreatsBonus_Defended
+    ];
+
+    private static int[][] UndefendedThreatsBonus =>
+    [
+        [],
+        KnightThreatsBonus,
+        BishopThreatsBonus,
+        RookThreatsBonus,
+        QueenThreatsBonus,
+        KingThreatsBonus
+    ];
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int Threats(int side, int oppositeSide)
     {
         int packedBonus = 0;
 
         var offset = Utils.PieceOffset(side);
-
         var oppositeSideOffset = 6 - offset;
         var oppositeSidePieces = OccupancyBitBoards[oppositeSide];
-
         var defendedSquares = _attacks[(int)Piece.P + oppositeSideOffset];
 
-        var knightThreats = _attacks[(int)Piece.N + offset] & oppositeSidePieces;
+        Span<BitBoard> threats = stackalloc BitBoard[6];
+        threats[(int)Piece.N] = _attacks[(int)Piece.N + offset] & oppositeSidePieces;
+        threats[(int)Piece.B] = _attacks[(int)Piece.B + offset] & oppositeSidePieces;
+        threats[(int)Piece.R] = _attacks[(int)Piece.R + offset] & oppositeSidePieces;
+        threats[(int)Piece.Q] = _attacks[(int)Piece.Q + offset] & oppositeSidePieces;
+        threats[(int)Piece.K] = _attacks[(int)Piece.K + offset] & oppositeSidePieces;
 
-        var defendedKnightThreats = knightThreats & defendedSquares;
-        while (defendedKnightThreats != 0)
+        for (int i = (int)Piece.N; i <= (int)Piece.K; ++i)
         {
-            defendedKnightThreats = defendedKnightThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
+            var defended = threats[i] & defendedSquares;
+            while (defended != 0)
+            {
+                defended = defended.WithoutLS1B(out var square);
+                var attackedPiece = Board[square];
 
-            packedBonus += KnightThreatsBonus_Defended[attackedPiece - oppositeSideOffset];
-        }
+                packedBonus += DefendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
+            }
 
-        var undefendedKnightThreats = knightThreats & (~defendedSquares);
-        while (undefendedKnightThreats != 0)
-        {
-            undefendedKnightThreats = undefendedKnightThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
+            var undefended = threats[i] & ~defendedSquares;
+            while (undefended != 0)
+            {
+                undefended = undefended.WithoutLS1B(out var square);
+                var attackedPiece = Board[square];
 
-            packedBonus += KnightThreatsBonus[attackedPiece - oppositeSideOffset];
-        }
-
-        var bishopThreats = _attacks[(int)Piece.B + offset] & oppositeSidePieces;
-
-        var defendedBishopThreats = bishopThreats & defendedSquares;
-        while (defendedBishopThreats != 0)
-        {
-            defendedBishopThreats = defendedBishopThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += BishopThreatsBonus_Defended[attackedPiece - oppositeSideOffset];
-        }
-
-        var undefendedBishopThreats = bishopThreats & (~defendedSquares);
-        while (undefendedBishopThreats != 0)
-        {
-            undefendedBishopThreats = undefendedBishopThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += BishopThreatsBonus[attackedPiece - oppositeSideOffset];
-        }
-
-        var rookThreats = _attacks[(int)Piece.R + offset] & oppositeSidePieces;
-
-        var defendedRookThreats = rookThreats & defendedSquares;
-        while (defendedRookThreats != 0)
-        {
-            defendedRookThreats = defendedRookThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += RookThreatsBonus_Defended[attackedPiece - oppositeSideOffset];
-        }
-
-        var undefendedRookThreats = rookThreats & (~defendedSquares);
-        while (undefendedRookThreats != 0)
-        {
-            undefendedRookThreats = undefendedRookThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += RookThreatsBonus[attackedPiece - oppositeSideOffset];
-        }
-
-        var queenThreats = _attacks[(int)Piece.Q + offset] & oppositeSidePieces;
-
-        var defendedQueenThreats = queenThreats & defendedSquares;
-        while (defendedQueenThreats != 0)
-        {
-            defendedQueenThreats = defendedQueenThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += QueenThreatsBonus_Defended[attackedPiece - oppositeSideOffset];
-        }
-
-        var undefendedQueenThreats = queenThreats & (~defendedSquares);
-        while (undefendedQueenThreats != 0)
-        {
-            undefendedQueenThreats = undefendedQueenThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += QueenThreatsBonus[attackedPiece - oppositeSideOffset];
-        }
-
-        var kingThreats = _attacks[(int)Piece.K + offset] & oppositeSidePieces;
-
-        var defendedKingThreats = kingThreats & defendedSquares;
-        while (defendedKingThreats != 0)
-        {
-            defendedKingThreats = defendedKingThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += KingThreatsBonus_Defended[attackedPiece - oppositeSideOffset];
-        }
-
-        var undefendedKingThreats = kingThreats & (~defendedSquares);
-        while (undefendedKingThreats != 0)
-        {
-            undefendedKingThreats = undefendedKingThreats.WithoutLS1B(out var square);
-            var attackedPiece = Board[square];
-
-            packedBonus += KingThreatsBonus[attackedPiece - oppositeSideOffset];
+                packedBonus += UndefendedThreatsBonus[i][attackedPiece - oppositeSideOffset];
+            }
         }
 
         return packedBonus;


### PR DESCRIPTION
```
Test  | perf/threats-loop-refactoring-2
Elo   | -3.26 +- 3.39 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [-3.00, 1.00]
Games | 16746: +4695 -4852 =7199
Penta | [421, 1930, 3762, 1905, 355]
https://openbench.lynx-chess.com/test/1854/
```

```
Test  | perf/threats-loop-refactoring-2
Elo   | -3.27 +- 3.39 (95%)
SPRT  | 16.0+0.16s Threads=1 Hash=32MB
LLR   | -2.06 (-2.25, 2.89) [-3.00, 1.00]
Games | 13184: +3354 -3478 =6352
Penta | [170, 1532, 3313, 1406, 171]
https://openbench.lynx-chess.com/test/1856/
```