### PR TITLE
Bump NLog to v6

### DIFF
--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.7" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -76,21 +76,18 @@
         "type": "File",
         "layout": "${time}|${uppercase:${level}}|${logger:shortName=true}|${message} ${exception:format=tostring}",
         "fileName": "${logDirectory}/errors-${date:format=yyyy-MM-dd}-${processid}.log",
-        "concurrentWrites": true,
         "keepFileOpen": false
       },
       "logs": {
         "type": "File",
         "layout": "${time}|${uppercase:${level}}|${logger:shortName=true}|${message} ${exception:format=tostring}",
         "fileName": "${logDirectory}/logs-${date:format=yyyy-MM-dd}-${processid}.log",
-        "concurrentWrites": true,
         "keepFileOpen": false
       },
       "debug": {
         "type": "File",
         "layout": "${time}|${uppercase:${level}}|${logger:shortName=true}|${message} ${exception:format=tostring}",
         "fileName": "${logDirectory}/debug.log",
-        "concurrentWrites": true,
         "keepFileOpen": false,
         "deleteOldFileOnStartup": true
       },
@@ -98,7 +95,6 @@
         "type": "File",
         "layout": "${message}",
         "fileName": "${logDirectory}/moves-${date:format=yyyy-MM-dd}-${processid}.log",
-        "concurrentWrites": true,
         "keepFileOpen": false
       },
       "console": {

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.7" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.7" />
-    <PackageReference Include="NLog" Version="5.4.0" />
+    <PackageReference Include="NLog" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -161,12 +161,9 @@ public sealed partial class Engine
                     alpha = Math.Clamp(lastSearchResult.Score - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
                     beta = Math.Clamp(lastSearchResult.Score + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
 
-                    if (_logger.IsEnabled(logLevel))
-                    {
-                        _logger.Log(logLevel,
-                            "[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
-                            _id, depth, alpha, beta, lastSearchResult.Score, _nodes);
-                    }
+                    _logger.Log(logLevel,
+                        "[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
+                        _id, depth, alpha, beta, lastSearchResult.Score, _nodes);
 
                     Debug.Assert(
                         lastSearchResult.Mate == 0
@@ -178,12 +175,9 @@ public sealed partial class Engine
                         var depthToSearch = depth - failHighReduction;
                         Debug.Assert(depthToSearch > 0);
 
-                        if (_logger.IsEnabled(logLevel))
-                        {
-                            _logger.Log(logLevel,
-                            "[#{EngineId}] Asp-win depth {Depth} ({DepthWithoutReduction} - {Reduction}), window {Window}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                            _id, depthToSearch, depth, failHighReduction, window, alpha, beta, bestScore, _nodes);
-                        }
+                        _logger.Log(logLevel,
+                        "[#{EngineId}] Asp-win depth {Depth} ({DepthWithoutReduction} - {Reduction}), window {Window}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
+                        _id, depthToSearch, depth, failHighReduction, window, alpha, beta, bestScore, _nodes);
 
                         bestScore = NegaMax(depth: depthToSearch, ply: 0, alpha, beta, cutnode: false, cancellationToken);
                         Debug.Assert(bestScore > EvaluationConstants.MinEval && bestScore < EvaluationConstants.MaxEval);
@@ -290,14 +284,11 @@ public sealed partial class Engine
                 : LogLevel.Off;
 #endif
 
-            if (_logger.IsEnabled(logLevel))
-            {
 #pragma warning disable S6667 // Logging in a catch clause should pass the caught exception as a parameter - expected exception we want to ignore
-                _logger.Log(higherLogLevel,
-                    "[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
-                    _id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
+            _logger.Log(higherLogLevel,
+                "[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
+                _id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
 #pragma warning restore S6667 // Logging in a catch clause should pass the caught exception as a parameter.
-            }
 
             for (int i = 0; i < lastSearchResult?.Moves.Length; ++i)
             {
@@ -359,49 +350,34 @@ public sealed partial class Engine
 
             var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
 
-            if (_logger.IsEnabled(logLevel))
-            {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
-                    _id, depth - 1, mate, bestScore, winningMateThreshold);
-            }
+            _logger.Log(logLevel,
+                "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+                _id, depth - 1, mate, bestScore, winningMateThreshold);
 
             if (!isPondering && (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold))
             {
                 if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
                 {
-                    if (_logger.IsEnabled(logLevel))
-                    {
-                        _logger.Log(logLevel,
-                            "[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
-                            _id, _searchConstraints.SoftLimitTimeBound);
-                    }
+                    _logger.Log(logLevel,
+                        "[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
+                        _id, _searchConstraints.SoftLimitTimeBound);
 
                     return false;
                 }
 
-                if (_logger.IsEnabled(logLevel))
-                {
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] Could stop search, since mate is short enough",
-                        _id, _searchConstraints.SoftLimitTimeBound);
-                }
+                _logger.Log(logLevel,
+                    "[#{EngineId}] Could stop search, since mate is short enough",
+                    _id, _searchConstraints.SoftLimitTimeBound);
             }
 
-            if (_logger.IsEnabled(logLevel))
-            {
-                _logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
-            }
+            _logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
         }
 
         if (depth >= Configuration.EngineSettings.MaxDepth)
         {
-            if (_logger.IsEnabled(logLevel))
-            {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Max depth reached: {MaxDepth}",
-                    _id, Configuration.EngineSettings.MaxDepth);
-            }
+            _logger.Log(logLevel,
+                "[#{EngineId}] Max depth reached: {MaxDepth}",
+                _id, Configuration.EngineSettings.MaxDepth);
 
             return false;
         }
@@ -413,12 +389,9 @@ public sealed partial class Engine
 
             if (!shouldContinue)
             {
-                if (_logger.IsEnabled(logLevel))
-                {
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
-                        _id, depth - 1);
-                }
+                _logger.Log(logLevel,
+                    "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
+                    _id, depth - 1);
             }
 
             return shouldContinue;
@@ -431,21 +404,15 @@ public sealed partial class Engine
             var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
             var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
 
-            if (_logger.IsEnabled(logLevel))
-            {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
-                    _id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
-            }
+            _logger.Log(logLevel,
+                "[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
+                _id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
             if (elapsedMilliseconds > scaledSoftLimitTimeBound)
             {
-                if (_logger.IsEnabled(logLevel))
-                {
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
-                        _id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
-                }
+                _logger.Log(logLevel,
+                    "[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
+                    _id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
 
                 return false;
             }


### PR DESCRIPTION
Relevant changes, from https://nlog-project.org/2025/04/29/nlog-6-0-major-changes.html:

> - NLog FileTarget without `ConcurrentWrites`
>   NLog FileTarget no longer supports ConcurrentWrites-option, where multiple processes running on the same machine can write to the same file with help from global operating-system-mutex.
> - NLog Logger API with ReadOnlySpan
>   NLog Logger API now supports params ReadOnlySpan and can skip params object[]-allocation, when many parameters and LogLevel is not enabled.
> 
>   NET9 introduced C# v13 that supports params ReadOnlySpan, which is now supported by NLog for NetStandard2.1.
> 
>   NLog extends the optimization to completely skip the params object[]-allocation, when using message-templates and it is not possible to defer the parsing of the message-template on background thread.

This allows us to revert #1658

```
Test  | bump-nlog-v6
Elo   | 0.52 +- 2.91 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [-5.00, 0.00]
Games | 21224: +5986 -5954 =9284
Penta | [412, 2447, 4860, 2483, 410]
https://openbench.lynx-chess.com/test/2008/
```