### PR TITLE
🔍 IIR: only on pvNode

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -117,7 +117,7 @@ public sealed partial class Engine
             // so the search will be potentially expensive.
             // Therefore, we search with reduced depth for now, expecting to record a TT move
             // which we'll be able to use later for the full depth search
-            if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            if (pvNode && depth >= Configuration.EngineSettings.IIR_MinDepth
                 && !ttEntryHasBestMove)
             {
                 --depthExtension;


### PR DESCRIPTION
```
Test  | search/iir-pvnode
Elo   | -45.38 +- 12.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 1278: +272 -438 =568
Penta | [45, 208, 264, 112, 10]
https://openbench.lynx-chess.com/test/2117/
```