### PR TITLE
Clear move string cache on new game

### DIFF
--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -393,7 +393,7 @@ public static class MoveExtensions
         return span[..^1].ToString();
     }
 
-    private static readonly Dictionary<int, string> _uCIStringCache = new(4096);
+    public static readonly Dictionary<int, string> UCIStringCache = new(4096);
 
     /// <summary>
     /// NOT thread-safe
@@ -402,13 +402,13 @@ public static class MoveExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static string UCIStringMemoized(this Move move)
     {
-        if (_uCIStringCache.TryGetValue(move, out var uciString))
+        if (UCIStringCache.TryGetValue(move, out var uciString))
         {
             return uciString;
         }
 
         var str = move.UCIString();
-        _uCIStringCache[move] = str;
+        UCIStringCache[move] = str;
 
         return str;
     }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -518,6 +518,8 @@ public sealed class Searcher
         }
         _firstRun = false;
 
+        MoveExtensions.UCIStringCache.Clear();
+
         sw.Stop();
         _logger.Info("ucinewgame duration: {Time}ms", sw.ElapsedMilliseconds);
 


### PR DESCRIPTION
```
Test  | perf/clear-movestringcache-newgame
Elo   | -1.23 +- 2.66 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 26572: +7521 -7615 =11436
Penta | [594, 3099, 5956, 3081, 556]
https://openbench.lynx-chess.com/test/2055/
```