### PR TITLE
⚡ FEN parsing optimization: en-passant parsing

### DIFF
--- a/src/Lynx.Benchmark/ParseFEN_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseFEN_Benchmark.cs
@@ -178,6 +178,8 @@
 using BenchmarkDotNet.Attributes;
 using Lynx.Model;
 using NLog;
+using System.Buffers;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
@@ -224,6 +226,10 @@ public partial class ParseFENBenchmark_Benchmark : BaseBenchmark
     [Benchmark]
     [ArgumentsSource(nameof(Data))]
     public ParseResult ParseFEN_OptimizedPopulateOccupancies(string fen) => ParseFEN_FENParser_OptimizedPopulateOccupancies.ParseFEN(fen);
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Data))]
+    public ParseFENResult ParseFEN_OptimizedParseEnPassant(string fen) => ParseFEN_FENParser_OptimizedParseEnPassant.ParseFEN(fen);
 
     public static partial class ParseFEN_FENParser_Original
     {
@@ -1505,6 +1511,442 @@ public partial class ParseFENBenchmark_Benchmark : BaseBenchmark
             }
 
             return (enPassant, success);
+        }
+    }
+
+    public static class ParseFEN_FENParser_OptimizedParseEnPassant
+    {
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+#pragma warning disable IDE1006 // Naming Styles
+        private static readonly SearchValues<char> _DFRCCastlingRightsChars =
+#pragma warning restore IDE1006 // Naming Styles
+            SearchValues.Create(
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h');
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParseFENResult ParseFEN(ReadOnlySpan<char> fen)
+        {
+            fen = fen.Trim();
+
+            // Arrays will be be returned as part of Position cleanaup
+            var pieceBitBoards = ArrayPool<BitBoard>.Shared.Rent(12);
+            var occupancyBitBoards = ArrayPool<BitBoard>.Shared.Rent(3);
+            var board = ArrayPool<int>.Shared.Rent(64);
+            Array.Fill(board, (int)Piece.None);
+
+            bool success;
+            Side side;
+            byte castlingRights = 0;
+            int halfMoveClock = 0/*, fullMoveCounter = 1*/;
+            BoardSquare enPassant = BoardSquare.noSquare;
+            CastlingData castlingData;
+
+            try
+            {
+                ParseBoard(fen, pieceBitBoards, occupancyBitBoards, board);
+
+                var unparsedStringAsSpan = fen[fen.IndexOf(' ')..];
+                Span<Range> parts = stackalloc Range[5];
+                var partsLength = unparsedStringAsSpan.Split(parts, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+                if (partsLength < 3)
+                {
+                    throw new LynxException($"Error parsing second half (after board) of fen {fen}");
+                }
+
+                side = ParseSide(unparsedStringAsSpan[parts[0]]);
+
+                castlingData = !Configuration.EngineSettings.IsChess960
+                        ? ParseStandardChessCastlingRights(unparsedStringAsSpan[parts[1]], pieceBitBoards, out castlingRights)
+                        : ParseDFRCCastlingRights(unparsedStringAsSpan[parts[1]], pieceBitBoards, out castlingRights);
+
+                (enPassant, success) = ParseEnPassant(unparsedStringAsSpan[parts[2]], pieceBitBoards, side);
+
+                if (partsLength < 4 || !int.TryParse(unparsedStringAsSpan[parts[3]], out halfMoveClock))
+                {
+                    _logger.Debug("No half move clock detected");
+                }
+
+                //if (partsLength < 5 || !int.TryParse(unparsedStringAsSpan[parts[4]], out fullMoveCounter))
+                //{
+                //    _logger.Debug("No full move counter detected");
+                //}
+
+                if (pieceBitBoards[(int)Piece.K].CountBits() != 1
+                    || pieceBitBoards[(int)Piece.k].CountBits() != 1)
+                {
+                    throw new LynxException("Missing or extra kings");
+                }
+            }
+#pragma warning disable S2139 // Exceptions should be either logged or rethrown but not both - meh
+            catch (Exception e)
+            {
+                _logger.Error(e, "Error parsing FEN {Fen}", fen.ToString());
+                success = false;
+                throw;
+            }
+#pragma warning restore S2139 // Exceptions should be either logged or rethrown but not both
+
+            return success
+                ? new(pieceBitBoards, occupancyBitBoards, board, side, castlingRights, enPassant,
+                    castlingData,
+                    halfMoveClock/*, fullMoveCounter*/)
+                : throw new LynxException($"Error parsing {fen.ToString()}");
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ParseBoard(ReadOnlySpan<char> fen, BitBoard[] pieceBitBoards, BitBoard[] occupancyBitBoards, int[] board)
+        {
+            var rankIndex = 0;
+            var end = fen.IndexOf('/');
+
+            while (end != -1)
+            {
+                var match = fen[..end];
+
+                ParseBoardSection(pieceBitBoards, board, rankIndex, match);
+
+                fen = fen[(end + 1)..];
+                end = fen.IndexOf('/');
+                ++rankIndex;
+            }
+
+            ParseBoardSection(pieceBitBoards, board, rankIndex, fen[..fen.IndexOf(' ')]);
+
+            // Populate occupancies
+            for (int piece = (int)Piece.P; piece <= (int)Piece.K; ++piece)
+            {
+                occupancyBitBoards[(int)Side.White] |= pieceBitBoards[piece];
+                occupancyBitBoards[(int)Side.Black] |= pieceBitBoards[piece + 6];
+            }
+
+            occupancyBitBoards[(int)Side.Both] = occupancyBitBoards[(int)Side.White] | occupancyBitBoards[(int)Side.Black];
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static void ParseBoardSection(BitBoard[] pieceBitBoards, int[] board, int rankIndex, ReadOnlySpan<char> boardfenSection)
+            {
+                int fileIndex = 0;
+
+                foreach (var ch in boardfenSection)
+                {
+                    var piece = ch switch
+                    {
+                        'P' => Piece.P,
+                        'N' => Piece.N,
+                        'B' => Piece.B,
+                        'R' => Piece.R,
+                        'Q' => Piece.Q,
+                        'K' => Piece.K,
+
+                        'p' => Piece.p,
+                        'n' => Piece.n,
+                        'b' => Piece.b,
+                        'r' => Piece.r,
+                        'q' => Piece.q,
+                        'k' => Piece.k,
+
+                        _ => Piece.None
+                    };
+
+                    if (piece != Piece.None)
+                    {
+                        var square = BitBoardExtensions.SquareIndex(rankIndex, fileIndex);
+                        pieceBitBoards[(int)piece] = pieceBitBoards[(int)piece].SetBit(square);
+                        board[square] = (int)piece;
+                        ++fileIndex;
+                    }
+                    else
+                    {
+                        fileIndex += ch - '0';
+                        Debug.Assert(fileIndex >= 1 && fileIndex <= 8, $"Error parsing char {ch} in fen {boardfenSection.ToString()}");
+                    }
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Side ParseSide(ReadOnlySpan<char> side)
+        {
+            return side[0] switch
+            {
+                'w' or 'W' => Side.White,
+                'b' or 'B' => Side.Black,
+                _ => throw new LynxException($"Unrecognized side: {side}")
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static CastlingData ParseStandardChessCastlingRights(ReadOnlySpan<char> castlingChars, ReadOnlySpan<BitBoard> pieceBitboards, out byte castlingRights)
+        {
+            if (castlingChars.ContainsAny(_DFRCCastlingRightsChars))
+            {
+                _logger.Warn("DFRC position detected without UCI_Chess960 set. Enabling it as a fallback");
+                Configuration.EngineSettings.IsChess960 = true;
+
+                return ParseDFRCCastlingRights(castlingChars, pieceBitboards, out castlingRights);
+            }
+
+            castlingRights = 0;
+            for (int i = 0; i < castlingChars.Length; ++i)
+            {
+                castlingRights |= castlingChars[i] switch
+                {
+                    'K' => (byte)CastlingRights.WK,
+                    'Q' => (byte)CastlingRights.WQ,
+                    'k' => (byte)CastlingRights.BK,
+                    'q' => (byte)CastlingRights.BQ,
+                    '-' => castlingRights,
+                    _ => throw new LynxException($"Unrecognized castling char: {castlingChars[i]}")
+                };
+            }
+
+            return new CastlingData(
+                Constants.InitialWhiteKingsideRookSquare, Constants.InitialWhiteQueensideRookSquare,
+                Constants.InitialBlackKingsideRookSquare, Constants.InitialBlackQueensideRookSquare);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static CastlingData ParseDFRCCastlingRights(ReadOnlySpan<char> castlingChars, ReadOnlySpan<BitBoard> pieceBitboards, out byte castlingRights)
+        {
+            // X-FEN uses KQkq notation when not ambiguous, with the letters referring to "the outermost rook of the affected side"
+
+            int whiteKingsideRook = CastlingData.DefaultValues, whiteQueensideRook = CastlingData.DefaultValues, blackKingsideRook = CastlingData.DefaultValues, blackQueensideRook = CastlingData.DefaultValues;
+
+            var whiteKing = pieceBitboards[(int)Piece.K].GetLS1BIndex();
+            var blackKing = pieceBitboards[(int)Piece.k].GetLS1BIndex();
+
+            Debug.Assert(whiteKing != 0);
+            Debug.Assert(blackKing != 0);
+
+            castlingRights = 0;
+
+            for (int i = 0; i < castlingChars.Length; ++i)
+            {
+                var ch = castlingChars[i];
+                switch (ch)
+                {
+                    case 'K':
+                        {
+                            Debug.Assert(whiteKingsideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple white kingside rooks detected {whiteKingsideRook}");
+
+                            castlingRights |= (byte)CastlingRights.WK;
+
+                            for (int potentialRookSquareIndex = Constants.InitialWhiteKingsideRookSquare; potentialRookSquareIndex > whiteKing; --potentialRookSquareIndex)
+                            {
+                                if (pieceBitboards[(int)Piece.R].GetBit(potentialRookSquareIndex))
+                                {
+                                    whiteKingsideRook = potentialRookSquareIndex;
+                                    break;
+                                }
+                            }
+
+                            if (whiteKingsideRook == CastlingData.DefaultValues)
+                            {
+                                throw new LynxException($"Invalid castling rights: {ch} specified, but no rook found");
+                            }
+
+                            break;
+                        }
+                    case 'Q':
+                        {
+                            Debug.Assert(whiteQueensideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple white queenside rooks detected {whiteQueensideRook}");
+
+                            castlingRights |= (byte)CastlingRights.WQ;
+
+                            for (int potentialRookSquareIndex = Constants.InitialWhiteQueensideRookSquare; potentialRookSquareIndex < whiteKing; ++potentialRookSquareIndex)
+                            {
+                                if (pieceBitboards[(int)Piece.R].GetBit(potentialRookSquareIndex))
+                                {
+                                    whiteQueensideRook = potentialRookSquareIndex;
+                                    break;
+                                }
+                            }
+
+                            if (whiteQueensideRook == CastlingData.DefaultValues)
+                            {
+                                throw new LynxException($"Invalid castling rights: {ch} specified, but no rook found");
+                            }
+
+                            break;
+                        }
+                    case 'k':
+                        {
+                            Debug.Assert(blackKingsideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple black kingside rooks detected {blackKingsideRook}");
+
+                            castlingRights |= (byte)CastlingRights.BK;
+
+                            for (int potentialRookSquareIndex = Constants.InitialBlackKingsideRookSquare; potentialRookSquareIndex > blackKing; --potentialRookSquareIndex)
+                            {
+                                if (pieceBitboards[(int)Piece.r].GetBit(potentialRookSquareIndex))
+                                {
+                                    blackKingsideRook = potentialRookSquareIndex;
+                                    break;
+                                }
+                            }
+
+                            if (blackKingsideRook == CastlingData.DefaultValues)
+                            {
+                                throw new LynxException($"Invalid castling rights: {ch} specified, but no rook found");
+                            }
+
+                            break;
+                        }
+                    case 'q':
+                        {
+                            Debug.Assert(blackQueensideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple black queenside rooks detected {blackQueensideRook}");
+
+                            castlingRights |= (byte)CastlingRights.BQ;
+
+                            for (int potentialRookSquareIndex = Constants.InitialBlackQueensideRookSquare; potentialRookSquareIndex < blackKing; ++potentialRookSquareIndex)
+                            {
+                                if (pieceBitboards[(int)Piece.r].GetBit(potentialRookSquareIndex))
+                                {
+                                    blackQueensideRook = potentialRookSquareIndex;
+                                    break;
+                                }
+                            }
+
+                            if (blackQueensideRook == CastlingData.DefaultValues)
+                            {
+                                throw new LynxException($"Invalid castling rights: {ch} specified, but no rook found");
+                            }
+
+                            break;
+                        }
+                    case '-':
+                        {
+                            //castle |= (byte)CastlingRights.None;
+                            break;
+                        }
+                    default:
+                        {
+                            if (ch >= 'A' && ch <= 'H')
+                            {
+                                var square = BitBoardExtensions.SquareIndex(rank: 7, file: ch - 'A');
+
+                                if (square < whiteKing)
+                                {
+                                    Debug.Assert(whiteQueensideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple white queenside rooks detected {whiteQueensideRook}");
+                                    castlingRights |= (byte)CastlingRights.WQ;
+                                    whiteQueensideRook = square;
+                                }
+                                else if (square > whiteKing)
+                                {
+                                    Debug.Assert(whiteKingsideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple white kingside rooks detected {whiteKingsideRook}");
+                                    castlingRights |= (byte)CastlingRights.WK;
+                                    whiteKingsideRook = square;
+                                }
+                                else
+                                {
+                                    throw new LynxException($"Invalid castle character {ch}: it matches white king square ({square})");
+                                }
+
+                                break;
+                            }
+                            else if (ch >= 'a' && ch <= 'h')
+                            {
+                                var square = BitBoardExtensions.SquareIndex(rank: 0, file: ch - 'a');
+
+                                if (square < blackKing)
+                                {
+                                    Debug.Assert(blackQueensideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple black queenside rooks detected {blackQueensideRook}");
+                                    castlingRights |= (byte)CastlingRights.BQ;
+                                    blackQueensideRook = square;
+                                }
+                                else if (square > blackKing)
+                                {
+                                    Debug.Assert(blackKingsideRook == CastlingData.DefaultValues, $"Invalid castle character {ch}", $"Multiple black kingside rooks detected {blackKingsideRook}");
+                                    castlingRights |= (byte)CastlingRights.BK;
+                                    blackKingsideRook = square;
+                                }
+                                else
+                                {
+                                    throw new LynxException($"Invalid castle character {ch}: it matches black king square ({square})");
+                                }
+
+                                break;
+                            }
+
+                            throw new LynxException($"Unrecognized castle character: {ch}");
+                        }
+                }
+            }
+
+            return new CastlingData(whiteKingsideRook, whiteQueensideRook, blackKingsideRook, blackQueensideRook);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static (BoardSquare EnPassant, bool Success) ParseEnPassant(ReadOnlySpan<char> enPassantSpan, BitBoard[] PieceBitBoards, Side side)
+        {
+            bool success = true;
+
+            if (TryParseEnPassantSquare(enPassantSpan, out var enPassant))
+            {
+                if (enPassant != BoardSquare.noSquare)
+                {
+                    // Check that there's an actual pawn to be captured
+                    var pawnOffset = ((int)side << 4) - 8; // side == Side.White ? +8 : -8
+                    var pawnSquare = (int)enPassant + pawnOffset;
+
+                    var pawnBitBoard = PieceBitBoards[(int)Piece.P + Utils.PieceOffset(Utils.OppositeSide(side))];
+
+                    if (!pawnBitBoard.GetBit(pawnSquare))
+                    {
+                        success = false;
+                        enPassant = BoardSquare.noSquare;
+                        _logger.Error("Invalid board: en passant square {0}, but no {1} pawn located in {2}", enPassantSpan.ToString(), side, pawnSquare);
+                    }
+                }
+            }
+            else if (enPassantSpan.Length != 1 || enPassantSpan[0] != '-')
+            {
+                success = false;
+                enPassant = BoardSquare.noSquare;
+                _logger.Error("Invalid en passant square: {0}", enPassantSpan.ToString());
+            }
+
+            return (enPassant, success);
+
+            /// <summary>
+            /// Fast alternative to Enum.TryParse
+            /// </summary>
+            /// <returns></returns>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            static bool TryParseEnPassantSquare(ReadOnlySpan<char> enPassantSpan, out BoardSquare square)
+            {
+                if (enPassantSpan.Length == 1 && enPassantSpan[0] == '-')
+                {
+                    square = BoardSquare.noSquare;
+                    return true;
+                }
+
+                if (enPassantSpan.Length != 2)
+                {
+                    square = BoardSquare.noSquare;
+                    return false;
+                }
+
+                // Normalize to lowercase without branching
+                // https://blog.cloudflare.com/the-oldest-trick-in-the-ascii-book/
+                // Lowercase ASCII is uppercase ASCII + 0x20
+                var fileChar = (char)(enPassantSpan[0] | 0x20);
+                int file = fileChar - 'a'; // 0-7
+                int rank = enPassantSpan[1] - '0';  // 1-8
+
+                // Only ranks 3 and 6 are legal en passant target squares.
+                if ((uint)file >= 8 || (rank != 3 && rank != 6))
+                {
+                    square = BoardSquare.noSquare;
+                    _logger.Error("Invalid en passant square: {0}", enPassantSpan.ToString());
+
+                    return false;
+                }
+
+                square = (BoardSquare)BitBoardExtensions.SquareIndex(8 - rank, file);
+                return true;
+            }
         }
     }
 }

--- a/src/Lynx.Benchmark/ParseFEN_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseFEN_Benchmark.cs
@@ -1,177 +1,199 @@
 ﻿/*
  *
- *  BenchmarkDotNet v0.13.11, Ubuntu 22.04.3 LTS (Jammy Jellyfish)
+ *  BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
  *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
- *  .NET SDK 8.0.100
- *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *  .NET SDK 9.0.305
+ *    [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  *
- *  | Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
- *  |-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|------------:|
- *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,524.7 ns | 12.02 ns | 10.66 ns |  1.00 | 0.0343 |    2960 B |        1.00 |
- *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 2,288.4 ns | 18.94 ns | 17.72 ns |  0.91 | 0.0305 |    2704 B |        0.91 |
- *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 2,367.6 ns |  7.51 ns |  6.27 ns |  0.94 | 0.0305 |    2760 B |        0.93 |
- *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] | 1,079.5 ns |  4.92 ns |  4.36 ns |  0.43 | 0.0057 |     480 B |        0.16 |
- *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   332.3 ns |  0.76 ns |  0.59 ns |  0.13 | 0.0019 |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   317.7 ns |  2.06 ns |  1.92 ns |  0.13 | 0.0019 |     168 B |        0.06 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 3,169.5 ns | 11.35 ns | 10.62 ns |  1.00 | 0.0343 |    3160 B |        1.00 |
- *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 3,135.9 ns |  4.78 ns |  4.24 ns |  0.99 | 0.0343 |    2904 B |        0.92 |
- *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 3,170.2 ns | 13.62 ns | 12.74 ns |  1.00 | 0.0343 |    3016 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,565.7 ns |  1.15 ns |  0.96 ns |  0.49 | 0.0057 |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   380.9 ns |  2.34 ns |  2.08 ns |  0.12 | 0.0019 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   390.8 ns |  1.56 ns |  1.39 ns |  0.12 | 0.0019 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,030.9 ns |  4.14 ns |  3.46 ns |  1.00 | 0.0343 |    3080 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,855.1 ns |  8.86 ns |  8.29 ns |  0.94 | 0.0305 |    2816 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,723.6 ns | 15.72 ns | 14.70 ns |  0.90 | 0.0343 |    2928 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,441.1 ns |  1.23 ns |  1.03 ns |  0.48 | 0.0057 |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   400.5 ns |  2.11 ns |  1.87 ns |  0.13 | 0.0019 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   371.0 ns |  1.56 ns |  1.46 ns |  0.12 | 0.0019 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,884.8 ns | 12.03 ns | 10.67 ns |  1.00 | 0.0343 |    3080 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,834.7 ns | 10.18 ns |  9.52 ns |  0.98 | 0.0305 |    2816 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,782.7 ns |  6.39 ns |  5.33 ns |  0.96 | 0.0343 |    2928 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,396.6 ns |  2.03 ns |  1.80 ns |  0.48 | 0.0057 |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   409.4 ns |  1.83 ns |  1.71 ns |  0.14 | 0.0019 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   374.5 ns |  3.72 ns |  3.30 ns |  0.13 | 0.0019 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 3,089.3 ns | 12.13 ns | 10.75 ns |  1.00 | 0.0343 |    3072 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,699.1 ns | 10.40 ns |  9.73 ns |  0.87 | 0.0305 |    2800 B |        0.91 |
- *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,795.3 ns |  8.82 ns |  7.82 ns |  0.90 | 0.0343 |    2904 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,328.5 ns |  1.40 ns |  1.17 ns |  0.43 | 0.0057 |     528 B |        0.17 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   400.5 ns |  0.84 ns |  0.74 ns |  0.13 | 0.0019 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   394.7 ns |  1.76 ns |  1.65 ns |  0.13 | 0.0019 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 2,059.5 ns |  4.90 ns |  4.59 ns |  1.00 | 0.0305 |    2760 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 2,007.0 ns |  5.08 ns |  4.75 ns |  0.97 | 0.0267 |    2496 B |        0.90 |
- *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,916.2 ns |  6.67 ns |  5.57 ns |  0.93 | 0.0305 |    2584 B |        0.94 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   776.1 ns |  0.99 ns |  0.83 ns |  0.38 | 0.0029 |     264 B |        0.10 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   374.3 ns |  0.60 ns |  0.50 ns |  0.18 | 0.0019 |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   356.9 ns |  1.50 ns |  1.26 ns |  0.17 | 0.0019 |     168 B |        0.06 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 3,124.3 ns | 10.80 ns | 10.10 ns |  1.00 | 0.0343 |    3168 B |        1.00 |
- *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 3,033.7 ns |  6.11 ns |  5.72 ns |  0.97 | 0.0343 |    2904 B |        0.92 |
- *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 3,127.4 ns |  5.19 ns |  4.33 ns |  1.00 | 0.0343 |    3024 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,590.6 ns |  8.02 ns |  7.50 ns |  0.51 | 0.0057 |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   380.7 ns |  1.12 ns |  1.05 ns |  0.12 | 0.0019 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   371.5 ns |  0.64 ns |  0.53 ns |  0.12 | 0.0019 |     168 B |        0.05 |
+ *  | Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
+ *  |-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|-------:|----------:|------------:|
+ *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,163.7 ns | 19.92 ns | 18.63 ns |  1.00 | 0.1755 |      - |    2961 B |        1.00 |
+ *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 1,955.1 ns | 20.14 ns | 18.84 ns |  0.90 | 0.1602 |      - |    2705 B |        0.91 |
+ *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 1,993.1 ns | 23.42 ns | 21.91 ns |  0.92 | 0.1640 |      - |    2761 B |        0.93 |
+ *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] |   885.5 ns |  8.15 ns |  7.63 ns |  0.41 | 0.0286 |      - |     480 B |        0.16 |
+ *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   309.3 ns |  1.96 ns |  1.74 ns |  0.14 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   328.5 ns |  0.65 ns |  0.58 ns |  0.15 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   272.4 ns |  1.56 ns |  1.46 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.20 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 2,612.0 ns | 21.50 ns | 20.11 ns |  1.00 | 0.1869 |      - |    3161 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 2,434.7 ns |  9.81 ns |  9.17 ns |  0.93 | 0.1717 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 2,504.4 ns |  6.07 ns |  5.38 ns |  0.96 | 0.1793 |      - |    3017 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,255.2 ns |  1.94 ns |  1.72 ns |  0.48 | 0.0362 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   393.0 ns |  0.59 ns |  0.53 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   413.8 ns |  0.41 ns |  0.32 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   333.7 ns |  0.62 ns |  0.52 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,477.0 ns |  8.02 ns |  7.11 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,587.7 ns |  5.15 ns |  4.57 ns |  1.04 | 0.1678 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,384.0 ns | 25.45 ns | 21.25 ns |  0.96 | 0.1717 |      - |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,125.9 ns | 11.10 ns | 10.38 ns |  0.45 | 0.0324 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   394.8 ns |  2.32 ns |  2.17 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   419.6 ns |  2.05 ns |  1.82 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   326.0 ns |  1.72 ns |  1.61 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,442.3 ns |  5.34 ns |  4.73 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,441.4 ns | 20.05 ns | 18.75 ns |  1.00 | 0.1678 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,395.8 ns | 16.90 ns | 14.98 ns |  0.98 | 0.1717 |      - |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,154.2 ns |  2.26 ns |  2.00 ns |  0.47 | 0.0324 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   395.0 ns |  1.84 ns |  1.72 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   410.1 ns |  0.53 ns |  0.45 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   345.8 ns |  1.32 ns |  1.17 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 2,436.6 ns |  2.64 ns |  2.34 ns |  1.00 | 0.1831 |      - |    3073 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,289.6 ns |  9.62 ns |  8.04 ns |  0.94 | 0.1640 |      - |    2801 B |        0.91 |
+ *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,329.7 ns | 20.01 ns | 18.71 ns |  0.96 | 0.1717 |      - |    2905 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,105.0 ns |  5.54 ns |  5.18 ns |  0.45 | 0.0305 |      - |     528 B |        0.17 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   412.3 ns |  0.99 ns |  0.87 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   388.8 ns |  2.03 ns |  1.90 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   335.5 ns |  2.57 ns |  2.28 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 1,802.3 ns |  3.97 ns |  3.32 ns |  1.00 | 0.1640 | 0.0019 |    2761 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 1,709.8 ns |  3.78 ns |  3.35 ns |  0.95 | 0.1488 | 0.0019 |    2496 B |        0.90 |
+ *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,798.2 ns |  9.45 ns |  8.84 ns |  1.00 | 0.1545 | 0.0019 |    2584 B |        0.94 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   634.8 ns |  1.00 ns |  0.83 ns |  0.35 | 0.0153 |      - |     264 B |        0.10 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   386.9 ns |  0.53 ns |  0.49 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   357.9 ns |  0.89 ns |  0.74 ns |  0.20 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   340.7 ns |  0.59 ns |  0.49 ns |  0.19 | 0.0348 | 0.0010 |     584 B |        0.21 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 2,746.8 ns |  3.55 ns |  3.15 ns |  1.00 | 0.1869 |      - |    3169 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 2,478.9 ns |  5.30 ns |  4.43 ns |  0.90 | 0.1717 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 2,597.1 ns |  5.84 ns |  5.17 ns |  0.95 | 0.1793 |      - |    3025 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,271.5 ns |  9.36 ns |  8.76 ns |  0.46 | 0.0362 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   397.2 ns |  1.51 ns |  1.26 ns |  0.14 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   411.8 ns |  0.47 ns |  0.42 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   346.1 ns |  3.78 ns |  3.54 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |
  *
  *
- *  BenchmarkDotNet v0.13.11, Windows 10 (10.0.20348.2159) (Hyper-V)
+ *  BenchmarkDotNet v0.14.0, Windows 10 (10.0.20348.4052) (Hyper-V)
  *  AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
- *  .NET SDK 8.0.100
- *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
- *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2
+ *  .NET SDK 9.0.305
+ *    [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  *
- *  | Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
- *  |-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|----------:|------------:|
- *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,125.6 ns | 15.09 ns | 12.60 ns |  1.00 | 0.1755 |    2961 B |        1.00 |
- *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 2,116.1 ns | 15.77 ns | 13.17 ns |  1.00 | 0.1602 |    2704 B |        0.91 |
- *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 2,047.4 ns | 26.62 ns | 24.90 ns |  0.96 | 0.1640 |    2760 B |        0.93 |
- *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] |   972.4 ns |  3.72 ns |  3.30 ns |  0.46 | 0.0286 |     480 B |        0.16 |
- *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   308.4 ns |  0.93 ns |  0.78 ns |  0.15 | 0.0100 |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   315.1 ns |  1.44 ns |  1.28 ns |  0.15 | 0.0100 |     168 B |        0.06 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 2,686.8 ns | 11.73 ns | 10.97 ns |  1.00 | 0.1869 |    3161 B |        1.00 |
- *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 2,686.6 ns | 15.47 ns | 14.47 ns |  1.00 | 0.1717 |    2905 B |        0.92 |
- *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 2,590.5 ns |  5.99 ns |  5.60 ns |  0.96 | 0.1793 |    3017 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,393.3 ns |  3.90 ns |  3.46 ns |  0.52 | 0.0362 |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   377.1 ns |  1.54 ns |  1.44 ns |  0.14 | 0.0100 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   375.4 ns |  0.91 ns |  0.80 ns |  0.14 | 0.0100 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,554.5 ns | 19.55 ns | 17.33 ns |  1.00 | 0.1831 |    3081 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,541.3 ns | 14.49 ns | 11.31 ns |  1.00 | 0.1678 |    2817 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,491.1 ns | 27.74 ns | 25.95 ns |  0.98 | 0.1717 |    2929 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,297.3 ns |  7.77 ns |  7.27 ns |  0.51 | 0.0324 |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   386.0 ns |  0.66 ns |  0.59 ns |  0.15 | 0.0100 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   383.5 ns |  1.15 ns |  1.02 ns |  0.15 | 0.0100 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,543.6 ns | 16.06 ns | 14.24 ns |  1.00 | 0.1831 |    3081 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,465.2 ns | 12.26 ns | 10.87 ns |  0.97 | 0.1678 |    2817 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,479.2 ns | 20.19 ns | 18.89 ns |  0.97 | 0.1717 |    2929 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,275.2 ns |  1.49 ns |  1.24 ns |  0.50 | 0.0324 |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   374.7 ns |  1.66 ns |  1.56 ns |  0.15 | 0.0100 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   358.2 ns |  1.76 ns |  1.47 ns |  0.14 | 0.0100 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 2,528.8 ns |  7.25 ns |  6.78 ns |  1.00 | 0.1831 |    3073 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,431.1 ns | 12.50 ns | 11.08 ns |  0.96 | 0.1640 |    2800 B |        0.91 |
- *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,418.0 ns |  6.77 ns |  5.29 ns |  0.96 | 0.1717 |    2905 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,205.9 ns |  4.79 ns |  4.48 ns |  0.48 | 0.0305 |     528 B |        0.17 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   350.5 ns |  0.98 ns |  0.82 ns |  0.14 | 0.0100 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   336.5 ns |  0.53 ns |  0.50 ns |  0.13 | 0.0100 |     168 B |        0.05 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 1,790.1 ns | 14.62 ns | 12.96 ns |  1.00 | 0.1640 |    2760 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 1,628.0 ns |  6.50 ns |  6.08 ns |  0.91 | 0.1488 |    2496 B |        0.90 |
- *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,645.9 ns |  5.81 ns |  4.85 ns |  0.92 | 0.1545 |    2584 B |        0.94 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   743.8 ns |  1.82 ns |  1.70 ns |  0.42 | 0.0153 |     264 B |        0.10 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   366.6 ns |  1.36 ns |  1.27 ns |  0.20 | 0.0100 |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   361.1 ns |  0.99 ns |  0.88 ns |  0.20 | 0.0100 |     168 B |        0.06 |
- *  |                                       |                      |            |          |          |       |        |           |             |
- *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 2,756.2 ns |  6.30 ns |  5.58 ns |  1.00 | 0.1869 |    3169 B |        1.00 |
- *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 2,686.1 ns |  9.56 ns |  8.94 ns |  0.97 | 0.1717 |    2905 B |        0.92 |
- *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 2,689.8 ns |  9.50 ns |  8.42 ns |  0.98 | 0.1793 |    3025 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,418.5 ns |  7.53 ns |  7.04 ns |  0.51 | 0.0362 |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   401.6 ns |  0.53 ns |  0.41 ns |  0.15 | 0.0100 |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   383.2 ns |  1.64 ns |  1.45 ns |  0.14 | 0.0100 |     168 B |        0.05 |
+ *  | Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
+ *  |-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|-------:|----------:|------------:|
+ *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 1,943.1 ns | 12.57 ns | 11.75 ns |  1.00 | 0.1755 |      - |    2961 B |        1.00 |
+ *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 1,856.3 ns | 14.68 ns | 13.73 ns |  0.96 | 0.1602 |      - |    2705 B |        0.91 |
+ *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 1,880.6 ns | 11.08 ns |  9.82 ns |  0.97 | 0.1640 |      - |    2761 B |        0.93 |
+ *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] |   806.5 ns |  2.16 ns |  2.02 ns |  0.42 | 0.0286 |      - |     480 B |        0.16 |
+ *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   348.3 ns |  1.13 ns |  1.06 ns |  0.18 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   340.9 ns |  0.72 ns |  0.64 ns |  0.18 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   280.1 ns |  2.10 ns |  1.96 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.20 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 2,447.4 ns | 14.02 ns | 12.43 ns |  1.00 | 0.1869 |      - |    3161 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 2,334.1 ns | 10.08 ns |  9.43 ns |  0.95 | 0.1717 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 2,321.8 ns | 12.74 ns | 11.92 ns |  0.95 | 0.1793 |      - |    3017 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,084.8 ns |  2.54 ns |  2.25 ns |  0.44 | 0.0362 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   422.6 ns |  1.00 ns |  0.88 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   407.0 ns |  1.12 ns |  1.04 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   330.7 ns |  2.53 ns |  2.36 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.18 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,343.7 ns | 11.56 ns | 10.82 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,275.1 ns | 13.01 ns | 12.17 ns |  0.97 | 0.1678 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,279.9 ns |  5.66 ns |  5.02 ns |  0.97 | 0.1717 |      - |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,004.1 ns |  1.78 ns |  1.66 ns |  0.43 | 0.0324 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   387.9 ns |  1.20 ns |  1.06 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   372.9 ns |  1.37 ns |  1.22 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   320.6 ns |  2.62 ns |  2.46 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,328.9 ns | 14.27 ns | 13.35 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,247.6 ns | 13.35 ns | 12.49 ns |  0.97 | 0.1678 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,221.3 ns | 10.52 ns |  9.84 ns |  0.95 | 0.1717 |      - |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,013.5 ns |  1.77 ns |  1.57 ns |  0.44 | 0.0324 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   388.7 ns |  1.13 ns |  1.01 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   389.4 ns |  0.69 ns |  0.61 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   335.5 ns |  1.86 ns |  1.74 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 2,243.5 ns |  9.02 ns |  7.99 ns |  1.00 | 0.1831 |      - |    3073 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,169.6 ns | 10.65 ns |  9.97 ns |  0.97 | 0.1640 |      - |    2801 B |        0.91 |
+ *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,187.3 ns |  9.47 ns |  8.86 ns |  0.97 | 0.1717 |      - |    2905 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] |   995.4 ns |  2.67 ns |  2.36 ns |  0.44 | 0.0305 |      - |     528 B |        0.17 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   394.4 ns |  1.12 ns |  0.99 ns |  0.18 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   397.1 ns |  1.12 ns |  0.99 ns |  0.18 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   326.9 ns |  2.19 ns |  1.82 ns |  0.15 | 0.0348 | 0.0010 |     584 B |        0.19 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 1,720.7 ns |  9.79 ns |  8.68 ns |  1.00 | 0.1640 | 0.0019 |    2761 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 1,601.6 ns |  9.60 ns |  8.98 ns |  0.93 | 0.1488 |      - |    2496 B |        0.90 |
+ *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,636.7 ns | 10.35 ns |  9.68 ns |  0.95 | 0.1545 |      - |    2584 B |        0.94 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   633.6 ns |  1.22 ns |  1.08 ns |  0.37 | 0.0153 |      - |     264 B |        0.10 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   361.1 ns |  0.79 ns |  0.74 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   360.4 ns |  0.55 ns |  0.46 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   349.0 ns |  1.74 ns |  1.54 ns |  0.20 | 0.0348 | 0.0010 |     584 B |        0.21 |
+ *  |                                       |                      |            |          |          |       |        |        |           |             |
+ *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 2,522.9 ns | 11.00 ns | 10.29 ns |  1.00 | 0.1869 |      - |    3169 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 2,383.1 ns | 13.18 ns | 12.33 ns |  0.94 | 0.1717 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 2,419.7 ns | 13.33 ns | 12.47 ns |  0.96 | 0.1793 |      - |    3025 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,138.6 ns |  2.89 ns |  2.41 ns |  0.45 | 0.0362 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   382.5 ns |  1.63 ns |  1.44 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   371.8 ns |  1.22 ns |  1.14 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   328.4 ns |  2.23 ns |  2.09 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |
  *
  *
- *  BenchmarkDotNet v0.13.11, macOS Monterey 12.7.2 (21G1974) [Darwin 21.6.0]
- *  Intel Xeon CPU E5-1650 v2 3.50GHz (Max: 3.34GHz), 1 CPU, 3 logical and 3 physical cores
- *  .NET SDK 8.0.100
- *    [Host]     : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX
- *    DefaultJob : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX
+ *  BenchmarkDotNet v0.14.0, macOS Ventura 13.7.6 (22H625) [Darwin 22.6.0]
+ *  Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
+ *  .NET SDK 9.0.305
+ *    [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
+ *    DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  *
- *  | Method                                | fen                  | Mean       | Error    | StdDev    | Median     | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
- *  |-------------------------------------- |--------------------- |-----------:|---------:|----------:|-----------:|------:|--------:|-------:|-------:|----------:|------------:|
- *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 3,027.5 ns | 60.25 ns | 154.45 ns | 2,978.2 ns |  1.00 |    0.00 | 0.4692 |      - |    2961 B |        1.00 |
- *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 2,646.7 ns | 49.90 ns |  57.47 ns | 2,655.1 ns |  0.88 |    0.06 | 0.4311 |      - |    2705 B |        0.91 |
- *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 2,757.1 ns | 18.09 ns |  16.92 ns | 2,753.3 ns |  0.92 |    0.05 | 0.4387 |      - |    2761 B |        0.93 |
- *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] | 1,283.2 ns |  6.19 ns |   5.48 ns | 1,282.6 ns |  0.43 |    0.02 | 0.0763 |      - |     480 B |        0.16 |
- *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   439.4 ns |  8.51 ns |   7.10 ns |   439.8 ns |  0.15 |    0.01 | 0.0267 |      - |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   410.6 ns |  3.45 ns |   3.23 ns |   409.8 ns |  0.14 |    0.01 | 0.0267 |      - |     168 B |        0.06 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 3,698.7 ns | 60.75 ns |  50.73 ns | 3,710.6 ns |  1.00 |    0.00 | 0.5035 |      - |    3161 B |        1.00 |
- *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 3,528.1 ns | 51.56 ns |  45.71 ns | 3,538.6 ns |  0.96 |    0.02 | 0.4616 |      - |    2905 B |        0.92 |
- *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 3,747.1 ns | 74.17 ns |  88.29 ns | 3,755.4 ns |  1.01 |    0.03 | 0.4807 |      - |    3017 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,942.1 ns | 29.20 ns |  25.89 ns | 1,940.5 ns |  0.53 |    0.01 | 0.0992 |      - |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   579.5 ns |  8.81 ns |   8.24 ns |   578.0 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   565.6 ns | 11.17 ns |  10.44 ns |   564.4 ns |  0.15 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,870.9 ns | 76.82 ns | 140.47 ns | 3,821.1 ns |  1.00 |    0.00 | 0.4883 |      - |    3081 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,421.6 ns | 64.83 ns |  77.18 ns | 3,406.2 ns |  0.87 |    0.05 | 0.4463 |      - |    2817 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 3,741.3 ns | 71.90 ns |  90.93 ns | 3,730.3 ns |  0.96 |    0.04 | 0.4654 |      - |    2929 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,687.8 ns | 33.75 ns |  38.87 ns | 1,669.9 ns |  0.43 |    0.02 | 0.0877 |      - |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   609.5 ns |  3.78 ns |   3.35 ns |   607.8 ns |  0.15 |    0.01 | 0.0267 |      - |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   591.3 ns |  5.60 ns |   5.23 ns |   590.6 ns |  0.15 |    0.01 | 0.0267 |      - |     168 B |        0.05 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,608.2 ns | 30.71 ns |  27.22 ns | 3,611.8 ns |  1.00 |    0.00 | 0.4883 |      - |    3081 B |        1.00 |
- *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,377.4 ns | 60.42 ns |  56.52 ns | 3,374.1 ns |  0.93 |    0.02 | 0.4463 |      - |    2817 B |        0.91 |
- *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 3,791.0 ns | 37.73 ns |  35.29 ns | 3,800.8 ns |  1.05 |    0.01 | 0.4654 |      - |    2929 B |        0.95 |
- *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,793.3 ns | 30.26 ns |  28.30 ns | 1,784.9 ns |  0.50 |    0.01 | 0.0877 |      - |     552 B |        0.18 |
- *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   635.5 ns | 12.54 ns |  23.87 ns |   642.7 ns |  0.17 |    0.01 | 0.0267 |      - |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   601.3 ns |  8.07 ns |   7.16 ns |   603.7 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 3,908.1 ns | 58.65 ns |  54.86 ns | 3,890.9 ns |  1.00 |    0.00 | 0.4883 |      - |    3073 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 3,512.7 ns | 35.79 ns |  29.88 ns | 3,510.1 ns |  0.90 |    0.01 | 0.4463 |      - |    2801 B |        0.91 |
- *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 3,573.5 ns | 70.68 ns | 121.92 ns | 3,578.9 ns |  0.93 |    0.04 | 0.4616 | 0.0038 |    2905 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,808.6 ns | 27.75 ns |  25.96 ns | 1,804.9 ns |  0.46 |    0.01 | 0.0839 |      - |     528 B |        0.17 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   573.3 ns |  3.23 ns |   2.86 ns |   573.4 ns |  0.15 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   566.5 ns |  5.64 ns |   5.28 ns |   564.6 ns |  0.14 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 2,689.6 ns | 35.42 ns |  29.57 ns | 2,679.4 ns |  1.00 |    0.00 | 0.4387 |      - |    2761 B |        1.00 |
- *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 2,500.6 ns | 16.87 ns |  15.78 ns | 2,497.4 ns |  0.93 |    0.01 | 0.3967 |      - |    2497 B |        0.90 |
- *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 2,546.0 ns | 23.64 ns |  20.96 ns | 2,552.9 ns |  0.95 |    0.02 | 0.4120 |      - |    2585 B |        0.94 |
- *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] | 1,008.9 ns | 14.43 ns |  13.50 ns | 1,011.0 ns |  0.38 |    0.00 | 0.0420 |      - |     264 B |        0.10 |
- *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   542.9 ns |  8.88 ns |   8.31 ns |   538.9 ns |  0.20 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   562.2 ns |  6.47 ns |   6.05 ns |   560.8 ns |  0.21 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
- *  |                                       |                      |            |          |           |            |       |         |        |        |           |             |
- *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 3,823.7 ns | 75.62 ns |  84.05 ns | 3,846.4 ns |  1.00 |    0.00 | 0.5035 |      - |    3170 B |        1.00 |
- *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 3,661.7 ns | 57.23 ns |  50.73 ns | 3,655.0 ns |  0.96 |    0.03 | 0.4616 |      - |    2905 B |        0.92 |
- *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 3,800.6 ns | 72.78 ns |  83.81 ns | 3,793.9 ns |  0.99 |    0.03 | 0.4807 |      - |    3025 B |        0.95 |
- *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 2,023.4 ns | 24.08 ns |  22.52 ns | 2,019.7 ns |  0.53 |    0.01 | 0.0992 |      - |     624 B |        0.20 |
- *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   631.5 ns |  6.95 ns |   6.50 ns |   629.9 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
- *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   600.8 ns |  5.86 ns |   4.57 ns |   601.4 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *
+ *  | Method                                | fen                  | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
+ *  |-------------------------------------- |--------------------- |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|-------:|----------:|------------:|
+ *  | ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,777.7 ns |  45.24 ns |  40.11 ns | 2,757.0 ns |  1.00 |    0.02 | 0.4692 |      - |    2961 B |        1.00 |
+ *  | ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 2,559.3 ns |  48.29 ns |  45.17 ns | 2,537.5 ns |  0.92 |    0.02 | 0.4311 |      - |    2705 B |        0.91 |
+ *  | ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 2,546.9 ns |  35.67 ns |  31.62 ns | 2,543.6 ns |  0.92 |    0.02 | 0.4387 |      - |    2761 B |        0.93 |
+ *  | ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] | 1,209.0 ns |   5.63 ns |   4.70 ns | 1,207.0 ns |  0.44 |    0.01 | 0.0763 |      - |     480 B |        0.16 |
+ *  | ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   383.7 ns |   2.67 ns |   2.37 ns |   382.8 ns |  0.14 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   380.9 ns |   2.09 ns |   1.63 ns |   380.6 ns |  0.14 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   314.6 ns |   2.35 ns |   2.08 ns |   314.9 ns |  0.11 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.20 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 3,351.3 ns |  18.48 ns |  15.43 ns | 3,349.0 ns |  1.00 |    0.01 | 0.5035 |      - |    3162 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 3,179.1 ns |  51.43 ns |  45.59 ns | 3,154.2 ns |  0.95 |    0.01 | 0.4616 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 3,127.7 ns |  31.87 ns |  29.81 ns | 3,113.8 ns |  0.93 |    0.01 | 0.4807 | 0.0038 |    3018 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,710.3 ns |  11.10 ns |  10.39 ns | 1,708.1 ns |  0.51 |    0.00 | 0.0992 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   536.3 ns |   1.63 ns |   1.45 ns |   536.4 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   541.8 ns |   4.25 ns |   3.97 ns |   543.1 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   498.9 ns |   4.60 ns |   4.08 ns |   497.7 ns |  0.15 |    0.00 | 0.0925 | 0.0029 |     584 B |        0.18 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,133.6 ns |  44.65 ns |  34.86 ns | 3,117.0 ns |  1.00 |    0.02 | 0.4883 |      - |    3082 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,030.9 ns |  22.14 ns |  18.49 ns | 3,025.9 ns |  0.97 |    0.01 | 0.4463 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,936.1 ns |  35.35 ns |  31.34 ns | 2,921.4 ns |  0.94 |    0.01 | 0.4654 | 0.0038 |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,514.0 ns |   5.18 ns |   4.33 ns | 1,513.6 ns |  0.48 |    0.01 | 0.0877 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   562.0 ns |   1.84 ns |   1.54 ns |   561.8 ns |  0.18 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   556.3 ns |   5.25 ns |   4.38 ns |   556.7 ns |  0.18 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   524.7 ns |  10.43 ns |  21.55 ns |   519.2 ns |  0.17 |    0.01 | 0.0925 | 0.0029 |     584 B |        0.19 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,319.1 ns |  47.31 ns |  39.51 ns | 3,312.4 ns |  1.00 |    0.02 | 0.4883 |      - |    3082 B |        1.00 |
+ *  | ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,455.2 ns | 115.86 ns | 322.98 ns | 3,324.5 ns |  1.04 |    0.10 | 0.4463 |      - |    2817 B |        0.91 |
+ *  | ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 3,112.7 ns |  60.80 ns | 169.48 ns | 3,078.8 ns |  0.94 |    0.05 | 0.4654 | 0.0038 |    2929 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,524.2 ns |  14.22 ns |  11.88 ns | 1,520.3 ns |  0.46 |    0.01 | 0.0877 |      - |     552 B |        0.18 |
+ *  | ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   566.5 ns |   5.42 ns |   4.81 ns |   564.7 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   555.5 ns |   4.91 ns |   4.59 ns |   553.5 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   470.3 ns |   2.98 ns |   2.49 ns |   470.7 ns |  0.14 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.19 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 3,105.8 ns |  23.61 ns |  19.72 ns | 3,113.0 ns |  1.00 |    0.01 | 0.4883 | 0.0038 |    3074 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,916.6 ns |  40.86 ns |  38.22 ns | 2,913.1 ns |  0.94 |    0.01 | 0.4463 |      - |    2801 B |        0.91 |
+ *  | ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,870.8 ns |  37.71 ns |  35.27 ns | 2,870.4 ns |  0.92 |    0.01 | 0.4616 | 0.0038 |    2905 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,485.7 ns |   6.61 ns |   5.52 ns | 1,484.2 ns |  0.48 |    0.00 | 0.0839 |      - |     528 B |        0.17 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   519.1 ns |   3.23 ns |   3.03 ns |   518.1 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   509.9 ns |   3.54 ns |   3.32 ns |   507.7 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   438.6 ns |   3.17 ns |   2.97 ns |   439.4 ns |  0.14 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.19 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 2,289.9 ns |  32.22 ns |  30.14 ns | 2,295.0 ns |  1.00 |    0.02 | 0.4387 |      - |    2761 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 2,113.1 ns |  22.55 ns |  21.09 ns | 2,105.6 ns |  0.92 |    0.01 | 0.3967 |      - |    2497 B |        0.90 |
+ *  | ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 2,149.3 ns |  34.28 ns |  28.62 ns | 2,153.1 ns |  0.94 |    0.02 | 0.4120 |      - |    2585 B |        0.94 |
+ *  | ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   771.0 ns |  15.22 ns |  16.92 ns |   765.6 ns |  0.34 |    0.01 | 0.0420 |      - |     264 B |        0.10 |
+ *  | ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   500.5 ns |   7.61 ns |   6.36 ns |   498.7 ns |  0.22 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   494.2 ns |   3.52 ns |   3.12 ns |   493.2 ns |  0.22 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   463.8 ns |   7.68 ns |   7.18 ns |   461.4 ns |  0.20 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.21 |
+ *  |                                       |                      |            |           |           |            |       |         |        |        |           |             |
+ *  | ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 3,472.7 ns |  27.23 ns |  24.14 ns | 3,480.3 ns |  1.00 |    0.01 | 0.5035 |      - |    3170 B |        1.00 |
+ *  | ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 3,278.9 ns |  33.31 ns |  31.15 ns | 3,284.4 ns |  0.94 |    0.01 | 0.4616 |      - |    2905 B |        0.92 |
+ *  | ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 3,271.0 ns |  41.79 ns |  37.05 ns | 3,264.5 ns |  0.94 |    0.01 | 0.4807 | 0.0038 |    3026 B |        0.95 |
+ *  | ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,762.6 ns |  23.54 ns |  22.02 ns | 1,762.0 ns |  0.51 |    0.01 | 0.0992 |      - |     624 B |        0.20 |
+ *  | ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   537.5 ns |   4.11 ns |   3.65 ns |   537.3 ns |  0.15 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   549.1 ns |  10.99 ns |  11.28 ns |   545.1 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
+ *  | ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   552.8 ns |   9.93 ns |   8.81 ns |   548.8 ns |  0.16 |    0.00 | 0.0925 | 0.0029 |     584 B |        0.18 |
  *
  */
 

--- a/src/Lynx/FENParser.cs
+++ b/src/Lynx/FENParser.cs
@@ -375,40 +375,72 @@ public static class FENParser
         bool success = true;
         BoardSquare enPassant = BoardSquare.noSquare;
 
-        if (Enum.TryParse(enPassantSpan, ignoreCase: true, out BoardSquare result))
+        // Enum.TryParse is too slow
+        if (TryParseEnPassantSquare(enPassantSpan, out var parsedSquare))
         {
-            enPassant = result;
+            enPassant = parsedSquare;
 
-            var rank = 1 + ((int)enPassant >> 3);
-            if (rank != 3 && rank != 6)
+            if (enPassant != BoardSquare.noSquare)
             {
-                success = false;
-                _logger.Error("Invalid en passant square: {0}", enPassantSpan.ToString());
-            }
+                // Check that there's an actual pawn to be captured
+                var pawnOffset = ((int)side << 4) - 8; // side == Side.White ? +8 : -8
+                var pawnSquare = (int)enPassant + pawnOffset;
 
-            // Check that there's an actual pawn to be captured
-            var pawnOffset = side == Side.White
-                ? +8
-                : -8;
+                var pawnBitBoard = PieceBitBoards[(int)Piece.P + Utils.PieceOffset(Utils.OppositeSide(side))];
 
-            var pawnSquare = (int)enPassant + pawnOffset;
-
-            var pawnBitBoard = side == Side.White
-                ? PieceBitBoards[(int)Piece.p]
-                : PieceBitBoards[(int)Piece.P];
-
-            if (!pawnBitBoard.GetBit(pawnSquare))
-            {
-                success = false;
-                _logger.Error("Invalid board: en passant square {0}, but no {1} pawn located in {2}", enPassantSpan.ToString(), side, pawnSquare);
+                if (!pawnBitBoard.GetBit(pawnSquare))
+                {
+                    success = false;
+                    enPassant = BoardSquare.noSquare;
+                    _logger.Error("Invalid board: en passant square {0}, but no {1} pawn located in {2}", enPassantSpan.ToString(), side, pawnSquare);
+                }
             }
         }
-        else if (enPassantSpan[0] != '-')
+        else if (enPassantSpan.Length != 1 || enPassantSpan[0] != '-')
         {
             success = false;
             _logger.Error("Invalid en passant square: {0}", enPassantSpan.ToString());
         }
 
         return (enPassant, success);
+
+        /// <summary>
+        /// Fast alternative to Enum.TryParse
+        /// </summary>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static bool TryParseEnPassantSquare(ReadOnlySpan<char> enPassantSpan, out BoardSquare square)
+        {
+            if (enPassantSpan.Length == 1 && enPassantSpan[0] == '-')
+            {
+                square = BoardSquare.noSquare;
+                return true;
+            }
+
+            if (enPassantSpan.Length != 2)
+            {
+                square = BoardSquare.noSquare;
+                return false;
+            }
+
+            // Normalize to lowercase without branching
+            // https://blog.cloudflare.com/the-oldest-trick-in-the-ascii-book/
+            // Lowercase ASCII is uppercase ASCII + 0x20
+            var fileChar = (char)(enPassantSpan[0] | 0x20);
+            int file = fileChar - 'a'; // 0-7
+            int rank = enPassantSpan[1] - '0';  // 1-8
+
+            // Only ranks 3 and 6 are legal en passant target squares.
+            if ((uint)file >= 8 || (rank != 3 && rank != 6))
+            {
+                square = BoardSquare.noSquare;
+                _logger.Error("Invalid en passant square: {0}", enPassantSpan.ToString());
+
+                return false;
+            }
+
+            square = (BoardSquare)BitBoardExtensions.SquareIndex(8 - rank, file);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Optimize `ParseEnpassant`, which happens to represent the.. 66.5% of ParseFEN!

Done by replacing enum `Enum.TryParse` with ASCII char-based parsing.

Flame graph before:
<img width="1510" height="167" alt="image" src="https://github.com/user-attachments/assets/43558641-fd35-474a-ad49-65c340e755ba" />

Flame graph after:
<img width="1641" height="215" alt="image" src="https://github.com/user-attachments/assets/74d0a001-ccf3-4a78-8648-66d3f9c21e01" />

<details>

Increase of allocations is caused due to of the `ParseFENResult` struct introduced as part of FRC support, and not this PR.

<Summary>Benchmarks:</Summary>

```
BenchmarkDotNet v0.14.0, Ubuntu 24.04.3 LTS (Noble Numbat)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK 9.0.305
  [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2

| Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|-------:|----------:|------------:|
| ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,163.7 ns | 19.92 ns | 18.63 ns |  1.00 | 0.1755 |      - |    2961 B |        1.00 |
| ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 1,955.1 ns | 20.14 ns | 18.84 ns |  0.90 | 0.1602 |      - |    2705 B |        0.91 |
| ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 1,993.1 ns | 23.42 ns | 21.91 ns |  0.92 | 0.1640 |      - |    2761 B |        0.93 |
| ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] |   885.5 ns |  8.15 ns |  7.63 ns |  0.41 | 0.0286 |      - |     480 B |        0.16 |
| ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   309.3 ns |  1.96 ns |  1.74 ns |  0.14 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   328.5 ns |  0.65 ns |  0.58 ns |  0.15 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   272.4 ns |  1.56 ns |  1.46 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.20 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 2,612.0 ns | 21.50 ns | 20.11 ns |  1.00 | 0.1869 |      - |    3161 B |        1.00 |
| ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 2,434.7 ns |  9.81 ns |  9.17 ns |  0.93 | 0.1717 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 2,504.4 ns |  6.07 ns |  5.38 ns |  0.96 | 0.1793 |      - |    3017 B |        0.95 |
| ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,255.2 ns |  1.94 ns |  1.72 ns |  0.48 | 0.0362 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   393.0 ns |  0.59 ns |  0.53 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   413.8 ns |  0.41 ns |  0.32 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   333.7 ns |  0.62 ns |  0.52 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,477.0 ns |  8.02 ns |  7.11 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,587.7 ns |  5.15 ns |  4.57 ns |  1.04 | 0.1678 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,384.0 ns | 25.45 ns | 21.25 ns |  0.96 | 0.1717 |      - |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,125.9 ns | 11.10 ns | 10.38 ns |  0.45 | 0.0324 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   394.8 ns |  2.32 ns |  2.17 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   419.6 ns |  2.05 ns |  1.82 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   326.0 ns |  1.72 ns |  1.61 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,442.3 ns |  5.34 ns |  4.73 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,441.4 ns | 20.05 ns | 18.75 ns |  1.00 | 0.1678 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,395.8 ns | 16.90 ns | 14.98 ns |  0.98 | 0.1717 |      - |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,154.2 ns |  2.26 ns |  2.00 ns |  0.47 | 0.0324 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   395.0 ns |  1.84 ns |  1.72 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   410.1 ns |  0.53 ns |  0.45 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   345.8 ns |  1.32 ns |  1.17 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 2,436.6 ns |  2.64 ns |  2.34 ns |  1.00 | 0.1831 |      - |    3073 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,289.6 ns |  9.62 ns |  8.04 ns |  0.94 | 0.1640 |      - |    2801 B |        0.91 |
| ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,329.7 ns | 20.01 ns | 18.71 ns |  0.96 | 0.1717 |      - |    2905 B |        0.95 |
| ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,105.0 ns |  5.54 ns |  5.18 ns |  0.45 | 0.0305 |      - |     528 B |        0.17 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   412.3 ns |  0.99 ns |  0.87 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   388.8 ns |  2.03 ns |  1.90 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   335.5 ns |  2.57 ns |  2.28 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 1,802.3 ns |  3.97 ns |  3.32 ns |  1.00 | 0.1640 | 0.0019 |    2761 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 1,709.8 ns |  3.78 ns |  3.35 ns |  0.95 | 0.1488 | 0.0019 |    2496 B |        0.90 |
| ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,798.2 ns |  9.45 ns |  8.84 ns |  1.00 | 0.1545 | 0.0019 |    2584 B |        0.94 |
| ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   634.8 ns |  1.00 ns |  0.83 ns |  0.35 | 0.0153 |      - |     264 B |        0.10 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   386.9 ns |  0.53 ns |  0.49 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   357.9 ns |  0.89 ns |  0.74 ns |  0.20 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   340.7 ns |  0.59 ns |  0.49 ns |  0.19 | 0.0348 | 0.0010 |     584 B |        0.21 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 2,746.8 ns |  3.55 ns |  3.15 ns |  1.00 | 0.1869 |      - |    3169 B |        1.00 |
| ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 2,478.9 ns |  5.30 ns |  4.43 ns |  0.90 | 0.1717 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 2,597.1 ns |  5.84 ns |  5.17 ns |  0.95 | 0.1793 |      - |    3025 B |        0.95 |
| ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,271.5 ns |  9.36 ns |  8.76 ns |  0.46 | 0.0362 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   397.2 ns |  1.51 ns |  1.26 ns |  0.14 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   411.8 ns |  0.47 ns |  0.42 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   346.1 ns |  3.78 ns |  3.54 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |


BenchmarkDotNet v0.14.0, Windows 10 (10.0.20348.4052) (Hyper-V)
AMD EPYC 7763, 1 CPU, 4 logical and 2 physical cores
.NET SDK 9.0.305
  [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2

| Method                                | fen                  | Mean       | Error    | StdDev   | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------------------------------------- |--------------------- |-----------:|---------:|---------:|------:|-------:|-------:|----------:|------------:|
| ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 1,943.1 ns | 12.57 ns | 11.75 ns |  1.00 | 0.1755 |      - |    2961 B |        1.00 |
| ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 1,856.3 ns | 14.68 ns | 13.73 ns |  0.96 | 0.1602 |      - |    2705 B |        0.91 |
| ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 1,880.6 ns | 11.08 ns |  9.82 ns |  0.97 | 0.1640 |      - |    2761 B |        0.93 |
| ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] |   806.5 ns |  2.16 ns |  2.02 ns |  0.42 | 0.0286 |      - |     480 B |        0.16 |
| ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   348.3 ns |  1.13 ns |  1.06 ns |  0.18 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   340.9 ns |  0.72 ns |  0.64 ns |  0.18 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   280.1 ns |  2.10 ns |  1.96 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.20 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 2,447.4 ns | 14.02 ns | 12.43 ns |  1.00 | 0.1869 |      - |    3161 B |        1.00 |
| ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 2,334.1 ns | 10.08 ns |  9.43 ns |  0.95 | 0.1717 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 2,321.8 ns | 12.74 ns | 11.92 ns |  0.95 | 0.1793 |      - |    3017 B |        0.95 |
| ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,084.8 ns |  2.54 ns |  2.25 ns |  0.44 | 0.0362 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   422.6 ns |  1.00 ns |  0.88 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   407.0 ns |  1.12 ns |  1.04 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   330.7 ns |  2.53 ns |  2.36 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.18 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,343.7 ns | 11.56 ns | 10.82 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,275.1 ns | 13.01 ns | 12.17 ns |  0.97 | 0.1678 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,279.9 ns |  5.66 ns |  5.02 ns |  0.97 | 0.1717 |      - |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,004.1 ns |  1.78 ns |  1.66 ns |  0.43 | 0.0324 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   387.9 ns |  1.20 ns |  1.06 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   372.9 ns |  1.37 ns |  1.22 ns |  0.16 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   320.6 ns |  2.62 ns |  2.46 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 2,328.9 ns | 14.27 ns | 13.35 ns |  1.00 | 0.1831 |      - |    3081 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 2,247.6 ns | 13.35 ns | 12.49 ns |  0.97 | 0.1678 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,221.3 ns | 10.52 ns |  9.84 ns |  0.95 | 0.1717 |      - |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,013.5 ns |  1.77 ns |  1.57 ns |  0.44 | 0.0324 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   388.7 ns |  1.13 ns |  1.01 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   389.4 ns |  0.69 ns |  0.61 ns |  0.17 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   335.5 ns |  1.86 ns |  1.74 ns |  0.14 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 2,243.5 ns |  9.02 ns |  7.99 ns |  1.00 | 0.1831 |      - |    3073 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,169.6 ns | 10.65 ns |  9.97 ns |  0.97 | 0.1640 |      - |    2801 B |        0.91 |
| ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,187.3 ns |  9.47 ns |  8.86 ns |  0.97 | 0.1717 |      - |    2905 B |        0.95 |
| ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] |   995.4 ns |  2.67 ns |  2.36 ns |  0.44 | 0.0305 |      - |     528 B |        0.17 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   394.4 ns |  1.12 ns |  0.99 ns |  0.18 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   397.1 ns |  1.12 ns |  0.99 ns |  0.18 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   326.9 ns |  2.19 ns |  1.82 ns |  0.15 | 0.0348 | 0.0010 |     584 B |        0.19 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 1,720.7 ns |  9.79 ns |  8.68 ns |  1.00 | 0.1640 | 0.0019 |    2761 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 1,601.6 ns |  9.60 ns |  8.98 ns |  0.93 | 0.1488 |      - |    2496 B |        0.90 |
| ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 1,636.7 ns | 10.35 ns |  9.68 ns |  0.95 | 0.1545 |      - |    2584 B |        0.94 |
| ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   633.6 ns |  1.22 ns |  1.08 ns |  0.37 | 0.0153 |      - |     264 B |        0.10 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   361.1 ns |  0.79 ns |  0.74 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   360.4 ns |  0.55 ns |  0.46 ns |  0.21 | 0.0100 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   349.0 ns |  1.74 ns |  1.54 ns |  0.20 | 0.0348 | 0.0010 |     584 B |        0.21 |
|                                       |                      |            |          |          |       |        |        |           |             |
| ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 2,522.9 ns | 11.00 ns | 10.29 ns |  1.00 | 0.1869 |      - |    3169 B |        1.00 |
| ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 2,383.1 ns | 13.18 ns | 12.33 ns |  0.94 | 0.1717 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 2,419.7 ns | 13.33 ns | 12.47 ns |  0.96 | 0.1793 |      - |    3025 B |        0.95 |
| ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,138.6 ns |  2.89 ns |  2.41 ns |  0.45 | 0.0362 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   382.5 ns |  1.63 ns |  1.44 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   371.8 ns |  1.22 ns |  1.14 ns |  0.15 | 0.0100 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   328.4 ns |  2.23 ns |  2.09 ns |  0.13 | 0.0348 | 0.0010 |     584 B |        0.18 |


BenchmarkDotNet v0.14.0, macOS Ventura 13.7.6 (22H625) [Darwin 22.6.0]
Intel Core i7-8700B CPU 3.20GHz (Max: 3.19GHz) (Coffee Lake), 1 CPU, 4 logical and 4 physical cores
.NET SDK 9.0.305
  [Host]     : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2
  DefaultJob : .NET 9.0.9 (9.0.925.41916), X64 RyuJIT AVX2


| Method                                | fen                  | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD | Gen0   | Gen1   | Allocated | Alloc Ratio |
|-------------------------------------- |--------------------- |-----------:|----------:|----------:|-----------:|------:|--------:|-------:|-------:|----------:|------------:|
| ParseFEN_Original                     | 8/k7/(...)- 0 1 [39] | 2,777.7 ns |  45.24 ns |  40.11 ns | 2,757.0 ns |  1.00 |    0.02 | 0.4692 |      - |    2961 B |        1.00 |
| ParseFEN_Improved1                    | 8/k7/(...)- 0 1 [39] | 2,559.3 ns |  48.29 ns |  45.17 ns | 2,537.5 ns |  0.92 |    0.02 | 0.4311 |      - |    2705 B |        0.91 |
| ParseFEN_Base2                        | 8/k7/(...)- 0 1 [39] | 2,546.9 ns |  35.67 ns |  31.62 ns | 2,543.6 ns |  0.92 |    0.02 | 0.4387 |      - |    2761 B |        0.93 |
| ParseFEN_NoRegex                      | 8/k7/(...)- 0 1 [39] | 1,209.0 ns |   5.63 ns |   4.70 ns | 1,207.0 ns |  0.44 |    0.01 | 0.0763 |      - |     480 B |        0.16 |
| ParseFEN_OptimizedParseBoard          | 8/k7/(...)- 0 1 [39] |   383.7 ns |   2.67 ns |   2.37 ns |   382.8 ns |  0.14 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | 8/k7/(...)- 0 1 [39] |   380.9 ns |   2.09 ns |   1.63 ns |   380.6 ns |  0.14 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | 8/k7/(...)- 0 1 [39] |   314.6 ns |   2.35 ns |   2.08 ns |   314.9 ns |  0.11 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.20 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | r2q1r(...)- 0 9 [68] | 3,351.3 ns |  18.48 ns |  15.43 ns | 3,349.0 ns |  1.00 |    0.01 | 0.5035 |      - |    3162 B |        1.00 |
| ParseFEN_Improved1                    | r2q1r(...)- 0 9 [68] | 3,179.1 ns |  51.43 ns |  45.59 ns | 3,154.2 ns |  0.95 |    0.01 | 0.4616 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | r2q1r(...)- 0 9 [68] | 3,127.7 ns |  31.87 ns |  29.81 ns | 3,113.8 ns |  0.93 |    0.01 | 0.4807 | 0.0038 |    3018 B |        0.95 |
| ParseFEN_NoRegex                      | r2q1r(...)- 0 9 [68] | 1,710.3 ns |  11.10 ns |  10.39 ns | 1,708.1 ns |  0.51 |    0.00 | 0.0992 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | r2q1r(...)- 0 9 [68] |   536.3 ns |   1.63 ns |   1.45 ns |   536.4 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r2q1r(...)- 0 9 [68] |   541.8 ns |   4.25 ns |   3.97 ns |   543.1 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r2q1r(...)- 0 9 [68] |   498.9 ns |   4.60 ns |   4.08 ns |   497.7 ns |  0.15 |    0.00 | 0.0925 | 0.0029 |     584 B |        0.18 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,133.6 ns |  44.65 ns |  34.86 ns | 3,117.0 ns |  1.00 |    0.02 | 0.4883 |      - |    3082 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,030.9 ns |  22.14 ns |  18.49 ns | 3,025.9 ns |  0.97 |    0.01 | 0.4463 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 2,936.1 ns |  35.35 ns |  31.34 ns | 2,921.4 ns |  0.94 |    0.01 | 0.4654 | 0.0038 |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,514.0 ns |   5.18 ns |   4.33 ns | 1,513.6 ns |  0.48 |    0.01 | 0.0877 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   562.0 ns |   1.84 ns |   1.54 ns |   561.8 ns |  0.18 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   556.3 ns |   5.25 ns |   4.38 ns |   556.7 ns |  0.18 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   524.7 ns |  10.43 ns |  21.55 ns |   519.2 ns |  0.17 |    0.01 | 0.0925 | 0.0029 |     584 B |        0.19 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | r3k2r(...)- 0 1 [68] | 3,319.1 ns |  47.31 ns |  39.51 ns | 3,312.4 ns |  1.00 |    0.02 | 0.4883 |      - |    3082 B |        1.00 |
| ParseFEN_Improved1                    | r3k2r(...)- 0 1 [68] | 3,455.2 ns | 115.86 ns | 322.98 ns | 3,324.5 ns |  1.04 |    0.10 | 0.4463 |      - |    2817 B |        0.91 |
| ParseFEN_Base2                        | r3k2r(...)- 0 1 [68] | 3,112.7 ns |  60.80 ns | 169.48 ns | 3,078.8 ns |  0.94 |    0.05 | 0.4654 | 0.0038 |    2929 B |        0.95 |
| ParseFEN_NoRegex                      | r3k2r(...)- 0 1 [68] | 1,524.2 ns |  14.22 ns |  11.88 ns | 1,520.3 ns |  0.46 |    0.01 | 0.0877 |      - |     552 B |        0.18 |
| ParseFEN_OptimizedParseBoard          | r3k2r(...)- 0 1 [68] |   566.5 ns |   5.42 ns |   4.81 ns |   564.7 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | r3k2r(...)- 0 1 [68] |   555.5 ns |   4.91 ns |   4.59 ns |   553.5 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | r3k2r(...)- 0 1 [68] |   470.3 ns |   2.98 ns |   2.49 ns |   470.7 ns |  0.14 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.19 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)6 0 1 [67] | 3,105.8 ns |  23.61 ns |  19.72 ns | 3,113.0 ns |  1.00 |    0.01 | 0.4883 | 0.0038 |    3074 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)6 0 1 [67] | 2,916.6 ns |  40.86 ns |  38.22 ns | 2,913.1 ns |  0.94 |    0.01 | 0.4463 |      - |    2801 B |        0.91 |
| ParseFEN_Base2                        | rnbqk(...)6 0 1 [67] | 2,870.8 ns |  37.71 ns |  35.27 ns | 2,870.4 ns |  0.92 |    0.01 | 0.4616 | 0.0038 |    2905 B |        0.95 |
| ParseFEN_NoRegex                      | rnbqk(...)6 0 1 [67] | 1,485.7 ns |   6.61 ns |   5.52 ns | 1,484.2 ns |  0.48 |    0.00 | 0.0839 |      - |     528 B |        0.17 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)6 0 1 [67] |   519.1 ns |   3.23 ns |   3.03 ns |   518.1 ns |  0.17 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)6 0 1 [67] |   509.9 ns |   3.54 ns |   3.32 ns |   507.7 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)6 0 1 [67] |   438.6 ns |   3.17 ns |   2.97 ns |   439.4 ns |  0.14 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.19 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | rnbqk(...)- 0 1 [56] | 2,289.9 ns |  32.22 ns |  30.14 ns | 2,295.0 ns |  1.00 |    0.02 | 0.4387 |      - |    2761 B |        1.00 |
| ParseFEN_Improved1                    | rnbqk(...)- 0 1 [56] | 2,113.1 ns |  22.55 ns |  21.09 ns | 2,105.6 ns |  0.92 |    0.01 | 0.3967 |      - |    2497 B |        0.90 |
| ParseFEN_Base2                        | rnbqk(...)- 0 1 [56] | 2,149.3 ns |  34.28 ns |  28.62 ns | 2,153.1 ns |  0.94 |    0.02 | 0.4120 |      - |    2585 B |        0.94 |
| ParseFEN_NoRegex                      | rnbqk(...)- 0 1 [56] |   771.0 ns |  15.22 ns |  16.92 ns |   765.6 ns |  0.34 |    0.01 | 0.0420 |      - |     264 B |        0.10 |
| ParseFEN_OptimizedParseBoard          | rnbqk(...)- 0 1 [56] |   500.5 ns |   7.61 ns |   6.36 ns |   498.7 ns |  0.22 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedPopulateOccupancies | rnbqk(...)- 0 1 [56] |   494.2 ns |   3.52 ns |   3.12 ns |   493.2 ns |  0.22 |    0.00 | 0.0267 |      - |     168 B |        0.06 |
| ParseFEN_OptimizedParseEnPassant      | rnbqk(...)- 0 1 [56] |   463.8 ns |   7.68 ns |   7.18 ns |   461.4 ns |  0.20 |    0.00 | 0.0930 | 0.0029 |     584 B |        0.21 |
|                                       |                      |            |           |           |            |       |         |        |        |           |             |
| ParseFEN_Original                     | rq2k2(...)- 0 1 [71] | 3,472.7 ns |  27.23 ns |  24.14 ns | 3,480.3 ns |  1.00 |    0.01 | 0.5035 |      - |    3170 B |        1.00 |
| ParseFEN_Improved1                    | rq2k2(...)- 0 1 [71] | 3,278.9 ns |  33.31 ns |  31.15 ns | 3,284.4 ns |  0.94 |    0.01 | 0.4616 |      - |    2905 B |        0.92 |
| ParseFEN_Base2                        | rq2k2(...)- 0 1 [71] | 3,271.0 ns |  41.79 ns |  37.05 ns | 3,264.5 ns |  0.94 |    0.01 | 0.4807 | 0.0038 |    3026 B |        0.95 |
| ParseFEN_NoRegex                      | rq2k2(...)- 0 1 [71] | 1,762.6 ns |  23.54 ns |  22.02 ns | 1,762.0 ns |  0.51 |    0.01 | 0.0992 |      - |     624 B |        0.20 |
| ParseFEN_OptimizedParseBoard          | rq2k2(...)- 0 1 [71] |   537.5 ns |   4.11 ns |   3.65 ns |   537.3 ns |  0.15 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedPopulateOccupancies | rq2k2(...)- 0 1 [71] |   549.1 ns |  10.99 ns |  11.28 ns |   545.1 ns |  0.16 |    0.00 | 0.0267 |      - |     168 B |        0.05 |
| ParseFEN_OptimizedParseEnPassant      | rq2k2(...)- 0 1 [71] |   552.8 ns |   9.93 ns |   8.81 ns |   548.8 ns |  0.16 |    0.00 | 0.0925 | 0.0029 |     584 B |        0.18 |
```

</details>
