### PR TITLE
🔍 Pawn History III

### DIFF
--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -586,6 +586,12 @@ public static class Constants
     public const int KingPawnHashSize = 262_144;
     public const int KingPawnHashMask = KingPawnHashSize - 1;
 
+    /// <summary>
+    /// 1024 * 12 * 64 entries, ~3MB
+    /// </summary>
+    public const int PawnHistorySize = 1024;
+    public const int PawnHistoryMask = PawnHistorySize - 1;
+
     public const int PawnCorrHistoryHashSize = 16_384;
     public const int PawnCorrHistoryHashMask = PawnCorrHistoryHashSize - 1;
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -76,6 +76,8 @@ public sealed partial class Engine : IDisposable
 
         Array.Clear(_captureHistory);
         Array.Clear(_continuationHistory);
+        Array.Clear(_pawnHistory);
+
         Array.Clear(_counterMoves);
 
         Array.Clear(_pawnEvalTable);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -88,6 +88,23 @@ public sealed partial class Engine
     }
 
     /// <summary>
+    /// [<see cref="Constants.PawnHistorySize"/>][12][64]
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int PawnHistoryEntry(ulong pawnKey, int piece, int targetSquare)
+    {
+        const int pawnKeyOffset = 12 * 64;
+        const int pieceOffset = 64;
+
+        var keyIndex = (int)(pawnKey & Constants.PawnHistoryMask);
+
+        return ref _pawnHistory[
+            (keyIndex * pawnKeyOffset)
+            + (piece * pieceOffset)
+            + targetSquare];
+    }
+
+    /// <summary>
     /// [12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -42,6 +42,12 @@ public sealed partial class Engine
     private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.PawnHistorySize"/> x 12 x 64
+    /// pawn key x piece x target square
+    /// </summary>
+    private readonly int[] _pawnHistory = GC.AllocateArray<int>(Constants.PawnHistorySize * 12 * 64, pinned: true);
+
+    /// <summary>
     /// <see cref="Constants.PawnCorrHistoryHashSize"/> x 2
     /// Pawn hash x side to move
     /// </summary>
@@ -606,7 +612,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, position.KingPawnUniqueIdentifier, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -211,7 +211,7 @@ public sealed partial class Engine
                     quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryMalus);
 
                     // 🔍 Pawn history penalty / malus
-                    pawnHistoryEntry = ref PawnHistoryEntry(position.KingPawnUniqueIdentifier, piece, targetSquare);
+                    pawnHistoryEntry = ref PawnHistoryEntry(position.KingPawnUniqueIdentifier, visitedMovePiece, visitedMoveTargetSquare);
                     pawnHistoryEntry = ScoreHistoryMove(pawnHistoryEntry, -rawHistoryBonus);
 
                     if (!isRoot)

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -212,7 +212,7 @@ public sealed partial class Engine
 
                     // 🔍 Pawn history penalty / malus
                     pawnHistoryEntry = ref PawnHistoryEntry(position.KingPawnUniqueIdentifier, piece, targetSquare);
-                    pawnHistoryEntry = ScoreHistoryMove(pawnHistoryEntry, rawHistoryBonus);
+                    pawnHistoryEntry = ScoreHistoryMove(pawnHistoryEntry, -rawHistoryBonus);
 
                     if (!isRoot)
                     {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -338,8 +338,9 @@ public sealed partial class Engine
             int? quietHistory = null;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            int QuietHistory() => quietHistory ??=
+            int QuietHistory(Position position) => quietHistory ??=
                 _quietHistory[move.Piece()][move.TargetSquare()]
+                + PawnHistoryEntry(position.KingPawnUniqueIdentifier, move.Piece(), move.TargetSquare())
                 + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
 
             // If we prune while getting checmated, we risk not finding any move and having an empty PV
@@ -365,7 +366,7 @@ public sealed partial class Engine
                 // once we find one with a history score too low
                 if (!isCapture
                     && depth < Configuration.EngineSettings.HistoryPrunning_MaxDepth    // TODO use LMR depth
-                    && QuietHistory() < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
+                    && QuietHistory(position) < Configuration.EngineSettings.HistoryPrunning_Margin * (depth - 1))
                 {
                     break;
                 }
@@ -573,7 +574,7 @@ public sealed partial class Engine
 
                                 // -= history/(maxHistory/2)
 
-                                reduction -= QuietHistory() / Configuration.EngineSettings.LMR_History_Divisor_Quiet;
+                                reduction -= QuietHistory(position) / Configuration.EngineSettings.LMR_History_Divisor_Quiet;
                             }
                         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -301,7 +301,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, position.KingPawnUniqueIdentifier, ttBestMove);
         }
 
         var nodeType = NodeType.Alpha;
@@ -696,7 +696,7 @@ public sealed partial class Engine
                     }
                     else
                     {
-                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
+                        UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(position, historyDepth, ply, visitedMoves, visitedMovesCounter, move, isRoot, pvNode);
                     }
 
                     nodeType = NodeType.Beta;


### PR DESCRIPTION
#1619 but with 1024 size

```
Test  | search/pawn-history-3-1024
Elo   | -16.40 +- 7.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 3456: +912 -1075 =1469
Penta | [99, 467, 728, 366, 68]
https://openbench.lynx-chess.com/test/1958/
```