### PR TITLE
🐛 Correction history: use node type instead of TT entry type for update checks

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -723,8 +723,8 @@ public sealed partial class Engine
             if (!(isInCheck
                 || bestMove?.IsCapture() == true
                 || bestMove?.IsPromotion() == true
-                || (ttElementType == NodeType.Beta && bestScore <= staticEval)
-                || (ttElementType == NodeType.Alpha && bestScore >= staticEval)))
+                || (nodeType == NodeType.Beta && bestScore <= staticEval)
+                || (nodeType == NodeType.Alpha && bestScore >= staticEval)))
             {
                 UpdateCorrectionHistory(position, bestScore - staticEval, depth);
             }


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: 15.44 +/- 7.43, nElo: 24.31 +/- 11.68
LOS: 100.00 %, DrawRatio: 41.41 %, PairsRatio: 1.29
Games: 3400, Wins: 979, Losses: 828, Draws: 1593, Points: 1775.5 (52.22 %)
Ptnml(0-2): [52, 383, 704, 484, 77], WL/DD Ratio: 0.94
LLR: 2.89 (100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H1 was accepted
Finished match
Total Time: 02:51:35 (hours:minutes:seconds)
```