### PR TITLE
🐛 TT static eval saving: depth overflow 

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -163,7 +163,7 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: 0, NodeType.None, wasPv ? 1 : 0, null);
     }
 
     /// <summary>


### PR DESCRIPTION
Depth wraps around to 255 when -1 is used, due to being saved using `byte` type

```
Test  | tt/bugfix-ttstaticeval-depth
Elo   | 0.17 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 69020: +18977 -18943 =31100
Penta | [1375, 8066, 15620, 8048, 1401]
https://openbench.lynx-chess.com/test/2077/
```