### PR TITLE
🔍 Correction history / corrhist gravity II - depth

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -112,7 +112,7 @@ public sealed partial class Engine
         var oppositeSide = Utils.OppositeSide((int)side);
 
         var maxBonus = Configuration.EngineSettings.CorrHistory_MaxRawBonus;
-        var bonus = Math.Clamp(evaluationDelta, -maxBonus, +maxBonus);
+        var bonus = Math.Clamp(evaluationDelta * 8 / depth, -maxBonus, +maxBonus);  // TODO tune
 
         var kingsHash = ZobristTable.PieceHash(position.WhiteKingSquare, (int)Piece.K)
             ^ ZobristTable.PieceHash(position.BlackKingSquare, (int)Piece.k);


### PR DESCRIPTION
```
Test  | search/corrhist-gravity-2
Elo   | -0.60 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 37558: +10140 -10205 =17213
Penta | [841, 4566, 7994, 4573, 805]
https://openbench.lynx-chess.com/test/1869/
```