### PR TITLE
🔍 IIR: reduce extra if pvNode

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -120,7 +120,7 @@ public sealed partial class Engine
             if (depth >= Configuration.EngineSettings.IIR_MinDepth
                 && !ttEntryHasBestMove)
             {
-                --depthExtension;
+                depthExtension -= 2;
             }
         }
         else

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -120,7 +120,12 @@ public sealed partial class Engine
             if (depth >= Configuration.EngineSettings.IIR_MinDepth
                 && !ttEntryHasBestMove)
             {
-                depthExtension -= 2;
+                --depthExtension;
+
+                if (pvNode)
+                {
+                    --depthExtension;
+                }
             }
         }
         else


### PR DESCRIPTION
#2024 + #2028 mix
Antiscaler :(

```
--------------------------------------------------
Results of dev vs main (8+0.08, 1t, 32MB, UHO_XXL_+0.90_+1.19.epd):
Elo: 3.39 +/- 2.74, nElo: 5.45 +/- 4.41
LOS: 99.23 %, DrawRatio: 44.18 %, PairsRatio: 1.05
Games: 23878, Wins: 6443, Losses: 6210, Draws: 11225, Points: 12055.5 (50.49 %)
Ptnml(0-2): [402, 2841, 5275, 2964, 457], WL/DD Ratio: 0.95
LLR: 2.90 (100.3%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
SPRT ([0.00, 3.00]) completed - H1 was accepted
```

```
Test  | search/iir-reduce-2-if-pvnode
Elo   | -0.16 +- 1.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 51164: +12469 -12493 =26202
Penta | [497, 6195, 12262, 6091, 537]
https://openbench.lynx-chess.com/test/2127/
```