### PR TITLE
🔍 IIR: only pvNode or cutnode, allowing on root

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -112,21 +112,22 @@ public sealed partial class Engine
 
             ttMoveIsCapture = ttEntryHasBestMove && position.Board[((int)ttEntry.BestMove).TargetSquare()] != (int)Piece.None;
 
-            // Internal iterative reduction (IIR)
-            // If this position isn't found in TT, it has never been searched before,
-            // so the search will be potentially expensive.
-            // Therefore, we search with reduced depth for now, expecting to record a TT move
-            // which we'll be able to use later for the full depth search
-            if (depth >= Configuration.EngineSettings.IIR_MinDepth
-                && !ttEntryHasBestMove)
-            {
-                --depthExtension;
-            }
         }
         else
         {
             ttEntry = default;
             ttWasPv = false;
+        }
+
+        // Internal iterative reduction (IIR)
+        // If this position isn't found in TT, it has never been searched before,
+        // so the search will be potentially expensive.
+        // Therefore, we search with reduced depth for now, expecting to record a TT move
+        // which we'll be able to use later for the full depth search
+        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            && (!ttEntryHasBestMove))
+        {
+            --depthExtension;
         }
 
         var ttPv = pvNode || ttWasPv;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -124,7 +124,7 @@ public sealed partial class Engine
         // so the search will be potentially expensive.
         // Therefore, we search with reduced depth for now, expecting to record a TT move
         // which we'll be able to use later for the full depth search
-        if (depth >= Configuration.EngineSettings.IIR_MinDepth
+        if (pvNode && depth >= Configuration.EngineSettings.IIR_MinDepth
             && (!ttEntryHasBestMove))
         {
             --depthExtension;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -124,8 +124,10 @@ public sealed partial class Engine
         // so the search will be potentially expensive.
         // Therefore, we search with reduced depth for now, expecting to record a TT move
         // which we'll be able to use later for the full depth search
-        if (pvNode && depth >= Configuration.EngineSettings.IIR_MinDepth
-            && (!ttEntryHasBestMove))
+        if (!isVerifyingSE
+            && depth >= Configuration.EngineSettings.IIR_MinDepth
+            && !ttEntryHasBestMove
+            && (pvNode || cutnode))
         {
             --depthExtension;
         }


### PR DESCRIPTION
#2024 + #2025 + cutnode
```
Test  | search/iir-root-pvnode-cutnode
Elo   | -19.75 +- 8.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 2994: +755 -925 =1314
Penta | [95, 427, 586, 331, 58]
https://openbench.lynx-chess.com/test/2122/
```