### PR TITLE
⚡ Make `TTResult` not readonly 

### DIFF
--- a/src/Lynx/Model/TTProbeResult.cs
+++ b/src/Lynx/Model/TTProbeResult.cs
@@ -2,21 +2,21 @@
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public ref struct TTResult
+public ref struct TTProbeResult
 {
     public int Score;
-
-    public short BestMove;
-
-    public NodeType NodeType;
 
     public int StaticEval;
 
     public int Depth;
 
+    public short BestMove;
+
+    public NodeType NodeType;
+
     public bool WasPv;
 
-    public TTResult()
+    public TTProbeResult()
     {
         Score = EvaluationConstants.NoScore;
         StaticEval = EvaluationConstants.NoScore;

--- a/src/Lynx/Model/TTResult.cs
+++ b/src/Lynx/Model/TTResult.cs
@@ -2,28 +2,24 @@
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly ref struct TTResult
+public ref struct TTResult
 {
-    public readonly int Score = EvaluationConstants.NoScore;
+    public int Score;
 
-    public readonly short BestMove;
+    public short BestMove;
 
-    public readonly NodeType NodeType;
+    public NodeType NodeType;
 
-    public readonly int StaticEval = EvaluationConstants.NoScore;
+    public int StaticEval;
 
-    public readonly int Depth;
+    public int Depth;
 
-    public readonly bool WasPv;
+    public bool WasPv;
 
-    public TTResult(int score, short bestMove, NodeType nodeType, int staticEval, int depth, bool wasPv)
+    public TTResult()
     {
-        Score = score;
-        BestMove = bestMove;
-        NodeType = nodeType;
-        StaticEval = staticEval;
-        Depth = depth;
-        WasPv = wasPv;
+        Score = EvaluationConstants.NoScore;
+        StaticEval = EvaluationConstants.NoScore;
     }
 }
 

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -95,7 +95,7 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, ref TTResult result) // [MaybeNullWhen(false)]
+    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, ref TTProbeResult result) // [MaybeNullWhen(false)]
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
         var entry = _tt[ttIndex];

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -95,14 +95,13 @@ public readonly struct TranspositionTable
     /// </summary>
     /// <param name="ply">Ply</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, out TTResult result) // [MaybeNullWhen(false)]
+    public bool ProbeHash(Position position, int halfMovesWithoutCaptureOrPawnMove, int ply, ref TTResult result) // [MaybeNullWhen(false)]
     {
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
         var entry = _tt[ttIndex];
 
         if ((ushort)position.UniqueIdentifier != entry.Key)
         {
-            result = default;
             return false;
         }
 
@@ -110,7 +109,12 @@ public readonly struct TranspositionTable
         // If the recorded score is a checkmate in 3 and we are at depth 5, we want to read checkmate in 8
         var recalculatedScore = RecalculateMateScores(entry.Score, ply);
 
-        result = new TTResult(recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
+        result.Score = recalculatedScore;
+        result.BestMove = entry.Move;
+        result.NodeType = entry.Type;
+        result.StaticEval = entry.StaticEval;
+        result.Depth = entry.Depth;
+        result.WasPv = entry.WasPv;
 
         return entry.Type != NodeType.Unknown && entry.Type != NodeType.None;
     }

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -565,7 +565,7 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
 
         using var position = new Position(Game.PositionBeforeLastSearch);
-        TTResult ttEntry = new();
+        TTProbeResult ttEntry = new();
         var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, ref ttEntry);
 
         if (ttHit)

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -565,7 +565,8 @@ public sealed partial class Engine
         ShortMove ttBestMove = default;
 
         using var position = new Position(Game.PositionBeforeLastSearch);
-        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, out var ttEntry);
+        TTResult ttEntry = new();
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, ref ttEntry);
 
         if (ttHit)
         {

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,8 +59,8 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        TTResult ttEntry;
-        bool ttWasPv;
+        TTResult ttEntry = new();
+        bool ttWasPv = false;
 
         bool ttHit = false;
         bool ttEntryHasBestMove = false;
@@ -70,7 +70,7 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out ttEntry);
+            ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, ref ttEntry);
 
             ttWasPv = ttEntry.WasPv;
             ttEntryHasBestMove = ttHit && ttEntry.BestMove != default;
@@ -120,13 +120,8 @@ public sealed partial class Engine
                 --depthExtension;
             }
         }
-        else
-        {
-            ttEntry = default;
-            ttWasPv = false;
-        }
 
-            var ttPv = pvNode || ttWasPv;
+        var ttPv = pvNode || ttWasPv;
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
         // the previous evaluation from the same side (ply - 2).
@@ -788,7 +783,8 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out var ttProbeResult);
+        TTResult ttProbeResult = new();
+        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, ref ttProbeResult);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;
         var ttPv = pvNode || ttProbeResult.WasPv;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -59,7 +59,7 @@ public sealed partial class Engine
         bool pvNode = beta - alpha > 1;
         int depthExtension = 0;
 
-        TTResult ttEntry = new();
+        TTProbeResult ttEntry = new();
         bool ttWasPv = false;
 
         bool ttHit = false;
@@ -783,7 +783,7 @@ public sealed partial class Engine
         var nextPvIndex = PVTable.Indexes[ply + 1];
         _pVTable[pvIndex] = _defaultMove;   // Nulling the first value before any returns
 
-        TTResult ttProbeResult = new();
+        TTProbeResult ttProbeResult = new();
         var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, ref ttProbeResult);
         var ttScore = ttProbeResult.Score;
         var ttNodeType = ttProbeResult.NodeType;


### PR DESCRIPTION
```
Test  | refactor/tt-probe-boolean-ref-struct
Elo   | 0.39 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 106236: +29276 -29157 =47803
Penta | [1896, 12123, 25047, 12070, 1982]
https://openbench.lynx-chess.com/test/2053/
```