### PR TITLE
⌛ Complexity - no min depth max 1

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -158,7 +158,22 @@ public sealed class EngineSettings
     public double NodeTmScale { get; set; } = 1.66;
 
     [SPSA<int>(enabled: false)]
-    public int ScoreStabiity_MinDepth { get; set; } = 7;
+    public int ScoreStabiity_MinDepth { get; set; } = 0;
+
+    [SPSA<int>(enabled: false)]
+    public int TM_Complexity_MinDepth { get; set; } = 4;
+
+    [SPSA<double>(enabled: false)]
+    public double TM_Complexity_Base { get; set; } = 0.8;
+
+    [SPSA<double>(enabled: false)]
+    public double TM_Complexity_FactorBase { get; set; } = 0.7;
+
+    [SPSA<int>(enabled: false)]
+    public int TM_Complexity_Max { get; set; } = 200;
+
+    [SPSA<int>(enabled: false)]
+    public int TM_Complexity_Divisor { get; set; } = 400;
 
     [SPSA<int>(enabled: false)]
     public int SoftTimeBoundLimitOnMate { get; set; } = 1_000;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -158,10 +158,10 @@ public sealed class EngineSettings
     public double NodeTmScale { get; set; } = 1.66;
 
     [SPSA<int>(enabled: false)]
-    public int ScoreStabiity_MinDepth { get; set; } = 0;
+    public int ScoreStabiity_MinDepth { get; set; } = 7;
 
     [SPSA<int>(enabled: false)]
-    public int TM_Complexity_MinDepth { get; set; } = 4;
+    public int TM_Complexity_MinDepth { get; set; } = 0;
 
     [SPSA<double>(enabled: false)]
     public double TM_Complexity_Base { get; set; } = 0.8;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -271,7 +271,7 @@ public sealed partial class Engine
                     _bestMoveStability = 0;
                 }
 
-                _scoreDelta = oldScore - bestScore;
+                _scoreDelta = oldScore - lastSearchResult.Score;
 
                 _engineWriter.TryWrite(lastSearchResult);
             } while (StopSearchCondition(lastSearchResult?.BestMove, ++depth, mate, bestScore, isPondering));

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -82,6 +82,7 @@ public sealed partial class Engine
 
     private int _bestMoveStability;
     private int _scoreDelta;
+    private int _rootStaticEval;
 
     /// <summary>
     /// Iterative Deepening Depth-First Search (IDDFS) using alpha-beta pruning.
@@ -132,6 +133,8 @@ public sealed partial class Engine
             // Not clearing _captureHistory on purpose
 
             int mate = 0;
+
+            _rootStaticEval = Game.CurrentPosition.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
 
             do
             {
@@ -268,7 +271,7 @@ public sealed partial class Engine
                     _bestMoveStability = 0;
                 }
 
-                _scoreDelta = oldScore - lastSearchResult.Score;
+                _scoreDelta = oldScore - bestScore;
 
                 _engineWriter.TryWrite(lastSearchResult);
             } while (StopSearchCondition(lastSearchResult?.BestMove, ++depth, mate, bestScore, isPondering));
@@ -423,7 +426,7 @@ public sealed partial class Engine
             var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
             var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
-            var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
+            var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta, mate, _rootStaticEval, bestScore);
 
             if (_logger.IsEnabled(logLevel))
             {

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -135,7 +135,7 @@ public static class TimeManager
                 complexityBase * Math.Log(depth) * Math.Abs(staticEval - score),
                 0, complexityMax);
 
-            double complexityFactor = factorBase + (complexity / complexityDivisor);
+            double complexityFactor = Math.Max(factorBase + (complexity / complexityDivisor), 1.0);
 
             scale *= complexityFactor;
         }


### PR DESCRIPTION
```
Test  | tm/complexity-nomindepth-max1
Elo   | -2.53 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 16504: +4507 -4627 =7370
Penta | [340, 1996, 3702, 1872, 342]
https://openbench.lynx-chess.com/test/1956/
```