### PR TITLE
⚖️ Endgames: scale down rook egs with <=3 pawns

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1052,32 +1052,50 @@ public class Position : IDisposable
             }
             else
             {
-                var winningSideOffset = Utils.PieceOffset(eval >= 0);
-
-                 if (gamePhase == 1)
+                switch (gamePhase)
                 {
-                    // Bishop vs A/H pawns: if the defending king reaches the corner, and the corner is the opposite color of the bishop, it's a draw
-                    // TODO implement that
-                    // For now, we reduce all endgames that only have one bishop and A/H pawns
-                    if (_pieceBitBoards[(int)Piece.B + winningSideOffset] != 0
-                        && (_pieceBitBoards[(int)Piece.P + winningSideOffset] & Constants.NotAorH) == 0)
-                    {
-                        eval >>= 1; // /2
-                    }
-                }
-                else if (gamePhase == 2)
-                {
-                    var whiteBishops = _pieceBitBoards[(int)Piece.B];
-                    var blackBishops = _pieceBitBoards[(int)Piece.b];
+                    case 1:
+                        {
+                            var winningSideOffset = Utils.PieceOffset(eval >= 0);
 
-                    // Opposite color bishop endgame with pawns are drawish
-                    if (whiteBishops > 0
-                        && blackBishops > 0
-                        && Constants.DarkSquares[whiteBishops.GetLS1BIndex()] !=
-                            Constants.DarkSquares[blackBishops.GetLS1BIndex()])
-                    {
-                        eval >>= 1; // /2
-                    }
+                            // Bishop vs A/H pawns: if the defending king reaches the corner, and the corner is the opposite color of the bishop, it's a draw
+                            // TODO implement that
+                            // For now, we reduce all endgames that only have one bishop and A/H pawns
+                            if (_pieceBitBoards[(int)Piece.B + winningSideOffset] != 0
+                                && (_pieceBitBoards[(int)Piece.P + winningSideOffset] & Constants.NotAorH) == 0)
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
+                    case 2:
+                        {
+                            var whiteBishops = _pieceBitBoards[(int)Piece.B];
+                            var blackBishops = _pieceBitBoards[(int)Piece.b];
+
+                            // Opposite color bishop endgame with pawns are drawish
+                            if (whiteBishops > 0
+                                && blackBishops > 0
+                                && Constants.DarkSquares[whiteBishops.GetLS1BIndex()] !=
+                                    Constants.DarkSquares[blackBishops.GetLS1BIndex()])
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
+                    case 4:
+                        {
+                            // Rook endgames with pawns are drawish
+                            if (_pieceBitBoards[(int)Piece.R] != 0
+                                && _pieceBitBoards[(int)Piece.r] != 0)
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
                 }
             }
         }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1089,7 +1089,8 @@ public class Position : IDisposable
                         {
                             // Rook endgames with pawns are drawish
                             if (_pieceBitBoards[(int)Piece.R] != 0
-                                && _pieceBitBoards[(int)Piece.r] != 0)
+                                && _pieceBitBoards[(int)Piece.r] != 0
+                                && totalPawnsCount <= 3)
                             {
                                 eval >>= 1; // /2
                             }


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1890 but <= 3 pawns

```
Test  | eval/scale-down-rook-eg-max-3pawns
Elo   | -8.20 +- 4.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 4660: +831 -941 =2888
Penta | [7, 512, 1399, 408, 4]
https://openbench.lynx-chess.com/test/1933/
```