### PR TITLE
🧹 Increase `NoHashEntry` so that it's bigger than `MaxEval`

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -147,9 +147,9 @@ public static class EvaluationConstants
     public const int MinStaticEval = NegativeCheckmateDetectionLimit + 1;
 
     /// <summary>
-    /// Outside of the evaluation ranges (higher than any sensible evaluation, lower than <see cref="PositiveCheckmateDetectionLimit"/>)
+    /// Outside of the evaluation ranges (higher than <see cref="MaxEval"/>)
     /// </summary>
-    public const int NoHashEntry = 25_000;
+    public const int NoHashEntry = 32_666;
 
     /// <summary>
     /// Evaluation to be returned when there's one single legal move.

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -124,8 +124,8 @@ public class EvaluationConstantsTest
     public void NoHashEntryConstant()
     {
         Assert.Greater(NoHashEntry, _sensibleEvaluation);
-        Assert.Greater(PositiveCheckmateDetectionLimit, NoHashEntry);
-        Assert.Greater(-NegativeCheckmateDetectionLimit, NoHashEntry);
+        Assert.Greater(NoHashEntry, MaxEval);
+        Assert.Greater(NoHashEntry, -MinEval);
     }
 
     [Test]


### PR DESCRIPTION
No bench change

```
Test  | refactor/increase-NoHashEntry
Elo   | 0.84 +- 3.31 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-5.00, 0.00]
Games | 18670: +5301 -5256 =8113
Penta | [474, 2195, 3958, 2228, 480]
https://openbench.lynx-chess.com/test/1862/
```