### PR TITLE
🔍 SPSA 2025-9-4

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -186,67 +186,67 @@ public sealed class EngineSettings
     public int LMR_MinFullDepthSearchedMoves_NonPV { get; set; } = 2;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Quiet { get; set; } = 0.20;
+    public double LMR_Base_Quiet { get; set; } = 0.53;
 
     [SPSA<double>(0.1, 2, 0.2)]
-    public double LMR_Base_Noisy { get; set; } = 0.21;
+    public double LMR_Base_Noisy { get; set; } = 0.17;
 
     [SPSA<double>(2, 6, 0.2)]
-    public double LMR_Divisor_Quiet { get; set; } = 4.31;
+    public double LMR_Divisor_Quiet { get; set; } = 4.56;
 
     [SPSA<double>(1, 5, 0.2)]
-    public double LMR_Divisor_Noisy { get; set; } = 2.25;
+    public double LMR_Divisor_Noisy { get; set; } = 2.27;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Improving { get; set; } = 93;
+    public int LMR_Improving { get; set; } = 86;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Cutnode { get; set; } = 109;
+    public int LMR_Cutnode { get; set; } = 77;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTPV { get; set; } = 40;
+    public int LMR_TTPV { get; set; } = 45;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_TTCapture { get; set; } = 202;
+    public int LMR_TTCapture { get; set; } = 167;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_PVNode { get; set; } = 45;
+    public int LMR_PVNode { get; set; } = 49;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_InCheck { get; set; } = 104;
+    public int LMR_InCheck { get; set; } = 108;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Quiet { get; set; } = 78;
+    public int LMR_Quiet { get; set; } = 68;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity { get; set; } = 197;
+    public int LMR_Corrplexity { get; set; } = 143;
 
     [SPSA<int>(25, 300, 30)]
-    public int LMR_Corrplexity_Delta { get; set; } = 124;
+    public int LMR_Corrplexity_Delta { get; set; } = 103;
 
     [SPSA<int>(enabled: false)]
     public int History_MinDepth { get; set; } = 3;
@@ -258,16 +258,16 @@ public sealed class EngineSettings
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2
     /// </summary>
     [SPSA<int>(1, 8192, 512)]
-    public int LMR_History_Divisor_Quiet { get; set; } = 3540;
+    public int LMR_History_Divisor_Quiet { get; set; } = 2549;
 
     /// <summary>
     /// Tuned from ~<see cref="History_MaxMoveValue"/> / 2 * (3 / 4)
     /// </summary>
     [SPSA<int>(4_096, 12_288, 512)]
-    public int LMR_History_Divisor_Noisy { get; set; } = 7706;
+    public int LMR_History_Divisor_Noisy { get; set; } = 6178;
 
     [SPSA<int>(20, 100, 8)]
-    public int LMR_DeeperBase { get; set; } = 68;
+    public int LMR_DeeperBase { get; set; } = 75;
 
     [SPSA<int>(enabled: false)]
     public int LMR_DeeperDepthMultiplier { get; set; } = 2;
@@ -290,7 +290,7 @@ public sealed class EngineSettings
     public int NMP_DepthDivisor { get; set; } = 3;
 
     [SPSA<int>(50, 350, 15)]
-    public int NMP_StaticEvalBetaDivisor { get; set; } = 82;
+    public int NMP_StaticEvalBetaDivisor { get; set; } = 83;
 
     [SPSA<int>(enabled: false)]
     public int NMP_StaticEvalBetaMaxReduction { get; set; } = 3;
@@ -299,7 +299,7 @@ public sealed class EngineSettings
     public int AspirationWindow_Base { get; set; } = 9;
 
     [SPSA<double>(1, 3, 0.1)]
-    public double AspirationWindow_Multiplier { get; set; } = 1.29;
+    public double AspirationWindow_Multiplier { get; set; } = 1.32;
 
     //[SPSA<int>(5, 30, 1)]
     //public int AspirationWindow_Delta { get; set; } = 13;
@@ -308,16 +308,16 @@ public sealed class EngineSettings
     public int AspirationWindow_MinDepth { get; set; } = 8;
 
     [SPSA<int>(10, 150, 10)]
-    public int ImprovingRate { get; set; } = 53;
+    public int ImprovingRate { get; set; } = 39;
 
     [SPSA<int>(enabled: false)]
     public int RFP_MaxDepth { get; set; } = 9;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_Improving_Margin { get; set; } = 75;
+    public int RFP_Improving_Margin { get; set; } = 71;
 
     [SPSA<int>(50, 150, 10)]
-    public int RFP_NotImproving_Margin { get; set; } = 117;
+    public int RFP_NotImproving_Margin { get; set; } = 103;
 
     /// <summary>
     /// Should be tuned only if improvingRate is ever used for something else
@@ -332,10 +332,10 @@ public sealed class EngineSettings
     public int Razoring_MaxDepth { get; set; } = 2;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_Depth1Bonus { get; set; } = 138;
+    public int Razoring_Depth1Bonus { get; set; } = 154;
 
     [SPSA<int>(1, 300, 15)]
-    public int Razoring_NotDepth1Bonus { get; set; } = 205;
+    public int Razoring_NotDepth1Bonus { get; set; } = 209;
 
     [SPSA<int>(enabled: false)]
     public int IIR_MinDepth { get; set; } = 4;
@@ -350,25 +350,25 @@ public sealed class EngineSettings
     public int History_MaxMoveValue { get; set; } = 8_192;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Bonus_MaxIncrement { get; set; } = 2440;
+    public int History_Bonus_MaxIncrement { get; set; } = 2589;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Constant { get; set; } = 243;
+    public int History_Bonus_Constant { get; set; } = 244;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Bonus_Linear { get; set; } = 178;
+    public int History_Bonus_Linear { get; set; } = 231;
 
     [SPSA<int>(1, 10, 1)]
-    public int History_Bonus_Quadratic { get; set; } = 3;
+    public int History_Bonus_Quadratic { get; set; } = 2;
 
     [SPSA<int>(512, 4096, 250)]
-    public int History_Malus_MaxDecrement { get; set; } = 1473;
+    public int History_Malus_MaxDecrement { get; set; } = 1247;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Constant { get; set; } = 220;
+    public int History_Malus_Constant { get; set; } = 251;
 
     [SPSA<int>(1, 500, 35)]
-    public int History_Malus_Linear { get; set; } = 253;
+    public int History_Malus_Linear { get; set; } = 347;
 
     [SPSA<int>(1, 10, 1)]
     public int History_Malus_Quadratic { get; set; } = 7;
@@ -377,7 +377,7 @@ public sealed class EngineSettings
     public int CounterMoves_MinDepth { get; set; } = 3;
 
     [SPSA<int>(0, 200, 10)]
-    public int History_BestScoreBetaMargin { get; set; } = 125;
+    public int History_BestScoreBetaMargin { get; set; } = 145;
 
     [SPSA<int>(enabled: false)]
     public int SEE_BadCaptureReduction { get; set; } = 2;
@@ -386,16 +386,16 @@ public sealed class EngineSettings
     public int FP_MaxDepth { get; set; } = 7;
 
     [SPSA<int>(1, 200, 10)]
-    public int FP_DepthScalingFactor { get; set; } = 76;
+    public int FP_DepthScalingFactor { get; set; } = 111;
 
     [SPSA<int>(0, 500, 25)]
-    public int FP_Margin { get; set; } = 115;
+    public int FP_Margin { get; set; } = 95;
 
     [SPSA<int>(enabled: false)]
     public int HistoryPrunning_MaxDepth { get; set; } = 5;
 
     [SPSA<int>(-8192, 0, 512)]
-    public int HistoryPrunning_Margin { get; set; } = -1506;
+    public int HistoryPrunning_Margin { get; set; } = -1639;
 
     [SPSA<int>(enabled: false)]
     public int TTHit_NoCutoffExtension_MaxDepth { get; set; } = 6;
@@ -407,10 +407,10 @@ public sealed class EngineSettings
     public int TTReplacement_TTPVDepthOffset { get; set; } = 2;
 
     [SPSA<int>(-100, -10, 10)]
-    public int PVS_SEE_Threshold_Quiet { get; set; } = -46;
+    public int PVS_SEE_Threshold_Quiet { get; set; } = -53;
 
     [SPSA<int>(-150, -50, 10)]
-    public int PVS_SEE_Threshold_Noisy { get; set; } = -111;
+    public int PVS_SEE_Threshold_Noisy { get; set; } = -107;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
@@ -428,31 +428,31 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Pawn { get; set; } = 87;
+    public int CorrHistoryWeight_Pawn { get; set; } = 96;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 74;
+    public int CorrHistoryWeight_NonPawnSTM { get; set; } = 63;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 115;
+    public int CorrHistoryWeight_NonPawnNoSTM { get; set; } = 100;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 200, 15)]
-    public int CorrHistoryWeight_Minor { get; set; } = 176;
+    public int CorrHistoryWeight_Minor { get; set; } = 160;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Major { get; set; } = 179;
+    public int CorrHistoryWeight_Major { get; set; } = 199;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
@@ -470,7 +470,7 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 1;
+    public int SE_DoubleExtensions_Margin { get; set; } = 2;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;


### PR DESCRIPTION
Continuation of #2021 

```
--------------------------------------------------
Results of dev vs main (40+0.4, 1t, 128MB, UHO_XXL_+0.90_+1.19.epd):
Elo: -2.53 +/- 5.07, nElo: -4.64 +/- 9.30
LOS: 16.42 %, DrawRatio: 48.62 %, PairsRatio: 0.96
Games: 5360, Wins: 1237, Losses: 1276, Draws: 2847, Points: 2660.5 (49.64 %)
Ptnml(0-2): [41, 662, 1303, 643, 31], WL/DD Ratio: 0.69
LLR: -1.81 (-80.2%) (-2.25, 2.89) [0.00, 3.00]
--------------------------------------------------
```

<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/1ce9a6d0-01ba-4d73-b5f6-413eb9ad4214" />


```
iterations: 4705 (145.81s per iter)
games: 37640 (18.23s per game)
LMR_Base_Quiet = 53(+33.18) in [10, 200]
LMR_Base_Noisy = 17(-4.106415) in [10, 200]
LMR_Divisor_Quiet = 456(+24.77) in [200, 600]
LMR_Divisor_Noisy = 227(+1.68) in [100, 500]
LMR_Improving = 86(-7.297850) in [25, 300]
LMR_Cutnode = 77(-32.217043) in [25, 300]
LMR_TTPV = 45(+4.93) in [25, 300]
LMR_TTCapture = 167(-34.829208) in [25, 300]
LMR_PVNode = 49(+3.57) in [25, 300]
LMR_InCheck = 108(+4.34) in [25, 300]
LMR_Quiet = 68(-9.949089) in [25, 300]
LMR_Corrplexity = 143(-53.662777) in [25, 300]
LMR_Corrplexity_Delta = 103(-20.634259) in [25, 300]
LMR_History_Divisor_Quiet = 2549(-991.419819) in [1, 8192]
LMR_History_Divisor_Noisy = 6178(-1528.110124) in [4096, 12288]
LMR_DeeperBase = 75(+6.65) in [20, 100]
NMP_StaticEvalBetaDivisor = 83(+0.54) in [50, 350]
AspirationWindow_Multiplier = 132(+3.03) in [100, 300]
ImprovingRate = 39(-13.511829) in [10, 150]
RFP_Improving_Margin = 71(-3.547069) in [50, 150]
RFP_NotImproving_Margin = 103(-13.544834) in [50, 150]
Razoring_Depth1Bonus = 154(+16.27) in [1, 300]
Razoring_NotDepth1Bonus = 209(+4.30) in [1, 300]
History_Bonus_MaxIncrement = 2589(+149.12) in [512, 4096]
History_Bonus_Constant = 244(+1.36) in [1, 500]
History_Bonus_Linear = 231(+52.61) in [1, 500]
History_Bonus_Quadratic = 2(-0.572298) in [1, 10]
History_Malus_MaxDecrement = 1247(-226.005388) in [512, 4096]
History_Malus_Constant = 251(+30.82) in [1, 500]
History_Malus_Linear = 347(+94.35) in [1, 500]
History_Malus_Quadratic = 7(+0.20) in [1, 10]
History_BestScoreBetaMargin = 145(+19.59) in [0, 200]
FP_DepthScalingFactor = 111(+34.56) in [1, 200]
FP_Margin = 95(-20.384652) in [0, 500]
HistoryPrunning_Margin = -1639(-133.246470) in [-8192, 0]
PVS_SEE_Threshold_Quiet = -53(-7.370396) in [-100, -10]
PVS_SEE_Threshold_Noisy = -107(+4.47) in [-150, -50]
CorrHistoryWeight_Pawn = 96(+9.23) in [25, 200]
CorrHistoryWeight_NonPawnSTM = 63(-10.546697) in [25, 200]
CorrHistoryWeight_NonPawnNoSTM = 100(-14.544487) in [25, 200]
CorrHistoryWeight_Minor = 160(-16.104964) in [25, 200]
CorrHistoryWeight_Major = 199(+20.14) in [50, 250]
SE_DoubleExtensions_Margin = 2(+1.33) in [0, 50]
```