### PR TITLE
NLog console configuration: remove word highlighting

### DIFF
--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -32,5 +32,436 @@
         "writeTo": "console"
       }
     }
+
+
+    //,"targets": {
+    //  "console": {
+    //    "wordHighlightingRules": [
+    //      {
+    //        "Text": "[Lynx]",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": true,
+    //        "WholeWords": false
+    //      },
+    //      {
+    //        "Text": "Lynx",
+    //        "foregroundColor": "DarkGreen",
+    //        "IgnoreCase": true,
+    //        "WholeWords": false
+    //      },
+
+    //      // UCI GUI commands
+    //      {
+    //        "Text": "[GUI]",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "debug",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "go",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "isready",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "ponderhit",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "position",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "quit",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "register",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "setoption",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "stop",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "uci",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "ucinewgame",
+    //        "foregroundColor": "Blue",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+
+    //      // UCI GUI subcommands
+    //      {
+    //        "Text": "searchmoves",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "ponder",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "wtime",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "btime",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "winc",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "binc",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "movestogo",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "depth",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "mate",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "movetime",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "infinite",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "startpos",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "fen",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "moves",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "later",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "name",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "value",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "type",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "min",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "max",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "default",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "author",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "code",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+
+    //      // UCI engine commands
+    //      {
+    //        "Text": "bestmove",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "copyprotection",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "id",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "info",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "option",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "readyok",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "registration",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "uciok",
+    //        "foregroundColor": "Green",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+
+    //      // UCI Engine subcommands
+    //      {
+    //        "Text": "checking",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "ok",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "error",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "seldepth",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "depth",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "time",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "nodes",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": true,
+    //        "WholeWords": false
+    //      },
+    //      {
+    //        "Text": "pv",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "multipv",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "score",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "cp",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "mate",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "lowerbound",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "upperbound",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "currmove",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "currmovenumber",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "hashfull",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "nps",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "tbhits",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "cpuload",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "string",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "refutation",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "currline",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      },
+    //      {
+    //        "Text": "wdl",
+    //        "foregroundColor": "DarkMagenta",
+    //        "IgnoreCase": false,
+    //        "WholeWords": true
+    //      }
+    //    ]
+    //  }
+    //}
+
   }
 }

--- a/src/Lynx.Cli/appsettings.Development.json
+++ b/src/Lynx.Cli/appsettings.Development.json
@@ -31,437 +31,434 @@
         "minLevel": "Debug",
         "writeTo": "console"
       }
+    },
+    "targets": {
+      "console": {
+        "wordHighlightingRules": [
+          {
+            "Text": "[Lynx]",
+            "foregroundColor": "Green",
+            "IgnoreCase": true,
+            "WholeWords": false
+          },
+          {
+            "Text": "Lynx",
+            "foregroundColor": "DarkGreen",
+            "IgnoreCase": true,
+            "WholeWords": false
+          },
+
+          // UCI GUI commands
+          {
+            "Text": "[GUI]",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "debug",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "go",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "isready",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "ponderhit",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "position",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "quit",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "register",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "setoption",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "stop",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "uci",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "ucinewgame",
+            "foregroundColor": "Blue",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+
+          // UCI GUI subcommands
+          {
+            "Text": "searchmoves",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "ponder",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "wtime",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "btime",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "winc",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "binc",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "movestogo",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "depth",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "mate",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "movetime",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "infinite",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "startpos",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "fen",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "moves",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "later",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "name",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "value",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "type",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "min",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "max",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "default",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "author",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "code",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+
+          // UCI engine commands
+          {
+            "Text": "bestmove",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "copyprotection",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "id",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "info",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "option",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "readyok",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "registration",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "uciok",
+            "foregroundColor": "Green",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+
+          // UCI Engine subcommands
+          {
+            "Text": "checking",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "ok",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "error",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "seldepth",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "depth",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "time",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "nodes",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": true,
+            "WholeWords": false
+          },
+          {
+            "Text": "pv",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "multipv",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "score",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "cp",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "mate",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "lowerbound",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "upperbound",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "currmove",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "currmovenumber",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "hashfull",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "nps",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "tbhits",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "cpuload",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "string",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "refutation",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "currline",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          },
+          {
+            "Text": "wdl",
+            "foregroundColor": "DarkMagenta",
+            "IgnoreCase": false,
+            "WholeWords": true
+          }
+        ]
+      }
     }
-
-
-    //,"targets": {
-    //  "console": {
-    //    "wordHighlightingRules": [
-    //      {
-    //        "Text": "[Lynx]",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": true,
-    //        "WholeWords": false
-    //      },
-    //      {
-    //        "Text": "Lynx",
-    //        "foregroundColor": "DarkGreen",
-    //        "IgnoreCase": true,
-    //        "WholeWords": false
-    //      },
-
-    //      // UCI GUI commands
-    //      {
-    //        "Text": "[GUI]",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "debug",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "go",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "isready",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "ponderhit",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "position",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "quit",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "register",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "setoption",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "stop",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "uci",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "ucinewgame",
-    //        "foregroundColor": "Blue",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-
-    //      // UCI GUI subcommands
-    //      {
-    //        "Text": "searchmoves",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "ponder",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "wtime",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "btime",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "winc",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "binc",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "movestogo",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "depth",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "mate",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "movetime",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "infinite",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "startpos",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "fen",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "moves",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "later",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "name",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "value",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "type",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "min",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "max",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "default",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "author",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "code",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-
-    //      // UCI engine commands
-    //      {
-    //        "Text": "bestmove",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "copyprotection",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "id",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "info",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "option",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "readyok",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "registration",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "uciok",
-    //        "foregroundColor": "Green",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-
-    //      // UCI Engine subcommands
-    //      {
-    //        "Text": "checking",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "ok",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "error",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "seldepth",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "depth",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "time",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "nodes",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": true,
-    //        "WholeWords": false
-    //      },
-    //      {
-    //        "Text": "pv",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "multipv",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "score",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "cp",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "mate",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "lowerbound",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "upperbound",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "currmove",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "currmovenumber",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "hashfull",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "nps",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "tbhits",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "cpuload",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "string",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "refutation",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "currline",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      },
-    //      {
-    //        "Text": "wdl",
-    //        "foregroundColor": "DarkMagenta",
-    //        "IgnoreCase": false,
-    //        "WholeWords": true
-    //      }
-    //    ]
-    //  }
-    //}
-
   }
 }

--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -122,32 +122,6 @@
             "condition": "level == LogLevel.Debug",
             "foregroundColor": "DarkGray"
           }
-        ],
-        "wordHighlightingRules": [
-          {
-            "regex": "Lynx\\.[^\\s:(|]*",
-            "foregroundColor": "DarkGreen"
-          },
-          {
-            "regex": "\\[GUI\\]|debug|go|isready|ponderhit|position|quit|register|setoption|stop|uci|ucinewgame",
-            "foregroundColor": "Blue",
-            "condition": "level == LogLevel.Debug"
-          },
-          {
-            "regex": "searchmoves|ponder|wtime|btime|winc|binc|movestogo|depth|mate|movetime|infinite|startpos|fen|moves|later|name|author|code",
-            "foregroundColor": "DarkMagenta",
-            "condition": "level == LogLevel.Debug"
-          },
-          {
-            "regex": "\\[Lynx\\]|bestmove|copyprotection|id|info|option|readyok|registration|uciok",
-            "foregroundColor": "Green",
-            "condition": "level == LogLevel.Debug"
-          },
-          {
-            "regex": "checking|ok|error|seldepth|depth|time|nodes|pv|multipv|score|cp|mate|lowerbound|upperbound|currmove|currmovenumber|hashfull|nps|tbhits|cpuload|string|refutation|currline|wdl",
-            "foregroundColor": "DarkMagenta",
-            "condition": "level == LogLevel.Debug"
-          }
         ]
       }
     }


### PR DESCRIPTION
After NLog v6 update, regex isn't supported and individual words need to be used.

However, that's not something actually useful anyway (or use without debug mode), so moving the transformed config code to `appsettings.Development.json`.