### PR TITLE
🔍 History min depth 3 -> 4

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -237,7 +237,7 @@ public sealed class EngineSettings
     public int LMR_Quiet { get; set; } = 84;
 
     [SPSA<int>(enabled: false)]
-    public int History_MinDepth { get; set; } = 3;
+    public int History_MinDepth { get; set; } = 4;
 
     [SPSA<int>(enabled: false)]
     public int History_MinVisitedMoves { get; set; } = 2;


### PR DESCRIPTION
Was runing as nonreg, but it doesn't really matter
```
Elo: -1.06 +/- 4.05, nElo: -1.67 +/- 6.37
LOS: 30.33 %, DrawRatio: 44.07 %, PairsRatio: 0.98
Games: 11440, Wins: 3025, Losses: 3060, Draws: 5355, Points: 5702.5 (49.85 %)
Ptnml(0-2): [235, 1384, 2521, 1341, 239], WL/DD Ratio: 0.92
LLR: 1.69 (58.3%) (-2.25, 2.89) [-5.00, 0.00]
--------------------------------------------------
```