### PR TITLE
:zap: Use threats to generate castling, ensuring they're populated beforehand

### DIFF
--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -412,7 +412,12 @@ static void _23_Castling_Moves()
     int index = 0;
     var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-    MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+    Span<BitBoard> attacks = stackalloc BitBoard[12];
+    Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+    var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+    evaluationContext.EnsureThreatsAreCalculated(position);
+
+    MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
     foreach (var move in moves[..index])
     {
@@ -703,6 +708,7 @@ static void _54_ScoreMove()
     Span<BitBoard> attacks = stackalloc BitBoard[12];
     Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
     var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+    evaluationContext.EnsureThreatsAreCalculated(position);
     foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
     {
         Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext)}");

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -151,6 +151,58 @@ public static class Constants
     /// </summary>
     public const BitBoard BlackLongCastleFreeSquares = 0xe;
 
+     /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 1 1 1 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteShortCastleNonAttackableSquares = 0x7000000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 0 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 1 1 1 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard WhiteLongCastleNonAttackableSquares = 0x1c00000000000000;
+
+    /// <summary>
+    /// 8   0 0 0 0 1 1 1 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackShortCastleNonAttackableSquares = 0x70;
+
+    /// <summary>
+    /// 8   0 0 1 1 1 0 0 0
+    /// 7   0 0 0 0 0 0 0 0
+    /// 6   0 0 0 0 0 0 0 0
+    /// 5   0 0 0 0 0 0 0 0
+    /// 4   0 0 0 0 0 0 0 0
+    /// 3   0 0 0 0 0 0 0 0
+    /// 2   0 0 0 0 0 0 0 0
+    /// 1   0 0 0 0 0 0 0 0
+    ///     a b c d e f g h
+    /// </summary>
+    public const BitBoard BlackLongCastleNonAttackableSquares = 0x1c;
+
     public static readonly string[] Coordinates =
     [
         "a8", "b8", "c8", "d8", "e8", "f8", "g8", "h8",

--- a/src/Lynx/Model/EvaluationContext.cs
+++ b/src/Lynx/Model/EvaluationContext.cs
@@ -15,6 +15,14 @@ public ref struct EvaluationContext
         Attacks.Clear();
         AttacksBySide.Clear();
     }
+
+    public void EnsureThreatsAreCalculated(Position position)
+    {
+        if(AttacksBySide[(int)Side.White] == 0)
+        {
+            position.CalculateThreats(ref this);
+        }
+    }
 }
 
 #pragma warning restore CA1051 // Do not declare visible instance fields

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -60,6 +60,7 @@ public sealed class Game : IDisposable
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(CurrentPosition);
 
         for (int i = 0; i < rangeSpan.Length; ++i)
         {

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -60,7 +60,6 @@ public sealed class Game : IDisposable
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        evaluationContext.EnsureThreatsAreCalculated(CurrentPosition);
 
         for (int i = 0; i < rangeSpan.Length; ++i)
         {
@@ -68,6 +67,9 @@ public sealed class Game : IDisposable
             {
                 break;
             }
+
+            CurrentPosition.CalculateThreats(ref evaluationContext);
+
             var moveString = rawMoves[rangeSpan[i]];
             var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, ref evaluationContext, movePool);
 

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -427,6 +427,7 @@ public static class MoveExtensions
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray();
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1703,6 +1703,9 @@ public class Position : IDisposable
 
     public void CalculateThreats(ref EvaluationContext evaluationContext)
     {
+        evaluationContext.AttacksBySide.Clear();
+        evaluationContext.Attacks.Clear();
+
         var occupancy = OccupancyBitBoards[(int)Side.Both];
 
         for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.K; ++pieceIndex)

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -67,6 +67,7 @@ public static class OnlineTablebaseProber
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         switch (tablebaseEval.Category)
         {

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -43,6 +43,7 @@ public static class Perft
             Span<BitBoard> attacks = stackalloc BitBoard[12];
             Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
             var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            evaluationContext.EnsureThreatsAreCalculated(position);
 
             foreach (var move in MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves))
             {
@@ -71,6 +72,7 @@ public static class Perft
             Span<BitBoard> attacks = stackalloc BitBoard[12];
             Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
             var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            evaluationContext.EnsureThreatsAreCalculated(position);
 
             foreach (var move in MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves))
             {

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -329,6 +329,7 @@ public sealed partial class Engine
             Span<BitBoard> attacks = stackalloc BitBoard[12];
             Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
             var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            evaluationContext.EnsureThreatsAreCalculated(position);
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -432,6 +432,7 @@ public sealed partial class Engine
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(Game.CurrentPosition);
 
         foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, ref evaluationContext, moves))
         {
@@ -581,6 +582,7 @@ public sealed partial class Engine
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         Span<Move> pseudoLegalMoves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
         pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, pseudoLegalMoves);

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -818,7 +818,7 @@ public sealed partial class Engine
         ShortMove ttBestMove = ttProbeResult.BestMove;
         _maxDepthReached[ply] = ply;
 
-        var rawStaticEval = ttHit
+        int rawStaticEval = ttHit
             ? ttProbeResult.StaticEval
             : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
 
@@ -857,6 +857,11 @@ public sealed partial class Engine
         if (standPat > alpha)
         {
             alpha = standPat;
+        }
+
+        if (ttHit)
+        {
+            evaluationContext.EnsureThreatsAreCalculated(position);
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -69,6 +69,7 @@ public sealed class PositionCommand
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(game.CurrentPosition);
 
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -227,6 +227,7 @@ public class RegressionTest : BaseTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(engine.Game.CurrentPosition);
 
         Assert.False(engine.Game.Is50MovesRepetition(ref evaluationContext));
         var bestMove = engine.BestMove(new GoCommand("go depth 1"));

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -190,6 +190,7 @@ public class GameTest : BaseTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(game.CurrentPosition);
 
         Assert.False(game.Is50MovesRepetition(ref evaluationContext));
     }
@@ -222,6 +223,7 @@ public class GameTest : BaseTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(game.CurrentPosition);
 
         Assert.True(game.Is50MovesRepetition(ref evaluationContext));
     }
@@ -258,6 +260,7 @@ public class GameTest : BaseTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(game.CurrentPosition);
 
         Assert.False(game.Is50MovesRepetition(ref evaluationContext));
     }

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -28,6 +28,7 @@ public class MoveScoreTest : BaseTest
             Span<BitBoard> attacks = stackalloc BitBoard[12];
             Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
             var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+
             return engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext);
         }).ToList();
 

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -97,6 +97,7 @@ public class MoveToEPDStringTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray();
 

--- a/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
@@ -17,6 +17,7 @@ public class GeneralMoveGeneratorTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(originalPosition);
 
         var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition, ref evaluationContext, moves).ToArray().Single(m => m.IsEnPassant());
         var positionAfterEnPassant = new Position(originalPosition);
@@ -45,6 +46,7 @@ public class GeneralMoveGeneratorTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         var allMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moveSpan);
 

--- a/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
@@ -11,6 +11,7 @@ public class GenerateBishopMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }
@@ -21,6 +22,7 @@ public class GenerateBishopMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }

--- a/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
@@ -1,5 +1,6 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+using System.Globalization;
 
 namespace Lynx.Test.MoveGeneration;
 
@@ -18,7 +19,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.True(1 == moves.Count(m => m.IsCastle()));
         Assert.True(1 == moves.Count(m => m.IsShortCastle()));
@@ -38,7 +44,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.True(1 == moves.Count(m => m.IsCastle()));
         Assert.True(1 == moves.Count(m => m.IsLongCastle()));
@@ -66,7 +77,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -92,7 +108,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }
@@ -116,7 +137,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -144,7 +170,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }
@@ -162,7 +193,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsShortCastle()));
     }
@@ -180,7 +216,12 @@ public class GenerateCastlingMovesTest
         int index = 0;
         var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position);
+        Span<BitBoard> attacks = stackalloc BitBoard[12];
+        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
 
         Assert.IsEmpty(moves.Where(m => m.IsLongCastle()));
     }

--- a/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
@@ -11,6 +11,7 @@ public class GenerateKingMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }
@@ -21,6 +22,7 @@ public class GenerateKingMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }

--- a/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
@@ -11,6 +11,7 @@ public class GenerateKnightMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }
@@ -21,6 +22,7 @@ public class GenerateKnightMovesTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }

--- a/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
@@ -13,6 +13,8 @@ public class GeneratePawnMovesTest
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 
@@ -23,6 +25,8 @@ public class GeneratePawnMovesTest
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 

--- a/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
@@ -12,6 +12,8 @@ public class GenerateQueenMovesTest
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 
@@ -22,6 +24,8 @@ public class GenerateQueenMovesTest
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 

--- a/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
@@ -10,7 +10,9 @@ public class GenerateRookMovesTest
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
+
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
@@ -22,6 +24,8 @@ public class GenerateRookMovesTest
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
+
         return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
 

--- a/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
@@ -23,6 +23,7 @@ public class MoveGeneratorRegressionTest : BaseTest
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        evaluationContext.EnsureThreatsAreCalculated(position);
 
         var captures = MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moveSpan).ToArray().ToList();
 


### PR DESCRIPTION
```
Test  | perf/movegen-castling-threats-revival-2
Elo   | -8.63 +- 5.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 5918: +1524 -1671 =2723
Penta | [130, 743, 1326, 664, 96]
https://openbench.lynx-chess.com/test/2137/
```