### PR TITLE
🧪🔍 Use TT score as static eval for razoring

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -185,15 +185,17 @@ public sealed partial class Engine
                 improvingRate = evalDiff / (double)Configuration.EngineSettings.ImprovingRate;
             }
 
+            var ttCorrectedStaticEval = staticEval;
+
             // From smol.cs
             // ttEvaluation can be used as a better positional evaluation:
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            //if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
-            //{
-            //    staticEval = ttScore;
-            //}
+            if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
+            {
+                ttCorrectedStaticEval = ttScore;
+            }
 
             bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
@@ -224,7 +226,7 @@ public sealed partial class Engine
                     // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
                     if (depth <= Configuration.EngineSettings.Razoring_MaxDepth)
                     {
-                        var score = staticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
+                        var score = ttCorrectedStaticEval + Configuration.EngineSettings.Razoring_Depth1Bonus;
 
                         if (score < beta)               // Static evaluation + bonus indicates fail-low node
                         {


### PR DESCRIPTION
vs main (cancelled)
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: 9.62 +/- 11.82, nElo: 15.39 +/- 18.89
LOS: 94.49 %, DrawRatio: 40.92 %, PairsRatio: 1.18
Games: 1300, Wins: 365, Losses: 329, Draws: 606, Points: 668.0 (51.38 %)
Ptnml(0-2): [19, 157, 266, 185, 23], WL/DD Ratio: 1.02
LLR: 0.67 (23.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

vs no using it at all
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -3.86 +/- 5.22, nElo: -6.20 +/- 8.40
LOS: 7.39 %, DrawRatio: 45.15 %, PairsRatio: 0.92
Games: 6578, Wins: 1708, Losses: 1781, Draws: 3089, Points: 3252.5 (49.45 %)
Ptnml(0-2): [121, 820, 1485, 737, 126], WL/DD Ratio: 0.94
LLR: -2.26 (-100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```