### PR TITLE
🐛 TT replacement policy: empty entries II

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -135,7 +135,7 @@ public readonly struct TranspositionTable
         var wasPvInt = wasPv ? 1 : 0;
 
         bool shouldReplace =
-            nodeType == NodeType.Unknown                        // No actual entry
+            entry.Type == NodeType.Unknown                      // No actual entry
             || (position.UniqueIdentifier >> 48) != entry.Key   // Different key: collision
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth


### PR DESCRIPTION
Use the entry type, not the new type 🤦🏼

```
Test  | tt/bugfix-noentry-replacement-2
Elo   | 1.32 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 27882: +7734 -7628 =12520
Penta | [536, 3096, 6569, 3206, 534]
https://openbench.lynx-chess.com/test/2095/
```