### PR TITLE
🧪 Add IDisposable analyzer and replace .FreeResources() with straight .Dispose() calls

### DIFF
--- a/src/Lynx.Benchmark/ParseFEN_tsoj_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseFEN_tsoj_Benchmark.cs
@@ -446,7 +446,6 @@ public class ParseFEN_tsoj_Benchmark : BaseBenchmark
                         pieceBitBoards[(int)piece] = pieceBitBoards[(int)piece].SetBit(squareIndex);
                         board[squareIndex] = (int)piece;
                     }
-
                 }
             }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -22,7 +22,9 @@ public sealed partial class Engine : IDisposable
 
     public double AverageDepth { get; private set; }
 
+#pragma warning disable IDISP008 // Don't assign member with injected and created disposables - caused by SetGame, internal-only for tests
     public Game Game { get; private set; }
+#pragma warning restore IDISP008 // Don't assign member with injected and created disposables
 
     public bool PendingConfirmation { get; set; }
 
@@ -88,16 +90,17 @@ public sealed partial class Engine : IDisposable
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }
 
+    [Obsolete("Test only")]
     internal void SetGame(Game game)
     {
-        Game.FreeResources();
+        Game.Dispose();
         Game = game;
     }
 
     public void NewGame()
     {
         AverageDepth = 0;
-        Game.FreeResources();
+        Game.Dispose();
         Game = new Game(Constants.InitialPositionFEN);
 
         ResetEngine();
@@ -107,7 +110,7 @@ public sealed partial class Engine : IDisposable
     public void AdjustPosition(ReadOnlySpan<char> rawPositionCommand)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Game.FreeResources();
+        Game.Dispose();
         Game = PositionCommand.ParseGame(rawPositionCommand, moves);
     }
 
@@ -220,19 +223,13 @@ public sealed partial class Engine : IDisposable
         }
     }
 
-    public void FreeResources()
-    {
-        Game.FreeResources();
-        _disposedValue = true;
-    }
-
     private void Dispose(bool disposing)
     {
         if (!_disposedValue)
         {
             if (disposing)
             {
-                FreeResources();
+                Game.Dispose();
             }
             _disposedValue = true;
         }
@@ -242,8 +239,5 @@ public sealed partial class Engine : IDisposable
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-#pragma warning disable S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors - https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose
-        GC.SuppressFinalize(this);
-#pragma warning restore S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors
     }
 }

--- a/src/Lynx/Lynx.csproj
+++ b/src/Lynx/Lynx.csproj
@@ -40,6 +40,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
+    <PackageReference Include="IDisposableAnalyzers" Version="4.0.8">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -221,14 +221,14 @@ public sealed class Game : IDisposable
     /// </summary>
     public void ResetCurrentPositionToBeforeSearchState()
     {
-        CurrentPosition.FreeResources();
+        CurrentPosition.Dispose();
         CurrentPosition = new(PositionBeforeLastSearch);
         //_positionHashHistoryPointer = _positionHashHistoryPointerBeforeLastSearch;    // TODO
     }
 
     public void UpdateInitialPosition()
     {
-        PositionBeforeLastSearch.FreeResources();
+        PositionBeforeLastSearch.Dispose();
         PositionBeforeLastSearch = new(CurrentPosition);
     }
 
@@ -264,24 +264,17 @@ public sealed class Game : IDisposable
 
     internal void ClearPositionHashHistory() => _positionHashHistoryPointer = 0;
 
-    public void FreeResources()
-    {
-        ArrayPool<PlyStackEntry>.Shared.Return(_stack, clearArray: true);
-        ArrayPool<ulong>.Shared.Return(_positionHashHistory);
-
-        CurrentPosition.FreeResources();
-        PositionBeforeLastSearch.FreeResources();
-
-        _disposedValue = true;
-    }
-
     private void Dispose(bool disposing)
     {
         if (!_disposedValue)
         {
             if (disposing)
             {
-                FreeResources();
+                ArrayPool<PlyStackEntry>.Shared.Return(_stack, clearArray: true);
+                ArrayPool<ulong>.Shared.Return(_positionHashHistory);
+
+                CurrentPosition.Dispose();
+                PositionBeforeLastSearch.Dispose();
             }
             _disposedValue = true;
         }
@@ -291,8 +284,5 @@ public sealed class Game : IDisposable
     {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
-#pragma warning disable S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors - https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose
-        GC.SuppressFinalize(this);
-#pragma warning restore S3234 // "GC.SuppressFinalize" should not be invoked for types without destructors
     }
 }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -2207,27 +2207,20 @@ public class Position : IDisposable
         Debug.Assert(evaluationContext.AttacksBySide[(int)Side.Black] != 0);
     }
 
-    public void FreeResources()
-    {
-        ArrayPool<BitBoard>.Shared.Return(_pieceBitBoards, clearArray: true);
-        ArrayPool<BitBoard>.Shared.Return(_occupancyBitBoards, clearArray: true);
-        ArrayPool<ulong>.Shared.Return(_nonPawnHash, clearArray: true);
-
-        // No need to clear, since we always have to initialize it to Piece.None after renting it anyway
-#pragma warning disable S3254 // Default parameter values should not be passed as arguments
-        ArrayPool<int>.Shared.Return(_board, clearArray: false);
-#pragma warning restore S3254 // Default parameter values should not be passed as arguments
-
-        _disposedValue = true;
-    }
-
     protected virtual void Dispose(bool disposing)
     {
         if (!_disposedValue)
         {
             if (disposing)
             {
-                FreeResources();
+                ArrayPool<BitBoard>.Shared.Return(_pieceBitBoards, clearArray: true);
+                ArrayPool<BitBoard>.Shared.Return(_occupancyBitBoards, clearArray: true);
+                ArrayPool<ulong>.Shared.Return(_nonPawnHash, clearArray: true);
+
+                // No need to clear, since we always have to initialize it to Piece.None after renting it anyway
+#pragma warning disable S3254 // Default parameter values should not be passed as arguments
+                ArrayPool<int>.Shared.Return(_board, clearArray: false);
+#pragma warning restore S3254 // Default parameter values should not be passed as arguments
             }
             _disposedValue = true;
         }

--- a/src/Lynx/OnlineTablebaseProber.cs
+++ b/src/Lynx/OnlineTablebaseProber.cs
@@ -31,10 +31,12 @@ public static class OnlineTablebaseProber
         .WaitAndRetryAsync(4, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(2, 10 + retryAttempt)));    // 128, 256, 512, 1024ms
 
     private readonly static HttpClient _client = new(
+#pragma warning disable IDISP004 // Don't ignore created IDisposable
         new PolicyHttpMessageHandler(_retryPolicy)
         {
             InnerHandler = new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(15) }
         })
+#pragma warning restore IDISP004 // Don't ignore created IDisposable
     {
         BaseAddress = new("http://tablebase.lichess.ovh/")
     };

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -311,7 +311,7 @@ public sealed partial class Engine
             var move = _pVTable[i];
             TryParseMove(position, i, move);
 
-#pragma warning disable CA2000 // Dispose objects before losing scope - disposing it fixes the existing logic, and this is a debug-only method anyway
+#pragma warning disable CA2000, IDISP001 // Dispose objects before losing scope - disposing it fixes the existing logic, and this is a debug-only method anyway
             var newPosition = new Position(position);
 #pragma warning restore CA2000 // Dispose objects before losing scope
             newPosition.MakeMove(move);
@@ -319,7 +319,9 @@ public sealed partial class Engine
             {
                 throw new LynxException($"Invalid position after move {move.UCIString()} from position {position.FEN(Game.HalfMovesWithoutCaptureOrPawnMove)}");
             }
+#pragma warning disable IDISP003 // Dispose previous before re-assigning - debug method
             position = newPosition;
+#pragma warning restore IDISP003 // Dispose previous before re-assigning
         }
 
         static void TryParseMove(Position position, int i, int move)

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -7,7 +7,7 @@ using System.Threading.Channels;
 
 namespace Lynx;
 
-public sealed class Searcher
+public sealed class Searcher : IDisposable
 {
     private readonly ChannelReader<string> _uciReader;
     private readonly ChannelWriter<object> _engineWriter;
@@ -30,6 +30,7 @@ public sealed class Searcher
     public string FEN => _mainEngine.Game.FEN;
 
     private bool _firstRun;
+    private bool _disposedValue;
 
     public Searcher(ChannelReader<string> uciReader, ChannelWriter<object> engineWriter)
     {
@@ -101,13 +102,17 @@ public sealed class Searcher
 
         if (!_absoluteSearchCancellationTokenSource.TryReset())
         {
+#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
             _absoluteSearchCancellationTokenSource.Dispose();
+#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
             _absoluteSearchCancellationTokenSource = new();
         }
 
         if (!_searchCancellationTokenSource.TryReset())
         {
+#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
             _searchCancellationTokenSource.Dispose();
+#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
             _searchCancellationTokenSource = new();
         }
 
@@ -175,7 +180,9 @@ public sealed class Searcher
             if (_isPonderHit)
             {
                 // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
+#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
                 _absoluteSearchCancellationTokenSource.Dispose();
+#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
                 _absoluteSearchCancellationTokenSource = new();
 
                 if (searchResult is null
@@ -255,7 +262,9 @@ public sealed class Searcher
             if (_isPonderHit)
             {
                 // PonderHit cancelled the token from _absoluteSearchCancellationTokenSource
+#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
                 _absoluteSearchCancellationTokenSource.Dispose();
+#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
                 _absoluteSearchCancellationTokenSource = new();
 
                 if (finalSearchResult is null
@@ -554,10 +563,12 @@ public sealed class Searcher
             // See https://stackoverflow.com/questions/2688466/why-mallocmemset-is-slower-than-calloc/2688522#2688522
             _ttWrapper.Clear();
 
-            _mainEngine.FreeResources();
+#pragma warning disable S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
+            _mainEngine.Dispose();
+#pragma warning restore S2952 // Classes should "Dispose" of members from the classes' own "Dispose" methods
             _mainEngine = new Engine(MainEngineId, _engineWriter, in _ttWrapper);
 
-            // We need extra engines to know about the nwe TT
+            // We need extra engines to know about the new TT
             AllocateExtraEngines();
 
             return true;
@@ -602,8 +613,10 @@ public sealed class Searcher
 
         foreach (var engine in _extraEngines)
         {
-            engine.FreeResources();
+            engine.Dispose();
         }
+
+        Array.Clear(_extraEngines);
 
         if (_searchThreadsCount > 1)
         {
@@ -658,7 +671,7 @@ public sealed class Searcher
         Parallel.For(0, warmupCount, i =>
         {
             var silentEngineWriter = Channel.CreateUnbounded<object>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false }).Writer;
-            var engine = new Engine(-i, silentEngineWriter, in _ttWrapper);
+            using var engine = new Engine(-i, silentEngineWriter, in _ttWrapper);
 
             engine.Warmup();
         });
@@ -666,4 +679,30 @@ public sealed class Searcher
         _logger.Info("Warm-up time:\t{0} ms", sw.ElapsedMilliseconds);
     }
 #pragma warning restore S1144, RCS1213 // Unused private types or members should be removed
+
+    private void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _mainEngine.Dispose();
+
+                foreach(var engine in _extraEngines)
+                {
+                    engine.Dispose();
+                }
+
+                _absoluteSearchCancellationTokenSource.Dispose();
+                _searchCancellationTokenSource.Dispose();
+            }
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+    }
 }

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -944,7 +944,6 @@ public class PositionTest
         var bitBoard = position.PieceBitBoards[(int)piece];
         int eval = 0;
 
-
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
         var evaluationContext = new EvaluationContext(attacks, attacksBySide);
@@ -975,7 +974,6 @@ public class PositionTest
         BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
 
         var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
-
 
         Span<BitBoard> attacks = stackalloc BitBoard[12];
         Span<BitBoard> attacksBySide = stackalloc BitBoard[2];


### PR DESCRIPTION
Not a winner, might just be neutral
```
Test  | refactor/movegenerator-to-position
Elo   | -1.87 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 20230: +5404 -5513 =9313
Penta | [395, 2239, 4899, 2244, 338]
https://openbench.lynx-chess.com/test/2159/
```