### PR TITLE
🔍 TT replacement depth offset 4

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -390,6 +390,15 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Step { get; set; } = 10;
 
+    [SPSA<int>(enabled: false)]
+    public int SE_MinDepth { get; set; } = 7;
+
+    [SPSA<int>(enabled: false)]
+    public int SE_TTDepthOffset { get; set; } = 3;
+
+    [SPSA<int>(enabled: false)]
+    public int SE_DepthMultiplier { get; set; } = 1;
+
     #endregion
 }
 


### PR DESCRIPTION
```
Test  | search/tt-replacement-depth-offset
Elo   | -2.16 +- 4.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 5.00]
Games | 9170: +2426 -2483 =4261
Penta | [165, 1077, 2148, 1040, 155]
https://openbench.lynx-chess.com/test/1741/
```