### PR TITLE
🔍 Simplify search/inCheck

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -152,7 +152,7 @@ public sealed partial class Engine
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, finalPositionEvaluation, depth, ply, finalPositionEvaluation, NodeType.Exact, ttPv);
             return finalPositionEvaluation;
         }
-        else if (!pvNode && !isInCheck)
+        else if (!pvNode)
         {
             if (ttElementType != NodeType.Unknown)   // Equivalent to ttHit || ttElementType == NodeType.None
             {
@@ -191,7 +191,7 @@ public sealed partial class Engine
             bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
             // Fail-high pruning (moves with high scores) - prune more when improving
-            if (isNotGettingCheckmated)
+            if (!isInCheck && isNotGettingCheckmated)
             {
                 if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
                 {


### PR DESCRIPTION
```
Test  | search/in-check
Elo   | -2.94 +- 4.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 5.00]
Games | 7328: +1768 -1830 =3730
Penta | [93, 934, 1679, 858, 100]
https://openbench.lynx-chess.com/test/1731/
```