### PR TITLE
🧪🔍 Use TT score for checkmate detection

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -185,17 +185,19 @@ public sealed partial class Engine
                 improvingRate = evalDiff / (double)Configuration.EngineSettings.ImprovingRate;
             }
 
+            var ttCorrectedStaticEval = staticEval;
+
             // From smol.cs
             // ttEvaluation can be used as a better positional evaluation:
             // If the score is outside what the current bounds are, but it did match flag and depth,
             // then we can trust that this score is more accurate than the current static evaluation,
             // and we can update our static evaluation for better accuracy in pruning
-            //if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
-            //{
-            //    staticEval = ttScore;
-            //}
+            if (ttHit && ttElementType != (ttScore > staticEval ? NodeType.Alpha : NodeType.Beta))
+            {
+                ttCorrectedStaticEval = ttScore;
+            }
 
-            bool isNotGettingCheckmated = staticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
+            bool isNotGettingCheckmated = ttCorrectedStaticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
             // Fail-high pruning (moves with high scores) - prune more when improving
             if (isNotGettingCheckmated)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -199,7 +199,7 @@ public sealed partial class Engine
 
             bool isNotGettingCheckmated = ttCorrectedStaticEval > EvaluationConstants.NegativeCheckmateDetectionLimit;
 
-            if(isNotGettingCheckmated)
+            if (isNotGettingCheckmated)
             {
                 // Fail-high pruning (moves with high scores) - prune more when improving
                 if (depth <= Configuration.EngineSettings.RFP_MaxDepth)
@@ -218,9 +218,9 @@ public sealed partial class Engine
 
                     if (staticEval - rfpThreshold >= beta)
                     {
-    #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
+#pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
                         return (staticEval + beta) / 2;
-    #pragma warning restore S3949 // Calculations should not overflow
+#pragma warning restore S3949 // Calculations should not overflow
                     }
 
                     // 🔍 Razoring - Strelka impl (CPW) - https://www.chessprogramming.org/Razoring#Strelka
@@ -255,7 +255,7 @@ public sealed partial class Engine
                     }
                 }
             }
-          
+
             var staticEvalBetaDiff = staticEval - beta;
 
             // 🔍 Null Move Pruning (NMP) - our position is so good that we can potentially afford giving our opponent a double move and still remain ahead of beta


### PR DESCRIPTION
Since static score will never return checkmate anyway.

```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -3.87 +/- 5.21, nElo: -6.68 +/- 8.99
LOS: 7.26 %, DrawRatio: 50.35 %, PairsRatio: 0.93
Games: 5740, Wins: 1496, Losses: 1560, Draws: 2684, Points: 2838.0 (49.44 %)
Ptnml(0-2): [90, 649, 1445, 607, 79], WL/DD Ratio: 1.02
LLR: -2.28 (-101.1%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```