### PR TITLE
🔍 IIR: only on pvNode, but allowing on root

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -112,21 +112,22 @@ public sealed partial class Engine
 
             ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttEntry.BestMove).TargetSquare()] != (int)Piece.None;
 
-            // Internal iterative reduction (IIR)
-            // If this position isn't found in TT, it has never been searched before,
-            // so the search will be potentially expensive.
-            // Therefore, we search with reduced depth for now, expecting to record a TT move
-            // which we'll be able to use later for the full depth search
-            if (depth >= Configuration.EngineSettings.IIR_MinDepth
-                && !ttEntryHasBestMove)
-            {
-                --depthExtension;
-            }
         }
         else
         {
             ttEntry = default;
             ttWasPv = false;
+        }
+
+        // Internal iterative reduction (IIR)
+        // If this position isn't found in TT, it has never been searched before,
+        // so the search will be potentially expensive.
+        // Therefore, we search with reduced depth for now, expecting to record a TT move
+        // which we'll be able to use later for the full depth search
+        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            && (!ttEntryHasBestMove))
+        {
+            --depthExtension;
         }
 
         var ttPv = pvNode || ttWasPv;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -124,7 +124,7 @@ public sealed partial class Engine
         // so the search will be potentially expensive.
         // Therefore, we search with reduced depth for now, expecting to record a TT move
         // which we'll be able to use later for the full depth search
-        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+        if (pvNode && depth >= Configuration.EngineSettings.IIR_MinDepth
             && (!ttEntryHasBestMove))
         {
             --depthExtension;


### PR DESCRIPTION
#2024 + #2025
```
Test  | search/iir-root-pvnode
Elo   | -46.88 +- 12.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 1290: +269 -442 =579
Penta | [46, 218, 260, 105, 16]
https://openbench.lynx-chess.com/test/2121/
```