### PR TITLE
 🔍LMR: reduce more unless killer or counter moves

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -246,6 +246,9 @@ public sealed class EngineSettings
     public int LMR_Corrplexity { get; set; } = 197;
 
     [SPSA<int>(25, 300, 30)]
+    public int LMR_KillerOrCounterMove { get; set; } = 100;
+
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Corrplexity_Delta { get; set; } = 124;
 
     [SPSA<int>(enabled: false)]

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -587,6 +587,11 @@ public sealed partial class Engine
                                     reduction -= Configuration.EngineSettings.LMR_Corrplexity;
                                 }
 
+                                if(moveScore <= EvaluationConstants.FirstKillerMoveValue && moveScore >= EvaluationConstants.CounterMoveValue)
+                                {
+                                    reduction -= Configuration.EngineSettings.LMR_KillerOrCounterMove;
+                                }
+
                                 reduction /= EvaluationConstants.LMRScaleFactor;
 
                                 // -= history/(maxHistory/2)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -572,6 +572,11 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_TTCapture;
                                 }
 
+                                if(moveScore > EvaluationConstants.FirstKillerMoveValue || moveScore < EvaluationConstants.CounterMoveValue)
+                                {
+                                    reduction += Configuration.EngineSettings.LMR_KillerOrCounterMove;
+                                }
+
                                 if (pvNode)
                                 {
                                     reduction -= Configuration.EngineSettings.LMR_PVNode;
@@ -585,11 +590,6 @@ public sealed partial class Engine
                                 if (Math.Abs(staticEval - rawStaticEval) >= Configuration.EngineSettings.LMR_Corrplexity_Delta)
                                 {
                                     reduction -= Configuration.EngineSettings.LMR_Corrplexity;
-                                }
-
-                                if(moveScore <= EvaluationConstants.FirstKillerMoveValue && moveScore >= EvaluationConstants.CounterMoveValue)
-                                {
-                                    reduction -= Configuration.EngineSettings.LMR_KillerOrCounterMove;
                                 }
 
                                 reduction /= EvaluationConstants.LMRScaleFactor;


### PR DESCRIPTION
Reverse impl of https://github.com/lynx-chess/Lynx/pull/2006

```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -2.33 +/- 4.42, nElo: -3.71 +/- 7.03
LOS: 15.06 %, DrawRatio: 43.64 %, PairsRatio: 0.96
Games: 9386, Wins: 2421, Losses: 2484, Draws: 4481, Points: 4661.5 (49.66 %)
Ptnml(0-2): [181, 1170, 2048, 1119, 175], WL/DD Ratio: 0.87
LLR: -2.26 (-100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H0 was accepted
```