### PR TITLE
⚖ Double attacks bonus by piece excluding defended by pawns II

### DIFF
--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -98,16 +98,15 @@ public static class MoveGenerator
         {
             GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
             GenerateCastlingMoves(ref localIndex, movePool, position);
-        }
-
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
-
-        if (noDoubleChecks)
-        {
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        }
+        else
+        {
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
         }
 
         return movePool[..localIndex];
@@ -157,16 +156,15 @@ public static class MoveGenerator
         {
             GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
             GenerateCastlingMoves(ref localIndex, movePool, position);
-        }
-
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
-
-        if (noDoubleChecks)
-        {
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        }
+        else
+        {
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
         }
 
         return movePool[..localIndex];

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -91,13 +91,19 @@ public static class MoveGenerator
         var oppositeSide = Utils.OppositeSide(position.Side);
         var sameSideKing = position.PieceBitBoards[(int)Piece.K + offset];
 
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+        bool noDoubleChecks = position._attacks[oppositeSide] == 0
+            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0;
 
-        if (position._attacks[oppositeSide] == 0
-            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0)
+        if (noDoubleChecks)
         {
             GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
             GenerateCastlingMoves(ref localIndex, movePool, position);
+        }
+
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+
+        if (noDoubleChecks)
+        {
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
             GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
@@ -144,13 +150,19 @@ public static class MoveGenerator
         var oppositeSide = Utils.OppositeSide(position.Side);
         var sameSideKing = position.PieceBitBoards[(int)Piece.K + offset];
 
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+        bool noDoubleChecks = position._attacks[oppositeSide] == 0
+            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0;
 
-        if (position._attacks[oppositeSide] == 0
-            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0)
+        if (noDoubleChecks)
         {
             GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
             GenerateCastlingMoves(ref localIndex, movePool, position);
+        }
+
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+
+        if (noDoubleChecks)
+        {
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
             GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -78,6 +78,36 @@ public static class MoveGenerator
     }
 
     /// <summary>
+    /// Generates all psuedo-legal moves from <paramref name="position"/>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<Move> GenerateAllMoves_DoubleChecks(Position position, Span<Move> movePool)
+    {
+        Debug.Assert(position.Side != Side.Both);
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+        var oppositeSide = Utils.OppositeSide(position.Side);
+        var sameSideKing = position.PieceBitBoards[(int)Piece.K + offset];
+
+        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.K + offset, position);
+
+        if (position._attacks[oppositeSide] == 0
+            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0)
+        {
+            GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
+            GenerateCastlingMoves(ref localIndex, movePool, position);
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
+            GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        }
+
+        return movePool[..localIndex];
+    }
+
+    /// <summary>
     /// Generates all psuedo-legal captures from <paramref name="position"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -96,6 +126,36 @@ public static class MoveGenerator
         GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
         GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
         GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+        return movePool[..localIndex];
+    }
+
+    /// <summary>
+    /// Generates all psuedo-legal captures from <paramref name="position"/>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static Span<Move> GenerateAllCaptures_DoubleChecks(Position position, Span<Move> movePool)
+    {
+        Debug.Assert(position.Side != Side.Both);
+
+        int localIndex = 0;
+
+        var offset = Utils.PieceOffset(position.Side);
+        var oppositeSide = Utils.OppositeSide(position.Side);
+        var sameSideKing = position.PieceBitBoards[(int)Piece.K + offset];
+
+        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.K + offset, position);
+
+        if (position._attacks[oppositeSide] == 0
+            || (sameSideKing & position._doubleAttacksBySide[oppositeSide]) == 0)
+        {
+            GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
+            GenerateCastlingMoves(ref localIndex, movePool, position);
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
+            GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+        }
 
         return movePool[..localIndex];
     }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -295,7 +295,7 @@ public sealed partial class Engine
         Debug.Assert(depth >= 0, "Assertion failed", "QSearch should have been triggered");
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, moves);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves_DoubleChecks(position, moves);
 
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
 
@@ -838,7 +838,7 @@ public sealed partial class Engine
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPossibleMovesInAPosition];
-        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures(position, moves);
+        var pseudoLegalMoves = MoveGenerator.GenerateAllCaptures_DoubleChecks(position, moves);
         if (pseudoLegalMoves.Length == 0)
         {
             // Checking if final position first: https://github.com/lynx-chess/Lynx/pull/358


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1870 without changing move ordering
```
Test  | perf/movegen-doublecheck-onlykingmoves-2-samebench
Elo   | -5.81 +- 4.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 8368: +2196 -2336 =3836
Penta | [157, 1046, 1912, 918, 151]
https://openbench.lynx-chess.com/test/1909/
```

After 'improvement':
```
Test  | perf/movegen-doublecheck-onlykingmoves-2-samebench
Elo   | -17.41 +- 7.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 3176: +803 -962 =1411
Penta | [78, 446, 672, 341, 51]
https://openbench.lynx-chess.com/test/1910/
```