### PR TITLE
⚖️ Endgames: scale down rook egs with 1 pawn

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1052,32 +1052,50 @@ public class Position : IDisposable
             }
             else
             {
-                var winningSideOffset = Utils.PieceOffset(eval >= 0);
-
-                 if (gamePhase == 1)
+                switch (gamePhase)
                 {
-                    // Bishop vs A/H pawns: if the defending king reaches the corner, and the corner is the opposite color of the bishop, it's a draw
-                    // TODO implement that
-                    // For now, we reduce all endgames that only have one bishop and A/H pawns
-                    if (_pieceBitBoards[(int)Piece.B + winningSideOffset] != 0
-                        && (_pieceBitBoards[(int)Piece.P + winningSideOffset] & Constants.NotAorH) == 0)
-                    {
-                        eval >>= 1; // /2
-                    }
-                }
-                else if (gamePhase == 2)
-                {
-                    var whiteBishops = _pieceBitBoards[(int)Piece.B];
-                    var blackBishops = _pieceBitBoards[(int)Piece.b];
+                    case 1:
+                        {
+                            var winningSideOffset = Utils.PieceOffset(eval >= 0);
 
-                    // Opposite color bishop endgame with pawns are drawish
-                    if (whiteBishops > 0
-                        && blackBishops > 0
-                        && Constants.DarkSquares[whiteBishops.GetLS1BIndex()] !=
-                            Constants.DarkSquares[blackBishops.GetLS1BIndex()])
-                    {
-                        eval >>= 1; // /2
-                    }
+                            // Bishop vs A/H pawns: if the defending king reaches the corner, and the corner is the opposite color of the bishop, it's a draw
+                            // TODO implement that
+                            // For now, we reduce all endgames that only have one bishop and A/H pawns
+                            if (_pieceBitBoards[(int)Piece.B + winningSideOffset] != 0
+                                && (_pieceBitBoards[(int)Piece.P + winningSideOffset] & Constants.NotAorH) == 0)
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
+                    case 2:
+                        {
+                            var whiteBishops = _pieceBitBoards[(int)Piece.B];
+                            var blackBishops = _pieceBitBoards[(int)Piece.b];
+
+                            // Opposite color bishop endgame with pawns are drawish
+                            if (whiteBishops > 0
+                                && blackBishops > 0
+                                && Constants.DarkSquares[whiteBishops.GetLS1BIndex()] !=
+                                    Constants.DarkSquares[blackBishops.GetLS1BIndex()])
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
+                    case 4:
+                        {
+                            // Rook endgames with pawns are drawish
+                            if (_pieceBitBoards[(int)Piece.R] != 0
+                                && _pieceBitBoards[(int)Piece.r] != 0)
+                            {
+                                eval >>= 1; // /2
+                            }
+
+                            break;
+                        }
                 }
             }
         }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1090,7 +1090,7 @@ public class Position : IDisposable
                             // Rook endgames with pawns are drawish
                             if (_pieceBitBoards[(int)Piece.R] != 0
                                 && _pieceBitBoards[(int)Piece.r] != 0
-                                && totalPawnsCount <= 3)
+                                && totalPawnsCount <= 2)
                             {
                                 eval >>= 1; // /2
                             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1089,7 +1089,8 @@ public class Position : IDisposable
                         {
                             // Rook endgames with pawns are drawish
                             if (_pieceBitBoards[(int)Piece.R] != 0
-                                && _pieceBitBoards[(int)Piece.r] != 0)
+                                && _pieceBitBoards[(int)Piece.r] != 0
+                                && totalPawnsCount <= 3)
                             {
                                 eval >>= 1; // /2
                             }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1087,10 +1087,10 @@ public class Position : IDisposable
                         }
                     case 4:
                         {
-                            // Rook endgames with pawns are drawish
+                            // Rook endgames with one pawn are drawish
                             if (_pieceBitBoards[(int)Piece.R] != 0
                                 && _pieceBitBoards[(int)Piece.r] != 0
-                                && totalPawnsCount <= 2)
+                                && totalPawnsCount == 1)
                             {
                                 eval >>= 1; // /2
                             }


### PR DESCRIPTION
```
Test  | eval/scale-down-rook-eg-1pawn
Elo   | -2.32 +- 3.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 17216: +4744 -4859 =7613
Penta | [336, 1980, 4099, 1849, 344]
https://openbench.lynx-chess.com/test/1938/
```