### PR TITLE
🔍 LMR: reduce less on both killer moves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,8 @@ jobs:
       run: dotnet build -c Release
 
     - name: Run ${{ matrix.category }} tests
-      run: dotnet test -c Release --no-build --filter "TestCategory=${{ matrix.category }}" -v normal --collect:"XPlat Code Coverage" --settings tests/runsettings.xml --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+      run: dotnet test -c Release --no-build --filter "TestCategory=${{ matrix.category }}" -v normal --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+        # --collect:"XPlat Code Coverage" causes too long test runs (>20 min) https://github.com/coverlet-coverage/coverlet/issues/1192
 
   perft-tests:
     runs-on: ${{ matrix.os }}
@@ -313,6 +314,7 @@ jobs:
 
     - name: Run ${{ matrix.category }} tests in Debug mode
       run: dotnet test -c Debug --no-build --filter "TestCategory=${{ matrix.category }}" -v normal --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
+        # --collect:"XPlat Code Coverage" causes too long test runs (>20 min) https://github.com/coverlet-coverage/coverlet/issues/1192
 
   perft-frc-tests-exhaustive:
     runs-on: ${{ matrix.os }}

--- a/tests/Lynx.Test/ZobristHashGenerationTest.cs
+++ b/tests/Lynx.Test/ZobristHashGenerationTest.cs
@@ -32,9 +32,9 @@ public class ZobristHashGenerationTest
     {
         var originalPosition = new Position(fen);
 
-        var fenDictionary = new Dictionary<string, (string Move, ulong Hash)>()
+        var fenDictionary = new Dictionary<ulong, (string Move, ulong Hash)>(Constants.MaxNumberOfPseudolegalMovesInAPosition)
         {
-            [originalPosition.FEN()] = ("", originalPosition.UniqueIdentifier)
+            [originalPosition.UniqueIdentifier] = ("", originalPosition.UniqueIdentifier)
         };
 
         TransversePosition(originalPosition, fenDictionary);
@@ -48,17 +48,17 @@ public class ZobristHashGenerationTest
     {
         var originalPosition = new Position(fen);
 
-        var fenDictionary = new Dictionary<string, (string Move, ulong Hash)>()
+        var uniqueIdDictionary = new Dictionary<ulong, (string Move, ulong Hash)>(Constants.MaxNumberOfPseudolegalMovesInAPosition)
         {
-            [originalPosition.FEN()] = ("", originalPosition.UniqueIdentifier)
+            [originalPosition.UniqueIdentifier] = ("", originalPosition.UniqueIdentifier)
         };
 
-        TransversePosition(originalPosition, fenDictionary);
+        TransversePosition(originalPosition, uniqueIdDictionary);
     }
 
 #pragma warning restore S4144 // Methods should not have identical implementations
 
-    private static void TransversePosition(Position originalPosition, Dictionary<string, (string Move, ulong Hash)> fenDictionary, int maxDepth = 10, int depth = 0)
+    private static void TransversePosition(Position originalPosition, Dictionary<ulong, (string Move, ulong Hash)> fenDictionary, int maxDepth = 10, int depth = 0)
     {
         foreach (var move in MoveGenerator.GenerateAllMoves(originalPosition))
         {
@@ -69,13 +69,13 @@ public class ZobristHashGenerationTest
                 continue;
             }
 
-            if (fenDictionary.TryGetValue(newPosition.FEN(), out var pair))
+            if (fenDictionary.TryGetValue(newPosition.UniqueIdentifier, out var pair))
             {
                 Assert.AreEqual(pair.Hash, newPosition.UniqueIdentifier, $"From {originalPosition.FEN()} using {move}: {newPosition.FEN()}");
             }
             else
             {
-                fenDictionary.Add(newPosition.FEN(), (move.ToString(), newPosition.UniqueIdentifier));
+                fenDictionary.Add(newPosition.UniqueIdentifier, (move.ToString(), newPosition.UniqueIdentifier));
             }
 
             if (depth < maxDepth)


### PR DESCRIPTION
Killer or counter moves: #2006 

```
Test  | search/lmr-killer
Elo   | -0.66 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.56 (-2.25, 2.89) [0.00, 3.00]
Games | 24610: +6643 -6690 =11277
Penta | [486, 2983, 5394, 2976, 466]
https://openbench.lynx-chess.com/test/2175/
```