### PR TITLE
🧪 Calculate threats separately

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1701,6 +1701,39 @@ public class Position : IDisposable
         KingThreatsBonus
     ];
 
+    private void CalculateThreats(ref EvaluationContext evaluationContext)
+    {
+        var occupancy = OccupancyBitBoards[(int)Side.Both];
+
+        for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.K; ++pieceIndex)
+        {
+            var board = PieceBitBoards[pieceIndex];
+            var attacks = MoveGenerator._pieceAttacks[pieceIndex];
+
+            while (board != 0)
+            {
+                board = board.WithoutLS1B(out var square);
+                evaluationContext.Attacks[pieceIndex] |= attacks(square, occupancy);
+            }
+
+            evaluationContext.AttacksBySide[(int)Side.White] |= evaluationContext.Attacks[pieceIndex];
+        }
+
+        for (int pieceIndex = (int)Piece.p; pieceIndex <= (int)Piece.k; ++pieceIndex)
+        {
+            var board = PieceBitBoards[pieceIndex];
+            var attacks = MoveGenerator._pieceAttacks[pieceIndex];
+
+            while (board != 0)
+            {
+                board = board.WithoutLS1B(out var square);
+                evaluationContext.Attacks[pieceIndex] |= attacks(square, occupancy);
+            }
+
+            evaluationContext.AttacksBySide[(int)Side.Black] |= evaluationContext.Attacks[pieceIndex];
+        }
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int Threats(EvaluationContext evaluationContext, int oppositeSide)
     {

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -21,7 +21,7 @@ public static class MoveGenerator
     /// Indexed by <see cref="Piece"/>.
     /// Checks are not considered
     /// </summary>
-    private static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
+    public static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
     [
 #pragma warning disable IDE0350 // Use implicitly typed lambda
         (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White][origin],


### PR DESCRIPTION
Obv a loss, but by how much?
Separate threats could be calculated when no static eval is invoked
```
Test  | perf/threat-calc-beforehand
Elo   | -12.16 +- 6.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 4346: +1119 -1271 =1956
Penta | [90, 581, 968, 459, 75]
https://openbench.lynx-chess.com/test/2118/
```