### PR TITLE
🔍 RFP: corrplexity factor II

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -321,11 +321,7 @@ public sealed class EngineSettings
 
     //[SPSA<int>(50, 250, 20)] // TODO
     [SPSA<double>(enabled: false)]
-    public int RFP_Corrplexity_Margin { get; set; } = 90;
-
-    //[SPSA<int>(0, 50, 5)] // TODO
-    [SPSA<double>(enabled: false)]
-    public int RFP_Corrplexity_Factor { get; set; } = 20;
+    public int RFP_Corrplexity_Divisor { get; set; } = 10;
 
     //[SPSA<int>(1, 300, 15)]
     //public int RFP_DepthScalingFactor { get; set; } = 55;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -319,6 +319,14 @@ public sealed class EngineSettings
     [SPSA<double>(enabled: false)]
     public double RFP_ImprovingFactor { get; set; } = 0.75;
 
+    //[SPSA<int>(50, 250, 20)] // TODO
+    [SPSA<double>(enabled: false)]
+    public int RFP_Corrplexity_Margin { get; set; } = 90;
+
+    //[SPSA<int>(0, 50, 5)] // TODO
+    [SPSA<double>(enabled: false)]
+    public int RFP_Corrplexity_Factor { get; set; } = 20;
+
     //[SPSA<int>(1, 300, 15)]
     //public int RFP_DepthScalingFactor { get; set; } = 55;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -210,7 +210,7 @@ public sealed partial class Engine
                     // Corrplexity idea by Potential author
                     var corrplexity = Math.Abs(staticEval - rawStaticEval);
                     var corrplexityFactor = corrplexity >= Configuration.EngineSettings.RFP_Corrplexity_Margin
-                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor * corrplexity
+                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor
                         : 0;
 
                     var rfpThreshold = rfpMargin + improvingFactor + corrplexityFactor;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -207,7 +207,13 @@ public sealed partial class Engine
                     // RFP_ImprovingFactor should be tuned if improvingRate is ever used for something else
                     var improvingFactor = improvingRate * (Configuration.EngineSettings.RFP_ImprovingFactor * depth);
 
-                    var rfpThreshold = rfpMargin + improvingFactor;
+                    // Corrplexity idea by Potential author
+                    var corrplexity = Math.Abs(staticEval - rawStaticEval);
+                    var corrplexityFactor = corrplexity >= Configuration.EngineSettings.RFP_Corrplexity_Margin
+                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor * corrplexity
+                        : 0;
+
+                    var rfpThreshold = rfpMargin + improvingFactor + corrplexityFactor;
 
                     if (staticEval - rfpThreshold >= beta)
                     {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -209,9 +209,7 @@ public sealed partial class Engine
 
                     // Corrplexity idea by Potential author
                     var corrplexity = Math.Abs(staticEval - rawStaticEval);
-                    var corrplexityFactor = corrplexity >= Configuration.EngineSettings.RFP_Corrplexity_Margin
-                        ? Configuration.EngineSettings.RFP_Corrplexity_Factor
-                        : 0;
+                    var corrplexityFactor = corrplexity / Configuration.EngineSettings.RFP_Corrplexity_Divisor;
 
                     var rfpThreshold = rfpMargin + improvingFactor + corrplexityFactor;
 


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/1925 for original impl

/10
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -0.60 +/- 3.28, nElo: -0.96 +/- 5.24
LOS: 36.05 %, DrawRatio: 44.51 %, PairsRatio: 0.98
Games: 16880, Wins: 4457, Losses: 4486, Draws: 7937, Points: 8425.5 (49.91 %)
Ptnml(0-2): [314, 2046, 3757, 2001, 322], WL/DD Ratio: 0.93
LLR: -2.25 (-100.0%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```

/5
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -2.58 +/- 4.57, nElo: -4.21 +/- 7.45
LOS: 13.39 %, DrawRatio: 44.93 %, PairsRatio: 0.96
Games: 8346, Wins: 2171, Losses: 2233, Draws: 3942, Points: 4142.0 (49.63 %)
Ptnml(0-2): [146, 1027, 1875, 993, 132], WL/DD Ratio: 0.95
LLR: -2.25 (-100.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```

/20
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -5.04 +/- 5.76, nElo: -8.08 +/- 9.23
LOS: 4.31 %, DrawRatio: 44.84 %, PairsRatio: 0.92
Games: 5446, Wins: 1394, Losses: 1473, Draws: 2579, Points: 2683.5 (49.27 %)
Ptnml(0-2): [113, 668, 1221, 627, 94], WL/DD Ratio: 0.90
LLR: -2.27 (-100.8%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```