### PR TITLE
🔍 RFP: corrplexity factor

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -319,6 +319,14 @@ public sealed class EngineSettings
     [SPSA<double>(enabled: false)]
     public double RFP_ImprovingFactor { get; set; } = 0.75;
 
+    //[SPSA<int>(50, 250, 20)] // TODO
+    [SPSA<double>(enabled: false)]
+    public int RFP_Corrplexity_Margin { get; set; } = 90;
+
+    //[SPSA<int>(0, 50, 5)] // TODO
+    [SPSA<double>(enabled: false)]
+    public int RFP_Corrplexity_Factor { get; set; } = 20;
+
     //[SPSA<int>(1, 300, 15)]
     //public int RFP_DepthScalingFactor { get; set; } = 55;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -210,7 +210,7 @@ public sealed partial class Engine
                     // Corrplexity idea by Potential author
                     var corrplexity = Math.Abs(staticEval - rawStaticEval);
                     var corrplexityFactor = corrplexity >= Configuration.EngineSettings.RFP_Corrplexity_Margin
-                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor * corrplexity
+                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor
                         : 0;
 
                     var rfpThreshold = rfpMargin + improvingFactor + corrplexityFactor;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -207,7 +207,13 @@ public sealed partial class Engine
                     // RFP_ImprovingFactor should be tuned if improvingRate is ever used for something else
                     var improvingFactor = improvingRate * (Configuration.EngineSettings.RFP_ImprovingFactor * depth);
 
-                    var rfpThreshold = rfpMargin + improvingFactor;
+                    // Corrplexity idea by Potential author
+                    var corrplexity = Math.Abs(staticEval - rawStaticEval);
+                    var corrplexityFactor = corrplexity >= Configuration.EngineSettings.RFP_Corrplexity_Margin
+                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor * corrplexity
+                        : 0;
+
+                    var rfpThreshold = rfpMargin + improvingFactor + corrplexityFactor;
 
                     if (staticEval - rfpThreshold >= beta)
                     {


### PR DESCRIPTION
Margin 90, factor 20 * corr
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -4.91 +/- 7.14, nElo: -7.87 +/- 11.45
LOS: 8.89 %, DrawRatio: 44.35 %, PairsRatio: 0.92
Games: 3540, Wins: 895, Losses: 945, Draws: 1700, Points: 1745.0 (49.29 %)
Ptnml(0-2): [71, 441, 785, 413, 60], WL/DD Ratio: 0.86
LLR: -1.45 (-64.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

Margin 90, factor 20 (~original Eren impl)
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -3.29 +/- 4.94, nElo: -5.19 +/- 7.81
LOS: 9.61 %, DrawRatio: 44.19 %, PairsRatio: 0.93
Games: 7608, Wins: 2010, Losses: 2082, Draws: 3516, Points: 3768.0 (49.53 %)
Ptnml(0-2): [153, 946, 1681, 868, 156], WL/DD Ratio: 0.98
LLR: -2.25 (-100.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
Finished match
Total Time: 06:14:16 (hours:minutes:seconds)
```