### PR TITLE
⚡ Refactor TT proving to return a boolean, an out-return a `TTProbeResult` ref readonly struct

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -1084,20 +1084,7 @@ static void TranspositionTableMethod()
     //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
     transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, false, move: 1234);
-    var entry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3);
-    Console.WriteLine(entry); // Expected 20
-
-    transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +21, nodeType: NodeType.Alpha, false, move: 1234);
-    entry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3);
-    Console.WriteLine(entry); // Expected 12_345_678
-
-    transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +29, nodeType: NodeType.Beta, false, move: 1234);
-    entry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3);
-    Console.WriteLine(entry); // Expected 12_345_678
-
-    transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +31, nodeType: NodeType.Beta, false, move: 1234);
-    entry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3);
-    Console.WriteLine(entry); // Expected 30
+    transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3, out var entry);
 }
 
 static void UnmakeMove()

--- a/src/Lynx/Model/TTProbeResult.cs
+++ b/src/Lynx/Model/TTProbeResult.cs
@@ -2,21 +2,21 @@
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly ref struct TTResult
+public readonly ref struct TTProbeResult
 {
     public readonly int Score = EvaluationConstants.NoScore;
-
-    public readonly short BestMove;
-
-    public readonly NodeType NodeType;
 
     public readonly int StaticEval = EvaluationConstants.NoScore;
 
     public readonly int Depth;
 
+    public readonly short BestMove;
+
+    public readonly NodeType NodeType;
+
     public readonly bool WasPv;
 
-    public TTResult(int score, short bestMove, NodeType nodeType, int staticEval, int depth, bool wasPv)
+    public TTProbeResult(int score, short bestMove, NodeType nodeType, int staticEval, int depth, bool wasPv)
     {
         Score = score;
         BestMove = bestMove;

--- a/src/Lynx/Model/TTResult.cs
+++ b/src/Lynx/Model/TTResult.cs
@@ -1,3 +1,30 @@
 ﻿namespace Lynx.Model;
 
-public record struct TTResult(int Score, short BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv);
+#pragma warning disable CA1051 // Do not declare visible instance fields
+
+public readonly ref struct TTResult
+{
+    public readonly int Score = EvaluationConstants.NoScore;
+
+    public readonly short BestMove;
+
+    public readonly NodeType NodeType;
+
+    public readonly int StaticEval = EvaluationConstants.NoScore;
+
+    public readonly int Depth;
+
+    public readonly bool WasPv;
+
+    public TTResult(int score, short bestMove, NodeType nodeType, int staticEval, int depth, bool wasPv)
+    {
+        Score = score;
+        BestMove = bestMove;
+        NodeType = nodeType;
+        StaticEval = staticEval;
+        Depth = depth;
+        WasPv = wasPv;
+    }
+}
+
+#pragma warning restore CA1051 // Do not declare visible instance fields

--- a/src/Lynx/Model/TTResult.cs
+++ b/src/Lynx/Model/TTResult.cs
@@ -1,0 +1,3 @@
+﻿namespace Lynx.Model;
+
+public record struct TTResult(int Score, short BestMove, NodeType NodeType, int StaticEval, int Depth, bool WasPv);

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -8,7 +8,6 @@ namespace Lynx.Model;
 public readonly struct TranspositionTable
 {
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-    public static readonly TTResult EmptyTTResult = new(EvaluationConstants.NoScore, default, default, EvaluationConstants.NoScore, default, default);
 
     private readonly TranspositionTableElement[] _tt = [];
 
@@ -103,7 +102,7 @@ public readonly struct TranspositionTable
 
         if ((ushort)position.UniqueIdentifier != entry.Key)
         {
-            result = EmptyTTResult;
+            result = default;
             return false;
         }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -95,7 +95,7 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, out TTResult result) // [MaybeNullWhen(false)]
+    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, out TTProbeResult result) // [MaybeNullWhen(false)]
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
         var entry = _tt[ttIndex];
@@ -110,7 +110,7 @@ public readonly struct TranspositionTable
         // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
         var recalculatedScore = RecalculateMateScores(entry.Score, ply);
 
-        result = new TTResult(recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
+        result = new TTProbeResult(recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
 
         return entry.Type != NodeType.Unknown && entry.Type != NodeType.None;
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -565,9 +565,9 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
 
         using var position = new Position(Game.PositionBeforeLastSearch);
-        var ttEntry = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0);
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, out var ttEntry);
 
-        if (ttEntry.NodeType != NodeType.Unknown)
+        if (ttHit)
         {
             ttBestMove = ttEntry.BestMove;
             score = ttEntry.Score;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,12 +59,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        ShortMove ttBestMove = default;
-        NodeType ttElementType = NodeType.Unknown;
-        int ttScore = EvaluationConstants.NoScore;
-        int ttStaticEval = int.MinValue;
-        int ttDepth = default;
-        bool ttWasPv = false;
+        TTResult ttEntry = TranspositionTable.EmptyTTResult;
+        var ttWasPv = false;
 
         bool ttHit = false;
         bool ttEntryHasBestMove = false;
@@ -74,19 +70,20 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            (ttScore, ttBestMove, ttElementType, ttStaticEval, ttDepth, ttWasPv) = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
+            ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out ttEntry);
 
-            // ttScore shouldn't be used, since it'll be 0 for default structs
-            ttHit = ttElementType != NodeType.Unknown && ttElementType != NodeType.None;
-
-            ttEntryHasBestMove = ttHit && ttBestMove != default;
+            ttWasPv = ttEntry.WasPv;
+            ttEntryHasBestMove = ttHit && ttEntry.BestMove != default;
 
             // TT cutoffs
-            if (!isVerifyingSE && ttHit && ttDepth >= depth)
+            if (!isVerifyingSE && ttHit && ttEntry.Depth >= depth)
             {
-                if (ttElementType == NodeType.Exact
-                    || (ttElementType == NodeType.Alpha && ttScore <= alpha)
-                    || (ttElementType == NodeType.Beta && ttScore >= beta))
+                var ttNodeType = ttEntry.NodeType;
+                var ttScore = ttEntry.Score;
+
+                if (ttNodeType == NodeType.Exact
+                    || (ttNodeType == NodeType.Alpha && ttScore <= alpha)
+                    || (ttNodeType == NodeType.Beta && ttScore >= beta))
                 {
                     if (!pvNode)
                     {
@@ -110,7 +107,7 @@ public sealed partial class Engine
                 }
             }
 
-            ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttBestMove).TargetSquare()] != (int)Piece.None;
+            ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttEntry.BestMove).TargetSquare()] != (int)Piece.None;
 
             // Internal iterative reduction (IIR)
             // If this position isn't found in TT, it has never been searched before,
@@ -163,11 +160,12 @@ public sealed partial class Engine
 
         if (!pvNode && !isInCheck && !isVerifyingSE)
         {
-            if (ttElementType != NodeType.Unknown)   // Equivalent to ttHit || ttElementType == NodeType.None
+            if (ttHit || ttEntry.NodeType == NodeType.None)
+            //if (ttHit && ttEntry.StaticEval != EvaluationConstants.NoScore)
             {
-                Debug.Assert(ttStaticEval != int.MinValue);
+                Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
 
-                rawStaticEval = ttStaticEval;
+                rawStaticEval = ttEntry.StaticEval;
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
                 phase = position.Phase();
             }
@@ -258,7 +256,7 @@ public sealed partial class Engine
                 && staticEvalBetaDiff >= Configuration.EngineSettings.NMP_Margin
                 && !parentWasNullMove
                 && phase > 2   // Zugzwang risk reduction: pieces other than pawn presents
-                && (ttElementType != NodeType.Alpha || ttScore >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
+                && (ttEntry.NodeType != NodeType.Alpha || ttEntry.Score >= beta))   // TT suggests NMP will fail: entry must not be a fail-low entry with a score below beta - Stormphrax and Ethereal
             {
                 var nmpReduction = Configuration.EngineSettings.NMP_BaseDepthReduction
                     + ((depth + Configuration.EngineSettings.NMP_DepthIncrement) / Configuration.EngineSettings.NMP_DepthDivisor)   // Clarity
@@ -303,7 +301,7 @@ public sealed partial class Engine
 
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttBestMove);
+            moveScores[i] = ScoreMove(pseudoLegalMoves[i], ply, ttEntry.BestMove);
         }
 
         var nodeType = NodeType.Alpha;
@@ -328,7 +326,7 @@ public sealed partial class Engine
             }
 
             var move = pseudoLegalMoves[moveIndex];
-            var isBestMove = (ShortMove)move == ttBestMove;
+            var isBestMove = (ShortMove)move == ttEntry.BestMove;
             if (isVerifyingSE && isBestMove)
             {
                 continue;
@@ -419,15 +417,15 @@ public sealed partial class Engine
                 //!isVerifyingSE        // Implicit, otherwise the move would have been skipped already
                 isBestMove      // Ensures !isRoot and TT hit (otherwise there wouldn't be a TT move)
                 && depth >= Configuration.EngineSettings.SE_MinDepth
-                && ttDepth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
-                && Math.Abs(ttScore) < EvaluationConstants.PositiveCheckmateDetectionLimit
-                && ttElementType != NodeType.Alpha
+                && ttEntry.Depth + Configuration.EngineSettings.SE_TTDepthOffset >= depth
+                && Math.Abs(ttEntry.Score) < EvaluationConstants.PositiveCheckmateDetectionLimit
+                && ttEntry.NodeType != NodeType.Alpha
                 && ply < 3 * depth)     // Preventing search explosions
             {
                 position.UnmakeMove(move, gameState);
 
                 var verificationDepth = (depth - 1) / 2;    // TODO tune?
-                var singularBeta = ttScore - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
+                var singularBeta = ttEntry.Score - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
 
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
@@ -458,7 +456,7 @@ public sealed partial class Engine
                     return singularScore;
                 }
                 // Negative extension
-                else if (ttScore >= beta)
+                else if (ttEntry.Score >= beta)
                 {
                     --singularDepthExtensions;
                 }
@@ -785,10 +783,9 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttProbeResult = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply);
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out var ttProbeResult);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
-        var ttHit = ttNodeType != NodeType.Unknown && ttNodeType != NodeType.None;
         var ttPv = pvNode || ttProbeResult.WasPv;
 
         // QS TT cutoff

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,7 +59,7 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        TTResult ttEntry;
+        TTProbeResult ttEntry;
         bool ttWasPv;
 
         bool ttHit = false;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,8 +59,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        TTResult ttEntry = TranspositionTable.EmptyTTResult;
-        var ttWasPv = false;
+        TTResult ttEntry;
+        bool ttWasPv;
 
         bool ttHit = false;
         bool ttEntryHasBestMove = false;
@@ -120,8 +120,13 @@ public sealed partial class Engine
                 --depthExtension;
             }
         }
+        else
+        {
+            ttEntry = default;
+            ttWasPv = false;
+        }
 
-        var ttPv = pvNode || ttWasPv;
+            var ttPv = pvNode || ttWasPv;
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
         // the previous evaluation from the same side (ply - 2).

--- a/tests/Lynx.Test/Model/TranspositionTableTest.cs
+++ b/tests/Lynx.Test/Model/TranspositionTableTest.cs
@@ -35,7 +35,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, staticEval, depth: 5, ply: 3, score: recordedEval, nodeType: recordNodeType, false, move: recordNodeType != NodeType.Alpha ? 1234 : null);
 
-        var ttEntry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3);
+        Assert.True(transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3, out var ttEntry));
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(staticEval, ttEntry.StaticEval);
     }
@@ -50,7 +50,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, recordedEval, depth: 10, ply: sharedDepth, score: recordedEval, nodeType: NodeType.Exact, false, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: sharedDepth);
+        Assert.True(transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: sharedDepth, out var ttEntry));
         Assert.AreEqual(recordedEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }
@@ -66,7 +66,7 @@ public class TranspositionTableTests
 
         transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, recordedEval, depth: 10, ply: recordedDeph, score: recordedEval, nodeType: NodeType.Exact, false, move: 1234);
 
-        var ttEntry = transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: probeDepth);
+        Assert.True(transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: probeDepth, out var ttEntry));
         Assert.AreEqual(expectedProbeEval, ttEntry.Score);
         Assert.AreEqual(recordedEval, ttEntry.StaticEval);
     }


### PR DESCRIPTION
```
Test  | refactor/tt-probe-boolean-ref-readonly
Elo   | 4.59 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 10304: +2877 -2741 =4686
Penta | [165, 1143, 2450, 1179, 215]
https://openbench.lynx-chess.com/test/2051/
```