### PR TITLE
 🔍LMR: reduce less on killer or counter moves

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -246,6 +246,9 @@ public sealed class EngineSettings
     public int LMR_Corrplexity { get; set; } = 197;
 
     [SPSA<int>(25, 300, 30)]
+    public int LMR_KillerOrCounterMove { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Corrplexity_Delta { get; set; } = 124;
 
     [SPSA<int>(enabled: false)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -587,6 +587,11 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_Corrplexity;
                                 }
 
+                                if(moveScore <= EvaluationConstants.FirstKillerMoveValue && moveScore >= EvaluationConstants.CounterMoveValue)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_KillerOrCounterMove;
+                                }
+
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // -= history/(maxHistory/2)


### PR DESCRIPTION
100
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -7.99 +/- 6.94, nElo: -12.90 +/- 11.20
LOS: 1.20 %, DrawRatio: 45.54 %, PairsRatio: 0.86
Games: 3698, Wins: 926, Losses: 1011, Draws: 1761, Points: 1806.5 (48.85 %)
Ptnml(0-2): [75, 465, 842, 404, 63], WL/DD Ratio: 0.89
LLR: -2.26 (-100.5%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```