### PR TITLE
🧹 `NoHashEntry` -> `NoScore`, and negative

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -149,7 +149,7 @@ public static class EvaluationConstants
     /// <summary>
     /// Outside of the evaluation ranges (higher than <see cref="MaxEval"/>)
     /// </summary>
-    public const int NoHashEntry = 32_666;
+    public const int NoScore = -32_666;
 
     /// <summary>
     /// Evaluation to be returned when there's one single legal move.

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -91,7 +91,7 @@ public readonly struct TranspositionTable
     }
 
     /// <summary>
-    /// Checks the transposition table and, if there's a eval value that can be deducted from it of there's a previously recorded <paramref name="position"/>, it's returned. <see cref="EvaluationConstants.NoHashEntry"/> is returned otherwise
+    /// Checks the transposition table and, if there's a eval value that can be deducted from it of there's a previously recorded <paramref name="position"/>, it's returned. <see cref="EvaluationConstants.NoScore"/> is returned otherwise
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -102,7 +102,7 @@ public readonly struct TranspositionTable
 
         if ((ushort)position.UniqueIdentifier != entry.Key)
         {
-            return (EvaluationConstants.NoHashEntry, default, default, EvaluationConstants.NoHashEntry, default, default);
+            return (EvaluationConstants.NoScore, default, default, EvaluationConstants.NoScore, default, default);
         }
 
         // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
@@ -160,7 +160,7 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoHashEntry, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
     }
 
     /// <summary>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -594,7 +594,7 @@ public sealed partial class Engine
             ttBestMove = ttEntry.BestMove;
             score = ttEntry.Score;
 
-            if (ttEntry.Score == EvaluationConstants.NoHashEntry)
+            if (ttEntry.Score == EvaluationConstants.NoScore)
             {
                 score = ttEntry.StaticEval;
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -57,7 +57,7 @@ public sealed partial class Engine
 
         ShortMove ttBestMove = default;
         NodeType ttElementType = NodeType.Unknown;
-        int ttScore = EvaluationConstants.NoHashEntry;
+        int ttScore = EvaluationConstants.NoScore;
         int ttStaticEval = int.MinValue;
         int ttDepth = default;
         bool ttWasPv = false;
@@ -800,7 +800,7 @@ public sealed partial class Engine
                 : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _kingPawnHashTable).Score;
         */
         var rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
-        Debug.Assert(rawStaticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
+        Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 
         var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
 

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -123,16 +123,16 @@ public class EvaluationConstantsTest
     [Test]
     public void NoHashEntryConstant()
     {
-        Assert.Greater(NoHashEntry, _sensibleEvaluation);
-        Assert.Greater(NoHashEntry, MaxEval);
-        Assert.Greater(NoHashEntry, -MinEval);
+        Assert.Less(NoScore, -_sensibleEvaluation);
+        Assert.Less(NoScore, NegativeCheckmateDetectionLimit);
+        Assert.Less(NoScore, MinEval);
     }
 
     [Test]
     public void EvaluationFitsIntoDepth16()
     {
         Assert.Greater(short.MaxValue, PositiveCheckmateDetectionLimit);
-        Assert.Greater(short.MaxValue, NoHashEntry);
+        Assert.Greater(short.MaxValue, -NoScore);
         Assert.Greater(short.MaxValue, _sensibleEvaluation);
     }
 


### PR DESCRIPTION
```
Test  | refactor/noscore
Elo   | 3.83 +- 5.17 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.66 (-2.25, 2.89) [-5.00, 0.00]
Games | 7796: +2331 -2245 =3220
Penta | [194, 894, 1672, 908, 230]
https://openbench.lynx-chess.com/test/1871/
```