### PR TITLE
🔍 Don't use exact TT bound in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -931,8 +931,6 @@ public sealed partial class Engine
 
                     _pVTable[pvIndex] = move;
                     CopyPVTableMoves(pvIndex + 1, nextPvIndex, Configuration.EngineSettings.MaxDepth - ply - 1);
-
-                    nodeType = NodeType.Exact;
                 }
             }
 


### PR DESCRIPTION
```
Test  | search/qsearch-noexactbound
Elo   | -5.98 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 8422: +2241 -2386 =3795
Penta | [197, 1065, 1792, 1000, 157]
https://openbench.lynx-chess.com/test/1930/
```