### PR TITLE
🔍 Threat history, but only whenever threats are precalculated

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -702,7 +702,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position.FEN()));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, default)}");
     }
 
     position = new Position(TrickyPosition);
@@ -711,7 +711,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position.FEN()));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, default)}");
     }
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -42,11 +42,9 @@ public sealed partial class Engine : IDisposable
         Game = new Game(Constants.InitialPositionFEN);
 
         // Update ResetEngine() after any changes here
-        _quietHistory = new int[12][];
         _moveNodeCount = new ulong[12][];
-        for (int i = 0; i < _quietHistory.Length; ++i)
+        for (int i = 0; i < _moveNodeCount.Length; ++i)
         {
-            _quietHistory[i] = new int[64];
             _moveNodeCount[i] = new ulong[64];
         }
 
@@ -70,10 +68,10 @@ public sealed partial class Engine : IDisposable
         // Clear histories
         for (int i = 0; i < 12; ++i)
         {
-            Array.Clear(_quietHistory[i]);
             Array.Clear(_moveNodeCount[i]);
         }
 
+        Array.Clear(_quietHistory);
         Array.Clear(_captureHistory);
         Array.Clear(_continuationHistory);
         Array.Clear(_counterMoves);

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -67,6 +67,8 @@ public class Position : IDisposable
     /// </summary>
     public byte Castle { get => _castle; private set => _castle = value; }
 
+    public BitBoard[] AttacksBySide => _attacksBySide;
+
 #pragma warning restore RCS1085 // Use auto-implemented property
 
     public BitBoard Queens => _pieceBitBoards[(int)Piece.Q] | _pieceBitBoards[(int)Piece.q];

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -46,6 +46,31 @@ public sealed partial class Engine
     }
 
     /// <summary>
+    /// [12][64][2][2]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int QuietHistoryEntry(Position position, Move move)
+    {
+        const int pieceOffset = 64 * 2 * 2;
+        const int targetSquareOffset = 2 * 2;
+        const int startSquareOffset = 2;
+
+        var sourceSquare = move.SourceSquare();
+        var targetSquare = move.TargetSquare();
+        var oppositeSide = Utils.OppositeSide(position.Side);
+
+        var isStartSquareAttacked = position.AttacksBySide[oppositeSide].GetBit(sourceSquare) ? 1 : 0;
+        var isTargetSquareAttacked = position.AttacksBySide[oppositeSide].GetBit(targetSquare) ? 1 : 0;
+
+        var index = (move.Piece() * pieceOffset)
+            + (targetSquare * targetSquareOffset)
+            + (isStartSquareAttacked * startSquareOffset)
+            + isTargetSquareAttacked;
+
+        return ref _quietHistory[index];
+    }
+
+    /// <summary>
     /// [12][64][12]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -400,28 +425,6 @@ $" {427,-3}                                                  {_pVTable[427].ToEP
 $" {484,-3}                                                         {_pVTable[484].ToEPDString(),-6} {_pVTable[485].ToEPDString(),-6} {_pVTable[486].ToEPDString(),-6}" + Environment.NewLine +
 (target == -1 ? "------------------------------------------------------------------------------------" + Environment.NewLine : ""));
 #pragma warning restore CS0618 // Type or member is obsolete
-    }
-
-    [Conditional("DEBUG")]
-    internal void PrintHistoryMoves()
-    {
-        int max = EvaluationConstants.MinEval;
-
-        for (int i = 0; i < 12; ++i)
-        {
-            var tmp = _quietHistory[i];
-            for (int j = 0; j < 64; ++j)
-            {
-                var item = tmp[j];
-
-                if (item > max)
-                {
-                    max = item;
-                }
-            }
-        }
-
-        _logger.ConditionalDebug($"Max history: {max}");
     }
 
 #pragma warning restore S125 // Sections of code should not be commented out

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -53,7 +53,7 @@ public sealed partial class Engine
     {
         const int pieceOffset = 64 * 2 * 2;
         const int targetSquareOffset = 2 * 2;
-        const int startSquareOffset = 2;
+        const int startSquareAttackedOffset = 2;
 
         var sourceSquare = move.SourceSquare();
         var targetSquare = move.TargetSquare();
@@ -64,7 +64,7 @@ public sealed partial class Engine
 
         var index = (move.Piece() * pieceOffset)
             + (targetSquare * targetSquareOffset)
-            + (isStartSquareAttacked * startSquareOffset)
+            + (isStartSquareAttacked * startSquareAttackedOffset)
             + isTargetSquareAttacked;
 
         return ref _quietHistory[index];

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -22,10 +22,10 @@ public sealed partial class Engine
     private readonly int[] _counterMoves = GC.AllocateArray<int>(12 * 64, pinned: true);
 
     /// <summary>
-    /// 12 x 64
-    /// piece x target square
+    /// 12 x 64 x 2 x 2
+    /// piece x target square x source is attacked x target is attacked
     /// </summary>
-    private readonly int[][] _quietHistory;
+    private readonly int[] _quietHistory = GC.AllocateArray<int>(12 * 64 * 2 * 2, pinned: true);
 
     /// <summary>
     /// 12 x 64 x 12,
@@ -606,7 +606,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, ttBestMove);
+            moveScores[i] = ScoreMove(position, pseudoLegalMoves[i], 0, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -301,7 +301,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(position, pseudoLegalMoves[i], ply, ttBestMove);
         }
 
         var nodeType = NodeType.Alpha;
@@ -339,7 +339,7 @@ public sealed partial class Engine
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             int QuietHistory() => quietHistory ??=
-                _quietHistory[move.Piece()][move.TargetSquare()]
+                QuietHistoryEntry(position, move)
                 + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
@@ -696,7 +696,7 @@ public sealed partial class Engine
                     }
                     else
                     {
-                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
+                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(position, historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
                     }
 
                     nodeType = NodeType.Beta;

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -23,7 +23,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(engine.Game.CurrentPosition, move, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
@@ -36,7 +36,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {
-            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default));
+            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(engine.Game.CurrentPosition, move, default, default));
         }
     }
 
@@ -58,9 +58,9 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(engine.Game.CurrentPosition, move, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0][6], engine.ScoreMove(allMoves[0], default, default));
+        Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0][6], engine.ScoreMove(engine.Game.CurrentPosition, allMoves[0], default, default));
     }
 }


### PR DESCRIPTION
```
Test  | search/threat-history
Elo   | -10.16 +- 6.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 5404: +1418 -1576 =2410
Penta | [140, 707, 1130, 621, 104]
https://openbench.lynx-chess.com/test/1891/
```

This second version ensures the correct side, but the bug somehow doesn't affect this branch (that is, whenever the history is used after make but before unmake, there are no threats available?)
```
Test  | search/threat-history-1-2
Elo   | -10.85 +- 6.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.32 (-2.25, 2.89) [0.00, 3.00]
Games | 5124: +1346 -1506 =2272
Penta | [127, 680, 1077, 582, 96]
https://openbench.lynx-chess.com/test/1895/
```