### PR TITLE
🪣 TT buckets I

### DIFF
--- a/src/Lynx/Bench.cs
+++ b/src/Lynx/Bench.cs
@@ -123,6 +123,8 @@ public partial class Engine
             var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
             totalSeconds += elapsedSeconds;
             totalNodes += result.Nodes;
+
+            _tt.Age();
         }
 
         _engineWriter.TryWrite($"Total time: {Utils.CalculateUCITime(totalSeconds)}");

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -625,6 +625,8 @@ public static class Constants
     public const int MajorCorrHistoryHashMask = MajorCorrHistoryHashSize - 1;
 
     public const string NumberWithSignFormat = "+#;-#;0";
+
+    public const int TranspositionTableElementsPerBucket = 1;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -626,7 +626,7 @@ public static class Constants
 
     public const string NumberWithSignFormat = "+#;-#;0";
 
-    public const int TranspositionTableElementsPerBucket = 1;
+    public const int TranspositionTableElementsPerBucket = 3;
 }
 
 #pragma warning restore IDE0055

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -192,7 +192,7 @@ public struct TranspositionTable
         bool shouldReplace =
             entry.Key == 0                                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
-            //|| entry.Age != _age                                // Different age
+            || entry.Age != _age                                // Different age
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
                 //+ Configuration.EngineSettings.TTReplacement_DepthOffset

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -5,17 +5,19 @@ using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
 
 namespace Lynx.Model;
-public readonly struct TranspositionTable
+public struct TranspositionTable
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
-    private readonly TranspositionTableElement[] _tt = [];
+    private readonly TranspositionTableBucket[] _tt = [];
+
+    private int _age = 0;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
     public readonly int Size;
 #pragma warning restore CA1051 // Do not declare visible instance fields
 
-    public int Length => _tt.Length;
+    public readonly int Length => _tt.Length;
 
     public TranspositionTable()
     {
@@ -25,9 +27,16 @@ public readonly struct TranspositionTable
         Size = Configuration.EngineSettings.TranspositionTableSize;
 
         var ttLength = CalculateLength(Size);
-        _tt = GC.AllocateArray<TranspositionTableElement>(ttLength, pinned: true);
+        _tt = GC.AllocateArray<TranspositionTableBucket>(ttLength, pinned: true);
 
         _logger.Info("TT allocation time:\t{0} ms", sw.ElapsedMilliseconds);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Age()
+    {
+        // Circular buffer
+        _age = (_age + 1) & TranspositionTableElement.AgeMask;
     }
 
     /// <summary>
@@ -54,13 +63,17 @@ public readonly struct TranspositionTable
                 : sizePerThread;
 
             Array.Clear(tt, start, length);
+
+            // Clusters are 'magically' taken care of
         });
+
+        _age = 0;
 
         _logger.Info("TT clearing/zeroing time:\t{0} ms", sw.ElapsedMilliseconds);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void PrefetchTTEntry(Position position, int halfMovesWithoutCaptureOrPawnMove)
+    public readonly void PrefetchTTEntry(Position position, int halfMovesWithoutCaptureOrPawnMove)
     {
         if (Sse.IsSupported)
         {
@@ -71,7 +84,7 @@ public readonly struct TranspositionTable
                 // Since _tt is a pinned array
                 // This is no-op pinning as it does not influence the GC compaction
                 // https://tooslowexception.com/pinned-object-heap-in-net-5/
-                fixed (TranspositionTableElement* ttPtr = _tt)
+                fixed (TranspositionTableBucket* ttPtr = _tt)
                 {
                     Sse.Prefetch0(ttPtr + index);
                 }
@@ -95,21 +108,29 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public (int Score, ShortMove BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv) ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply)
+    public readonly (int Score, ShortMove BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv) ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply)
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
-        var entry = _tt[ttIndex];
+        var bucket = _tt[ttIndex];
 
-        if ((ushort)position.UniqueIdentifier != entry.Key)
+        // We simply take the first entry
+        for (int i = 0; i < Constants.TranspositionTableElementsPerBucket; ++i)
         {
-            return (EvaluationConstants.NoScore, default, default, EvaluationConstants.NoScore, default, default);
+            ref var entry = ref bucket[i];
+
+            if ((ushort)position.UniqueIdentifier != entry.Key)
+            {
+                continue;
+            }
+
+            // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
+            // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
+            var recalculatedScore = RecalculateMateScores(entry.Score, ply);
+
+            return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
         }
 
-        // We want to translate the checkmate position relative to the saved node to our root position from which we're searching
-        // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
-        var recalculatedScore = RecalculateMateScores(entry.Score, ply);
-
-        return (recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
+        return (EvaluationConstants.NoScore, default, default, EvaluationConstants.NoScore, default, default);
     }
 
     /// <summary>
@@ -117,12 +138,48 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void RecordHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, int depth, int ply, int score, NodeType nodeType, bool wasPv, Move? move = null)
+    public readonly void RecordHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, int depth, int ply, int score, NodeType nodeType, bool wasPv, Move? move = null)
     {
         Debug.Assert(nodeType != NodeType.Alpha || move is null, "Assertion failed", "There's no 'best move' on fail-lows, so TT one won't be overriden");
 
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
-        ref var entry = ref _tt[ttIndex];
+        ref var bucket = ref _tt[ttIndex];
+
+        ref TranspositionTableElement entry = ref bucket[0];
+
+        if (entry.Key != 0 || entry.Type != NodeType.None)
+        {
+            int minValue = int.MaxValue;
+
+            for (int i = 0; i < Constants.TranspositionTableElementsPerBucket; ++i)
+            {
+                ref var candidateEntry = ref bucket[i];
+
+                // Bucket policy to discard very old entries
+
+                // Always take an empty entry, or one with just static eval
+                if (entry.Key == 0 || nodeType == NodeType.None)
+                {
+                    entry = candidateEntry;
+                }
+
+                // Otherwise, take the entry with the lowest weight (calculated based on depth and age)
+                // Current formula from Stormphrax
+
+                // Another way ot doing:
+                // var ageDiff = age - entry.Age
+                // if (ageDiff <0) ageDiff += maxAge
+                var relativeAge = (_age - entry.Age + TranspositionTableElement.MaxAge) & TranspositionTableElement.AgeMask;
+
+                var value = entry.Depth - (2 * relativeAge);
+
+                if (value < minValue)
+                {
+                    minValue = value;
+                    entry = candidateEntry;
+                }
+            }
+        }
 
         //if (entry.Key != default && entry.Key != position.UniqueIdentifier)
         //{
@@ -131,9 +188,11 @@ public readonly struct TranspositionTable
 
         var wasPvInt = wasPv ? 1 : 0;
 
+        // Replacement policy
         bool shouldReplace =
             entry.Key == 0                                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
+            //|| entry.Age != _age                                // Different age
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth
                 //+ Configuration.EngineSettings.TTReplacement_DepthOffset
@@ -150,17 +209,29 @@ public readonly struct TranspositionTable
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
-        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
+        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move, _age);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv)
+    public readonly void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv)
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
-        ref var entry = ref _tt[ttIndex];
+        ref var bucket = ref _tt[ttIndex];
 
-        // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        for (int i = 0; i < Constants.TranspositionTableElementsPerBucket; ++i)
+        {
+            ref var entry = ref bucket[i];
+
+            // TODO test again
+            //if ((ushort)position.UniqueIdentifier != entry.Key)
+            //{
+            //    continue;
+            //}
+
+            // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
+            // TODO is this just OK for bucketing, overriding the first entry?
+            entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null, _age);
+        }
     }
 
     /// <summary>
@@ -168,7 +239,7 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <returns></returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public int HashfullPermill() => _tt.Length > 0
+    public readonly int HashfullPermill() => _tt.Length > 0
         ? (int)(1000L * PopulatedItemsCount() / _tt.LongLength)
         : 0;
 
@@ -185,23 +256,28 @@ public readonly struct TranspositionTable
         {
             for (int i = 0; i < 1_000; ++i)
             {
-                if (_tt[i].Key != default)
+                var bucket = _tt[i];
+                for(int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
                 {
-                    ++items;
+                    if (bucket[j].Key != default)
+                    {
+                        ++items;
+                    }
                 }
             }
         }
 
         //Console.WriteLine($"Real: {HashfullPermill(transpositionTable)}, estimated: {items}");
-        return items;
+        return items / Constants.TranspositionTableElementsPerBucket;
     }
 
     internal static int CalculateLength(int size)
     {
         var ttEntrySize = TranspositionTableElement.Size;
+        var ttBucketSize = TranspositionTableBucket.Size;
 
         ulong sizeBytes = (ulong)size * 1024ul * 1024ul;
-        ulong ttLength = sizeBytes / ttEntrySize;
+        ulong ttLength = sizeBytes / ttBucketSize;
         var ttLengthMb = (double)ttLength / 1024 / 1024;
 
         if (ttLength > (ulong)Array.MaxLength)
@@ -212,6 +288,7 @@ public readonly struct TranspositionTable
         _logger.Info("Hash value:\t{0} MB", size);
         _logger.Info("TT memory:\t{0} MB", (ttLengthMb * ttEntrySize).ToString("F"));
         _logger.Info("TT length:\t{0} items", ttLength);
+        _logger.Info("TT bucket:\t{0} bytes", ttBucketSize);
         _logger.Info("TT entry:\t{0} bytes", ttEntrySize);
 
         return (int)ttLength;
@@ -243,9 +320,13 @@ public readonly struct TranspositionTable
         int items = 0;
         for (int i = 0; i < _tt.Length; ++i)
         {
-            if (_tt[i].Key != default)
+            var bucket = _tt[i];
+            for (int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
             {
-                ++items;
+                if (bucket[j].Key != default)
+                {
+                    ++items;
+                }
             }
         }
 
@@ -253,35 +334,25 @@ public readonly struct TranspositionTable
     }
 
     [Obsolete("Only tests")]
-    internal ref TranspositionTableElement Get(int index) => ref _tt[index];
+    internal readonly ref TranspositionTableBucket Get(int index) => ref _tt[index];
 
     [Conditional("DEBUG")]
-    private void Stats()
+    private readonly void Stats()
     {
         int items = 0;
         for (int i = 0; i < _tt.Length; ++i)
         {
-            if (_tt[i].Key != default)
+            var bucket = _tt[i];
+            for (int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
             {
-                ++items;
+                if (bucket[j].Key != default)
+                {
+                    ++items;
+                }
             }
         }
         _logger.Info("TT Occupancy:\t{0}% ({1}MB)",
             100 * PopulatedItemsCount() / _tt.Length,
-            _tt.Length * Marshal.SizeOf<TranspositionTableElement>() / 1024 / 1024);
-    }
-
-    [Conditional("DEBUG")]
-    private readonly void Print()
-    {
-        Console.WriteLine("Transposition table content:");
-        for (int i = 0; i < _tt.Length; ++i)
-        {
-            if (_tt[i].Key != default)
-            {
-                Console.WriteLine($"{i}: Key = {_tt[i].Key}, Depth: {_tt[i].Depth}, Score: {_tt[i].Score}, Move: {(_tt[i].Move != 0 ? ((Move)_tt[i].Move).UCIString() : "-")} {_tt[i].Type}");
-            }
-        }
-        Console.WriteLine("");
+            _tt.Length * Marshal.SizeOf<TranspositionTableBucket>() / 1024 / 1024);
     }
 }

--- a/src/Lynx/Model/TranspositionTableBucket.cs
+++ b/src/Lynx/Model/TranspositionTableBucket.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Lynx.Model;
+
+[InlineArray(Constants.TranspositionTableElementsPerBucket)]
+public struct TranspositionTableBucket
+{
+#pragma warning disable S1144, RCS1213 // Unused private types or members should be removed
+    private TranspositionTableElement _ttEntry;
+#pragma warning restore S1144 // Unused private types or members should be removed
+
+    /// <summary>
+    /// Struct size in bytes
+    /// </summary>
+    public static ulong Size
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (ulong)Marshal.SizeOf<TranspositionTableBucket>();
+    }
+}

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
@@ -46,11 +47,21 @@ public struct TranspositionTableElement
     /// 1 byte
     /// Binary move bits    Hexadecimal
     /// 0000 0001              0x1           Was PV (0-1)
-    /// 0000 1110              0xE           NodeType (0-3)
+    /// 0000 1110              0xE           NodeType (0-4)
+    /// 1111 0000              0xE           NodeType (0-4)
     /// </summary>
-    private byte _type_WasPv;
+    private byte _age_type_WasPv;
 
     private const int NodeTypeOffset = 1;
+    private const int NodeTypeMask = 0xE;
+
+    private const int AgeOffset = 4;
+
+    /// <summary>
+    /// Max age, 15
+    /// </summary>
+    public const int MaxAge = 0xF0;
+    public const int AgeMask = MaxAge - 1 ;
 
     /// <summary>
     /// 16 MSB of Position's Zobrist key
@@ -106,13 +117,19 @@ public struct TranspositionTableElement
     public readonly NodeType Type
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (NodeType)((_type_WasPv & 0xE) >> NodeTypeOffset);
+        get => (NodeType)((_age_type_WasPv & NodeTypeMask) >> NodeTypeOffset);
     }
 
     public readonly bool WasPv
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (_type_WasPv & 0x1) == 1;
+        get => (_age_type_WasPv & 0x1) == 1;
+    }
+
+    public readonly int Age
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (_age_type_WasPv /*& AgeExtractionMask*/) >> AgeOffset;
     }
 
     /// <summary>
@@ -125,13 +142,16 @@ public struct TranspositionTableElement
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
+    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move, int age)
     {
+        Debug.Assert(age <= MaxAge);
+        Debug.Assert(nodeType != NodeType.Unknown);
+
         _key = (ushort)key;
         _score = (short)score;
         _staticEval = (short)staticEval;
         _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
-        _type_WasPv = (byte)(wasPv | ((int)nodeType << NodeTypeOffset));
+        _age_type_WasPv = (byte)(wasPv | ((int)nodeType << NodeTypeOffset) | age << AgeOffset);
         _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
     }
 }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -107,6 +107,8 @@ public sealed partial class Engine
             Array.Clear(_moveNodeCount[i]);
         }
 
+        // Can't age TT here, since neeeds to be done only once for all the threads
+
         int bestScore = 0;
         int alpha = EvaluationConstants.MinEval;
         int beta = EvaluationConstants.MaxEval;

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -119,6 +119,8 @@ public sealed class Searcher
             await MultiThreadedSearch(goCommand);
         }
 
+        _ttWrapper.Age();
+
         _isProcessingGoCommand = false;
     }
 

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+
 using static Lynx.EvaluationConstants;
 
 namespace Lynx.Test.Model;
@@ -74,7 +75,6 @@ public class TranspositionTableTests
     [Test]
     [Explicit]
     [NonParallelizable]
-    [Category(Categories.LongRunning)]
     public void ClearTT()
     {
         Configuration.EngineSettings.TranspositionTableSize = 31;
@@ -86,23 +86,48 @@ public class TranspositionTableTests
 
         for (int index = 0; index < tt.Length; ++index)
         {
-            ref var ttEntry = ref tt.Get(index);
-            ttEntry.Update(1, 2, 3, 4, NodeType.Exact, 5, 6);
+            ref var ttBucket = ref tt.Get(index);
+            for (int i = 0; i < Constants.TranspositionTableElementsPerBucket; ++i)
+            {
+                ref var ttEntry = ref ttBucket[i];
+                ttEntry.Update(1, 2, 3, 4, NodeType.Exact, 5, 6, 10 + i);
+            }
+
+            Assert.AreEqual(10, ttBucket[0].Age);
+            Assert.AreEqual(11, ttBucket[1].Age);
+            Assert.AreEqual(12, ttBucket[2].Age);
+
+            //Assert.AreEqual(10, tt._tt[0][0].Age);
+            //Assert.AreEqual(11, tt._tt[0][1].Age);
+            //Assert.AreEqual(12, tt._tt[0][2].Age);
+
+            Assert.AreEqual(10, tt.Get(0)[0].Age);
+            Assert.AreEqual(11, tt.Get(0)[1].Age);
+            Assert.AreEqual(12, tt.Get(0)[2].Age);
+
+            var newBucket = tt.Get(0);
+            Assert.AreEqual(10, newBucket[0].Age);
+            Assert.AreEqual(11, newBucket[1].Age);
+            Assert.AreEqual(12, newBucket[2].Age);
         }
 
         tt.Clear();
 
         for (int index = 0; index < tt.Length; ++index)
         {
-            var ttEntry = tt.Get(index);
+            var ttBucket = tt.Get(index);
+            for (int i = 0; i < Constants.TranspositionTableElementsPerBucket; ++i)
+            {
+                var ttEntry = ttBucket[i];
 
-            Assert.AreEqual(0, ttEntry.Score);
-            Assert.AreEqual(0, ttEntry.StaticEval);
-            Assert.AreEqual(0, ttEntry.Depth);
-            Assert.AreEqual(NodeType.Unknown, ttEntry.Type);
-            Assert.AreEqual(false, ttEntry.WasPv);
-            Assert.AreEqual(0, ttEntry.Move);
-            Assert.AreEqual(0, ttEntry.Key);
+                Assert.AreEqual(0, ttEntry.Score);
+                Assert.AreEqual(0, ttEntry.StaticEval);
+                Assert.AreEqual(0, ttEntry.Depth);
+                Assert.AreEqual(NodeType.Unknown, ttEntry.Type);
+                Assert.AreEqual(false, ttEntry.WasPv);
+                Assert.AreEqual(0, ttEntry.Move);
+                Assert.AreEqual(0, ttEntry.Key);
+            }
         }
     }
 }


### PR DESCRIPTION
No age in replacement formula, hash pressure
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 4MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -25.77 +/- 11.56, nElo: -43.02 +/- 19.21
LOS: 0.00 %, DrawRatio: 45.38 %, PairsRatio: 0.61
Games: 1256, Wins: 272, Losses: 365, Draws: 619, Points: 581.5 (46.30 %)
Ptnml(0-2): [25, 188, 285, 115, 15], WL/DD Ratio: 0.80
LLR: -2.26 (-100.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```

Age in replacement formula

Hash pressure
```
Test  | tt/buckets-1
Elo   | -32.87 +- 10.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 1696: +377 -537 =782
Penta | [45, 262, 367, 156, 18]
https://openbench.lynx-chess.com/test/2035/
```

No hash pressure
```
Test  | tt/buckets-1
Elo   | -14.15 +- 7.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.29 (-2.25, 2.89) [0.00, 3.00]
Games | 4028: +1036 -1200 =1792
Penta | [126, 514, 848, 450, 76]
https://openbench.lynx-chess.com/test/2036/
```