### PR TITLE
 🔍SE: don't correct eval when verifying SE

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -181,8 +181,13 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CorrectStaticEvaluation(Position position, int staticEvaluation)
+    private int CorrectStaticEvaluation(Position position, int staticEvaluation, bool isVerifyingSE)
     {
+        if (isVerifyingSE)
+        {
+            return staticEvaluation;
+        }
+
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -160,14 +160,14 @@ public sealed partial class Engine
                 Debug.Assert(ttStaticEval != int.MinValue);
 
                 rawStaticEval = ttStaticEval;
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, isVerifyingSE);
                 phase = position.Phase();
             }
             else
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable);
                 _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, isVerifyingSE);
             }
 
             stack.StaticEval = staticEval;
@@ -277,7 +277,7 @@ public sealed partial class Engine
         else
         {
             rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
-            staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+            staticEval = CorrectStaticEvaluation(position, rawStaticEval, isVerifyingSE);
 
             if (!ttHit)
             {
@@ -758,7 +758,7 @@ public sealed partial class Engine
         var rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable).Score;
         Debug.Assert(rawStaticEval != EvaluationConstants.NoHashEntry, "Assertion failed", "All TT entries should have a static eval");
 
-        var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+        var staticEval = CorrectStaticEvaluation(position, rawStaticEval, isVerifyingSE: false);
 
         ref var stack = ref Game.Stack(ply);
         stack.StaticEval = staticEval;


### PR DESCRIPTION
```
Test  | search/se-no-eval-correction
Elo   | 0.20 +- 2.86 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.53 (-2.25, 2.89) [0.00, 3.00]
Games | 18666: +4461 -4450 =9755
Penta | [199, 2253, 4431, 2238, 212]
https://openbench.lynx-chess.com/test/1735/
```