### PR TITLE
🧪⚡ Use array pools instead of `stackalloc` arrays, reusing them between plies - pinned

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -89,11 +89,11 @@ public sealed partial class Engine : IDisposable
         int attacksBySideSize = _poolsPerPly * maxDepth * 2;
         int movesSize = _poolsPerPly * maxDepth * Constants.MaxNumberOfPseudolegalMovesInAPosition;
 
-        _attacksPool = new BitBoard[attacksSize];
-        _attacksBySidePool = new BitBoard[attacksBySideSize];
-        _movesPool = new Move[movesSize];
-        _moveScoresPool = new int[movesSize];
-        _visitedMovesPool = new Move[movesSize];
+        _attacksPool = GC.AllocateArray<BitBoard>(attacksSize, pinned: true);
+        _attacksBySidePool = GC.AllocateArray<BitBoard>(attacksBySideSize, pinned: true);
+        _movesPool = GC.AllocateArray<int>(movesSize, pinned: true);
+        _moveScoresPool = GC.AllocateArray<int>(movesSize, pinned: true);
+        _visitedMovesPool = GC.AllocateArray<int>(movesSize, pinned: true);
 
         _logger.Info("Engine {0} initialized", _id);
     }


### PR DESCRIPTION
#2076 but pinned

```
Test  | perf/search-array-pools-pinned
Elo   | 0.83 +- 0.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.19 (-2.25, 2.89) [0.00, 3.00]
Games | 251020: +68272 -67675 =115073
Penta | [3337, 25937, 66470, 26324, 3442]
https://openbench.lynx-chess.com/test/2194/
```