### PR TITLE
🐛 Ensure TT clearing on first `ucinewgame`, regardless of previous `go` commands

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -96,6 +96,7 @@ public sealed class Searcher
 
     private async Task OnGoCommand(GoCommand goCommand)
     {
+        _firstRun = false;
         _isProcessingGoCommand = true;
 
         if (!_absoluteSearchCancellationTokenSource.TryReset())


### PR DESCRIPTION
This fixes the case when:
- `go` commands are sent without a previous it `ucinewgame` hapenning beforehand
- `ucinewgame` is used, but doesn't clear the TT

Why couldn't UCI make `ucinewgame` compulsory. WHY?