### PR TITLE
º🧹 Refactor `ProbeHash` to return a boolean and out-return a TT result object

### DIFF
--- a/src/Lynx/Model/TTResult.cs
+++ b/src/Lynx/Model/TTResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Lynx.Model;
+
+public record struct TTResult(int Score, short BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -565,9 +565,9 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
 
         using var position = new Position(Game.PositionBeforeLastSearch);
-        var ttEntry = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0);
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, out var ttEntry);
 
-        if (ttEntry.NodeType != NodeType.Unknown)
+        if (ttHit)
         {
             ttBestMove = ttEntry.BestMove;
             score = ttEntry.Score;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,12 +59,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        ShortMove ttBestMove = default;
-        NodeType ttElementType = NodeType.Unknown;
-        int ttScore = EvaluationConstants.NoScore;
-        int ttStaticEval = int.MinValue;
-        int ttDepth = default;
-        bool ttWasPv = false;
+        TTResult ttEntry = TranspositionTable.EmptyTTResult;
+        var ttWasPv = false;
 
         bool ttHit = false;
         bool ttEntryHasBestMove = false;
@@ -74,19 +70,20 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
+            ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out ttEntry);
 
-            // ttScore shouldn't be used, since it'll be 0 for default structs
-            ttHit = ttElementType != NodeType.Unknown && ttElementType != NodeType.None;
-
-            ttEntryHasBestMove = ttHit && ttBestMove != default;
+            ttWasPv = ttEntry.WasPv;
+            ttEntryHasBestMove = ttHit && ttEntry.BestMove != default;
 
             // TT cutoffs
-            if (!isVerifyingSE && ttHit && ttDepth >= depth)
+            if (!isVerifyingSE && ttHit && ttEntry.Depth >= depth)
             {
-                if (ttElementType == NodeType.Exact
-                    || (ttElementType == NodeType.Alpha && ttScore <= alpha)
-                    || (ttElementType == NodeType.Beta && ttScore >= beta))
+                var ttNodeType = ttEntry.NodeType;
+                var ttScore = ttEntry.Score;
+
+                if (ttNodeType == NodeType.Exact
+                    || (ttNodeType == NodeType.Alpha && ttScore <= alpha)
+                    || (ttNodeType == NodeType.Beta && ttScore >= beta))
                 {
                     if (!pvNode)
                     {
@@ -110,7 +107,7 @@ public sealed partial class Engine
                 }
             }
 
-            ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttBestMove).TargetSquare()] != (int)Piece.None;
+            ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttEntry.BestMove).TargetSquare()] != (int)Piece.None;
 
             // Internal iterative reduction (IIR)
             // If this position isn't found in TT, it has never been searched before,
@@ -163,11 +160,12 @@ public sealed partial class Engine
 
         if (!pvNode && !isInCheck && !isVerifyingSE)
         {
-            if (ttElementType != NodeType.Unknown)   // Equivalent to ttHit || ttElementType == NodeType.None
+            if (ttHit || ttEntry.NodeType == NodeType.None)
+            //if (ttHit && ttEntry.StaticEval != EvaluationConstants.NoScore)
             {
-                Debug.Assert(ttStaticEval != int.MinValue);
+                Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
 
-                rawStaticEval = ttStaticEval;
+                rawStaticEval = ttEntry.StaticEval;
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
                 phase = position.Phase();
             }
@@ -258,7 +256,7 @@ public sealed partial class Engine
                 && staticEvalBetaDiff >= Configuration.EngineSettings.NMP_Margin
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                && (ttEntry.NodeType != NodeType.Alpha || ttEntry.Score >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
                     + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
@@ -303,7 +301,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttEntry.BestMove);
         }
 
         var nodeType = NodeType.Alpha;
@@ -328,7 +326,7 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[moveIndex];
-            var isBestMove = (ShortMove)move == ttBestMove;
+            var isBestMove = (ShortMove)move == ttEntry.BestMove;
             if (isVerifyingSE && isBestMove)
             {
                 continue;
@@ -419,15 +417,15 @@ public sealed partial class Engine
                 //!isVerifyingSE        // Implicit, otherwise the move would have been skipped already
                 isBestMove      // Ensures !isRoot and TT hit (otherwise there wouldn't be a TT move)
                 && depth >= Configuration.EngineSettings.SE_MinDepth
-                && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
-                && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && ttElementType != NodeType.Alpha
+                && ttEntry.Depth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
+                && Math.Abs(ttEntry.Score) < EvaluationConstants.PositiveCheckmateDetectionLimit
+                && ttEntry.NodeType != NodeType.Alpha
                 && ply < 3 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 
                 var verificationDepth = (depth - 1) / 2;    // TODO tune?
-                var singularBeta = ttScore - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
+                var singularBeta = ttEntry.Score - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
 
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
@@ -458,7 +456,7 @@ public sealed partial class Engine
                     return singularScore;
                 }
                 // Negative extension
-                else if (ttScore >= beta)
+                else if (ttEntry.Score >= beta)
                 {
                     --singularDepthExtensions;
                 }
@@ -785,10 +783,9 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out var ttProbeResult);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttNodeType != NodeType.Unknown && ttNodeType != NodeType.None;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff


### PR DESCRIPTION
```
Test  | refactor/tt-probe-boolean
Elo   | -10.81 +- 6.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [-3.00, 1.00]
Games | 4242: +1118 -1250 =1874
Penta | [104, 514, 999, 418, 86]
https://openbench.lynx-chess.com/test/2049/
```