### PR TITLE
🔍 Low depth history, used in low depth move ordering

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -702,7 +702,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position.FEN()));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default, default)}");
     }
 
     position = new Position(TrickyPosition);
@@ -711,7 +711,7 @@ static void _54_ScoreMove()
     engine.SetGame(new(position.FEN()));
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
-        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default)}");
+        Console.WriteLine($"{move} {engine.ScoreMove(move, default, default, default)}");
     }
 }
 

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -323,6 +323,9 @@ public sealed class EngineSettings
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
     [SPSA<int>(enabled: false)]
+    public int History_LowDepth { get; set; } = 3;
+
+    [SPSA<int>(enabled: false)]
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     [SPSA<int>(512, 4096, 250)]

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -43,10 +43,12 @@ public sealed partial class Engine : IDisposable
 
         // Update ResetEngine() after any changes here
         _quietHistory = new int[12][];
+        _lowDepthQuietHistory = new int[12][];
         _moveNodeCount = new ulong[12][];
         for (int i = 0; i < _quietHistory.Length; ++i)
         {
             _quietHistory[i] = new int[64];
+            _lowDepthQuietHistory[i] = new int[64];
             _moveNodeCount[i] = new ulong[64];
         }
 
@@ -71,6 +73,7 @@ public sealed partial class Engine : IDisposable
         for (int i = 0; i < 12; ++i)
         {
             Array.Clear(_quietHistory[i]);
+            Array.Clear(_lowDepthQuietHistory[i]);
             Array.Clear(_moveNodeCount[i]);
         }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -612,7 +612,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 1, 0, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -28,6 +28,12 @@ public sealed partial class Engine
     private readonly int[][] _quietHistory;
 
     /// <summary>
+    /// 12 x 64
+    /// piece x target square
+    /// </summary>
+    private readonly int[][] _lowDepthQuietHistory;
+
+    /// <summary>
     /// 12 x 64 x 12,
     /// piece x target square x captured piece
     /// </summary>

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -12,7 +12,7 @@ public sealed partial class Engine
     /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Move move, int ply, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Move move, int depth, int ply, ShortMove bestMoveTTCandidate = default)
     {
         if ((ShortMove)move == bestMoveTTCandidate)
         {
@@ -55,7 +55,9 @@ public sealed partial class Engine
 
             // History move or 0 if not found
             return BaseMoveScore
-                + _quietHistory[move.Piece()][move.TargetSquare()];
+                + depth >= Configuration.EngineSettings.History_LowDepth
+                ? _quietHistory[move.Piece()][move.TargetSquare()]
+                : _lowDepthQuietHistory[move.Piece()][move.TargetSquare()];
         }
 
         // Queen promotion

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -301,7 +301,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], depth, ply, ttBestMove);
         }
 
         var nodeType = NodeType.Alpha;

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -23,7 +23,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default, default)).ToList();
 
         Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
         Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
@@ -36,7 +36,7 @@ public class MoveScoreTest : BaseTest
 
         foreach (var move in allMoves.Where(move => !move.IsCapture() && !move.IsCastle()))
         {
-            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default));
+            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(move, default, default, default));
         }
     }
 
@@ -58,7 +58,7 @@ public class MoveScoreTest : BaseTest
     {
         var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default)).ToList();
+        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move => engine.ScoreMove(move, default, default, default)).ToList();
 
         Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
         Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0][6], engine.ScoreMove(allMoves[0], default, default));


### PR DESCRIPTION
Also: #1887, #1886 

```
Test  | search/lowdepth-hist-move-ordering
Elo   | -3.66 +- 3.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 12628: +3396 -3529 =5703
Penta | [289, 1552, 2706, 1537, 230]
https://openbench.lynx-chess.com/test/1926/
```