### PR TITLE
TT buckets: replace `InlineArray` with explicit struct + pointers 

### DIFF
--- a/src/Lynx/Model/TranspositionTable.cs
+++ b/src/Lynx/Model/TranspositionTable.cs
@@ -291,7 +291,7 @@ public struct TranspositionTable
 
                         for (int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
                         {
-                            TranspositionTableElement entry = bucket[0];
+                            TranspositionTableElement entry = bucket[j];
                             if (entry.Key != default)
                             {
                                 ++items;
@@ -364,7 +364,7 @@ public struct TranspositionTable
 
                     for (int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
                     {
-                        TranspositionTableElement entry = bucket[0];
+                        TranspositionTableElement entry = bucket[j];
                         if (entry.Key != default)
                         {
                             ++items;
@@ -395,7 +395,7 @@ public struct TranspositionTable
 
                     for (int j = 0; j < Constants.TranspositionTableElementsPerBucket; ++j)
                     {
-                        TranspositionTableElement entry = bucket[0];
+                        TranspositionTableElement entry = bucket[j];
                         if (entry.Key != default)
                         {
                             ++items;

--- a/src/Lynx/Model/TranspositionTableBucket.cs
+++ b/src/Lynx/Model/TranspositionTableBucket.cs
@@ -3,11 +3,21 @@ using System.Runtime.InteropServices;
 
 namespace Lynx.Model;
 
-[InlineArray(Constants.TranspositionTableElementsPerBucket)]
+/// <summary>
+/// A pointer to this (TranspositionTableBucket*) can be casted to a TranspositionTableElement* and indexed from 0 to <see cref="Constants.TranspositionTableElementsPerBucket"/> - 1 to access each entry.
+/// </summary>
+[StructLayout(LayoutKind.Explicit, Size = 30)]
 public struct TranspositionTableBucket
 {
 #pragma warning disable S1144, RCS1213 // Unused private types or members should be removed
-    private TranspositionTableElement _ttEntry;
+    [FieldOffset(0)]
+    private TranspositionTableElement _ttEntry0;
+
+    [FieldOffset(10)]
+    private TranspositionTableElement _ttEntry1;
+
+    [FieldOffset(20)]
+    private TranspositionTableElement _ttEntry2;
 #pragma warning restore S1144 // Unused private types or members should be removed
 
     // TODO Add byte padding to align with 32 or 64 bytes


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/2009 but:

Change implementation to use explicit struct with three fields and access them by casting pointers.

Same bench

```
Test  | tt/buckets-2-explicitstruct
Elo   | -9.40 +- 5.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 5768: +1497 -1653 =2618
Penta | [148, 742, 1207, 692, 95]
https://openbench.lynx-chess.com/test/2109/
```