### PR TITLE
⚖️ Pawnless endgames: scale down R vs R and R vs 2 minors

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1006,9 +1006,9 @@ public class Position : IDisposable
                         }
                     case 4:
                         {
-                            // Rook vs 2 minors should be a draw
-                            // Rook and minor vs minor it doesn't matter if it's reduced
-                            if ((_pieceBitBoards[(int)Piece.Q] | _pieceBitBoards[(int)Piece.q]) == 0)
+                            // Rook vs 2 minors and R vs r should be a draw
+                            if ((_pieceBitBoards[(int)Piece.R] != 0 && (_pieceBitBoards[(int)Piece.B] | _pieceBitBoards[(int)Piece.N]) == 0)
+								|| ((_pieceBitBoards[(int)Piece.r] != 0 && (_pieceBitBoards[(int)Piece.b] | _pieceBitBoards[(int)Piece.n]) == 0)))
                             {
                                 eval >>= 1; // /2
                             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1004,16 +1004,23 @@ public class Position : IDisposable
 
                             break;
                         }
-                    //case 4:
-                    //    {
-                    //        // Rook vs 2 minors should be a draw
+                    case 4:
+                        {
+                            // Rook vs 2 minors should be a draw
+                            // Rook and minor vs minor it doesn't matter if it's reduced
+                            if ((_pieceBitBoards[(int)Piece.Q] | _pieceBitBoards[(int)Piece.q]) == 0)
+                            {
+                                eval >>= 1; // /2
+                            }
 
-                    //    }
+                            break;
+                        }
                     case 3:
                         {
                             var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                            if (_pieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            // NN vs N, NN vs B
+                            if (_pieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)
                             {
                                 return (0, gamePhase);
                             }


### PR DESCRIPTION
```
Test  | eval/scale-down-r-vs-mn
Elo   | -0.23 +- 1.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.22 (-2.25, 2.89) [0.00, 3.00]
Games | 43898: +8361 -8390 =27147
Penta | [50, 3849, 14193, 3794, 63]
https://openbench.lynx-chess.com/test/1925/
```

but them, somehow it came back:
```
Test  | eval/scale-down-r-vs-mn
Elo   | 1.17 +- 0.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | 98090: +18858 -18529 =60703
Penta | [112, 8458, 31587, 8765, 123]
https://openbench.lynx-chess.com/test/1925/
```