### PR TITLE
🔍 NMP min depth 3 -> 1

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -255,7 +255,7 @@ public sealed class EngineSettings
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
 
     [SPSA<int>(enabled: false)]
-    public int NMP_MinDepth { get; set; } = 3;
+    public int NMP_MinDepth { get; set; } = 1;
 
     [SPSA<int>(enabled: false)]
     public int NMP_BaseDepthReduction { get; set; } = 2;


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -6.58 +/- 6.41, nElo: -10.31 +/- 10.04
LOS: 2.22 %, DrawRatio: 41.12 %, PairsRatio: 0.91
Games: 4596, Wins: 1152, Losses: 1239, Draws: 2205, Points: 2254.5 (49.05 %)
Ptnml(0-2): [100, 607, 945, 572, 74], WL/DD Ratio: 0.84
LLR: -2.26 (-100.6%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
Finished match
Total Time: 03:51:46 (hours:minutes:seconds)
```