### PR TITLE
🔍 RFP: add offset to the margin

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -200,9 +200,12 @@ public sealed partial class Engine
                     // 🔍 Reverse Futility Pruning (RFP) - https://www.chessprogramming.org/Reverse_Futility_Pruning
                     // Return formula by Ciekce, instead of just returning static eval
                     // Improving impl. based on Potential's
-                    var rfpMargin = improving
-                        ? Configuration.EngineSettings.RFP_Improving_Margin * (depth - 1)
-                        : Configuration.EngineSettings.RFP_NotImproving_Margin * depth;
+                    var rfpMargin =
+						(improving
+							? Configuration.EngineSettings.RFP_Improving_Margin * (depth - 1)
+							: Configuration.EngineSettings.RFP_NotImproving_Margin * depth)
+						- 50;
+
 
                     // RFP_ImprovingFactor should be tuned if improvingRate is ever used for something else
                     var improvingFactor = improvingRate * (Configuration.EngineSettings.RFP_ImprovingFactor * depth);


### PR DESCRIPTION
```
Test  | search/rfp-margin-offset
Elo   | -9.64 +- 5.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 5482: +1423 -1575 =2484
Penta | [127, 709, 1198, 603, 104]
https://openbench.lynx-chess.com/test/1992/
```