### PR TITLE
🔍 NMP: add `staticEval - beta` margin >= 10

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
 
                 // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
                 if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                    && staticEvalBetaDiff >= 0
+                    && staticEvalBetaDiff >= 10
                     && !parentWasNullMove
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                     && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -0.00 +/- 4.05, nElo: 0.00 +/- 6.54
LOS: 50.00 %, DrawRatio: 44.10 %, PairsRatio: 1.00
Games: 10840, Wins: 2818, Losses: 2818, Draws: 5204, Points: 5420.0 (50.00 %)
Ptnml(0-2): [190, 1324, 2390, 1328, 188], WL/DD Ratio: 0.87
LLR: -1.05 (-46.7%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```