### PR TITLE
🔍 IIR: reduce 2

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -120,7 +120,7 @@ public sealed partial class Engine
             if (depth >= Configuration.EngineSettings.IIR_MinDepth
                 && !ttEntryHasBestMove)
             {
-                --depthExtension;
+                depthExtension -= 2;
             }
         }
         else


### PR DESCRIPTION
Already tested in #1361 
```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -46.23 +/- 20.61, nElo: -73.29 +/- 32.24
LOS: 0.00 %, DrawRatio: 41.26 %, PairsRatio: 0.49
Games: 446, Wins: 92, Losses: 151, Draws: 203, Points: 193.5 (43.39 %)
Ptnml(0-2): [17, 71, 92, 40, 3], WL/DD Ratio: 1.00
LLR: -1.25 (-55.6%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```