### PR TITLE
🔍 Use regular update rules when saving static eval to TT

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -154,13 +154,9 @@ public readonly struct TranspositionTable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv)
+    public void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, int depth, int ply, bool wasPv)
     {
-        var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
-        ref var entry = ref _tt[ttIndex];
-
-        // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        RecordHash(position, halfMovesWithoutCaptureOrPawnMove, staticEval, depth, ply, EvaluationConstants.NoScore, NodeType.None, wasPv);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -174,7 +174,7 @@ public sealed partial class Engine
             else
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, ttPv);
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
             }
 
@@ -290,7 +290,7 @@ public sealed partial class Engine
 
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, ttPv);
             }
         }
 
@@ -832,7 +832,7 @@ public sealed partial class Engine
         {
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, 0, ply, ttPv);
             }
 
             // Standing pat beta-cutoff (updating alpha after this check)


### PR DESCRIPTION
```
Test  | tt/savestaticeval-regularsavemethod
Elo   | -1.06 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=4MB
LLR   | -1.85 (-2.25, 2.89) [-3.00, 1.00]
Games | 80158: +21849 -22094 =36215
Penta | [1565, 9581, 18017, 9366, 1550]
https://openbench.lynx-chess.com/test/2044/
```