### PR TITLE
🐛 TT replacement: on collision

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -400,10 +400,8 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
 
-#pragma warning disable CA1805 // Do not initialize unnecessarily
     [SPSA<int>(enabled: false)]
-    public int TTReplacement_DepthOffset { get; set; } = 0;
-#pragma warning restore CA1805 // Do not initialize unnecessarily
+    public int TTReplacement_DepthOffset { get; set; } = 4;
 
     [SPSA<int>(enabled: false)]
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -132,10 +132,10 @@ public readonly struct TranspositionTable
         bool shouldReplace =
             (position.UniqueIdentifier >> 48) != entry.Key      // Different key: collision or no actual entry
             || nodeType == NodeType.Exact                       // Entering PV data
-            || depth
-                //+ Configuration.EngineSettings.TTReplacement_DepthOffset
-                + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt) >= entry.Depth    // Higher depth
-                ;
+            || depth                                            // Higher depth
+                    + Configuration.EngineSettings.TTReplacement_DepthOffset
+                    + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt)
+                >= entry.Depth;
 
         if (!shouldReplace)
         {

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -100,7 +100,9 @@ public readonly struct TranspositionTable
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
         var entry = _tt[ttIndex];
 
-        if ((ushort)position.UniqueIdentifier != entry.Key)
+        var key = GenerateTTKey(position.UniqueIdentifier);
+
+        if (key != entry.Key)
         {
             result = default;
             return false;
@@ -127,12 +129,14 @@ public readonly struct TranspositionTable
         var ttIndex = CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove);
         ref var entry = ref _tt[ttIndex];
 
+        var newKey = GenerateTTKey(position.UniqueIdentifier);
+
         var wasPvInt = wasPv ? 1 : 0;
 
         bool shouldReplace =
-            entry.Key != (ushort)position.UniqueIdentifier      // Different key: collision or no actual entry
-            || nodeType == NodeType.Exact                       // Entering PV data
-            || depth                                            // Higher depth
+            entry.Key != newKey                 // Different key: collision or no actual entry
+            || nodeType == NodeType.Exact       // Entering PV data
+            || depth                            // Higher depth
                     + Configuration.EngineSettings.TTReplacement_DepthOffset
                     + (Configuration.EngineSettings.TTReplacement_TTPVDepthOffset * wasPvInt)
                 >= entry.Depth;
@@ -146,7 +150,7 @@ public readonly struct TranspositionTable
         // If the evaluated score is a checkmate in 8 and we're at depth 5, we want to store checkmate value in 3
         var recalculatedScore = RecalculateMateScores(score, -ply);
 
-        entry.Update(position.UniqueIdentifier, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
+        entry.Update(newKey, recalculatedScore, staticEval, depth, nodeType, wasPvInt, move);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -156,8 +160,14 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: 0, NodeType.None, wasPv ? 1 : 0, null);
+        entry.Update(GenerateTTKey(position.UniqueIdentifier), EvaluationConstants.NoScore, staticEval, depth: 0, NodeType.None, wasPv ? 1 : 0, null);
     }
+
+    /// <summary>
+    /// Use lowest 16 bits of the position unique identifier as the key
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ushort GenerateTTKey(ulong positionUniqueIdentifier) => (ushort)positionUniqueIdentifier;
 
     /// <summary>
     /// Exact TT occupancy per mill

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -130,7 +130,7 @@ public readonly struct TranspositionTable
         var wasPvInt = wasPv ? 1 : 0;
 
         bool shouldReplace =
-            (position.UniqueIdentifier >> 48) != entry.Key      // Different key: collision or no actual entry
+            entry.Key != (ushort)position.UniqueIdentifier      // Different key: collision or no actual entry
             || nodeType == NodeType.Exact                       // Entering PV data
             || depth                                            // Higher depth
                     + Configuration.EngineSettings.TTReplacement_DepthOffset

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -125,9 +125,9 @@ public struct TranspositionTableElement
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void Update(ulong key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
+    public void Update(ushort key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
     {
-        _key = (ushort)key;
+        _key = key;
         _score = (short)score;
         _staticEval = (short)staticEval;
         _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];


### PR DESCRIPTION
Only offset;
```
Test  | tt/replacement-addoffset-4
Elo   | -1.68 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 21700: +5925 -6030 =9745
Penta | [434, 2530, 4998, 2483, 405]
https://openbench.lynx-chess.com/test/2101/
```

Only bugfix:
```
Test  | tt/bugfix-key-collision-3
Elo   | -6.36 +- 4.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | -2.29 (-2.25, 2.89) [-3.00, 1.00]
Games | 7756: +2053 -2195 =3508
Penta | [165, 1024, 1629, 908, 152]
https://openbench.lynx-chess.com/test/2099/
```

Together (this PR):
```
Test  | tt/bugfix-key-collision-4
Elo   | 0.85 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | 37804: +10340 -10247 =17217
Penta | [784, 4583, 8098, 4630, 807]
https://openbench.lynx-chess.com/test/2100/
```
