### PR TITLE
🔍 Corrplexity revival

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -240,7 +240,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_CorrectedStaticEval { get; set; } = 100;
+    public int LMR_CorrectedStaticEval { get; set; } = 125;
 
     [SPSA<int>(25, 300, 30)]
     public int LMR_CorrectedStaticEval_Delta { get; set; } = 90;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -236,6 +236,15 @@ public sealed class EngineSettings
     [SPSA<int>(25, 300, 30)]
     public int LMR_Quiet { get; set; } = 84;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_CorrectedStaticEval_Delta { get; set; } = 90;
+
     [SPSA<int>(enabled: false)]
     public int History_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -569,6 +569,11 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_InCheck;
                                 }
 
+                                if (Math.Abs(staticEval - rawStaticEval) >= Configuration.EngineSettings.LMR_CorrectedStaticEval_Delta)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_CorrectedStaticEval;
+                                }
+
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // -= history/(maxHistory/2)


### PR DESCRIPTION
#1685/ #1686 revival, a version of #1922
```
Test  | search/corrplexity-revival-3
Elo   | 2.30 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 55404: +15362 -14996 =25046
Penta | [1121, 6581, 11948, 6915, 1137]
https://openbench.lynx-chess.com/test/1989/
```

Other less successful variant:
```
Test  | search/corrplexity-revival-2
Elo   | 0.40 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.03 (-2.25, 2.89) [0.00, 3.00]
Games | 47616: +13029 -12974 =21613
Penta | [961, 5847, 10200, 5776, 1024]
https://openbench.lynx-chess.com/test/1988/
```