### PR TITLE
🧹 TT: remove `NodeType.None`

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -112,7 +112,7 @@ public readonly struct TranspositionTable
 
         result = new TTProbeResult(recalculatedScore, entry.Move, entry.Type, entry.StaticEval, entry.Depth, entry.WasPv);
 
-        return entry.Type != NodeType.Unknown && entry.Type != NodeType.None;
+        return true;
     }
 
     /// <summary>
@@ -163,7 +163,7 @@ public readonly struct TranspositionTable
         ref var entry = ref _tt[ttIndex];
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.None, wasPv ? 1 : 0, null);
+        entry.Update(position.UniqueIdentifier, EvaluationConstants.NoScore, staticEval, depth: -1, NodeType.Unknown, wasPv ? 1 : 0, null);
     }
 
     /// <summary>

--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -167,7 +167,7 @@ public readonly struct TranspositionTable
     /// Use lowest 16 bits of the position unique identifier as the key
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ushort GenerateTTKey(ulong positionUniqueIdentifier) => (ushort)positionUniqueIdentifier;
+    internal static ushort GenerateTTKey(ulong positionUniqueIdentifier) => (ushort)positionUniqueIdentifier;
 
     /// <summary>
     /// Exact TT occupancy per mill

--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -19,12 +19,7 @@ public enum NodeType : byte
     /// <summary>
     /// LowerBound
     /// </summary>
-    Beta,
-
-    /// <summary>
-    /// i.e. when storing only static evaluation
-    /// </summary>
-    None
+    Beta
 }
 
 /// <summary>
@@ -46,7 +41,7 @@ public struct TranspositionTableElement
     /// 1 byte
     /// Binary move bits    Hexadecimal
     /// 0000 0001              0x1           Was PV (0-1)
-    /// 0000 1110              0xE           NodeType (0-3)
+    /// 0000 0110              0x6           NodeType (0-3)
     /// </summary>
     private byte _type_WasPv;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -171,13 +171,11 @@ public sealed partial class Engine
             var ttNodeType = ttEntry.NodeType;
             var ttScore = ttEntry.Score;
 
-            if (realttHit
-                && ttEntry.StaticEval != EvaluationConstants.NoScore
-                // This is the only way I found to differentiate
-                // uninitalized entries from static eval ones that actually have 0 as static eval
-                // I'm really sorry about positions with key 0, they won't ever reuse static eval.
-                && TranspositionTable.GenerateTTKey(position.UniqueIdentifier) != 0)
+            if (realttHit)
             {
+                Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
+                Debug.Assert(ttEntry.Score != EvaluationConstants.NoScore || ttEntry.NodeType == NodeType.Unknown);
+
                 rawStaticEval = ttEntry.StaticEval;
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
                 phase = position.Phase();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -62,6 +62,7 @@ public sealed partial class Engine
         TTProbeResult ttEntry;
         bool ttWasPv;
 
+        bool realttHit = false;
         bool ttHit = false;
         bool ttEntryHasBestMove = false;
         bool ttMoveIsCapture = false;
@@ -70,7 +71,10 @@ public sealed partial class Engine
 
         if (!isRoot)
         {
-            ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out ttEntry);
+            realttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply, out ttEntry);
+            var ttNodeType = ttEntry.NodeType;
+
+            ttHit = realttHit && ttNodeType != NodeType.Unknown;
 
             ttWasPv = ttEntry.WasPv;
             ttEntryHasBestMove = ttHit && ttEntry.BestMove != default;
@@ -78,7 +82,6 @@ public sealed partial class Engine
             // TT cutoffs
             if (!isVerifyingSE && ttHit && ttEntry.Depth >= depth)
             {
-                var ttNodeType = ttEntry.NodeType;
                 var ttScore = ttEntry.Score;
 
                 if (ttNodeType == NodeType.Exact
@@ -126,7 +129,7 @@ public sealed partial class Engine
             ttWasPv = false;
         }
 
-            var ttPv = pvNode || ttWasPv;
+        var ttPv = pvNode || ttWasPv;
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than
         // the previous evaluation from the same side (ply - 2).
@@ -168,8 +171,7 @@ public sealed partial class Engine
             var ttNodeType = ttEntry.NodeType;
             var ttScore = ttEntry.Score;
 
-            if (ttHit || ttNodeType == NodeType.None)
-            //if (ttHit && ttEntry.StaticEval != EvaluationConstants.NoScore)
+            if (realttHit && ttEntry.StaticEval != EvaluationConstants.NoScore)
             {
                 Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
 
@@ -220,10 +222,10 @@ public sealed partial class Engine
 
                 var rfpThreshold = rfpMargin + improvingFactor;
 
-                    if (ttCorrectedStaticEval - rfpThreshold >= beta)
-                    {
+                if (ttCorrectedStaticEval - rfpThreshold >= beta)
+                {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
-                        return (ttCorrectedStaticEval + beta) / 2;
+                    return (ttCorrectedStaticEval + beta) / 2;
 #pragma warning restore S3949 // Calculations should not overflow
                 }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -171,14 +171,13 @@ public sealed partial class Engine
             var ttNodeType = ttEntry.NodeType;
             var ttScore = ttEntry.Score;
 
-            if (realttHit && ttEntry.StaticEval != EvaluationConstants.NoScore
+            if (realttHit
+                && ttEntry.StaticEval != EvaluationConstants.NoScore
                 // This is the only way I found to differentiate
                 // uninitalized entries from static eval ones that actually have 0 as static eval
                 // I'm really sorry about positions with key 0, they won't ever reuse static eval.
-                && (short)position.UniqueIdentifier != 0)
+                && TranspositionTable.GenerateTTKey(position.UniqueIdentifier) != 0)
             {
-                Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
-
                 rawStaticEval = ttEntry.StaticEval;
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
                 phase = position.Phase();

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -171,7 +171,11 @@ public sealed partial class Engine
             var ttNodeType = ttEntry.NodeType;
             var ttScore = ttEntry.Score;
 
-            if (realttHit && ttEntry.StaticEval != EvaluationConstants.NoScore)
+            if (realttHit && ttEntry.StaticEval != EvaluationConstants.NoScore
+                // This is the only way I found to differentiate
+                // uninitalized entries from static eval ones that actually have 0 as static eval
+                // I'm really sorry about positions with key 0, they won't ever reuse static eval.
+                && (short)position.UniqueIdentifier != 0)
             {
                 Debug.Assert(ttEntry.StaticEval != EvaluationConstants.NoScore);
 


### PR DESCRIPTION
This will allow one more bit for TT age, assuming it ever gains...

```
Test  | tt/remove-nodetype-none-2
Elo   | 1.52 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | 25828: +7086 -6973 =11769
Penta | [535, 3105, 5497, 3266, 511]
https://openbench.lynx-chess.com/test/2106/
```