### PR TITLE
🔍 SE: negative extensions if `ttScore <= alpha && cutnode`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -444,7 +444,11 @@ public sealed partial class Engine
                 // Negative extension
                 else if (ttScore >= beta)
                 {
-                    --singularDepthExtensions;
+                    singularDepthExtensions = -1;
+                }
+                else if (ttScore <= alpha && cutnode)
+                {
+                    singularDepthExtensions = -1;
                 }
 
                 gameState = position.MakeMove(move);


### PR DESCRIPTION
```
Test  | search/se-negative-extensions-ttscore-less-than-alpha-cutnode
Elo   | -1.28 +- 2.43 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 24458: +5533 -5623 =13302
Penta | [218, 2993, 5898, 2901, 219]
https://openbench.lynx-chess.com/test/1801/
```