### PR TITLE
🔍 Only reduce more on cutnode if !ttpv

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -544,13 +544,13 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_Improving;
                                 }
 
-                                if (cutnode)
-                                {
-                                    reduction += Configuration.EngineSettings.LMR_Cutnode;
-                                }
-
                                 if (!ttPv)
                                 {
+                                    if (cutnode)
+                                    {
+                                        reduction += Configuration.EngineSettings.LMR_Cutnode;
+                                    }
+
                                     reduction += Configuration.EngineSettings.LMR_TTPV;
                                 }
 


### PR DESCRIPTION
Cie idea, will credit in code if it passes

--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -0.27 +/- 3.00, nElo: -0.44 +/- 4.78
LOS: 42.91 %, DrawRatio: 43.68 %, PairsRatio: 1.01
Games: 20296, Wins: 5416, Losses: 5432, Draws: 9448, Points: 10140.0 (49.96 %)
Ptnml(0-2): [399, 2450, 4433, 2500, 366], WL/DD Ratio: 0.97
LLR: -2.27 (-100.7%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted