### PR TITLE
🔍 Major correction history / corrhist - major key revival I

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -432,6 +432,12 @@ public sealed class EngineSettings
     [SPSA<int>(25, 200, 15)]
     public int CorrHistoryWeight_Minor { get; set; } = 149;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 200, 15)]
+    public int CorrHistoryWeight_Major { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -595,6 +595,9 @@ public static class Constants
     public const int MinorCorrHistoryHashSize = 16_384;
     public const int MinorCorrHistoryHashMask = MinorCorrHistoryHashSize - 1;
 
+    public const int MajorCorrHistoryHashSize = 16_384;
+    public const int MajorCorrHistoryHashMask = MajorCorrHistoryHashSize - 1;
+
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -83,6 +83,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_pawnCorrHistory);
         Array.Clear(_nonPawnCorrHistory);
         Array.Clear(_minorCorrHistory);
+        Array.Clear(_majorCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -14,6 +14,8 @@ public readonly struct GameState
 
     public readonly ulong MinorKey;
 
+    public readonly ulong MajorKey;
+
     public readonly int IncrementalEvalAccumulator;
 
     public readonly int IncrementalPhaseAccumulator;
@@ -32,6 +34,7 @@ public readonly struct GameState
         NonPawnWhiteKey = position.NonPawnHash[(int)Side.White];
         NonPawnBlackKey = position.NonPawnHash[(int)Side.Black];
         MinorKey = position.MinorHash;
+        MajorKey = position.MajorHash;
 
         EnPassant = position.EnPassant;
         Castle = position.Castle;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -21,6 +21,7 @@ public class Position : IDisposable
     private ulong _kingPawnUniqueIdentifier;
     private readonly ulong[] _nonPawnHash;
     private ulong _minorHash;
+    private ulong _majorHash;
 
     private readonly ulong[] _pieceBitBoards;
     private readonly ulong[] _occupancyBitBoards;
@@ -42,6 +43,8 @@ public class Position : IDisposable
     public ulong[] NonPawnHash => _nonPawnHash;
 
     public ulong MinorHash => _minorHash;
+
+    public ulong MajorHash => _majorHash;
 
     /// <summary>
     /// Use <see cref="Piece"/> as index
@@ -105,6 +108,7 @@ public class Position : IDisposable
         _nonPawnHash[(int)Side.Black] = ZobristTable.NonPawnSideHash(this, (int)Side.Black);
 
         _minorHash = ZobristTable.MinorHash(this);
+        _majorHash = ZobristTable.MajorHash(this);
         _kingPawnUniqueIdentifier = ZobristTable.KingPawnHash(this);
 
         _uniqueIdentifier = ZobristTable.PositionHash(this, _kingPawnUniqueIdentifier, _nonPawnHash[(int)Side.White], _nonPawnHash[(int)Side.Black]);
@@ -124,6 +128,7 @@ public class Position : IDisposable
         _uniqueIdentifier = position._uniqueIdentifier;
         _kingPawnUniqueIdentifier = position._kingPawnUniqueIdentifier;
         _minorHash = position._minorHash;
+        _majorHash = position._majorHash;
 
         _nonPawnHash = ArrayPool<ulong>.Shared.Rent(2);
         _nonPawnHash[(int)Side.White] = position._nonPawnHash[(int)Side.White];
@@ -163,6 +168,7 @@ public class Position : IDisposable
         Debug.Assert(ZobristTable.NonPawnSideHash(this, (int)Side.White) == _nonPawnHash[(int)Side.White]);
         Debug.Assert(ZobristTable.NonPawnSideHash(this, (int)Side.Black) == _nonPawnHash[(int)Side.Black]);
         Debug.Assert(ZobristTable.MinorHash(this) == _minorHash);
+        Debug.Assert(ZobristTable.MajorHash(this) == _majorHash);
 
         var gameState = new GameState(this);
 
@@ -222,6 +228,10 @@ public class Position : IDisposable
                 {
                     _minorHash ^= targetPieceHash;
                 }
+                else if (Utils.IsMajorPiece(newPiece))
+                {
+                    _majorHash ^= targetPieceHash;
+                }
             }
         }
         else
@@ -239,6 +249,10 @@ public class Position : IDisposable
             else if (Utils.IsMinorPiece(piece))
             {
                 _minorHash ^= fullPieceMovementHash;
+            }
+            else if (Utils.IsMajorPiece(piece))
+            {
+                _majorHash ^= fullPieceMovementHash;
             }
         }
 
@@ -295,6 +309,10 @@ public class Position : IDisposable
                                 if (Utils.IsMinorPiece(capturedPiece))
                                 {
                                     _minorHash ^= capturedPieceHash;
+                                }
+                                else if (Utils.IsMajorPiece(capturedPiece))
+                                {
+                                    _majorHash ^= capturedPieceHash;
                                 }
                             }
 
@@ -372,6 +390,10 @@ public class Position : IDisposable
                                 {
                                     _minorHash ^= capturedPieceHash;
                                 }
+                                else if (Utils.IsMajorPiece(capturedPiece))
+                                {
+                                    _majorHash ^= capturedPieceHash;
+                                }
                             }
                         }
 
@@ -407,6 +429,7 @@ public class Position : IDisposable
 
                         _uniqueIdentifier ^= hashChange;
                         _nonPawnHash[oldSide] ^= hashChange;
+                        _majorHash ^= hashChange;
 
                         break;
                     }
@@ -429,6 +452,7 @@ public class Position : IDisposable
 
                         _uniqueIdentifier ^= hashChange;
                         _nonPawnHash[oldSide] ^= hashChange;
+                        _majorHash ^= hashChange;
 
                         break;
                     }
@@ -466,6 +490,7 @@ public class Position : IDisposable
         Debug.Assert(ZobristTable.NonPawnSideHash(this, (int)Side.White) == _nonPawnHash[(int)Side.White]);
         Debug.Assert(ZobristTable.NonPawnSideHash(this, (int)Side.Black) == _nonPawnHash[(int)Side.Black]);
         Debug.Assert(ZobristTable.MinorHash(this) == _minorHash);
+        Debug.Assert(ZobristTable.MajorHash(this) == _majorHash);
 
         // KingPawn hash assert won't work due to PassedPawnBonusNoEnemiesAheadBonus
         //Debug.Assert(ZobristTable.PawnKingHash(this) != _kingPawnUniqueIdentifier && WasProduceByAValidMove());
@@ -577,6 +602,7 @@ public class Position : IDisposable
         _uniqueIdentifier = gameState.ZobristKey;
         _kingPawnUniqueIdentifier = gameState.KingPawnKey;
         _minorHash = gameState.MinorKey;
+        _majorHash = gameState.MajorKey;
         _nonPawnHash[(int)Side.White] = gameState.NonPawnWhiteKey;
         _nonPawnHash[(int)Side.Black] = gameState.NonPawnBlackKey;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -204,11 +204,6 @@ public class Position : IDisposable
             ^ ZobristTable.EnPassantHash((int)_enPassant)            // We clear the existing enpassant square, if any
             ^ ZobristTable.CastleHash(_castle);                      // We clear the existing castle rights
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        static bool IsMinorPiece(int piece) =>
-            piece == (int)Piece.N || piece == (int)Piece.n
-            || piece == (int)Piece.B || piece == (int)Piece.b;
-
         if (piece == (int)Piece.P || piece == (int)Piece.p)
         {
             _kingPawnUniqueIdentifier ^= sourcePieceHash;       // We remove pawn from start square
@@ -223,7 +218,7 @@ public class Position : IDisposable
                 // We do need to update the NonPawn hash
                 _nonPawnHash[oldSide] ^= targetPieceHash;       // We add piece piece to the end square
 
-                if (IsMinorPiece(newPiece))
+                if (Utils.IsMinorPiece(newPiece))
                 {
                     _minorHash ^= targetPieceHash;
                 }
@@ -241,7 +236,7 @@ public class Position : IDisposable
 
                 _kingPawnUniqueIdentifier ^= fullPieceMovementHash;
             }
-            else if (IsMinorPiece(piece))
+            else if (Utils.IsMinorPiece(piece))
             {
                 _minorHash ^= fullPieceMovementHash;
             }
@@ -297,7 +292,7 @@ public class Position : IDisposable
                             {
                                 _nonPawnHash[oppositeSide] ^= capturedPieceHash;
 
-                                if (IsMinorPiece(capturedPiece))
+                                if (Utils.IsMinorPiece(capturedPiece))
                                 {
                                     _minorHash ^= capturedPieceHash;
                                 }
@@ -373,7 +368,7 @@ public class Position : IDisposable
                             {
                                 _nonPawnHash[oppositeSide] ^= capturedPieceHash;
 
-                                if (IsMinorPiece(capturedPiece))
+                                if (Utils.IsMinorPiece(capturedPiece))
                                 {
                                     _minorHash ^= capturedPieceHash;
                                 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -60,6 +60,12 @@ public sealed partial class Engine
     private readonly int[] _minorCorrHistory = GC.AllocateArray<int>(Constants.MinorCorrHistoryHashSize * 2, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.MajorCorrHistoryHashSize"/> x 2
+    /// Major hash x side to move
+    /// </summary>
+    private readonly int[] _majorCorrHistory = GC.AllocateArray<int>(Constants.MajorCorrHistoryHashSize * 2, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -226,6 +226,14 @@ public static class Utils
         return ((1 << piece) & MinorPieceMask) != 0;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsMajorPiece(int piece)
+    {
+        const int MajorPieceMask = (1 << (int)Piece.R) | (1 << (int)Piece.r) | (1 << (int)Piece.Q) | (1 << (int)Piece.q);
+
+        return ((1 << piece) & MajorPieceMask) != 0;
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -218,6 +218,14 @@ public static class Utils
         return (short)((packed + 0x8000) >> 16);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsMinorPiece(int piece)
+    {
+        const int MinorPieceMask = (1 << (int)Piece.N) | (1 << (int)Piece.n) | (1 << (int)Piece.B) | (1 << (int)Piece.b);
+
+        return ((1 << piece) & MinorPieceMask) != 0;
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/src/Lynx/ZobristTable.cs
+++ b/src/Lynx/ZobristTable.cs
@@ -243,6 +243,31 @@ public static class ZobristTable
         return minorHash;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong MajorHash(Position position)
+    {
+        ulong majorHash = 0;
+
+        for (int pieceIndex = (int)Piece.R; pieceIndex <= (int)Piece.Q; ++pieceIndex)
+        {
+            var whiteBitboard = position.PieceBitBoards[pieceIndex];
+            while (whiteBitboard != default)
+            {
+                whiteBitboard = whiteBitboard.WithoutLS1B(out var pieceSquareIndex);
+                majorHash ^= PieceHash(pieceSquareIndex, pieceIndex);
+            }
+
+            var blackBitboard = position.PieceBitBoards[pieceIndex + 6];
+            while (blackBitboard != default)
+            {
+                blackBitboard = blackBitboard.WithoutLS1B(out var pieceSquareIndex);
+                majorHash ^= PieceHash(pieceSquareIndex, pieceIndex + 6);
+            }
+        }
+
+        return majorHash;
+    }
+
     private static ulong[][] InitializeZobristTable() => InitializeZobristTable(_random);
 
     /// <summary>

--- a/tests/Lynx.Test/UtilsTest.cs
+++ b/tests/Lynx.Test/UtilsTest.cs
@@ -148,4 +148,22 @@ public class UtilsTest
     {
         Assert.AreEqual(isMinor, Utils.IsMinorPiece((int)piece));
     }
+
+    [TestCase(Piece.P, false)]
+    [TestCase(Piece.N, false)]
+    [TestCase(Piece.B, false)]
+    [TestCase(Piece.R, true)]
+    [TestCase(Piece.Q, true)]
+    [TestCase(Piece.K, false)]
+    [TestCase(Piece.p, false)]
+    [TestCase(Piece.n, false)]
+    [TestCase(Piece.b, false)]
+    [TestCase(Piece.r, true)]
+    [TestCase(Piece.q, true)]
+    [TestCase(Piece.k, false)]
+    [TestCase(Piece.None, false)]
+    public void IsMajorPiece(Piece piece, bool isMinor)
+    {
+        Assert.AreEqual(isMinor, Utils.IsMajorPiece((int)piece));
+    }
 }

--- a/tests/Lynx.Test/UtilsTest.cs
+++ b/tests/Lynx.Test/UtilsTest.cs
@@ -130,4 +130,22 @@ public class UtilsTest
     {
         Assert.AreEqual(1, Utils.CalculateNps(0, 0));
     }
+
+    [TestCase(Piece.P, false)]
+    [TestCase(Piece.N, true)]
+    [TestCase(Piece.B, true)]
+    [TestCase(Piece.R, false)]
+    [TestCase(Piece.Q, false)]
+    [TestCase(Piece.K, false)]
+    [TestCase(Piece.p, false)]
+    [TestCase(Piece.n, true)]
+    [TestCase(Piece.b, true)]
+    [TestCase(Piece.r, false)]
+    [TestCase(Piece.q, false)]
+    [TestCase(Piece.k, false)]
+    [TestCase(Piece.None, false)]
+    public void IsMinorPiece(Piece piece, bool isMinor)
+    {
+        Assert.AreEqual(isMinor, Utils.IsMinorPiece((int)piece));
+    }
 }


### PR DESCRIPTION
Based on https://github.com/lynx-chess/Lynx/pull/1711 after some time bugfix #1909 and #1910 

SSS
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -1.35 +/- 5.41, nElo: -2.20 +/- 8.84
LOS: 31.30 %, DrawRatio: 45.10 %, PairsRatio: 0.96
Games: 5938, Wins: 1534, Losses: 1557, Draws: 2847, Points: 2957.5 (49.81 %)
Ptnml(0-2): [93, 740, 1339, 691, 106], WL/DD Ratio: 0.89
LLR: -1.12 (-49.7%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```