### PR TITLE
🔍 Move ordering: replace MVVLVA with MVV

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -185,6 +185,8 @@ public static class EvaluationConstants
 
     public const int BadCaptureMoveBaseScoreValue = 16_384;
 
+    public const int MoveOrderingMVVMultiplier = 10;
+
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 
     /// <summary>

--- a/src/Lynx/SEE.cs
+++ b/src/Lynx/SEE.cs
@@ -11,7 +11,7 @@ public static class SEE
 {
     #pragma warning disable IDE0055 // Discard formatting in this region
 
-    private static ReadOnlySpan<int> PieceValues =>
+    public static ReadOnlySpan<int> PieceValues =>
     [
         100, 450, 450, 650, 1250, 0,
         100, 450, 450, 650, 1250, 0,

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -86,7 +86,7 @@ public sealed partial class Engine
 
             return baseCaptureScore
                 + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
-                //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
+                + (MoveOrderingMVVMultiplier * SEE.PieceValues[capturedPiece])
                 + CaptureHistoryEntry(move);
         }
 
@@ -143,7 +143,7 @@ public sealed partial class Engine
 
             return baseCaptureScore
                 + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
-                //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
+                + (MoveOrderingMVVMultiplier * SEE.PieceValues[capturedPiece])
                 + CaptureHistoryEntry(move);
         }
 

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -85,7 +85,6 @@ public sealed partial class Engine
                 : BadCaptureMoveBaseScoreValue;
 
             return baseCaptureScore
-                + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
                 + (MoveOrderingMVVMultiplier * SEE.PieceValues[capturedPiece])
                 + CaptureHistoryEntry(move);
         }
@@ -142,7 +141,6 @@ public sealed partial class Engine
                 $"{move.UCIString()} capturing king is generated in position {Game.CurrentPosition.FEN(Game.HalfMovesWithoutCaptureOrPawnMove)}");
 
             return baseCaptureScore
-                + MostValueableVictimLeastValuableAttacker[piece][capturedPiece]
                 + (MoveOrderingMVVMultiplier * SEE.PieceValues[capturedPiece])
                 + CaptureHistoryEntry(move);
         }


### PR DESCRIPTION
Previously attempted, but without the multiplier IIRC

```
Test  | moveordering-mvv-nomvla
Elo   | -1.59 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 23096: +6304 -6410 =10382
Penta | [512, 2843, 4941, 2743, 509]
https://openbench.lynx-chess.com/test/1887/
``` 