### PR TITLE
🔍 Don't reuse TT static eval on `NodeType.None` TT hits

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -161,7 +161,7 @@ public sealed partial class Engine
         }
         else if (!pvNode && !isInCheck && !isVerifyingSE)
         {
-            if (ttElementType != NodeType.Unknown)   // Equivalent to ttHit || ttElementType == NodeType.None
+            if (ttHit)
             {
                 Debug.Assert(ttStaticEval != int.MinValue);
 


### PR DESCRIPTION
This kinda makes no sense, since we save static evals as NodeType.None, but still