### PR TITLE
🐛 Make UCI booleans lowercase

### DIFF
--- a/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
+++ b/src/Lynx/UCI/Commands/Engine/OptionCommand.cs
@@ -127,12 +127,12 @@ public sealed class OptionCommand
         [
             "option name UCI_Opponent type string",
             $"option name UCI_EngineAbout type string default {IdCommand.EngineName} by {IdCommand.EngineAuthor}, see https://github.com/lynx-chess/Lynx",
-            $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL}",
-            $"option name UCI_Chess960 type check default {Configuration.EngineSettings.IsChess960}",
+            $"option name UCI_ShowWDL type check default {Configuration.EngineSettings.ShowWDL.ToLowerString()}",
+            $"option name UCI_Chess960 type check default {Configuration.EngineSettings.IsChess960.ToLowerString()}",
             $"option name Threads type spin default {Configuration.EngineSettings.Threads} min 1 max {Constants.MaxThreadCount}",
             $"option name Hash type spin default {Configuration.EngineSettings.TranspositionTableSize} min {Constants.AbsoluteMinTTSize} max {Constants.AbsoluteMaxTTSize}",
-            $"option name Ponder type check default {Configuration.EngineSettings.IsPonder}",
-            $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions}",
+            $"option name Ponder type check default {Configuration.EngineSettings.IsPonder.ToLowerString()}",
+            $"option name OnlineTablebaseInRootPositions type check default {Configuration.EngineSettings.UseOnlineTablebaseInRootPositions.ToLowerString()}",
             $"option name MoveOverhead type spin default {Configuration.EngineSettings.MoveOverhead} min 1 max {Constants.MaxMoveOverhead}",
             .. Configuration.GeneralSettings.EnableTuning ? SPSAAttributeHelpers.GenerateOptionStrings() : []
         ];

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -150,7 +150,7 @@ public sealed class UCIHandler
 
     private async Task HandleStop() => await _searcher.StopSearching();
 
-    private async Task HandleUCI(CancellationToken cancellationToken)
+    internal async Task HandleUCI(CancellationToken cancellationToken)
     {
         await SendCommand(IdCommand.NameString, cancellationToken);
         await SendCommand(IdCommand.AuthorString, cancellationToken);

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -244,6 +244,14 @@ public static class Utils
         return ((1 << piece) & MajorPieceMask) != 0;
     }
 
+    /// <summary>
+    /// Recommended in https://learn.microsoft.com/en-us/dotnet/api/system.boolean.tostring
+    /// </summary>
+    public static string ToLowerString(this bool b)
+    {
+        return b.ToString().ToLowerInvariant();
+    }
+
     [Conditional("DEBUG")]
     private static void GuardAgainstSideBoth(int side)
     {

--- a/tests/Lynx.Test/UCIHandlerTest.cs
+++ b/tests/Lynx.Test/UCIHandlerTest.cs
@@ -1,0 +1,48 @@
+﻿using Lynx.UCI.Commands.Engine;
+using NUnit.Framework;
+using System.Buffers;
+using System.Diagnostics;
+using System.Threading.Channels;
+
+namespace Lynx.Test;
+
+public class UCIHandlerTest
+{
+    [Test]
+    public async Task HandleUCI()
+    {
+        var engineChannel = Channel.CreateUnbounded<object>();
+        var guiChannel = Channel.CreateUnbounded<string>();
+
+        using var searcher = new Searcher(guiChannel.Reader, engineChannel.Writer);
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(5_000);
+
+        await new UCIHandler(guiChannel, engineChannel, searcher).HandleUCI(cts.Token);
+
+        var booleansDetected = 0;
+
+        var correctValues = SearchValues.Create(["true", "false"], StringComparison.Ordinal);
+        var incorrectValues = SearchValues.Create([bool.TrueString, bool.FalseString], StringComparison.Ordinal);
+
+        await foreach (var command in engineChannel.Reader.ReadAllAsync(cts.Token))
+        {
+            var str = command.ToString();
+            var span = str.AsSpan();
+
+            if (span == UciOKCommand.Id)
+            {
+                break;
+            }
+
+            Assert.False(span.ContainsAny(incorrectValues), "No 'True' or 'False' or expected, only lowercase in: " + str);
+
+            if (span.ContainsAny(correctValues))
+            {
+                booleansDetected++;
+            }
+        }
+
+        Debug.Assert(booleansDetected >= 4);
+    }
+}


### PR DESCRIPTION
This explains why lichess-bot doesn't send Lynx `UCI_Chess960` in FRC games (https://github.com/lichess-bot-devs/lichess-bot/issues/1129, see https://github.com/lichess-bot-devs/lichess-bot/issues/1129#issuecomment-3287513444).