### PR TITLE
🔍 NMP: add `staticEval - beta` margin >= 30

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -264,7 +264,7 @@ public sealed class EngineSettings
     public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(enabled: false)]
-    public int NMP_Margin { get; set; } = -10;
+    public int NMP_Margin { get; set; } = -30;
 
     [SPSA<int>(enabled: false)]
     public int NMP_BaseDepthReduction { get; set; } = 2;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -264,7 +264,7 @@ public sealed class EngineSettings
     public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(enabled: false)]
-    public int NMP_Margin { get; set; } = -30;
+    public int NMP_Margin { get; set; } = +30;
 
     [SPSA<int>(enabled: false)]
     public int NMP_BaseDepthReduction { get; set; } = 2;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -264,6 +264,9 @@ public sealed class EngineSettings
     public int NMP_MinDepth { get; set; } = 3;
 
     [SPSA<int>(enabled: false)]
+    public int NMP_Margin { get; set; } = -10;
+
+    [SPSA<int>(enabled: false)]
     public int NMP_BaseDepthReduction { get; set; } = 2;
 
 #pragma warning disable CA1805 // Do not initialize unnecessarily

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
 
                 // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
                 if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                    && staticEvalBetaDiff >= 0
+                    && staticEvalBetaDiff >= 10
                     && !parentWasNullMove
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                     && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
 
                 // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
                 if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                    && staticEvalBetaDiff >= 10
+                    && staticEvalBetaDiff >= -10
                     && !parentWasNullMove
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                     && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -252,7 +252,7 @@ public sealed partial class Engine
 
                 // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta
                 if (depth >= Configuration.EngineSettings.NMP_MinDepth
-                    && staticEvalBetaDiff >= -10
+                    && staticEvalBetaDiff >= Configuration.EngineSettings.NMP_Margin
                     && !parentWasNullMove
                     && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
                     && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal


### PR DESCRIPTION
```
Test  | search/nmp-margin-30
Elo   | 6.13 +- 3.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 14520: +4109 -3853 =6558
Penta | [303, 1643, 3127, 1869, 318]
https://openbench.lynx-chess.com/test/1977/
```

```
Test  | search/nmp-margin-30
Elo   | 6.23 +- 4.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 7366: +1900 -1768 =3698
Penta | [77, 832, 1726, 978, 70]
https://openbench.lynx-chess.com/test/1978/
```
