### PR TITLE
🔍 LMR 50mr: reduce less if we're resetting a high counter

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -248,6 +248,12 @@ public sealed class EngineSettings
     [SPSA<int>(25, 300, 30)]
     public int LMR_Corrplexity_Delta { get; set; } = 124;
 
+    [SPSA<int>(50, 100, 5, enabled: false)]
+    public int LMR_50mrReset_MinCounter { get; set; } = 80;
+
+    [SPSA<int>(25, 300, 30)]
+    public int LMR_50mrReset { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int History_MinDepth { get; set; } = 3;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -126,7 +126,7 @@ public sealed partial class Engine
             ttWasPv = false;
         }
 
-            var ttPv = pvNode || ttWasPv;
+        var ttPv = pvNode || ttWasPv;
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
         // the previous evaluation from the same side (ply - 2).
@@ -220,10 +220,10 @@ public sealed partial class Engine
 
                 var rfpThreshold = rfpMargin + improvingFactor;
 
-                    if (ttCorrectedStaticEval - rfpThreshold >= beta)
-                    {
+                if (ttCorrectedStaticEval - rfpThreshold >= beta)
+                {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
-                        return (ttCorrectedStaticEval + beta) / 2;
+                    return (ttCorrectedStaticEval + beta) / 2;
 #pragma warning restore S3949 // Calculations should not overflow
                 }
 
@@ -412,6 +412,13 @@ public sealed partial class Engine
                 }
             }
 
+            var moveResets50mr = isCapture
+                || piece == (int)Piece.P
+                || piece == (int)Piece.p;
+
+            var moveResetsHigh50mr = moveResets50mr
+                && Game.HalfMovesWithoutCaptureOrPawnMove >= Configuration.EngineSettings.LMR_50mrReset_MinCounter;
+
             var gameState = position.MakeMove(move);
 
             if (!position.WasProduceByAValidMove())
@@ -512,7 +519,7 @@ public sealed partial class Engine
             }
             else
             {
-                var nextHalfMovesCounter = (isCapture || piece == (int)Piece.P || piece == (int)Piece.p)
+                var nextHalfMovesCounter = moveResets50mr
                     ? 0
                     : Game.HalfMovesWithoutCaptureOrPawnMove + 1;
 
@@ -585,6 +592,11 @@ public sealed partial class Engine
                                 if (Math.Abs(staticEval - rawStaticEval) >= Configuration.EngineSettings.LMR_Corrplexity_Delta)
                                 {
                                     reduction -= Configuration.EngineSettings.LMR_Corrplexity;
+                                }
+
+                                if (moveResetsHigh50mr)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_50mrReset;
                                 }
 
                                 reduction /= EvaluationConstants.LMRScaleFactor;


### PR DESCRIPTION
Idea currently being tested in SF

```
Test  | search/sf-zeroing-extension
Elo   | -0.34 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 44472: +12205 -12249 =20018
Penta | [802, 5142, 10403, 5076, 813]
https://openbench.lynx-chess.com/test/2066/
```


Endgame book
```
Test  | search/sf-zeroing-extension
Elo   | -1.55 +- 2.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 17248: +3246 -3323 =10679
Penta | [27, 1407, 5823, 1350, 17]
https://openbench.lynx-chess.com/test/2087/
```