### PR TITLE
🐛 TT replacement policy: empty entries

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -135,7 +135,7 @@ public readonly struct TranspositionTable
         var wasPvInt = wasPv ? 1 : 0;
 
         bool shouldReplace =
-            entry.Key == 0                                      // No actual entry
+            nodeType == NodeType.Unknown                        // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth


### PR DESCRIPTION
```
Test  | tt/bugfix-noentry-replacement
Elo   | 2.80 +- 3.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 15624: +4350 -4224 =7050
Penta | [276, 1706, 3732, 1812, 286]
https://openbench.lynx-chess.com/test/2085/
```