### PR TITLE
⚡ Castling movegen: use threats instead of calculating square attacks individually (when possible)

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -120,10 +120,36 @@ public static class Constants
     /// 4   0 0 0 0 0 0 0 0
     /// 3   0 0 0 0 0 0 0 0
     /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 1 1 1 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteShortCastleNonAttackableSquares = 0x7000000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
     /// 1   0 1 1 1 0 0 0 0
     ///     a b c d e f g h
     /// </summary>
     public const BitBoard WhiteLongCastleFreeSquares = 0xe00000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 1 1 1 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteLongCastleNonAttackableSquares = 0x1c00000000000000;
 
     /// <summary>
     /// 8   0 0 0 0 0 1 1 0
@@ -139,6 +165,19 @@ public static class Constants
     public const BitBoard BlackShortCastleFreeSquares = 0x60;
 
     /// <summary>
+    /// 8   0 0 0 0 1 1 1 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackShortCastleNonAttackableSquares = 0x70;
+
+    /// <summary>
     /// 8   0 1 1 1 0 0 0 0
     /// 7   0 0 0 0 0 0 0 0
     /// 6   0 0 0 0 0 0 0 0
@@ -150,6 +189,19 @@ public static class Constants
     ///     a b c d e f g h
     /// </summary>
     public const BitBoard BlackLongCastleFreeSquares = 0xe;
+
+    /// <summary>
+    /// 8   0 0 1 1 1 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackLongCastleNonAttackableSquares = 0x1c;
 
     public static readonly string[] Coordinates =
     [

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -268,13 +268,35 @@ public static class MoveGenerator
 
             if (position.Side == Side.White)
             {
-                bool ise1Attacked = position.IsSquareAttacked(Constants.WhiteKingSourceSquare, Side.Black);
+                var blackAttacks = position._attacksBySide[(int)Side.Black];
 
-                if (!ise1Attacked
-                    && (position.Castle & (int)CastlingRights.WK) != default
-                    && (occupancy & Constants.WhiteShortCastleFreeSquares) == 0
-                    && !position.IsSquareAttacked((int)BoardSquare.f1, Side.Black)
-                    && !position.IsSquareAttacked((int)BoardSquare.g1, Side.Black))
+                var areShortCastleSquaresFree = (occupancy & Constants.WhiteShortCastleFreeSquares) == 0;
+                var areLongCastleSquaresFree = (occupancy & Constants.WhiteLongCastleFreeSquares) == 0;
+
+                bool areShortCastleSquaresAttacked, areLongCastleSquaresAttacked;
+
+                if (blackAttacks != 0)
+                {
+                    areShortCastleSquaresAttacked = (blackAttacks & Constants.WhiteShortCastleNonAttackableSquares) != 0;
+                    areLongCastleSquaresAttacked = (blackAttacks & Constants.WhiteLongCastleNonAttackableSquares) != 0;
+                }
+                else
+                {
+                    bool ise1Attacked = position.IsSquareAttacked(Constants.WhiteKingSourceSquare, Side.Black);
+
+                    areShortCastleSquaresAttacked =
+                        ise1Attacked
+                        || position.IsSquareAttacked((int)BoardSquare.f1, Side.Black)
+                        || position.IsSquareAttacked((int)BoardSquare.g1, Side.Black);
+
+                    areLongCastleSquaresAttacked =
+                        ise1Attacked
+                        || position.IsSquareAttacked((int)BoardSquare.d1, Side.Black)
+                        || position.IsSquareAttacked((int)BoardSquare.c1, Side.Black);
+                }
+
+                if ((position.Castle & (int)CastlingRights.WK) != default
+                   && areShortCastleSquaresFree && !areShortCastleSquaresAttacked)
                 {
                     movePool[localIndex++] = WhiteShortCastle;
 
@@ -282,11 +304,8 @@ public static class MoveGenerator
                         $"Wrong hardcoded white short castle move, expected {WhiteShortCastle}, got {MoveExtensions.EncodeShortCastle(Constants.WhiteKingSourceSquare, Constants.WhiteShortCastleKingSquare, (int)Piece.K)}");
                 }
 
-                if (!ise1Attacked
-                    && (position.Castle & (int)CastlingRights.WQ) != default
-                    && (occupancy & Constants.WhiteLongCastleFreeSquares) == 0
-                    && !position.IsSquareAttacked((int)BoardSquare.d1, Side.Black)
-                    && !position.IsSquareAttacked((int)BoardSquare.c1, Side.Black))
+                if ((position.Castle & (int)CastlingRights.WQ) != default
+                    && areLongCastleSquaresFree && !areLongCastleSquaresAttacked)
                 {
                     movePool[localIndex++] = WhiteLongCastle;
 
@@ -296,13 +315,35 @@ public static class MoveGenerator
             }
             else
             {
-                bool ise8Attacked = position.IsSquareAttacked(Constants.BlackKingSourceSquare, Side.White);
+                var whiteAttacks = position._attacksBySide[(int)Side.White];
 
-                if ((!ise8Attacked
-                    && (position.Castle & (int)CastlingRights.BK) != default)
-                    && (occupancy & Constants.BlackShortCastleFreeSquares) == 0
-                    && !position.IsSquareAttacked((int)BoardSquare.f8, Side.White)
-                    && !position.IsSquareAttacked((int)BoardSquare.g8, Side.White))
+                var areShortCastleSquaresFree = (occupancy & Constants.BlackShortCastleFreeSquares) == 0;
+                var areLongCastleSquaresFree = (occupancy & Constants.BlackLongCastleFreeSquares) == 0;
+
+                bool areShortCastleSquaresAttacked, areLongCastleSquaresAttacked;
+
+                if (whiteAttacks != 0)
+                {
+                    areShortCastleSquaresAttacked = (whiteAttacks & Constants.BlackShortCastleNonAttackableSquares) != 0;
+                    areLongCastleSquaresAttacked = (whiteAttacks & Constants.BlackLongCastleNonAttackableSquares) != 0;
+                }
+                else
+                {
+                    bool ise8Attacked = position.IsSquareAttacked(Constants.BlackKingSourceSquare, Side.White);
+
+                    areShortCastleSquaresAttacked =
+                        ise8Attacked
+                        || position.IsSquareAttacked((int)BoardSquare.f8, Side.White)
+                        || position.IsSquareAttacked((int)BoardSquare.g8, Side.White);
+
+                    areLongCastleSquaresAttacked =
+                        ise8Attacked
+                        || position.IsSquareAttacked((int)BoardSquare.d8, Side.White)
+                        || position.IsSquareAttacked((int)BoardSquare.c8, Side.White);
+                }
+
+                if ((position.Castle & (int)CastlingRights.BK) != default
+                   && areShortCastleSquaresFree && !areShortCastleSquaresAttacked)
                 {
                     movePool[localIndex++] = BlackShortCastle;
 
@@ -310,11 +351,8 @@ public static class MoveGenerator
                         $"Wrong hardcoded black short castle move, expected {BlackShortCastle}, got {MoveExtensions.EncodeShortCastle(Constants.BlackKingSourceSquare, Constants.BlackShortCastleKingSquare, (int)Piece.k)}");
                 }
 
-                if (!ise8Attacked
-                    && (position.Castle & (int)CastlingRights.BQ) != default
-                    && (occupancy & Constants.BlackLongCastleFreeSquares) == 0
-                    && !position.IsSquareAttacked((int)BoardSquare.d8, Side.White)
-                    && !position.IsSquareAttacked((int)BoardSquare.c8, Side.White))
+                if ((position.Castle & (int)CastlingRights.BQ) != default
+                    && areLongCastleSquaresFree && !areLongCastleSquaresAttacked)
                 {
                     movePool[localIndex++] = BlackLongCastle;
 


### PR DESCRIPTION
```
Test  | perf/movegen-castling-threats
Elo   | -2.01 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [-3.00, 1.00]
Games | 30142: +8142 -8316 =13684
Penta | [561, 3536, 7044, 3376, 554]
https://openbench.lynx-chess.com/test/1902/
```