### PR TITLE
🔍 Move ordering: penalize moves what bring pieces to attacked squares

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -192,6 +192,8 @@ public static class EvaluationConstants
     /// </summary>
     public const int BaseMoveScore = int.MinValue / 2;
 
+    public const int EvadeCaptureMoveBonus = 32_768;
+
     #endregion
 
     public const int ContinuationHistoryPlyCount = 1;

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -192,7 +192,11 @@ public static class EvaluationConstants
     /// </summary>
     public const int BaseMoveScore = int.MinValue / 2;
 
-    public const int EvadeCaptureMoveBonus = 32_768;
+    /// <summary>
+    /// Value that compensates any history, positive or negative (hence the x2)
+    /// 32_768
+    /// </summary>
+    public static readonly int EvadeCaptureMoveBonus = Configuration.EngineSettings.History_MaxMoveValue * 2 * (1 + ContinuationHistoryPlyCount);
 
     #endregion
 

--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -192,11 +192,7 @@ public static class EvaluationConstants
     /// </summary>
     public const int BaseMoveScore = int.MinValue / 2;
 
-    /// <summary>
-    /// Value that compensates any history, positive or negative (hence the x2)
-    /// 32_768
-    /// </summary>
-    public static readonly int EvadeCaptureMoveBonus = Configuration.EngineSettings.History_MaxMoveValue * 2 * (1 + ContinuationHistoryPlyCount);
+    public static readonly int EvadeCaptureMoveMalus = -1024;
 
     #endregion
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -588,7 +588,7 @@ public sealed partial class Engine
         Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], 0, ttBestMove);
+            moveScores[i] = ScoreMove(evaluationContext, pseudoLegalMoves[i], 0, ttBestMove);
         }
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -41,12 +41,14 @@ public sealed partial class Engine
             }
 
             var targetSquare = move.TargetSquare();
+            var piece = move.Piece();
             int bonus = 0;
 
+            // Bonus for avoiding a capture threat
             var oppositeSideAttacks = evaluationContext.Attacks[Utils.OppositeSide(Game.CurrentPosition.Side)];
             if (oppositeSideAttacks.GetBit(move.SourceSquare()) && !oppositeSideAttacks.GetBit(targetSquare))
             {
-                bonus = EvadeCaptureMoveBonus;
+                bonus = EvadeCaptureMoveBonus + piece;
             }
 
             if (ply >= 1)
@@ -59,14 +61,14 @@ public sealed partial class Engine
 
                 // Counter move history
                 return BaseMoveScore
-                    + _quietHistory[move.Piece()][targetSquare]
-                    + ContinuationHistoryEntry(move.Piece(), targetSquare, ply - 1)
+                    + _quietHistory[piece][targetSquare]
+                    + ContinuationHistoryEntry(piece, targetSquare, ply - 1)
                     + bonus;
             }
 
             // History move or 0 if not found
             return BaseMoveScore
-                + _quietHistory[move.Piece()][targetSquare]
+                + _quietHistory[piece][targetSquare]
                 + bonus;
         }
 

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -45,10 +45,12 @@ public sealed partial class Engine
             int bonus = 0;
 
             // Bonus for avoiding a capture threat
-            var oppositeSideAttacks = evaluationContext.Attacks[Utils.OppositeSide(Game.CurrentPosition.Side)];
-            if (oppositeSideAttacks.GetBit(move.SourceSquare()) && !oppositeSideAttacks.GetBit(targetSquare))
+            var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide(Game.CurrentPosition.Side)];
+
+            if (!oppositeSideAttacks.GetBit(move.SourceSquare())
+                && oppositeSideAttacks.GetBit(targetSquare))
             {
-                bonus = EvadeCaptureMoveBonus + piece;
+                bonus = EvadeCaptureMoveMalus - piece;
             }
 
             if (ply >= 1)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -306,7 +306,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(evaluationContext, pseudoLegalMoves[i], ply, ttBestMove);
         }
 
         var nodeType = NodeType.Alpha;


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -5.79 +/- 7.02, nElo: -9.21 +/- 11.17
LOS: 5.29 %, DrawRatio: 43.41 %, PairsRatio: 0.89
Games: 3718, Wins: 945, Losses: 1007, Draws: 1766, Points: 1828.0 (49.17 %)
Ptnml(0-2): [70, 487, 807, 425, 70], WL/DD Ratio: 0.89
LLR: -1.70 (-75.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```