### PR TITLE
⚖️ Pawnless endgames: scale down all phase 4 eg with a rook

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1004,16 +1004,23 @@ public class Position : IDisposable
 
                             break;
                         }
-                    //case 4:
-                    //    {
-                    //        // Rook vs 2 minors should be a draw
+                    case 4:
+                        {
+                            // Rook vs 2 minors should be a draw
+                            // Rook and minor vs minor it doesn't matter if it's reduced
+                            if ((_pieceBitBoards[(int)Piece.Q] | _pieceBitBoards[(int)Piece.q]) == 0)
+                            {
+                                eval >>= 1; // /2
+                            }
 
-                    //    }
+                            break;
+                        }
                     case 3:
                         {
                             var winningSideOffset = Utils.PieceOffset(packedScore >= 0);
 
-                            if (_pieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)      // NN vs N, NN vs B
+                            // NN vs N, NN vs B
+                            if (_pieceBitBoards[(int)Piece.N + winningSideOffset].CountBits() == 2)
                             {
                                 return (0, gamePhase);
                             }


### PR DESCRIPTION
```
Test  | eval/scale-down-phase4
Elo   | -0.56 +- 2.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.95 (-2.25, 2.89) [0.00, 3.00]
Games | 13696: +2598 -2620 =8478
Penta | [14, 1217, 4407, 1197, 13]
https://openbench.lynx-chess.com/test/1924/
```