### PR TITLE
🔍 IIR: allow on root

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -112,21 +112,22 @@ public sealed partial class Engine
 
             ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttEntry.BestMove).TargetSquare()] != (int)Piece.None;
 
-            // Internal iterative reduction (IIR)
-            // If this position isn't found in TT, it has never been searched before,
-            // so the search will be potentially expensive.
-            // Therefore, we search with reduced depth for now, expecting to record a TT move
-            // which we'll be able to use later for the full depth search
-            if (depth >= Configuration.EngineSettings.IIR_MinDepth
-                && !ttEntryHasBestMove)
-            {
-                --depthExtension;
-            }
         }
         else
         {
             ttEntry = default;
             ttWasPv = false;
+        }
+
+        // Internal iterative reduction (IIR)
+        // If this position isn't found in TT, it has never been searched before,
+        // so the search will be potentially expensive.
+        // Therefore, we search with reduced depth for now, expecting to record a TT move
+        // which we'll be able to use later for the full depth search
+        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            && (!ttEntryHasBestMove))
+        {
+            --depthExtension;
         }
 
         var ttPv = pvNode || ttWasPv;


### PR DESCRIPTION
```
Test  | search/iir-root
Elo   | 0.62 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.02 (-2.25, 2.89) [0.00, 3.00]
Games | 78326: +21304 -21164 =35858
Penta | [1555, 9494, 16956, 9572, 1586]
https://openbench.lynx-chess.com/test/2119/
```