### PR TITLE
🔍 SPSA 2025-8-29

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -186,67 +186,67 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.20;
+    public double LMR_Base_Quiet { get; set; } = 0.55;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.21;
+    public double LMR_Base_Noisy { get; set; } = 0.29;
 
     [SPSA<double>(2, 6, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 4.31;
+    public double LMR_Divisor_Quiet { get; set; } = 4.50;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.25;
+    public double LMR_Divisor_Noisy { get; set; } = 2.19;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 93;
+    public int LMR_Improving { get; set; } = 101;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 109;
+    public int LMR_Cutnode { get; set; } = 67;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 40;
+    public int LMR_TTPV { get; set; } = 34;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 202;
+    public int LMR_TTCapture { get; set; } = 177;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 45;
+    public int LMR_PVNode { get; set; } = 57;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 104;
+    public int LMR_InCheck { get; set; } = 94;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 78;
+    public int LMR_Quiet { get; set; } = 76;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity { get; set; } = 197;
+    public int LMR_Corrplexity { get; set; } = 166;
 
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity_Delta { get; set; } = 124;
+    public int LMR_Corrplexity_Delta { get; set; } = 127;
 
     [SPSA<int>(enabled: false)]
     public int History_MinDepth { get; set; } = 3;
@@ -258,16 +258,16 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3540;
+    public int LMR_History_Divisor_Quiet { get; set; } = 3045;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(4_096, 12_288, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 7706;
+    public int LMR_History_Divisor_Noisy { get; set; } = 6722;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 68;
+    public int LMR_DeeperBase { get; set; } = 72;
 
     [SPSA<int>(enabled: false)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -290,7 +290,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 82;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 85;
 
     [SPSA<int>(enabled: false)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
@@ -299,7 +299,7 @@ public sealed class EngineSettings
     public int AspirationWindow_Base { get; set; } = 9;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double AspirationWindow_Multiplier { get; set; } = 1.29;
+    public double AspirationWindow_Multiplier { get; set; } = 1.34;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -308,16 +308,16 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(10, 150, 10)]
-    public int ImprovingRate { get; set; } = 53;
+    public int ImprovingRate { get; set; } = 37;
 
     [SPSA<int>(enabled: false)]
     public int RFP_MaxDepth { get; set; } = 9;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_Improving_Margin { get; set; } = 75;
+    public int RFP_Improving_Margin { get; set; } = 78;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_NotImproving_Margin { get; set; } = 117;
+    public int RFP_NotImproving_Margin { get; set; } = 106;
 
     /// <summary>
     /// Should be tuned only if improvingRate is ever used for something else
@@ -332,10 +332,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 138;
+    public int Razoring_Depth1Bonus { get; set; } = 160;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 205;
+    public int Razoring_NotDepth1Bonus { get; set; } = 190;
 
     [SPSA<int>(enabled: false)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -350,25 +350,25 @@ public sealed class EngineSettings
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Bonus_MaxIncrement { get; set; } = 2440;
+    public int History_Bonus_MaxIncrement { get; set; } = 2684;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Constant { get; set; } = 243;
+    public int History_Bonus_Constant { get; set; } = 237;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Linear { get; set; } = 178;
+    public int History_Bonus_Linear { get; set; } = 222;
 
     [SPSA<int>(1, 10, 1)]
-    public int History_Bonus_Quadratic { get; set; } = 3;
+    public int History_Bonus_Quadratic { get; set; } = 2;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Malus_MaxDecrement { get; set; } = 1473;
+    public int History_Malus_MaxDecrement { get; set; } = 972;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Constant { get; set; } = 220;
+    public int History_Malus_Constant { get; set; } = 249;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Linear { get; set; } = 253;
+    public int History_Malus_Linear { get; set; } = 318;
 
     [SPSA<int>(1, 10, 1)]
     public int History_Malus_Quadratic { get; set; } = 7;
@@ -377,7 +377,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 125;
+    public int History_BestScoreBetaMargin { get; set; } = 134;
 
     [SPSA<int>(enabled: false)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -386,16 +386,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 76;
+    public int FP_DepthScalingFactor { get; set; } = 100;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 115;
+    public int FP_Margin { get; set; } = 108;
 
     [SPSA<int>(enabled: false)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1506;
+    public int HistoryPrunning_Margin { get; set; } = -1237;
 
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -407,10 +407,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -46;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -47;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -111;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -115;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -428,31 +428,31 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 87;
+    public int CorrHistoryWeight_Pawn { get; set; } = 79;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 74;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 68;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 115;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 106;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 176;
+    public int CorrHistoryWeight_Minor { get; set; } = 153;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Major { get; set; } = 179;
+    public int CorrHistoryWeight_Major { get; set; } = 191;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
@@ -470,7 +470,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 1;
+    public int SE_DoubleExtensions_Margin { get; set; } = 5;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;


### PR DESCRIPTION
```
Test  | spsa/29-08
Elo   | -15.28 +- 7.63 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.80 (-2.25, 2.89) [0.00, 3.00]
Games | 2526: +561 -672 =1293
Penta | [36, 337, 605, 272, 13]
https://openbench.lynx-chess.com/test/2116/
```


<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/815dc3d5-f989-40bd-8536-66f6a49437bd" />

```
iterations: 1463 (128.54s per iter)
games: 11704 (16.07s per game)
LMR_Base_Quiet = 55(+34.62) in [10, 200]
LMR_Base_Noisy = 29(+8.08) in [10, 200]
LMR_Divisor_Quiet = 450(+18.64) in [200, 600]
LMR_Divisor_Noisy = 219(-6.388506) in [100, 500]
LMR_Improving = 101(+7.54) in [25, 300]
LMR_Cutnode = 67(-42.075531) in [25, 300]
LMR_TTPV = 34(-5.842887) in [25, 300]
LMR_TTCapture = 177(-24.682870) in [25, 300]
LMR_PVNode = 57(+12.04) in [25, 300]
LMR_InCheck = 94(-9.667455) in [25, 300]
LMR_Quiet = 76(-2.461660) in [25, 300]
LMR_Corrplexity = 166(-31.017734) in [25, 300]
LMR_Corrplexity_Delta = 127(+3.33) in [25, 300]
LMR_History_Divisor_Quiet = 3045(-495.247112) in [1, 8192]
LMR_History_Divisor_Noisy = 6722(-983.781801) in [4096, 12288]
LMR_DeeperBase = 72(+4.46) in [20, 100]
NMP_StaticEvalBetaDivisor = 85(+2.74) in [50, 350]
AspirationWindow_Multiplier = 134(+4.80) in [100, 300]
ImprovingRate = 37(-15.857596) in [10, 150]
RFP_Improving_Margin = 78(+2.91) in [50, 150]
RFP_NotImproving_Margin = 106(-11.274053) in [50, 150]
Razoring_Depth1Bonus = 160(+21.53) in [1, 300]
Razoring_NotDepth1Bonus = 190(-15.212819) in [1, 300]
History_Bonus_MaxIncrement = 2684(+244.02) in [512, 4096]
History_Bonus_Constant = 237(-5.953070) in [1, 500]
History_Bonus_Linear = 222(+43.52) in [1, 500]
History_Bonus_Quadratic = 2(-1.003628) in [1, 10]
History_Malus_MaxDecrement = 972(-500.839479) in [512, 4096]
History_Malus_Constant = 249(+29.19) in [1, 500]
History_Malus_Linear = 318(+64.93) in [1, 500]
History_Malus_Quadratic = 7(+0.14) in [1, 10]
History_BestScoreBetaMargin = 134(+9.21) in [0, 200]
FP_DepthScalingFactor = 100(+24.37) in [1, 200]
FP_Margin = 108(-7.200099) in [0, 500]
HistoryPrunning_Margin = -1237(+268.79) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -47(-1.493370) in [-100, -10]
PVS_SEE_Threshold_Noisy = -115(-3.851908) in [-150, -50]
CorrHistoryWeight_Pawn = 79(-7.738799) in [25, 200]
CorrHistoryWeight_NonPawnSTM = 68(-5.771219) in [25, 200]
CorrHistoryWeight_NonPawnNoSTM = 106(-9.445661) in [25, 200]
CorrHistoryWeight_Minor = 153(-22.761145) in [25, 200]
CorrHistoryWeight_Major = 191(+11.89) in [50, 250]
SE_DoubleExtensions_Margin = 5(+3.95) in [0, 50]
```