### PR TITLE
🔍 History min depth 3 -> 2

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,7 +237,7 @@ public sealed class EngineSettings
     public int LMR_Quiet { get; set; } = 84;
 
     [SPSA<int>(enabled: false)]
-    public int History_MinDepth { get; set; } = 3;
+    public int History_MinDepth { get; set; } = 2;
 
     [SPSA<int>(enabled: false)]
     public int History_MinVisitedMoves { get; set; } = 2;


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -1.07 +/- 3.62, nElo: -1.68 +/- 5.69
LOS: 28.17 %, DrawRatio: 43.72 %, PairsRatio: 0.99
Games: 14332, Wins: 3799, Losses: 3843, Draws: 6690, Points: 7144.0 (49.85 %)
Ptnml(0-2): [302, 1729, 3133, 1715, 287], WL/DD Ratio: 0.93
LLR: -2.26 (-100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```