### PR TITLE
⚡ Movegen promotion: increment index only once

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -149,10 +149,12 @@ public static class MoveGenerator
                 var targetRank = (singlePushSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                    movePool[localIndex] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex + 1] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex + 2] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex + 3] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+
+                    localIndex += 4;
                 }
                 else
                 {
@@ -192,10 +194,12 @@ public static class MoveGenerator
                 var targetRank = (targetSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, capturedPiece);
+                    movePool[localIndex] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, capturedPiece);
+                    movePool[localIndex + 1] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, capturedPiece);
+                    movePool[localIndex + 2] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, capturedPiece);
+                    movePool[localIndex + 3] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, capturedPiece);
+
+                    localIndex += 4;
                 }
                 else
                 {
@@ -231,10 +235,12 @@ public static class MoveGenerator
                 var targetRank = (singlePushSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Promotion
                 {
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+                    movePool[localIndex] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.Q + offset);
+                    movePool[localIndex + 1] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.R + offset);
+                    movePool[localIndex + 2] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.N + offset);
+                    movePool[localIndex + 3] = MoveExtensions.EncodePromotion(sourceSquare, singlePushSquare, piece, promotedPiece: (int)Piece.B + offset);
+
+                    localIndex += 4;
                 }
             }
 
@@ -257,10 +263,12 @@ public static class MoveGenerator
                 var targetRank = (targetSquare >> 3) + 1;
                 if (targetRank == 1 || targetRank == 8)  // Capture with promotion
                 {
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, capturedPiece: capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, capturedPiece: capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, capturedPiece: capturedPiece);
-                    movePool[localIndex++] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, capturedPiece: capturedPiece);
+                    movePool[localIndex] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.Q + offset, capturedPiece: capturedPiece);
+                    movePool[localIndex + 1] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.R + offset, capturedPiece: capturedPiece);
+                    movePool[localIndex + 2] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.N + offset, capturedPiece: capturedPiece);
+                    movePool[localIndex + 3] = MoveExtensions.EncodePromotion(sourceSquare, targetSquare, piece, promotedPiece: (int)Piece.B + offset, capturedPiece: capturedPiece);
+
+                    localIndex += 4;
                 }
                 else
                 {


### PR DESCRIPTION
Before:
```asm
C.Original(Int32 ByRef, System.Span`1<Int32>)
    L0000: sub rsp, 0x28
    L0004: mov rax, [r8]
    L0007: mov ecx, [r8+8]
    L000b: mov r8d, [rdx]
    L000e: lea r10d, [r8+1]
    L0012: mov [rdx], r10d
    L0015: cmp r8d, ecx
    L0018: jae short L006e
    L001a: mov dword ptr [rax+r8*4], 1
    L0022: mov r8d, [rdx]
    L0025: lea r10d, [r8+1]
    L0029: mov [rdx], r10d
    L002c: cmp r8d, ecx
    L002f: jae short L006e
    L0031: mov dword ptr [rax+r8*4], 2
    L0039: mov r8d, [rdx]
    L003c: lea r10d, [r8+1]
    L0040: mov [rdx], r10d
    L0043: cmp r8d, ecx
    L0046: jae short L006e
    L0048: mov dword ptr [rax+r8*4], 3
    L0050: mov r8d, [rdx]
    L0053: lea r10d, [r8+1]
    L0057: mov [rdx], r10d
    L005a: cmp r8d, ecx
    L005d: jae short L006e
    L005f: mov ecx, r8d
    L0062: mov dword ptr [rax+rcx*4], 4
    L0069: add rsp, 0x28
    L006d: ret
    L006e: call 0x00000131b7dc0128
    L0073: int3
```

After:
```asm
C.New(Int32 ByRef, System.Span`1<Int32>)
    L0000: sub rsp, 0x28
    L0004: mov rax, [r8]
    L0007: mov ecx, [r8+8]
    L000b: mov r8d, [rdx]
    L000e: cmp r8d, ecx
    L0011: jae short L0060
    L0013: mov dword ptr [rax+r8*4], 1
    L001b: mov r8d, [rdx]
    L001e: inc r8d
    L0021: cmp r8d, ecx
    L0024: jae short L0060
    L0026: mov dword ptr [rax+r8*4], 2
    L002e: mov r8d, [rdx]
    L0031: add r8d, 2
    L0035: cmp r8d, ecx
    L0038: jae short L0060
    L003a: mov dword ptr [rax+r8*4], 3
    L0042: mov r8d, [rdx]
    L0045: add r8d, 3
    L0049: cmp r8d, ecx
    L004c: jae short L0060
    L004e: mov ecx, r8d
    L0051: mov dword ptr [rax+rcx*4], 4
    L0058: add dword ptr [rdx], 4
    L005b: add rsp, 0x28
    L005f: ret
    L0060: call 0x00000131b7dc0128
    L0065: int3

```

```
Test  | perf/movegen-promotions
Elo   | 2.13 +- 4.07 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | 12396: +3698 -3622 =5076
Penta | [305, 1435, 2689, 1417, 352]
https://openbench.lynx-chess.com/test/1897/
```