### PR TITLE
⚡  Don't accept `EvaluationContext` as `ref readonly` parameter

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -155,14 +155,14 @@ public sealed class Game : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition(ref readonly EvaluationContext evaluationContext)
+    public bool Is50MovesRepetition(ref EvaluationContext evaluationContext)
     {
         if (HalfMovesWithoutCaptureOrPawnMove < 100)
         {
             return false;
         }
 
-        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, in evaluationContext);
+        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, ref evaluationContext);
     }
 
     /// <summary>

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -522,7 +522,6 @@ public class Position : IDisposable
 
                     if (capturedPiece != (int)Piece.None)
                     {
-
                         _pieceBitBoards[capturedPiece].SetBit(targetSquare);
                         _occupancyBitBoards[oppositeSide].SetBit(targetSquare);
                         _board[targetSquare] = capturedPiece;
@@ -805,7 +804,6 @@ public class Position : IDisposable
             {
                 Debug.Assert(whiteKings.GetBit(Constants.WhiteKingSourceSquare), failureMessage, "No white king on e1 when short castling rights");
                 Debug.Assert(whiteRooks.GetBit(BoardSquare.h1), failureMessage, "No white rook on h1 when short castling rights");
-
             }
 
             if ((_castle & (int)CastlingRights.WQ) != 0)
@@ -818,7 +816,6 @@ public class Position : IDisposable
             {
                 Debug.Assert(blackKings.GetBit(Constants.BlackKingSourceSquare), failureMessage, "No black king on e8 when short castling rights");
                 Debug.Assert(blackRooks.GetBit(BoardSquare.h8), failureMessage, "No black rook on h8 when short castling rights");
-
             }
 
             if ((_castle & (int)CastlingRights.BQ) != 0)
@@ -2189,7 +2186,7 @@ public class Position : IDisposable
 #pragma warning restore S106, S2228 // Standard outputs should not be used directly to log anything
 
     [Conditional("DEBUG")]
-    private void AssertAttackPopulation(ref readonly EvaluationContext evaluationContext)
+    private void AssertAttackPopulation(ref EvaluationContext evaluationContext)
     {
         var attacks = evaluationContext.Attacks;
 

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -64,10 +64,6 @@ public static class OnlineTablebaseProber
 
         int[]? allPossibleMoves = null;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-
         switch (tablebaseEval.Category)
         {
             case TablebaseEvaluationCategory.Unknown:
@@ -122,7 +118,7 @@ public static class OnlineTablebaseProber
                 if (bestMoveList is not null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
-                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position, ref evaluationContext);
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -183,7 +179,7 @@ public static class OnlineTablebaseProber
                 if (bestMoveList is not null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
-                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position, ref evaluationContext);
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -246,7 +242,7 @@ public static class OnlineTablebaseProber
                 if (bestMoveList is not null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
-                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position, ref evaluationContext);
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -306,7 +302,7 @@ public static class OnlineTablebaseProber
                 if (bestMoveList is not null)
                 {
 #pragma warning disable CS0618 // Type or member is obsolete
-                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position, ref evaluationContext);
+                    allPossibleMoves ??= MoveGenerator.GenerateAllMoves(position);
 
                     foreach (var move in bestMoveList)
                     {
@@ -350,7 +346,7 @@ public static class OnlineTablebaseProber
 
         Move? parsedMove = 0;
 #pragma warning disable CS0618 // Type or member is obsolete
-        if (bestMove?.Uci is not null && !MoveExtensions.TryParseFromUCIString(bestMove.Uci, MoveGenerator.GenerateAllMoves(position, ref evaluationContext), out parsedMove))
+        if (bestMove?.Uci is not null && !MoveExtensions.TryParseFromUCIString(bestMove.Uci, MoveGenerator.GenerateAllMoves(position), out parsedMove))
         {
             throw new LynxException($"{bestMove.Uci} should be parsable from position {fen}");
         }


### PR DESCRIPTION
Using callling a method that requires a ref readonly parameter from a method that requires the same ref readonly param forces us to use in, which is bad in case of non-readonly structs.

```
Test  | perf/no-refreadonly-evaluationcontext
Elo   | 0.87 +- 2.21 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 36292: +10171 -10080 =16041
Penta | [681, 4130, 8476, 4135, 724]
https://openbench.lynx-chess.com/test/2144/
```