### PR TITLE
🔍 Consider `tthit` when there's only eval in TT too

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -62,7 +62,7 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
         NodeType ttElementType = NodeType.Unknown;
         int ttScore = EvaluationConstants.NoScore;
-        int ttStaticEval = int.MinValue;
+        int ttStaticEval = EvaluationConstants.NoScore;
         int ttDepth = default;
         bool ttWasPv = false;
 
@@ -163,10 +163,8 @@ public sealed partial class Engine
 
         if (!pvNode && !isInCheck && !isVerifyingSE)
         {
-            if (ttElementType != NodeType.Unknown)   // Equivalent to ttHit || ttElementType == NodeType.None
+            if (ttHit && ttStaticEval != EvaluationConstants.NoScore)   // Equivalent to ttHit || ttElementType == NodeType.None
             {
-                Debug.Assert(ttStaticEval != int.MinValue);
-
                 rawStaticEval = ttStaticEval;
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
                 phase = position.Phase();
@@ -788,7 +786,7 @@ public sealed partial class Engine
         var ttProbeResult = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttNodeType != NodeType.Unknown && ttNodeType != NodeType.None;
+        var ttHit = ttNodeType != NodeType.Unknown;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff


### PR DESCRIPTION
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 4MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -5.82 +/- 6.11, nElo: -9.27 +/- 9.73
LOS: 3.10 %, DrawRatio: 44.22 %, PairsRatio: 0.93
Games: 4894, Wins: 1262, Losses: 1344, Draws: 2288, Points: 2406.0 (49.16 %)
Ptnml(0-2): [111, 596, 1082, 580, 78], WL/DD Ratio: 0.95
LLR: -2.26 (-100.4%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```

```
Test  | tt/tthit-eval-only
Elo   | -12.51 +- 6.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 4362: +1112 -1269 =1981
Penta | [107, 584, 915, 509, 66]
https://openbench.lynx-chess.com/test/2050/
```