### PR TITLE
🔍 PVS SEE pruning: not on ttPv

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -379,22 +379,25 @@ public sealed partial class Engine
                 }
 
                 // 🔍 PVS SEE pruning
-                if (isCapture)
+                if (!ttPv)
                 {
-                    var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Noisy * depth * depth;
-
-                    if (!SEE.IsGoodCapture(position, move, threshold))
+                    if (isCapture)
                     {
-                        continue;
+                        var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Noisy * depth * depth;
+
+                        if (!SEE.IsGoodCapture(position, move, threshold))
+                        {
+                            continue;
+                        }
                     }
-                }
-                else
-                {
-                    var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Quiet * depth;
-
-                    if (!SEE.HasPositiveScore(position, move, threshold))
+                    else
                     {
-                        continue;
+                        var threshold = Configuration.EngineSettings.PVS_SEE_Threshold_Quiet * depth;
+
+                        if (!SEE.HasPositiveScore(position, move, threshold))
+                        {
+                            continue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
```
Test  | search/see-pruning-nottpv
Elo   | -0.99 +- 2.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 29952: +8192 -8277 =13483
Penta | [645, 3660, 6428, 3621, 622]
https://openbench.lynx-chess.com/test/1986/
```