### PR TITLE
🔍 SPSA 2025-5-10 - including TM tuning

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -146,13 +146,13 @@ public sealed class EngineSettings
     public double HardTimeBoundMultiplier { get; set; } = 0.52;
 
     [SPSA<double>(1.0, 2.0, 0.05)]
-    public double MoveDivisor { get; set; } = 1.41;
+    public double MoveDivisor { get; set; } = 1.50;
 
     [SPSA<double>(enabled: false)]
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
     [SPSA<double>(0.5, 1, 0.025)]
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.84;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.80;
 
     [SPSA<double>(1, 3, 0.1)]
     public double NodeTmBase { get; set; } = 2.56;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -142,13 +142,16 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int MinSearchTime { get; set; } = 50;
 
-    [SPSA<double>(enabled: false)]
+    [SPSA<double>(0.25, 0.75, 0.025)]
     public double HardTimeBoundMultiplier { get; set; } = 0.52;
+
+    [SPSA<double>(1.0, 2.0, 0.05)]
+    public double MoveDivisor { get; set; } = 1.5;
 
     [SPSA<double>(enabled: false)]
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
-    [SPSA<double>(enabled: false)]
+    [SPSA<double>(0.5, 1, 0.025)]
     public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
 
     [SPSA<double>(1, 3, 0.1)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -143,22 +143,22 @@ public sealed class EngineSettings
     public int MinSearchTime { get; set; } = 50;
 
     [SPSA<double>(0.25, 0.75, 0.025)]
-    public double HardTimeBoundMultiplier { get; set; } = 0.52;
+    public double HardTimeBoundMultiplier { get; set; } = 0.51;
 
     [SPSA<double>(1.0, 2.0, 0.05)]
-    public double MoveDivisor { get; set; } = 1.50;
+    public double MoveDivisor { get; set; } = 1.40;
 
     [SPSA<double>(enabled: false)]
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
     [SPSA<double>(0.5, 1, 0.025)]
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.80;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.81;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double NodeTmBase { get; set; } = 2.56;
+    public double NodeTmBase { get; set; } = 2.74;
 
     [SPSA<double>(0.5, 2.5, 0.1)]
-    public double NodeTmScale { get; set; } = 1.66;
+    public double NodeTmScale { get; set; } = 1.80;
 
     [SPSA<int>(enabled: false)]
     public int ScoreStabiity_MinDepth { get; set; } = 7;
@@ -186,67 +186,67 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.38;
+    public double LMR_Base_Quiet { get; set; } = 0.20;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.23;
+    public double LMR_Base_Noisy { get; set; } = 0.21;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 4.02;
+    public double LMR_Divisor_Quiet { get; set; } = 4.31;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.37;
+    public double LMR_Divisor_Noisy { get; set; } = 2.25;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 64;
+    public int LMR_Improving { get; set; } = 93;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 78;
+    public int LMR_Cutnode { get; set; } = 109;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 64;
+    public int LMR_TTPV { get; set; } = 40;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 114;
+    public int LMR_TTCapture { get; set; } = 202;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 57;
+    public int LMR_PVNode { get; set; } = 45;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 96;
+    public int LMR_InCheck { get; set; } = 104;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 84;
+    public int LMR_Quiet { get; set; } = 78;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity { get; set; } = 125;
+    public int LMR_Corrplexity { get; set; } = 197;
 
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity_Delta { get; set; } = 90;
+    public int LMR_Corrplexity_Delta { get; set; } = 124;
 
     [SPSA<int>(enabled: false)]
     public int History_MinDepth { get; set; } = 3;
@@ -258,16 +258,16 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 2950;
+    public int LMR_History_Divisor_Quiet { get; set; } = 3540;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 7211;
+    public int LMR_History_Divisor_Noisy { get; set; } = 7706;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 74;
+    public int LMR_DeeperBase { get; set; } = 68;
 
     [SPSA<int>(enabled: false)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -290,7 +290,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 88;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 82;
 
     [SPSA<int>(enabled: false)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
@@ -299,7 +299,7 @@ public sealed class EngineSettings
     public int AspirationWindow_Base { get; set; } = 9;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double AspirationWindow_Multiplier { get; set; } = 1.16;
+    public double AspirationWindow_Multiplier { get; set; } = 1.29;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -308,17 +308,20 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(10, 150, 10)]
-    public int ImprovingRate { get; set; } = 59;
+    public int ImprovingRate { get; set; } = 53;
 
     [SPSA<int>(enabled: false)]
     public int RFP_MaxDepth { get; set; } = 9;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_Improving_Margin { get; set; } = 83;
+    public int RFP_Improving_Margin { get; set; } = 75;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_NotImproving_Margin { get; set; } = 112;
+    public int RFP_NotImproving_Margin { get; set; } = 117;
 
+    /// <summary>
+    /// Should be tuned only if improvingRate is ever used for something else
+    /// </summary>
     [SPSA<double>(enabled: false)]
     public double RFP_ImprovingFactor { get; set; } = 0.75;
 
@@ -329,10 +332,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 111;
+    public int Razoring_Depth1Bonus { get; set; } = 138;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 200;
+    public int Razoring_NotDepth1Bonus { get; set; } = 205;
 
     [SPSA<int>(enabled: false)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -347,34 +350,34 @@ public sealed class EngineSettings
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Bonus_MaxIncrement { get; set; } = 2106;
+    public int History_Bonus_MaxIncrement { get; set; } = 2440;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Constant { get; set; } = 147;
+    public int History_Bonus_Constant { get; set; } = 243;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Linear { get; set; } = 185;
+    public int History_Bonus_Linear { get; set; } = 178;
 
     [SPSA<int>(1, 10, 1)]
-    public int History_Bonus_Quadratic { get; set; } = 4;
+    public int History_Bonus_Quadratic { get; set; } = 3;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Malus_MaxDecrement { get; set; } = 1744;
+    public int History_Malus_MaxDecrement { get; set; } = 1473;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Constant { get; set; } = 186;
+    public int History_Malus_Constant { get; set; } = 220;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Linear { get; set; } = 218;
+    public int History_Malus_Linear { get; set; } = 253;
 
     [SPSA<int>(1, 10, 1)]
-    public int History_Malus_Quadratic { get; set; } = 6;
+    public int History_Malus_Quadratic { get; set; } = 7;
 
     [SPSA<int>(enabled: false)]
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 136;
+    public int History_BestScoreBetaMargin { get; set; } = 125;
 
     [SPSA<int>(enabled: false)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -383,16 +386,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 81;
+    public int FP_DepthScalingFactor { get; set; } = 76;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 84;
+    public int FP_Margin { get; set; } = 115;
 
     [SPSA<int>(enabled: false)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -3;
+    public int HistoryPrunning_Margin { get; set; } = -1506;
 
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -406,10 +409,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -36;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -46;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -102;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -111;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -427,31 +430,31 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 107;
+    public int CorrHistoryWeight_Pawn { get; set; } = 87;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 49;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 74;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 117;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 115;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 149;
+    public int CorrHistoryWeight_Minor { get; set; } = 176;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Major { get; set; } = 150;
+    public int CorrHistoryWeight_Major { get; set; } = 179;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
@@ -469,7 +472,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 4;
+    public int SE_DoubleExtensions_Margin { get; set; } = 1;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -146,13 +146,13 @@ public sealed class EngineSettings
     public double HardTimeBoundMultiplier { get; set; } = 0.52;
 
     [SPSA<double>(1.0, 2.0, 0.05)]
-    public double MoveDivisor { get; set; } = 1.5;
+    public double MoveDivisor { get; set; } = 1.41;
 
     [SPSA<double>(enabled: false)]
     public double SoftTimeBoundMultiplier { get; set; } = 1;
 
     [SPSA<double>(0.5, 1, 0.025)]
-    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.8;
+    public double SoftTimeBaseIncrementMultiplier { get; set; } = 0.84;
 
     [SPSA<double>(1, 3, 0.1)]
     public double NodeTmBase { get; set; } = 2.56;

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -182,7 +182,7 @@ public static class TimeManager
     /// <returns></returns>
     private static int MovesDivisor(int expectedMovesLeft)
     {
-        return expectedMovesLeft * 3 / 2;
+        return (int)(expectedMovesLeft * Configuration.EngineSettings.MoveDivisor);
     }
 
     /// <summary>


### PR DESCRIPTION
4d17c3b4386ec63575c9e4ecc76f78a2a75954b0: wasn't looking that great by itself
```
Test  | tm/tunable-1
Elo   | -0.10 +- 6.28 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.14 (-2.25, 2.89) [0.00, 3.00]
Games | 3404: +811 -812 =1781
Penta | [21, 404, 858, 393, 26]
https://openbench.lynx-chess.com/test/1994/
```

095ded471a178283f4ddc441e128f414f0cf220e:
```
Test  | tm/tunable-1
Elo   | 9.76 +- 4.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 7368: +1921 -1714 =3733
Penta | [62, 801, 1765, 980, 76]
https://openbench.lynx-chess.com/test/2027/
```
