### PR TITLE
🧪 Transform `EvaluationContext` from ref struct into class

### DIFF
--- a/src/Lynx.Benchmark/BitBoard_Struct_ReadonlyStruct_Class_Record_Benchmark.cs
+++ b/src/Lynx.Benchmark/BitBoard_Struct_ReadonlyStruct_Class_Record_Benchmark.cs
@@ -32,7 +32,7 @@ using Lynx.Model;
 
 namespace Lynx.Benchmark;
 
-public class BitBoard_Struct_ReadonlyStruct_Class_Record_Benchmark  : BaseBenchmark
+public class BitBoard_Struct_ReadonlyStruct_Class_Record_Benchmark : BaseBenchmark
 {
     private struct BitBoardOps
     {

--- a/src/Lynx.Benchmark/ParseGame_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseGame_Benchmark.cs
@@ -149,569 +149,567 @@ namespace Lynx.Benchmark;
 
 public partial class ParseGame_Benchmark : BaseBenchmark
 {
-    public static IEnumerable<string> Data =>
-    [
-        "position startpos",    // No moves
+	public static IEnumerable<string> Data =>
+	[
+		"position startpos",    // No moves
         "position startpos moves d2d4 d7d5 b1c3 g8f6 f2f3 c7c5 e2e3 b8c6 a2a3 e7e6 f1e2 c8d7 d4c5 f8c5 h2h3 f6h5 h1h2 d8h4 e1d2 h4f2 c3d5 e6d5 d2c3 c5e3 c1d2 c6a5 a3a4 e3d4 c3b4 d4c5 b4a5 a7a6 a1a2 b7b6",    // 17 moves
         "position startpos moves d2d4 d7d5 g1f3 g8f6 e2e3 b8c6 f1e2 c8f5 b1c3 f6e4 e1g1 e4c3 b2c3 e7e6 a1b1 a8b8 c1b2 b7b5 f3e5 c6e5 d4e5 f8c5 e2f3 e8g8 f1e1 d8h4 g2g4 f5g6 b1c1 f7f6 e5f6 h4f6 g1g2 g6e4 f3e4 f6f2 g2h1 d5e4 d1e2 f2f3 e2f3 e4f3 e3e4 f3f2 e1f1 f8f4 c1d1 f4e4 g4g5 e4g4 b2c1 b8f8 a2a3 e6e5 h2h3 g4g3 c1b2 f8f3 d1d8 g8f7 d8d7 f7e6 d7c7 g3h3 h1g2 f3g3",    // 36 moves
         "position startpos moves g1f3 e7e6 e2e4 b7b6 d2d4 g8f6 e4e5 f6d5 c2c4 f8b4 b1d2 d5e7 a2a3 b4d2 c1d2 d7d6 d2c3 d6e5 f3e5 c8b7 f1e2 e8g8 e2f3 b7f3 d1f3 b8d7 a1d1 f7f6 e5c6 e7c6 f3c6 f8e8 e1g1 d7f8 f1e1 d8d7 c6f3 f8g6 f3b7 a7a5 c4c5 a8b8 b7e4 d7b5 d4d5 e6e5 d5d6 b5c5 d6d7 e8d8 e1e3 g6f4 g2g3 f4h3 g1g2 h3g5 e4a4 g5f7 e3d3 f7d6 d3d5 c5c4 a4c4 d6c4 b2b4 a5a4 d1c1 c4d6 c3e5 d8d7 e5d6 d7d6 d5d6 c7d6 c1c6 d6d5 c6d6 b8c8 d6d5 c8c3 b4b5 c3b3 d5d4 b3a3 d4d6 a3a1 d6b6 a4a3 b6b8 g8f7 b5b6 a1b1 b8a8 b1b6 a8a3 b6b8 a3a7 f7g8 h2h4 b8e8 g3g4 e8d8 g2f3 d8d3 f3e4 d3d8 e4f4 d8d4 f4g3 d4d8 h4h5 d8f8 g3f4 f8b8 f4f3 b8b3 f3g2 b3b8 a7c7 b8a8 g2f3 a8a3 f3f4 a3a4 f4g3 a4a8 c7b7 a8f8 g3f4 f8c8 f4e4 c8c4 e4f3 c4c3 f3g2 c3c8 f2f4 c8c2 g2f3 c2c3 f3e4 c3c4 e4f5 c4c5 f5e6 c5c6 e6d5 c6c8 h5h6 g7h6 d5e6 c8c4 e6f5 c4c6 b7a7 c6d6 a7c7 d6d4 c7b7 d4a4 b7e7 a4a6 e7e6 a6e6 f5e6 g8g7 f4f5 h6h5 g4h5 h7h6 e6e7 g7g8 e7f6 g8f8 f6e6 f8g7 e6e7 g7h8 f5f6 h8g8 f6f7 g8h8 f7f8Q h8h7 f8f4 h7g8 f4g4 g8h8 e7f8 h8h7 g4g8",  // 96 movws
         Constants.LongPositionCommand, // 296 moves
     ];
 
-    [Benchmark(Baseline = true)]
-    [ArgumentsSource(nameof(Data))]
-    public OriginalGame ParseGame_Original(string positionCommand) => ParseGame_OriginalClass.ParseGame(positionCommand);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public OriginalGame ParseGame_Improved1(string positionCommand) => ParseGame_ImprovedClass1.ParseGame(positionCommand);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public ImprovedGame ParseGame_Improved2(string positionCommand) => ParseGame_ImprovedClass2.ParseGame(positionCommand);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public ImprovedGame ParseGame_Improved3(string positionCommand) => ParseGame_ImprovedClass3.ParseGame(positionCommand);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public ImprovedGame2 ParseGame_Improved4(string positionCommand) => ParseGame_ImprovedClass4.ParseGame(positionCommand);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Data))]
-    public ImprovedGame2 ParseGame_Improved5(string positionCommand) => ParseGame_ImprovedClass5.ParseGame(positionCommand);
-
-    public static partial class ParseGame_OriginalClass
-    {
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        [GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex FenRegex();
-
-        [GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex MovesRegex();
-
-        private static readonly Regex _fenRegex = FenRegex();
-        private static readonly Regex _movesRegex = MovesRegex();
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static OriginalGame ParseGame(string positionCommand)
-        {
-            try
-            {
-                var items = positionCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                bool isInitialPosition = string.Equals(items.ElementAtOrDefault(1), StartPositionString, StringComparison.OrdinalIgnoreCase);
-
-                var initialPosition = isInitialPosition
-                        ? Constants.InitialPositionFEN
-                        : _fenRegex.Match(positionCommand).Value.Trim();
-
-                if (string.IsNullOrEmpty(initialPosition))
-                {
-                    _logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
-                }
-
-                var moves = _movesRegex.Match(positionCommand).Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-                return new OriginalGame(initialPosition, moves);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
-
-    public static partial class ParseGame_ImprovedClass1
-    {
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        [GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex FenRegex();
-
-        [GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex MovesRegex();
-
-        private static readonly Regex _fenRegex = FenRegex();
-        private static readonly Regex _movesRegex = MovesRegex();
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static OriginalGame ParseGame(string positionCommand)
-        {
-            try
-            {
-                var positionCommandSpan = positionCommand.AsSpan();
-                Span<Range> items = stackalloc Range[3];    // Leaving 'everything else' in the third one
-                positionCommandSpan.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
-                bool isInitialPosition = positionCommandSpan[items[1]].Equals(StartPositionString, StringComparison.OrdinalIgnoreCase);
-
-                var initialPosition = isInitialPosition
-                        ? Constants.InitialPositionFEN
-                        : _fenRegex.Match(positionCommand).Value.Trim();
-
-                if (string.IsNullOrEmpty(initialPosition))
-                {
-                    _logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
-                }
-
-                var moves = _movesRegex.Match(positionCommand).Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-                return new OriginalGame(initialPosition, moves);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
-
-    public static partial class ParseGame_ImprovedClass2
-    {
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        [GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex FenRegex();
-
-        [GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex MovesRegex();
-
-        private static readonly Regex _fenRegex = FenRegex();
-        private static readonly Regex _movesRegex = MovesRegex();
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static ImprovedGame ParseGame(string positionCommand)
-        {
-            try
-            {
-                var positionCommandSpan = positionCommand.AsSpan();
-                Span<Range> items = stackalloc Range[3];    // Leaving 'everything else' in the third one
-                positionCommandSpan.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
-                bool isInitialPosition = positionCommandSpan[items[1]].Equals(StartPositionString, StringComparison.OrdinalIgnoreCase);
-
-                var initialPosition = isInitialPosition
-                        ? Constants.InitialPositionFEN
-                        : _fenRegex.Match(positionCommand).Value.Trim();
-
-                if (string.IsNullOrEmpty(initialPosition))
-                {
-                    _logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
-                }
-
-                var movesRegexResultAsSpan = _movesRegex.Match(positionCommand).ValueSpan;
-                Span<Range> moves = stackalloc Range[(movesRegexResultAsSpan.Length / 5) + 1];
-                movesRegexResultAsSpan.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries);
-
-                return new ImprovedGame(initialPosition, movesRegexResultAsSpan, moves);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
-
-    public static partial class ParseGame_ImprovedClass3
-    {
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        [GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex FenRegex();
-
-        [GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
-        private static partial Regex MovesRegex();
-
-        private static readonly Regex _fenRegex = FenRegex();
-        private static readonly Regex _movesRegex = MovesRegex();
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static ImprovedGame ParseGame(string positionCommand)
-        {
-            try
-            {
-                var items = positionCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                bool isInitialPosition = string.Equals(items.ElementAtOrDefault(1), StartPositionString, StringComparison.OrdinalIgnoreCase);
-
-                var initialPosition = isInitialPosition
-                        ? Constants.InitialPositionFEN
-                        : _fenRegex.Match(positionCommand).Value.Trim();
-
-                if (string.IsNullOrEmpty(initialPosition))
-                {
-                    _logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
-                }
-
-                var movesRegexResultAsSpan = _movesRegex.Match(positionCommand).ValueSpan;
-                Span<Range> moves = stackalloc Range[(movesRegexResultAsSpan.Length / 5) + 1];
-                movesRegexResultAsSpan.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries);
-
-                return new ImprovedGame(initialPosition, movesRegexResultAsSpan, moves);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
-
-    public static class ParseGame_ImprovedClass4
-    {
-        private static readonly Move[] _movePool = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-
-        public const string Id = "position";
-
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static ImprovedGame2 ParseGame(string positionCommand)
-        {
-            try
-            {
-                var positionCommandSpan = positionCommand.AsSpan();
-
-                // We divide the position command in these two sections:
-                // "position startpos                       ||"
-                // "position startpos                       || moves e2e4 e7e5"
-                // "position fen 8/8/8/8/8/8/8/8 w - - 0 1  ||"
-                // "position fen 8/8/8/8/8/8/8/8 w - - 0 1  || moves e2e4 e7e5"
-                Span<Range> items = stackalloc Range[2];
-                positionCommandSpan.Split(items, "moves", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                var initialPositionSection = positionCommandSpan[items[0]];
-
-                // We divide in these two parts
-                // "position startpos ||"       <-- If "fen" doesn't exist in the section
-                // "position || (fen) 8/8/8/8/8/8/8/8 w - - 0 1"  <-- If "fen" does exist
-                Span<Range> initialPositionParts = stackalloc Range[2];
-                initialPositionSection.Split(initialPositionParts, "fen", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                ReadOnlySpan<char> fen = initialPositionSection[initialPositionParts[0]].Length == Id.Length   // "position" o "position startpos"
-                    ? initialPositionSection[initialPositionParts[1]]
-                    : Constants.InitialPositionFEN.AsSpan();
-
-                var movesSection = positionCommandSpan[items[1]];
-
-                Span<Range> moves = stackalloc Range[2048]; // Number of potential half-moves provided in the string
-                movesSection.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                return new ImprovedGame2(fen, movesSection, moves, _movePool);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
-
-    public static class ParseGame_ImprovedClass5
-    {
-        private static readonly Move[] _movePool = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-
-        public const string Id = "position";
-
-        public const string StartPositionString = "startpos";
-        public const string MovesString = "moves";
-
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-        public static ImprovedGame2 ParseGame(string positionCommand)
-        {
-            try
-            {
-                var positionCommandSpan = positionCommand.AsSpan();
-
-                // We divide the position command in these two sections:
-                // "position startpos                       ||"
-                // "position startpos                       || moves e2e4 e7e5"
-                // "position fen 8/8/8/8/8/8/8/8 w - - 0 1  ||"
-                // "position fen 8/8/8/8/8/8/8/8 w - - 0 1  || moves e2e4 e7e5"
-                Span<Range> items = stackalloc Range[2];
-                positionCommandSpan.Split(items, "moves", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                var initialPositionSection = positionCommandSpan[items[0]];
-
-                // We divide in these two parts
-                // "position startpos ||"       <-- If "fen" doesn't exist in the section
-                // "position || (fen) 8/8/8/8/8/8/8/8 w - - 0 1"  <-- If "fen" does exist
-                Span<Range> initialPositionParts = stackalloc Range[2];
-                initialPositionSection.Split(initialPositionParts, "fen", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                ReadOnlySpan<char> fen = initialPositionSection[initialPositionParts[0]].Length == Id.Length   // "position" o "position startpos"
-                    ? initialPositionSection[initialPositionParts[1]]
-                    : Constants.InitialPositionFEN.AsSpan();
-
-                var movesSection = positionCommandSpan[items[1]];
-
-                Span<Range> moves = stackalloc Range[(movesSection.Length / 5) + 1]; // Number of potential half-moves provided in the string
-                movesSection.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-                return new ImprovedGame2(fen, movesSection, moves, _movePool);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Error parsing position command '{0}'", positionCommand);
-                throw;
-            }
-        }
-    }
+	[Benchmark(Baseline = true)]
+	[ArgumentsSource(nameof(Data))]
+	public OriginalGame ParseGame_Original(string positionCommand) => ParseGame_OriginalClass.ParseGame(positionCommand);
+
+	[Benchmark]
+	[ArgumentsSource(nameof(Data))]
+	public OriginalGame ParseGame_Improved1(string positionCommand) => ParseGame_ImprovedClass1.ParseGame(positionCommand);
+
+	[Benchmark]
+	[ArgumentsSource(nameof(Data))]
+	public ImprovedGame ParseGame_Improved2(string positionCommand) => ParseGame_ImprovedClass2.ParseGame(positionCommand);
+
+	[Benchmark]
+	[ArgumentsSource(nameof(Data))]
+	public ImprovedGame ParseGame_Improved3(string positionCommand) => ParseGame_ImprovedClass3.ParseGame(positionCommand);
+
+	[Benchmark]
+	[ArgumentsSource(nameof(Data))]
+	public ImprovedGame2 ParseGame_Improved4(string positionCommand) => ParseGame_ImprovedClass4.ParseGame(positionCommand);
+
+	[Benchmark]
+	[ArgumentsSource(nameof(Data))]
+	public ImprovedGame2 ParseGame_Improved5(string positionCommand) => ParseGame_ImprovedClass5.ParseGame(positionCommand);
+
+	public static partial class ParseGame_OriginalClass
+	{
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		[GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex FenRegex();
+
+		[GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex MovesRegex();
+
+		private static readonly Regex _fenRegex = FenRegex();
+		private static readonly Regex _movesRegex = MovesRegex();
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static OriginalGame ParseGame(string positionCommand)
+		{
+			try
+			{
+				var items = positionCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+				bool isInitialPosition = string.Equals(items.ElementAtOrDefault(1), StartPositionString, StringComparison.OrdinalIgnoreCase);
+
+				var initialPosition = isInitialPosition
+						? Constants.InitialPositionFEN
+						: _fenRegex.Match(positionCommand).Value.Trim();
+
+				if (string.IsNullOrEmpty(initialPosition))
+				{
+					_logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
+				}
+
+				var moves = _movesRegex.Match(positionCommand).Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+				return new OriginalGame(initialPosition, moves);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
+
+	public static partial class ParseGame_ImprovedClass1
+	{
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		[GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex FenRegex();
+
+		[GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex MovesRegex();
+
+		private static readonly Regex _fenRegex = FenRegex();
+		private static readonly Regex _movesRegex = MovesRegex();
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static OriginalGame ParseGame(string positionCommand)
+		{
+			try
+			{
+				var positionCommandSpan = positionCommand.AsSpan();
+				Span<Range> items = stackalloc Range[3];    // Leaving 'everything else' in the third one
+				positionCommandSpan.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+				bool isInitialPosition = positionCommandSpan[items[1]].Equals(StartPositionString, StringComparison.OrdinalIgnoreCase);
+
+				var initialPosition = isInitialPosition
+						? Constants.InitialPositionFEN
+						: _fenRegex.Match(positionCommand).Value.Trim();
+
+				if (string.IsNullOrEmpty(initialPosition))
+				{
+					_logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
+				}
+
+				var moves = _movesRegex.Match(positionCommand).Value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+				return new OriginalGame(initialPosition, moves);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
+
+	public static partial class ParseGame_ImprovedClass2
+	{
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		[GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex FenRegex();
+
+		[GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex MovesRegex();
+
+		private static readonly Regex _fenRegex = FenRegex();
+		private static readonly Regex _movesRegex = MovesRegex();
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static ImprovedGame ParseGame(string positionCommand)
+		{
+			try
+			{
+				var positionCommandSpan = positionCommand.AsSpan();
+				Span<Range> items = stackalloc Range[3];    // Leaving 'everything else' in the third one
+				positionCommandSpan.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);
+				bool isInitialPosition = positionCommandSpan[items[1]].Equals(StartPositionString, StringComparison.OrdinalIgnoreCase);
+
+				var initialPosition = isInitialPosition
+						? Constants.InitialPositionFEN
+						: _fenRegex.Match(positionCommand).Value.Trim();
+
+				if (string.IsNullOrEmpty(initialPosition))
+				{
+					_logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
+				}
+
+				var movesRegexResultAsSpan = _movesRegex.Match(positionCommand).ValueSpan;
+				Span<Range> moves = stackalloc Range[(movesRegexResultAsSpan.Length / 5) + 1];
+				movesRegexResultAsSpan.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+				return new ImprovedGame(initialPosition, movesRegexResultAsSpan, moves);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
+
+	public static partial class ParseGame_ImprovedClass3
+	{
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		[GeneratedRegex("(?<=fen).+?(?=moves|$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex FenRegex();
+
+		[GeneratedRegex("(?<=moves).+?(?=$)", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+		private static partial Regex MovesRegex();
+
+		private static readonly Regex _fenRegex = FenRegex();
+		private static readonly Regex _movesRegex = MovesRegex();
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static ImprovedGame ParseGame(string positionCommand)
+		{
+			try
+			{
+				var items = positionCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+				bool isInitialPosition = string.Equals(items.ElementAtOrDefault(1), StartPositionString, StringComparison.OrdinalIgnoreCase);
+
+				var initialPosition = isInitialPosition
+						? Constants.InitialPositionFEN
+						: _fenRegex.Match(positionCommand).Value.Trim();
+
+				if (string.IsNullOrEmpty(initialPosition))
+				{
+					_logger.Error("Error parsing position command '{0}': no initial position found", positionCommand);
+				}
+
+				var movesRegexResultAsSpan = _movesRegex.Match(positionCommand).ValueSpan;
+				Span<Range> moves = stackalloc Range[(movesRegexResultAsSpan.Length / 5) + 1];
+				movesRegexResultAsSpan.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries);
+
+				return new ImprovedGame(initialPosition, movesRegexResultAsSpan, moves);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
+
+	public static class ParseGame_ImprovedClass4
+	{
+		private static readonly Move[] _movePool = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+
+		public const string Id = "position";
+
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static ImprovedGame2 ParseGame(string positionCommand)
+		{
+			try
+			{
+				var positionCommandSpan = positionCommand.AsSpan();
+
+				// We divide the position command in these two sections:
+				// "position startpos                       ||"
+				// "position startpos                       || moves e2e4 e7e5"
+				// "position fen 8/8/8/8/8/8/8/8 w - - 0 1  ||"
+				// "position fen 8/8/8/8/8/8/8/8 w - - 0 1  || moves e2e4 e7e5"
+				Span<Range> items = stackalloc Range[2];
+				positionCommandSpan.Split(items, "moves", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				var initialPositionSection = positionCommandSpan[items[0]];
+
+				// We divide in these two parts
+				// "position startpos ||"       <-- If "fen" doesn't exist in the section
+				// "position || (fen) 8/8/8/8/8/8/8/8 w - - 0 1"  <-- If "fen" does exist
+				Span<Range> initialPositionParts = stackalloc Range[2];
+				initialPositionSection.Split(initialPositionParts, "fen", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				ReadOnlySpan<char> fen = initialPositionSection[initialPositionParts[0]].Length == Id.Length   // "position" o "position startpos"
+					? initialPositionSection[initialPositionParts[1]]
+					: Constants.InitialPositionFEN.AsSpan();
+
+				var movesSection = positionCommandSpan[items[1]];
+
+				Span<Range> moves = stackalloc Range[2048]; // Number of potential half-moves provided in the string
+				movesSection.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				return new ImprovedGame2(fen, movesSection, moves, _movePool);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
+
+	public static class ParseGame_ImprovedClass5
+	{
+		private static readonly Move[] _movePool = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+
+		public const string Id = "position";
+
+		public const string StartPositionString = "startpos";
+		public const string MovesString = "moves";
+
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+		public static ImprovedGame2 ParseGame(string positionCommand)
+		{
+			try
+			{
+				var positionCommandSpan = positionCommand.AsSpan();
+
+				// We divide the position command in these two sections:
+				// "position startpos                       ||"
+				// "position startpos                       || moves e2e4 e7e5"
+				// "position fen 8/8/8/8/8/8/8/8 w - - 0 1  ||"
+				// "position fen 8/8/8/8/8/8/8/8 w - - 0 1  || moves e2e4 e7e5"
+				Span<Range> items = stackalloc Range[2];
+				positionCommandSpan.Split(items, "moves", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				var initialPositionSection = positionCommandSpan[items[0]];
+
+				// We divide in these two parts
+				// "position startpos ||"       <-- If "fen" doesn't exist in the section
+				// "position || (fen) 8/8/8/8/8/8/8/8 w - - 0 1"  <-- If "fen" does exist
+				Span<Range> initialPositionParts = stackalloc Range[2];
+				initialPositionSection.Split(initialPositionParts, "fen", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				ReadOnlySpan<char> fen = initialPositionSection[initialPositionParts[0]].Length == Id.Length   // "position" o "position startpos"
+					? initialPositionSection[initialPositionParts[1]]
+					: Constants.InitialPositionFEN.AsSpan();
+
+				var movesSection = positionCommandSpan[items[1]];
+
+				Span<Range> moves = stackalloc Range[(movesSection.Length / 5) + 1]; // Number of potential half-moves provided in the string
+				movesSection.Split(moves, ' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+				return new ImprovedGame2(fen, movesSection, moves, _movePool);
+			}
+			catch (Exception e)
+			{
+				_logger.Error(e, "Error parsing position command '{0}'", positionCommand);
+				throw;
+			}
+		}
+	}
 
 #pragma warning disable RCS1169, S2933, S4487, IDE0044, IDE0052, RCS1170 // Readonly, not used
 
-    public sealed class OriginalGame
-    {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+	public sealed class OriginalGame
+	{
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
 #if DEBUG
-        public List<Move> MoveHistory { get; }
+		public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<ulong> PositionHashHistory { get; }
+		public HashSet<ulong> PositionHashHistory { get; }
 
-        public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
+		public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 
-        public Position CurrentPosition { get; private set; }
+		public Position CurrentPosition { get; private set; }
 
-        private Position _gameInitialPosition;
+		private Position _gameInitialPosition;
 
-        public OriginalGame(ReadOnlySpan<char> fen)
-        {
-            var parsedFen = FENParser.ParseFEN(fen);
-            CurrentPosition = new Position(parsedFen);
-            if (!CurrentPosition.IsValid())
-            {
-                _logger.Warn($"Invalid position detected: {fen.ToString()}");
-            }
+		public OriginalGame(ReadOnlySpan<char> fen)
+		{
+			var parsedFen = FENParser.ParseFEN(fen);
+			CurrentPosition = new Position(parsedFen);
+			if (!CurrentPosition.IsValid())
+			{
+				_logger.Warn($"Invalid position detected: {fen.ToString()}");
+			}
 
-            PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
-            HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
-            _gameInitialPosition = new Position(CurrentPosition);
+			PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
+			HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
+			_gameInitialPosition = new Position(CurrentPosition);
 #if DEBUG
-            MoveHistory = new(1024);
+			MoveHistory = new(1024);
 #endif
-        }
+		}
 
-        internal OriginalGame(string fen, string[] movesUCIString) : this(fen)
-        {
-            foreach (var moveString in movesUCIString)
-            {
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
+		internal OriginalGame(string fen, string[] movesUCIString) : this(fen)
+		{
+			foreach (var moveString in movesUCIString)
+			{
+				var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
 
-                if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
-                {
-                    _logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', movesUCIString), moveString);
-                    break;
-                }
+				if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
+				{
+					_logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', movesUCIString), moveString);
+					break;
+				}
 
-                MakeMove(parsedMove.Value);
-            }
+				MakeMove(parsedMove.Value);
+			}
 
-            _gameInitialPosition = new Position(CurrentPosition);
-        }
+			_gameInitialPosition = new Position(CurrentPosition);
+		}
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public GameState MakeMove(Move moveToPlay)
-        {
-            var gameState = CurrentPosition.MakeMove(moveToPlay);
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public GameState MakeMove(Move moveToPlay)
+		{
+			var gameState = CurrentPosition.MakeMove(moveToPlay);
 
-            if (CurrentPosition.WasProduceByAValidMove())
-            {
+			if (CurrentPosition.WasProduceByAValidMove())
+			{
 #if DEBUG
-                MoveHistory.Add(moveToPlay);
+				MoveHistory.Add(moveToPlay);
 #endif
-            }
-            else
-            {
-                _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
-            }
+			}
+			else
+			{
+				_logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
+				CurrentPosition.UnmakeMove(moveToPlay, gameState);
+			}
 
-            PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
-            HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
+			PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
+			HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
 
-            return gameState;
-        }
-    }
+			return gameState;
+		}
+	}
 
-    public sealed class ImprovedGame
-    {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
-
-#if DEBUG
-        public List<Move> MoveHistory { get; }
-#endif
-
-        public HashSet<ulong> PositionHashHistory { get; }
-
-        public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
-
-        public Position CurrentPosition { get; private set; }
-
-        private Position _gameInitialPosition;
-
-        public ImprovedGame(ReadOnlySpan<char> fen)
-        {
-            var parsedFen = FENParser.ParseFEN(fen);
-            CurrentPosition = new Position(parsedFen);
-            if (!CurrentPosition.IsValid())
-            {
-                _logger.Warn($"Invalid position detected: {fen.ToString()}");
-            }
-
-            PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
-            HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
-            _gameInitialPosition = new Position(CurrentPosition);
-#if DEBUG
-            MoveHistory = new(1024);
-#endif
-        }
-
-        internal ImprovedGame(string fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan) : this(fen)
-        {
-            for (int i = 0; i < rangeSpan.Length; ++i)
-            {
-                var range = rangeSpan[i];
-                if (range.Start.Equals(range.End))
-                {
-                    break;
-                }
-                var moveString = rawMoves[range];
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
-
-                if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
-                {
-                    _logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', rawMoves.ToString()), moveString.ToString());
-                    break;
-                }
-
-                MakeMove(parsedMove.Value);
-            }
-
-            _gameInitialPosition = new Position(CurrentPosition);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public GameState MakeMove(Move moveToPlay)
-        {
-            var gameState = CurrentPosition.MakeMove(moveToPlay);
-
-            if (CurrentPosition.WasProduceByAValidMove())
-            {
-#if DEBUG
-                MoveHistory.Add(moveToPlay);
-#endif
-            }
-            else
-            {
-                _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
-            }
-
-            PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
-            HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
-
-            return gameState;
-        }
-    }
-
-    public sealed class ImprovedGame2
-    {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+	public sealed class ImprovedGame
+	{
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
 #if DEBUG
-        public List<Move> MoveHistory { get; }
+		public List<Move> MoveHistory { get; }
 #endif
 
-        public HashSet<ulong> PositionHashHistory { get; }
+		public HashSet<ulong> PositionHashHistory { get; }
 
-        public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
+		public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
 
-        public Position CurrentPosition { get; private set; }
+		public Position CurrentPosition { get; private set; }
 
-        private Position _gameInitialPosition;
+		private Position _gameInitialPosition;
 
-        public ImprovedGame2(ReadOnlySpan<char> fen)
-        {
-            var parsedFen = FENParser.ParseFEN(fen);
-            CurrentPosition = new Position(parsedFen);
-            if (!CurrentPosition.IsValid())
-            {
-                _logger.Warn($"Invalid position detected: {fen.ToString()}");
-            }
+		public ImprovedGame(ReadOnlySpan<char> fen)
+		{
+			var parsedFen = FENParser.ParseFEN(fen);
+			CurrentPosition = new Position(parsedFen);
+			if (!CurrentPosition.IsValid())
+			{
+				_logger.Warn($"Invalid position detected: {fen.ToString()}");
+			}
 
-            PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
-            HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
-            _gameInitialPosition = new Position(CurrentPosition);
+			PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
+			HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
+			_gameInitialPosition = new Position(CurrentPosition);
 #if DEBUG
-            MoveHistory = new(1024);
+			MoveHistory = new(1024);
 #endif
-        }
+		}
 
-        public ImprovedGame2(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Move[] movePool) : this(fen)
-        {
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		internal ImprovedGame(string fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan) : this(fen)
+		{
+			for (int i = 0; i < rangeSpan.Length; ++i)
+			{
+				var range = rangeSpan[i];
+				if (range.Start.Equals(range.End))
+				{
+					break;
+				}
+				var moveString = rawMoves[range];
+				var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition);
 
-            for (int i = 0; i < rangeSpan.Length; ++i)
-            {
-                if (rangeSpan[i].Start.Equals(rangeSpan[i].End))
-                {
-                    break;
-                }
-                var moveString = rawMoves[rangeSpan[i]];
+				if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
+				{
+					_logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen, string.Join(' ', rawMoves.ToString()), moveString.ToString());
+					break;
+				}
 
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, ref evaluationContext, movePool);
+				MakeMove(parsedMove.Value);
+			}
 
-                if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
-                {
-                    _logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen.ToString(), rawMoves.ToString(), moveString.ToString());
-                    break;
-                }
+			_gameInitialPosition = new Position(CurrentPosition);
+		}
 
-                MakeMove(parsedMove.Value);
-            }
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public GameState MakeMove(Move moveToPlay)
+		{
+			var gameState = CurrentPosition.MakeMove(moveToPlay);
 
-            _gameInitialPosition = new Position(CurrentPosition);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public GameState MakeMove(Move moveToPlay)
-        {
-            var gameState = CurrentPosition.MakeMove(moveToPlay);
-
-            if (CurrentPosition.WasProduceByAValidMove())
-            {
+			if (CurrentPosition.WasProduceByAValidMove())
+			{
 #if DEBUG
-                MoveHistory.Add(moveToPlay);
+				MoveHistory.Add(moveToPlay);
 #endif
-            }
-            else
-            {
-                _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
-            }
+			}
+			else
+			{
+				_logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
+				CurrentPosition.UnmakeMove(moveToPlay, gameState);
+			}
 
-            PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
-            HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
+			PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
+			HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
 
-            return gameState;
-        }
-    }
+			return gameState;
+		}
+	}
+
+	public sealed class ImprovedGame2
+	{
+		private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+#if DEBUG
+		public List<Move> MoveHistory { get; }
+#endif
+
+		public HashSet<ulong> PositionHashHistory { get; }
+
+		public int HalfMovesWithoutCaptureOrPawnMove { get; set; }
+
+		public Position CurrentPosition { get; private set; }
+
+		private Position _gameInitialPosition;
+
+		public ImprovedGame2(ReadOnlySpan<char> fen)
+		{
+			var parsedFen = FENParser.ParseFEN(fen);
+			CurrentPosition = new Position(parsedFen);
+			if (!CurrentPosition.IsValid())
+			{
+				_logger.Warn($"Invalid position detected: {fen.ToString()}");
+			}
+
+			PositionHashHistory = new(1024) { CurrentPosition.UniqueIdentifier };
+			HalfMovesWithoutCaptureOrPawnMove = parsedFen.HalfMoveClock;
+			_gameInitialPosition = new Position(CurrentPosition);
+#if DEBUG
+			MoveHistory = new(1024);
+#endif
+		}
+
+		public ImprovedGame2(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Move[] movePool) : this(fen)
+		{
+			using var evaluationContext = new EvaluationContext();
+
+			for (int i = 0; i < rangeSpan.Length; ++i)
+			{
+				if (rangeSpan[i].Start.Equals(rangeSpan[i].End))
+				{
+					break;
+				}
+				var moveString = rawMoves[rangeSpan[i]];
+
+				var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, evaluationContext, movePool);
+
+				if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
+				{
+					_logger.Error("Error parsing game with fen {0} and moves {1}: error detected in {2}", fen.ToString(), rawMoves.ToString(), moveString.ToString());
+					break;
+				}
+
+				MakeMove(parsedMove.Value);
+			}
+
+			_gameInitialPosition = new Position(CurrentPosition);
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public GameState MakeMove(Move moveToPlay)
+		{
+			var gameState = CurrentPosition.MakeMove(moveToPlay);
+
+			if (CurrentPosition.WasProduceByAValidMove())
+			{
+#if DEBUG
+				MoveHistory.Add(moveToPlay);
+#endif
+			}
+			else
+			{
+				_logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
+				CurrentPosition.UnmakeMove(moveToPlay, gameState);
+			}
+
+			PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
+			HalfMovesWithoutCaptureOrPawnMove = Utils.Update50movesRule(moveToPlay, HalfMovesWithoutCaptureOrPawnMove);
+
+			return gameState;
+		}
+	}
 
 #pragma warning restore RCS1169, S2933, S4487, IDE0044, IDE0052, RCS1170,  // Readonly, not used
 }

--- a/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
+++ b/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
@@ -204,9 +204,7 @@ public class TryParseFromUCIString_Benchmark : BaseBenchmark
 
         public TryParseFromUCIString_Benchmark_Game(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves, Span<Range> rangeSpan, Move[] movePool) : this(fen)
         {
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            using var evaluationContext = new EvaluationContext();
 
             for (int i = 0; i < rangeSpan.Length; ++i)
             {
@@ -216,7 +214,7 @@ public class TryParseFromUCIString_Benchmark : BaseBenchmark
                 }
                 var moveString = rawMoves[rangeSpan[i]];
 
-                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, ref evaluationContext, movePool);
+                var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, evaluationContext, movePool);
 
                 if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
                 {

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -66,729 +66,726 @@ const string CmkPosition = Constants.CmkTestPositionFEN;
 
 static void _2_GettingStarted()
 {
-    var board = 4UL;
-    board.SetBit(BoardSquare.e4);
-    board.Print();
-    board.PopBit(BoardSquare.e4);
-    board.Print();
-    board.PopBit(BoardSquare.e4);
-    board.Print();
+	var board = 4UL;
+	board.SetBit(BoardSquare.e4);
+	board.Print();
+	board.PopBit(BoardSquare.e4);
+	board.Print();
+	board.PopBit(BoardSquare.e4);
+	board.Print();
 
-    Console.ReadKey();
+	Console.ReadKey();
 }
 
 static void _3_PawnAttacks()
 {
-    var whiteAttacks = AttackGenerator.MaskPawnAttacks((int)BoardSquare.e4, isWhite: true);
-    var blackAttacks = AttackGenerator.MaskPawnAttacks((int)BoardSquare.e4, isWhite: false);
+	var whiteAttacks = AttackGenerator.MaskPawnAttacks((int)BoardSquare.e4, isWhite: true);
+	var blackAttacks = AttackGenerator.MaskPawnAttacks((int)BoardSquare.e4, isWhite: false);
 
-    whiteAttacks.Print();
-    blackAttacks.Print();
+	whiteAttacks.Print();
+	blackAttacks.Print();
 
-    AttackGenerator.InitializePawnAttacks();
+	AttackGenerator.InitializePawnAttacks();
 }
 
 static void _4_KnightAttacks()
 {
-    var attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.e4);
-    attacks.Print();
+	var attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.e4);
+	attacks.Print();
 
-    attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.h4);
-    attacks.Print();
+	attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.h4);
+	attacks.Print();
 
-    attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.a4);
-    attacks.Print();
+	attacks = AttackGenerator.MaskKnightAttacks((int)BoardSquare.a4);
+	attacks.Print();
 
-    AttackGenerator.InitializeKnightAttacks();
+	AttackGenerator.InitializeKnightAttacks();
 }
 
 static void _5_KingAttacks()
 {
-    var attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.e4);
-    attacks.Print();
+	var attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.e4);
+	attacks.Print();
 
-    attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.h4);
-    attacks.Print();
+	attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.h4);
+	attacks.Print();
 
-    attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.a4);
-    attacks.Print();
+	attacks = AttackGenerator.MaskKingAttacks((int)BoardSquare.a4);
+	attacks.Print();
 
-    AttackGenerator.InitializeKingAttacks();
+	AttackGenerator.InitializeKingAttacks();
 }
 
 static void _6_Bishop_Occupancy()
 {
-    var occupancy = AttackGenerator.MaskBishopOccupancy((int)BoardSquare.h8);
-    occupancy.Print();
+	var occupancy = AttackGenerator.MaskBishopOccupancy((int)BoardSquare.h8);
+	occupancy.Print();
 
-    AttackGenerator.InitializeBishopOccupancy();
+	AttackGenerator.InitializeBishopOccupancy();
 }
 
 static void _7_Rook_Occupancy()
 {
-    var occupancy = AttackGenerator.MaskRookOccupancy((int)BoardSquare.e4);
-    occupancy.Print();
+	var occupancy = AttackGenerator.MaskRookOccupancy((int)BoardSquare.e4);
+	occupancy.Print();
 
-    AttackGenerator.InitializeRookOccupancy();
+	AttackGenerator.InitializeRookOccupancy();
 }
 
 static void _8_Slider_Pieces_Attacks()
 {
-    // Occupancy bitboard
-    BitBoard block = default;
+	// Occupancy bitboard
+	BitBoard block = default;
 
-    block.SetBit(BoardSquare.b6);
-    block.SetBit(BoardSquare.g7);
-    block.SetBit(BoardSquare.f2);
-    block.SetBit(BoardSquare.b2);
+	block.SetBit(BoardSquare.b6);
+	block.SetBit(BoardSquare.g7);
+	block.SetBit(BoardSquare.f2);
+	block.SetBit(BoardSquare.b2);
 
-    var bishopAttacks = AttackGenerator.GenerateBishopAttacksOnTheFly((int)BoardSquare.d4, block);
+	var bishopAttacks = AttackGenerator.GenerateBishopAttacksOnTheFly((int)BoardSquare.d4, block);
 
-    block.Print();
-    bishopAttacks.Print();
+	block.Print();
+	bishopAttacks.Print();
 
-    block = BitBoardExtensions.Initialize(BoardSquare.d3, BoardSquare.b4, BoardSquare.d7, BoardSquare.h4);
+	block = BitBoardExtensions.Initialize(BoardSquare.d3, BoardSquare.b4, BoardSquare.d7, BoardSquare.h4);
 
-    var rookAttacks = AttackGenerator.GenerateRookAttacksOnTheFly((int)BoardSquare.d4, block);
-    block.Print();
-    rookAttacks.Print();
+	var rookAttacks = AttackGenerator.GenerateRookAttacksOnTheFly((int)BoardSquare.d4, block);
+	block.Print();
+	rookAttacks.Print();
 }
 
 static void _9_BitCount()
 {
-    BitBoard bitBoard = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
+	BitBoard bitBoard = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
 
-    bitBoard.ResetLS1B();
-    bitBoard.Print();
+	bitBoard.ResetLS1B();
+	bitBoard.Print();
 
-    var bb = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
+	var bb = BitBoardExtensions.Initialize(BoardSquare.d5, BoardSquare.e4);
 
-    Console.WriteLine(bb.GetLS1BIndex());
-    Console.WriteLine(bb.GetLS1BIndex());
-    Console.WriteLine(Constants.Coordinates[bb.GetLS1BIndex()]);
+	Console.WriteLine(bb.GetLS1BIndex());
+	Console.WriteLine(bb.GetLS1BIndex());
+	Console.WriteLine(Constants.Coordinates[bb.GetLS1BIndex()]);
 }
 
 static void _10_SetOccupancy()
 {
-    // Mask piece attacks at given square
-    var occupancyMask = AttackGenerator.MaskRookOccupancy((int)BoardSquare.a5);
+	// Mask piece attacks at given square
+	var occupancyMask = AttackGenerator.MaskRookOccupancy((int)BoardSquare.a5);
 
-    var occupancy = AttackGenerator.SetBishopOrRookOccupancy(4095, occupancyMask);
-    occupancy.Print();
+	var occupancy = AttackGenerator.SetBishopOrRookOccupancy(4095, occupancyMask);
+	occupancy.Print();
 
-    var ind = (int)Math.Pow(2, 6) - 1;
-    occupancy = AttackGenerator.SetBishopOrRookOccupancy(ind, occupancyMask);
-    occupancy.Print();
+	var ind = (int)Math.Pow(2, 6) - 1;
+	occupancy = AttackGenerator.SetBishopOrRookOccupancy(ind, occupancyMask);
+	occupancy.Print();
 
-    // Loop over occupancy indexes
-    for (int index = 0; index < 4096; ++index)
-    {
-        occupancy = AttackGenerator.SetBishopOrRookOccupancy(index, occupancyMask);
-        occupancy.Print();
-        Console.ReadKey();
-    }
+	// Loop over occupancy indexes
+	for (int index = 0; index < 4096; ++index)
+	{
+		occupancy = AttackGenerator.SetBishopOrRookOccupancy(index, occupancyMask);
+		occupancy.Print();
+		Console.ReadKey();
+	}
 
-    occupancyMask = AttackGenerator.MaskBishopOccupancy((int)BoardSquare.d4);
-    occupancyMask.Print();
+	occupancyMask = AttackGenerator.MaskBishopOccupancy((int)BoardSquare.d4);
+	occupancyMask.Print();
 
-    // Loop over occupancy indexes
-    for (int index = 0; index < 64; ++index)
-    {
-        occupancy = AttackGenerator.SetBishopOrRookOccupancy(index, occupancyMask);
-        occupancy.Print();
-        Console.ReadKey();
-    }
+	// Loop over occupancy indexes
+	for (int index = 0; index < 64; ++index)
+	{
+		occupancy = AttackGenerator.SetBishopOrRookOccupancy(index, occupancyMask);
+		occupancy.Print();
+		Console.ReadKey();
+	}
 }
 
 static void _11_OccupancyBitCountLookupTables()
 {
-    for (var rank = 0; rank < 8; ++rank)
-    {
-        for (var file = 0; file < 8; ++file)
-        {
-            int square = BitBoardExtensions.SquareIndex(rank, file);
+	for (var rank = 0; rank < 8; ++rank)
+	{
+		for (var file = 0; file < 8; ++file)
+		{
+			int square = BitBoardExtensions.SquareIndex(rank, file);
 
-            var bishopOccupancy = AttackGenerator.MaskBishopOccupancy(square);
-            Console.Write($"{bishopOccupancy.CountBits()}, ");
-        }
+			var bishopOccupancy = AttackGenerator.MaskBishopOccupancy(square);
+			Console.Write($"{bishopOccupancy.CountBits()}, ");
+		}
 
-        Console.WriteLine();
-    }
+		Console.WriteLine();
+	}
 
-    for (var rank = 0; rank < 8; ++rank)
-    {
-        for (var file = 0; file < 8; ++file)
-        {
-            int square = BitBoardExtensions.SquareIndex(rank, file);
+	for (var rank = 0; rank < 8; ++rank)
+	{
+		for (var file = 0; file < 8; ++file)
+		{
+			int square = BitBoardExtensions.SquareIndex(rank, file);
 
-            var bishopOccupancy = AttackGenerator.MaskRookOccupancy(square);
-            Console.Write($"{bishopOccupancy.CountBits()}, ");
-        }
+			var bishopOccupancy = AttackGenerator.MaskRookOccupancy(square);
+			Console.Write($"{bishopOccupancy.CountBits()}, ");
+		}
 
-        Console.WriteLine();
-    }
+		Console.WriteLine();
+	}
 }
 
 static void _13_GeneratingMagicNumbersCandidates()
 {
-    const int randomlyGeneratedSeed = 1160218972;
-    var generator = new Random(randomlyGeneratedSeed);
+	const int randomlyGeneratedSeed = 1160218972;
+	var generator = new Random(randomlyGeneratedSeed);
 
-    var randomNumber = (ulong)generator.Next();
-    // Slice upper (from MS1b side) 16 bits
-    randomNumber &= 0xFFFF;
+	var randomNumber = (ulong)generator.Next();
+	// Slice upper (from MS1b side) 16 bits
+	randomNumber &= 0xFFFF;
 
-    // int(uint really), which is 32 bits -> ulong, 64 bits leaves the seconf half of the board empty
-    // The slicing leaves the second quarter empty as well
-    var randomBoard = randomNumber;
-    randomBoard.Print();
+	// int(uint really), which is 32 bits -> ulong, 64 bits leaves the seconf half of the board empty
+	// The slicing leaves the second quarter empty as well
+	var randomBoard = randomNumber;
+	randomBoard.Print();
 
-    var candidate = MagicNumberGenerator.GenerateMagicNumber();
+	var candidate = MagicNumberGenerator.GenerateMagicNumber();
 
-    var board = candidate;
-    board.Print();
+	var board = candidate;
+	board.Print();
 }
 
 static void _14_GeneratingMagicNumbersByBruteForce()
 {
-    var sw = Stopwatch.StartNew();
-    MagicNumberGenerator.InitializeMagicNumbers();
-    Console.WriteLine($"Time: {sw.ElapsedMilliseconds}ms");
+	var sw = Stopwatch.StartNew();
+	MagicNumberGenerator.InitializeMagicNumbers();
+	Console.WriteLine($"Time: {sw.ElapsedMilliseconds}ms");
 
-    // Should generate something similar to Constants.RookMagicNumbers
+	// Should generate something similar to Constants.RookMagicNumbers
 }
 
 static void _16_InitializingSliderPiecesAttackTables()
 {
-    var occupancy = new BitBoard();
-    occupancy.SetBit(BoardSquare.e5);
-    occupancy.SetBit(BoardSquare.d5);
-    occupancy.SetBit(BoardSquare.d8);
-    occupancy.Print();
+	var occupancy = new BitBoard();
+	occupancy.SetBit(BoardSquare.e5);
+	occupancy.SetBit(BoardSquare.d5);
+	occupancy.SetBit(BoardSquare.d8);
+	occupancy.Print();
 
-    var bishopAttacks = Attacks.BishopAttacks((int)BoardSquare.d4, occupancy);
-    bishopAttacks.Print();
+	var bishopAttacks = Attacks.BishopAttacks((int)BoardSquare.d4, occupancy);
+	bishopAttacks.Print();
 
-    var rookAttacks = Attacks.RookAttacks((int)BoardSquare.d4, occupancy);
-    rookAttacks.Print();
+	var rookAttacks = Attacks.RookAttacks((int)BoardSquare.d4, occupancy);
+	rookAttacks.Print();
 }
 
 static void _17_Defining_variables()
 {
-    var position = new Position(Constants.EmptyBoardFEN);
+	var position = new Position(Constants.EmptyBoardFEN);
 
-    var whitePawnBitBoard = position.PieceBitBoards[(int)Piece.P];
-    whitePawnBitBoard.SetBit(BoardSquare.e2);
-    whitePawnBitBoard.Print();
+	var whitePawnBitBoard = position.PieceBitBoards[(int)Piece.P];
+	whitePawnBitBoard.SetBit(BoardSquare.e2);
+	whitePawnBitBoard.Print();
 
-    Console.WriteLine($"Piece: {Constants.PiecesByChar['K']}");
+	Console.WriteLine($"Piece: {Constants.PiecesByChar['K']}");
 
-    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-    {
-        Console.WriteLine($"Piece: {Constants.UnicodePieces[(int)Piece.K]}");
-        // Simulating from FEN
-        Console.WriteLine($"Piece: {Constants.UnicodePieces[(int)Constants.PiecesByChar['K']]}");
-    }
-    else
-    {
-        Console.WriteLine($"Piece: {Constants.AsciiPieces[(int)Piece.K]}");
-        // Simulating from FEN
-        Console.WriteLine($"Piece: {Constants.AsciiPieces[(int)Constants.PiecesByChar['K']]}");
-    }
+	if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+	{
+		Console.WriteLine($"Piece: {Constants.UnicodePieces[(int)Piece.K]}");
+		// Simulating from FEN
+		Console.WriteLine($"Piece: {Constants.UnicodePieces[(int)Constants.PiecesByChar['K']]}");
+	}
+	else
+	{
+		Console.WriteLine($"Piece: {Constants.AsciiPieces[(int)Piece.K]}");
+		// Simulating from FEN
+		Console.WriteLine($"Piece: {Constants.AsciiPieces[(int)Constants.PiecesByChar['K']]}");
+	}
 }
 
 static void _18_Printing_Chess_Board()
 {
-    var position = new Position(Constants.InitialPositionFEN);
-    position.Print();
+	var position = new Position(Constants.InitialPositionFEN);
+	position.Print();
 
-    for (int bbIndex = 0; bbIndex < position.PieceBitBoards.Length; ++bbIndex)
-    {
-        position.PieceBitBoards[bbIndex].Print();
-    }
+	for (int bbIndex = 0; bbIndex < position.PieceBitBoards.Length; ++bbIndex)
+	{
+		position.PieceBitBoards[bbIndex].Print();
+	}
 }
 
 static void _19_Parse_FEN()
 {
-    var position = new Position(CmkPosition);
+	var position = new Position(CmkPosition);
 
-    position.PieceBitBoards[(int)Piece.Q].Print();
+	position.PieceBitBoards[(int)Piece.Q].Print();
 
-    position.Print();
-    position.OccupancyBitBoards[(int)Side.White].Print();
-    position.OccupancyBitBoards[(int)Side.Black].Print();
-    position.OccupancyBitBoards[(int)Side.Both].Print();
+	position.Print();
+	position.OccupancyBitBoards[(int)Side.White].Print();
+	position.OccupancyBitBoards[(int)Side.Black].Print();
+	position.OccupancyBitBoards[(int)Side.Both].Print();
 }
 
 static void _20_QueenAttacks()
 {
-    var position = new Position(Constants.InitialPositionFEN);
-    Attacks.QueenAttacks((int)BoardSquare.e4, position.OccupancyBitBoards[(int)Side.Both]).Print();
+	var position = new Position(Constants.InitialPositionFEN);
+	Attacks.QueenAttacks((int)BoardSquare.e4, position.OccupancyBitBoards[(int)Side.Both]).Print();
 }
 
 static void _21_IsSquareAttacked()
 {
-    var position = new Position("8/8/8/3p4/8/8/8/8 w - - 0 1");
+	var position = new Position("8/8/8/3p4/8/8/8/8 w - - 0 1");
 
-    position.PieceBitBoards[(int)Piece.p].Print();
+	position.PieceBitBoards[(int)Piece.p].Print();
 
-    Attacks.PawnAttacks[(int)Side.White][(int)BoardSquare.e4].Print();
+	Attacks.PawnAttacks[(int)Side.White][(int)BoardSquare.e4].Print();
 
-    var and =
-        position.PieceBitBoards[(int)Piece.p]
-        & Attacks.PawnAttacks[(int)Side.White][(int)BoardSquare.e4];
-    and.Print();
+	var and =
+		position.PieceBitBoards[(int)Piece.p]
+		& Attacks.PawnAttacks[(int)Side.White][(int)BoardSquare.e4];
+	and.Print();
 
-    Console.WriteLine("=====================================");
+	Console.WriteLine("=====================================");
 
-    position = new Position(Constants.EmptyBoardFEN);
-    position.PieceBitBoards[(int)Piece.n].SetBit(BoardSquare.c6);
-    position.PieceBitBoards[(int)Piece.n].SetBit(BoardSquare.f6);
+	position = new Position(Constants.EmptyBoardFEN);
+	position.PieceBitBoards[(int)Piece.n].SetBit(BoardSquare.c6);
+	position.PieceBitBoards[(int)Piece.n].SetBit(BoardSquare.f6);
 
-    position.PrintAttackedSquares(Side.Black);
+	position.PrintAttackedSquares(Side.Black);
 
-    Console.WriteLine(position.IsSquareAttacked((int)BoardSquare.e4, Side.Black));
+	Console.WriteLine(position.IsSquareAttacked((int)BoardSquare.e4, Side.Black));
 
-    Console.WriteLine("=====================================");
+	Console.WriteLine("=====================================");
 
-    position = new Position(Constants.EmptyBoardFEN);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.b7);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d7);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.f7);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.h7);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.b3);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d3);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.f3);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.h3);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d1);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.c4);
-    position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.g4);
+	position = new Position(Constants.EmptyBoardFEN);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.b7);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d7);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.f7);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.h7);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.b3);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d3);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.f3);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.h3);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.d1);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.c4);
+	position.PieceBitBoards[(int)Piece.q].SetBit(BoardSquare.g4);
 
-    position.PrintAttackedSquares(Side.Black);
+	position.PrintAttackedSquares(Side.Black);
 
-    Console.WriteLine("=====================================");
+	Console.WriteLine("=====================================");
 
-    position = new Position(Constants.EmptyBoardFEN);
-    position.PieceBitBoards[(int)Piece.K].SetBit(BoardSquare.e4);
-    position.PrintAttackedSquares(Side.White);
+	position = new Position(Constants.EmptyBoardFEN);
+	position.PieceBitBoards[(int)Piece.K].SetBit(BoardSquare.e4);
+	position.PrintAttackedSquares(Side.White);
 
-    Console.WriteLine("=====================================");
+	Console.WriteLine("=====================================");
 
-    position = new Position(Constants.InitialPositionFEN);
-    position.PrintAttackedSquares(Side.White);
-    position.PrintAttackedSquares(Side.Black);
+	position = new Position(Constants.InitialPositionFEN);
+	position.PrintAttackedSquares(Side.White);
+	position.PrintAttackedSquares(Side.Black);
 }
 
 static void _22_Generate_Moves()
 {
-    var position = new Position("r1P1k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1 ");
-    position.Print();
+	var position = new Position("r1P1k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1 ");
+	position.Print();
 
-    //position.OccupancyBitBoards[2] |= 0b11100111UL << 8 * 4;
-    var moves = MoveGenerator.GenerateAllMoves(position);
+	//position.OccupancyBitBoards[2] |= 0b11100111UL << 8 * 4;
+	var moves = MoveGenerator.GenerateAllMoves(position);
 
-    foreach (var move in moves)
-    {
-        Console.WriteLine(move);
-    }
+	foreach (var move in moves)
+	{
+		Console.WriteLine(move);
+	}
 
-    position = new Position(KillerPosition);
-    position.PieceBitBoards[0].Print();
-    position.PieceBitBoards[6].Print();
-    position.Print();
-    moves = MoveGenerator.GenerateAllMoves(position);
+	position = new Position(KillerPosition);
+	position.PieceBitBoards[0].Print();
+	position.PieceBitBoards[6].Print();
+	position.Print();
+	moves = MoveGenerator.GenerateAllMoves(position);
 
-    foreach (var move in moves)
-    {
-        Console.WriteLine(move);
-    }
+	foreach (var move in moves)
+	{
+		Console.WriteLine(move);
+	}
 }
 
 static void _23_Castling_Moves()
 {
-    var position = new Position("rn2k2r/pppppppp/8/8/8/8/PPPPPPPP/RN2K2R w KQkq - 0 1");
-    position.Print();
+	var position = new Position("rn2k2r/pppppppp/8/8/8/8/PPPPPPPP/RN2K2R w KQkq - 0 1");
+	position.Print();
 
-    int index = 0;
-    var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+	int index = 0;
+	var moves = new Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-    Span<BitBoard> attacks = stackalloc BitBoard[12];
-    Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-    var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+	using var evaluationContext = new EvaluationContext();
 
-    MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
+	MoveGenerator.GenerateCastlingMoves(ref index, moves, position, evaluationContext);
 
-    foreach (var move in moves[..index])
-    {
-        Console.WriteLine(move);
-    }
+	foreach (var move in moves[..index])
+	{
+		Console.WriteLine(move);
+	}
 }
 
 static void _26_Piece_Moves()
 {
-    var position = new Position(TrickyPosition);
-    position.Print();
+	var position = new Position(TrickyPosition);
+	position.Print();
 
-    var moves = MoveGenerator.GenerateAllMoves(position).Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n).ToList();
-    moves.ForEach(m => Console.WriteLine(m));
+	var moves = MoveGenerator.GenerateAllMoves(position).Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n).ToList();
+	moves.ForEach(m => Console.WriteLine(m));
 
-    moves = [.. MoveGenerator.GenerateAllMoves(position)];
-    Console.WriteLine($"Expected 48, found: {moves.Count}");
-    foreach (var move in moves)
-    {
-        Console.WriteLine(move);
-    }
+	moves = [.. MoveGenerator.GenerateAllMoves(position)];
+	Console.WriteLine($"Expected 48, found: {moves.Count}");
+	foreach (var move in moves)
+	{
+		Console.WriteLine(move);
+	}
 }
 
 static void _28_Move_Encoding()
 {
-    int move = 0;
+	int move = 0;
 
-    // Target square: h1 (63)
-    const BoardSquare targetSquare = BoardSquare.h1;
+	// Target square: h1 (63)
+	const BoardSquare targetSquare = BoardSquare.h1;
 
-    // Encode move
+	// Encode move
 #pragma warning disable S2437 // Silly bit operations should not be performed - ¬¬
-    move = (move | (int)targetSquare) << 6;
+	move = (move | (int)targetSquare) << 6;
 #pragma warning restore S2437 // Silly bit operations should not be performed
-    Console.WriteLine($"{Convert.ToString(move, 2)}");
+	Console.WriteLine($"{Convert.ToString(move, 2)}");
 
-    // Decode move
-    int square = (move & 0xFC0) >> 6;
-    Console.WriteLine(Constants.Coordinates[square]);
+	// Decode move
+	int square = (move & 0xFC0) >> 6;
+	Console.WriteLine(Constants.Coordinates[square]);
 }
 
 static void PrintMoveList(IEnumerable<Move> moves)
 {
-    Console.WriteLine($"{"#",-3}{"Pc",-3}{"src",-4}{"x",-2}{"tgt",-4}{"DPP",-4}{"ep",-3}{"O-O",-4}{"O-O-O",-7}\n");
+	Console.WriteLine($"{"#",-3}{"Pc",-3}{"src",-4}{"x",-2}{"tgt",-4}{"DPP",-4}{"ep",-3}{"O-O",-4}{"O-O-O",-7}\n");
 
-    static string bts(bool b) => b ? "1" : "0";
-    static string isCapture(bool c) => c ? "x" : "";
+	static string bts(bool b) => b ? "1" : "0";
+	static string isCapture(bool c) => c ? "x" : "";
 
-    var sb = new StringBuilder();
-    for (int i = 0; i < moves.Count(); ++i)
-    {
-        var move = moves.ElementAt(i);
+	var sb = new StringBuilder();
+	for (int i = 0; i < moves.Count(); ++i)
+	{
+		var move = moves.ElementAt(i);
 
-        sb.AppendFormat("{0,-3}", i + 1)
-          .AppendFormat("{0,-3}", Constants.AsciiPieces[move.Piece()])
-          .AppendFormat("{0,-4}", Constants.Coordinates[move.SourceSquare()])
-          .AppendFormat("{0,-2}", isCapture(move.CapturedPiece() != (int)Piece.None))
-          .AppendFormat("{0,-4}", Constants.Coordinates[move.TargetSquare()])
-          .AppendFormat("{0,-4}", bts(move.IsDoublePawnPush()))
-          .AppendFormat("{0,-3}", bts(move.IsEnPassant()))
-          .AppendFormat("{0,-4}", bts(move.IsShortCastle()))
-          .AppendFormat("{0,-4}", bts(move.IsLongCastle()))
-          .Append(Environment.NewLine);
-    }
+		sb.AppendFormat("{0,-3}", i + 1)
+		  .AppendFormat("{0,-3}", Constants.AsciiPieces[move.Piece()])
+		  .AppendFormat("{0,-4}", Constants.Coordinates[move.SourceSquare()])
+		  .AppendFormat("{0,-2}", isCapture(move.CapturedPiece() != (int)Piece.None))
+		  .AppendFormat("{0,-4}", Constants.Coordinates[move.TargetSquare()])
+		  .AppendFormat("{0,-4}", bts(move.IsDoublePawnPush()))
+		  .AppendFormat("{0,-3}", bts(move.IsEnPassant()))
+		  .AppendFormat("{0,-4}", bts(move.IsShortCastle()))
+		  .AppendFormat("{0,-4}", bts(move.IsLongCastle()))
+		  .Append(Environment.NewLine);
+	}
 
-    Console.WriteLine(sb.ToString());
+	Console.WriteLine(sb.ToString());
 }
 
 static void _29_Move_List()
 {
-    var position = new Position(TrickyPosition);
-    var moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+	var position = new Position(TrickyPosition);
+	var moves = MoveGenerator.GenerateAllMoves(position);
+	PrintMoveList(moves);
 
-    position = new Position(TrickyPositionReversed);
-    moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+	position = new Position(TrickyPositionReversed);
+	moves = MoveGenerator.GenerateAllMoves(position);
+	PrintMoveList(moves);
 
-    position = new Position(KillerPosition);
-    position.Print();
-    moves = MoveGenerator.GenerateAllMoves(position);
-    PrintMoveList(moves);
+	position = new Position(KillerPosition);
+	position.Print();
+	moves = MoveGenerator.GenerateAllMoves(position);
+	PrintMoveList(moves);
 }
 
 static void _32_Make_Move()
 {
-    // Arrange
-    var position = new Position("r3k2r/1r6/8/3B4/8/8/8/R3K2R w KQkq - 0 1");
-    position.Print();
+	// Arrange
+	var position = new Position("r3k2r/1r6/8/3B4/8/8/8/R3K2R w KQkq - 0 1");
+	position.Print();
 
-    position = new Position("r3k2r/8/8/3b4/8/8/6R1/R3K2R b KQkq - 0 1");
-    position.Print();
+	position = new Position("r3k2r/8/8/3b4/8/8/6R1/R3K2R b KQkq - 0 1");
+	position.Print();
 
-    var game = new Game(TrickyPosition);
-    var reversedGame = new Game(TrickyPositionReversed);
-    var gameWithPromotion = new Game("r3k2r/pPppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
-    //GeneralMoveTest(game);
-    //CastlingRightsTest(game);
-    //CastlingRightsTest(reversedGame);
+	var game = new Game(TrickyPosition);
+	var reversedGame = new Game(TrickyPositionReversed);
+	var gameWithPromotion = new Game("r3k2r/pPppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1");
+	//GeneralMoveTest(game);
+	//CastlingRightsTest(game);
+	//CastlingRightsTest(reversedGame);
 
-    PrintMoveList(MoveGenerator.GenerateAllMoves(gameWithPromotion.CurrentPosition));
+	PrintMoveList(MoveGenerator.GenerateAllMoves(gameWithPromotion.CurrentPosition));
 
-    GeneralMoveTest(gameWithPromotion);
+	GeneralMoveTest(gameWithPromotion);
 
-    static void GeneralMoveTest(Game game)
-    {
-        foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
-        {
-            game.CurrentPosition.Print();
+	static void GeneralMoveTest(Game game)
+	{
+		foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
+		{
+			game.CurrentPosition.Print();
 
-            Console.WriteLine(move.ToEPDString(game.CurrentPosition));
-            var gameState = game.MakeMove(move);
-            game.CurrentPosition.Print();
+			Console.WriteLine(move.ToEPDString(game.CurrentPosition));
+			var gameState = game.MakeMove(move);
+			game.CurrentPosition.Print();
 
-            Console.WriteLine("White occupancy:");
-            game.CurrentPosition.OccupancyBitBoards[(int)Side.White].Print();
+			Console.WriteLine("White occupancy:");
+			game.CurrentPosition.OccupancyBitBoards[(int)Side.White].Print();
 
-            Console.WriteLine("Black occupancy:");
-            game.CurrentPosition.OccupancyBitBoards[(int)Side.Black].Print();
+			Console.WriteLine("Black occupancy:");
+			game.CurrentPosition.OccupancyBitBoards[(int)Side.Black].Print();
 
-            game.CurrentPosition.UnmakeMove(move, gameState);
-        }
-    }
+			game.CurrentPosition.UnmakeMove(move, gameState);
+		}
+	}
 
-    static void CastlingRightsTest(Game game)
-    {
-        foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
-        {
-            if (move.Piece() == (int)Piece.R || (move.Piece() == (int)Piece.r)
-             || move.Piece() == (int)Piece.K || (move.Piece() == (int)Piece.k))
-            {
-                game.CurrentPosition.Print();
+	static void CastlingRightsTest(Game game)
+	{
+		foreach (var move in MoveGenerator.GenerateAllMoves(game.CurrentPosition))
+		{
+			if (move.Piece() == (int)Piece.R || (move.Piece() == (int)Piece.r)
+			 || move.Piece() == (int)Piece.K || (move.Piece() == (int)Piece.k))
+			{
+				game.CurrentPosition.Print();
 
-                Console.WriteLine(move.ToEPDString(game.CurrentPosition));
-                var gameState = game.MakeMove(move);
-                game.CurrentPosition.Print();
-                game.CurrentPosition.UnmakeMove(move, gameState);
-            }
-        }
-    }
+				Console.WriteLine(move.ToEPDString(game.CurrentPosition));
+				var gameState = game.MakeMove(move);
+				game.CurrentPosition.Print();
+				game.CurrentPosition.UnmakeMove(move, gameState);
+			}
+		}
+	}
 }
 
 static void _42_Perft()
 {
-    // Leaf nodes (number of positions) reached dring the test if the move generator at a given depth
+	// Leaf nodes (number of positions) reached dring the test if the move generator at a given depth
 
-    var pos = new Position(TrickyPosition);
+	var pos = new Position(TrickyPosition);
 
-    for (int depth = 0; depth < 7; ++depth)
-    {
-        Perft.RunPerft(pos, depth, Console.WriteLine);
-    }
+	for (int depth = 0; depth < 7; ++depth)
+	{
+		Perft.RunPerft(pos, depth, Console.WriteLine);
+	}
 }
 
 static void _43_Divide()
 {
-    Perft.RunDivide(new Position(Constants.InitialPositionFEN), 5, Console.WriteLine);
-    Perft.RunDivide(new Position(TrickyPosition), 5, Console.WriteLine);
+	Perft.RunDivide(new Position(Constants.InitialPositionFEN), 5, Console.WriteLine);
+	Perft.RunDivide(new Position(TrickyPosition), 5, Console.WriteLine);
 }
 
 static void _44_ParseUCI()
 {
-    var position = new Position("r1b1k2r/pPppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q2/P1PB1PpP/R3KB1R w KQkq - 0 1");
-    position.Print();
+	var position = new Position("r1b1k2r/pPppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q2/P1PB1PpP/R3KB1R w KQkq - 0 1");
+	position.Print();
 }
 
 static void _49_Rudimetary_Evaluation()
 {
-    //var position = new Position(Constants.InitialPositionFEN);
+	//var position = new Position(Constants.InitialPositionFEN);
 
-    //foreach (var move in MoveGenerator.GenerateAllMoves(position))
-    //{
-    //    var newBlackPosition = new Position(position, move);
-    //    if (newBlackPosition.IsValid())
-    //    {
-    //        var newWhitePosition = new Position(newBlackPosition, newBlackPosition.AllPossibleMoves()[0]);
-    //        if (newBlackPosition.IsValid())
-    //        {
-    //            Console.WriteLine($"{move} | {newWhitePosition.EvaluateMaterial()} | {newWhitePosition.EvaluateMaterialAndPosition_MiniMax()}");
-    //        }
-    //    }
-    //}
+	//foreach (var move in MoveGenerator.GenerateAllMoves(position))
+	//{
+	//    var newBlackPosition = new Position(position, move);
+	//    if (newBlackPosition.IsValid())
+	//    {
+	//        var newWhitePosition = new Position(newBlackPosition, newBlackPosition.AllPossibleMoves()[0]);
+	//        if (newBlackPosition.IsValid())
+	//        {
+	//            Console.WriteLine($"{move} | {newWhitePosition.EvaluateMaterial()} | {newWhitePosition.EvaluateMaterialAndPosition_MiniMax()}");
+	//        }
+	//    }
+	//}
 }
 
 static void _50_MiniMax_AlphaBeta()
 {
-    //const string fen = "7k/6b1/7p/2p1pPpP/2P3P1/5P2/7N/7K w - - 0 1";
+	//const string fen = "7k/6b1/7p/2p1pPpP/2P3P1/5P2/7N/7K w - - 0 1";
 
-    //{
-    //    var game = new Game(fen);
-    //    var (evaluation, moveList) = SearchAlgorithms.MiniMax(game.CurrentPosition, Configuration.EngineSettings.Depth);
-    //    Console.WriteLine($"Evaluation: {evaluation}");
+	//{
+	//    var game = new Game(fen);
+	//    var (evaluation, moveList) = SearchAlgorithms.MiniMax(game.CurrentPosition, Configuration.EngineSettings.Depth);
+	//    Console.WriteLine($"Evaluation: {evaluation}");
 
-    //    var bestMove = moveList!.Moves.Last();
-    //    Console.WriteLine($"Best move: {bestMove}");
-    //}
+	//    var bestMove = moveList!.Moves.Last();
+	//    Console.WriteLine($"Best move: {bestMove}");
+	//}
 
-    //Console.WriteLine("=====================================================================================");
+	//Console.WriteLine("=====================================================================================");
 
-    //*
-    // * 8   . . . . . . . k
-    // * 7   . . . . . . b .
-    // * 6   . . . . . . . p
-    // * 5   . . p . p P p P
-    // * 4   . . P . . . P .
-    // * 3   . . . . . P . .
-    // * 2   . . . . . . . N
-    // * 1   . . . . . . . K
-    // *     a b c d e f g h
-    // *
-    // *          o
-    // *            \ f5f6
-    // *             * -----------
-    // *     e5e4  /   \  h8h7     \  g7f8
-    // *          /     \           \
-    // *         o       o ----      o
-    // *    f6g7 |  f6f7 | \   \
-    // *         |       |  \   \
-    // *         *       *   *   *
-    // *       +415    +415  ??  ??
-    // *
-    // *  o -> White
-    // *  * -> Black
-    // *
-    // *       1/     f5f6
-    // *       2/     e5e4
-    // *       3/     f6g7 + resto de hermanos
-    // *       2.a/   e5e4 -> +415
-    // *       4/     h8h7
-    // *       5/     f6f7 -> +415
-    // *       4.a8   h8h7 >= +415 -> Las blancas nunca van a hacer algo peor que eso
-    // */
-    //{
-    //    var game = new Game(fen);
-    //    var (evaluation, moveList) = SearchAlgorithms.MiniMax_AlphaBeta(game.CurrentPosition, Configuration.EngineSettings.Depth);
-    //    Console.WriteLine($"Evaluation: {evaluation}");
+	//*
+	// * 8   . . . . . . . k
+	// * 7   . . . . . . b .
+	// * 6   . . . . . . . p
+	// * 5   . . p . p P p P
+	// * 4   . . P . . . P .
+	// * 3   . . . . . P . .
+	// * 2   . . . . . . . N
+	// * 1   . . . . . . . K
+	// *     a b c d e f g h
+	// *
+	// *          o
+	// *            \ f5f6
+	// *             * -----------
+	// *     e5e4  /   \  h8h7     \  g7f8
+	// *          /     \           \
+	// *         o       o ----      o
+	// *    f6g7 |  f6f7 | \   \
+	// *         |       |  \   \
+	// *         *       *   *   *
+	// *       +415    +415  ??  ??
+	// *
+	// *  o -> White
+	// *  * -> Black
+	// *
+	// *       1/     f5f6
+	// *       2/     e5e4
+	// *       3/     f6g7 + resto de hermanos
+	// *       2.a/   e5e4 -> +415
+	// *       4/     h8h7
+	// *       5/     f6f7 -> +415
+	// *       4.a8   h8h7 >= +415 -> Las blancas nunca van a hacer algo peor que eso
+	// */
+	//{
+	//    var game = new Game(fen);
+	//    var (evaluation, moveList) = SearchAlgorithms.MiniMax_AlphaBeta(game.CurrentPosition, Configuration.EngineSettings.Depth);
+	//    Console.WriteLine($"Evaluation: {evaluation}");
 
-    //    var bestMove = moveList!.Moves.Last();
-    //    Console.WriteLine($"Best move: {bestMove}");
-    //}
+	//    var bestMove = moveList!.Moves.Last();
+	//    Console.WriteLine($"Best move: {bestMove}");
+	//}
 }
 
 static void _52_Quiescence_Search()
 {
-    //const string fen = "8/1p4pp/kPp5/p1P3PP/KpP5/1Pp2P2/2P5/8 w - - 0 1";
+	//const string fen = "8/1p4pp/kPp5/p1P3PP/KpP5/1Pp2P2/2P5/8 w - - 0 1";
 
-    //var game = new Game(fen);
+	//var game = new Game(fen);
 
-    //game.CurrentPosition.Print();
+	//game.CurrentPosition.Print();
 
-    //var (evaluation, moveList) = SearchAlgorithms.MiniMax_AlphaBeta_Quiescence(game.CurrentPosition, Configuration.EngineSettings.Depth - 1);
-    //Console.WriteLine($"Evaluation: {evaluation}");
+	//var (evaluation, moveList) = SearchAlgorithms.MiniMax_AlphaBeta_Quiescence(game.CurrentPosition, Configuration.EngineSettings.Depth - 1);
+	//Console.WriteLine($"Evaluation: {evaluation}");
 
-    //var bestMove = moveList!.Moves.Last();
-    //Console.WriteLine($"Best move: {bestMove}");
+	//var bestMove = moveList!.Moves.Last();
+	//Console.WriteLine($"Best move: {bestMove}");
 }
 
 static void _53_MVVLVA()
 {
-    for (int attacker = (int)Piece.P; attacker <= (int)Piece.K; ++attacker)
-    {
-        for (int victim = (int)Piece.p; victim <= (int)Piece.k; ++victim)
-        {
-            var score = MostValueableVictimLeastValuableAttacker[attacker][victim];
-            Console.WriteLine($"Score {(Piece)attacker}x{(Piece)victim}: {score}");
-        }
-        Console.WriteLine();
-    }
+	for (int attacker = (int)Piece.P; attacker <= (int)Piece.K; ++attacker)
+	{
+		for (int victim = (int)Piece.p; victim <= (int)Piece.k; ++victim)
+		{
+			var score = MostValueableVictimLeastValuableAttacker[attacker][victim];
+			Console.WriteLine($"Score {(Piece)attacker}x{(Piece)victim}: {score}");
+		}
+		Console.WriteLine();
+	}
 
-    for (int attacker = (int)Piece.p; attacker <= (int)Piece.k; ++attacker)
-    {
-        for (int victim = (int)Piece.P; victim <= (int)Piece.K; ++victim)
-        {
-            var score = MostValueableVictimLeastValuableAttacker[attacker][victim];
-            Console.WriteLine($"Score {(Piece)attacker}x{(Piece)victim}: {score}");
-        }
-        Console.WriteLine();
-    }
+	for (int attacker = (int)Piece.p; attacker <= (int)Piece.k; ++attacker)
+	{
+		for (int victim = (int)Piece.P; victim <= (int)Piece.K; ++victim)
+		{
+			var score = MostValueableVictimLeastValuableAttacker[attacker][victim];
+			Console.WriteLine($"Score {(Piece)attacker}x{(Piece)victim}: {score}");
+		}
+		Console.WriteLine();
+	}
 }
 
 static void _54_ScoreMove()
 {
-    var position = new Position(KillerPosition);
-    position.Print();
+	var position = new Position(KillerPosition);
+	position.Print();
 
-    var engine = new Engine(Channel.CreateBounded<object>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
-    engine.SetGame(new(position.FEN()));
-    Span<BitBoard> attacks = stackalloc BitBoard[12];
-    Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-    var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
-    {
-        Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext)}");
-    }
+	var engine = new Engine(Channel.CreateBounded<object>(new BoundedChannelOptions(100) { SingleReader = true, SingleWriter = false }));
+	engine.SetGame(new(position.FEN()));
 
-    position = new Position(TrickyPosition);
-    position.Print();
+	using var evaluationContext = new EvaluationContext();
+	foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+	{
+		Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, evaluationContext)}");
+	}
 
-    engine.SetGame(new(position.FEN()));
-    foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
-    {
-        Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext)}");
-    }
+	position = new Position(TrickyPosition);
+	position.Print();
+
+	engine.SetGame(new(position.FEN()));
+	foreach (var move in MoveGenerator.GenerateAllMoves(position, capturesOnly: true))
+	{
+		Console.WriteLine($"{move} {engine.ScoreMove(engine.Game.CurrentPosition, move, default, evaluationContext)}");
+	}
 }
 
 static void ZobristTable()
 {
-    var pos = new Position(KillerPosition);
-    var zobristTable = InitializeZobristTable();
-    var hash = CalculatePositionHash(zobristTable, pos);
-    var updatedHash = UpdatePositionHash(zobristTable, hash, MoveGenerator.GenerateAllMoves(pos)[0]);
+	var pos = new Position(KillerPosition);
+	var zobristTable = InitializeZobristTable();
+	var hash = CalculatePositionHash(zobristTable, pos);
+	var updatedHash = UpdatePositionHash(zobristTable, hash, MoveGenerator.GenerateAllMoves(pos)[0]);
 
-    Console.WriteLine(updatedHash);
+	Console.WriteLine(updatedHash);
 }
 
 static long[,] InitializeZobristTable()
 {
-    var randomInstance = new Random(int.MaxValue);
-    var zobristTable = new long[64, 12];
+	var randomInstance = new Random(int.MaxValue);
+	var zobristTable = new long[64, 12];
 
-    for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
-    {
-        for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
-        {
-            zobristTable[squareIndex, pieceIndex] = randomInstance.NextInt64();
-        }
-    }
+	for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
+	{
+		for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
+		{
+			zobristTable[squareIndex, pieceIndex] = randomInstance.NextInt64();
+		}
+	}
 
-    return zobristTable;
+	return zobristTable;
 }
 
 static long CalculatePositionHash(long[,] zobristTable, Position position)
 {
-    long positionHash = 0;
+	long positionHash = 0;
 
-    for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
-    {
-        for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
-        {
-            if (position.PieceBitBoards[pieceIndex].GetBit(squareIndex))
-            {
-                positionHash ^= zobristTable[squareIndex, pieceIndex];
-            }
-        }
-    }
+	for (int squareIndex = 0; squareIndex < 64; ++squareIndex)
+	{
+		for (int pieceIndex = 0; pieceIndex < 12; ++pieceIndex)
+		{
+			if (position.PieceBitBoards[pieceIndex].GetBit(squareIndex))
+			{
+				positionHash ^= zobristTable[squareIndex, pieceIndex];
+			}
+		}
+	}
 
-    return positionHash;
+	return positionHash;
 }
 
 static long UpdatePositionHash(long[,] zobristTable, long positionHash, Move move)
 {
-    var sourcePiece = move.Piece();
-    var piece = move.PromotedPiece();
-    if (piece == default)
-    {
-        piece = sourcePiece;
-    }
+	var sourcePiece = move.Piece();
+	var piece = move.PromotedPiece();
+	if (piece == default)
+	{
+		piece = sourcePiece;
+	}
 
-    var sourceSquare = move.SourceSquare();
-    var targetSquare = move.TargetSquare();
+	var sourceSquare = move.SourceSquare();
+	var targetSquare = move.TargetSquare();
 
-    return positionHash
-        ^ zobristTable[sourcePiece, sourceSquare]
-        ^ zobristTable[piece, targetSquare]
-        ^ zobristTable[piece, targetSquare];
+	return positionHash
+		^ zobristTable[sourcePiece, sourceSquare]
+		^ zobristTable[piece, targetSquare]
+		^ zobristTable[piece, targetSquare];
 }
 
 static void PV_Table()
 {
-    // Debugging, Configuration.EngineSettings.MaxDepth = 32
+	// Debugging, Configuration.EngineSettings.MaxDepth = 32
 
-    /*
+	/*
      * Watch optimized
      *
      *  $"{pvTable[0].ToString()} {pvTable[1].ToString()}" + $" {pvTable[2].ToString()} {pvTable[3].ToString()}" + $"{pvTable[4].ToString()} {pvTable[5].ToString()}" + $" {pvTable[6].ToString()} {pvTable[7].ToString()}"
@@ -820,417 +817,417 @@ $"                                   {pvTable[150], -6} {pvTable[151], -6}" + $"
 
 static void CountBits()
 {
-    var Data = new[] {
-        new Position(Constants.InitialPositionFEN),
-        new Position(Constants.TrickyTestPositionFEN),
-        new Position(Constants.TrickyTestPositionReversedFEN),
-        new Position(Constants.CmkTestPositionFEN),
-        new Position(Constants.ComplexPositionFEN),
-        new Position(Constants.KillerTestPositionFEN),
-    };
+	var Data = new[] {
+		new Position(Constants.InitialPositionFEN),
+		new Position(Constants.TrickyTestPositionFEN),
+		new Position(Constants.TrickyTestPositionReversedFEN),
+		new Position(Constants.CmkTestPositionFEN),
+		new Position(Constants.ComplexPositionFEN),
+		new Position(Constants.KillerTestPositionFEN),
+	};
 
-    foreach (var position in Data)
-    {
-        var oldC = Check_LS1B_And_Reset(position);
-        var newC = BitOperations_PopCount(position);
+	foreach (var position in Data)
+	{
+		var oldC = Check_LS1B_And_Reset(position);
+		var newC = BitOperations_PopCount(position);
 
-        Console.WriteLine($"{oldC} | {newC}");
-    }
-    Console.WriteLine("=========================================================================");
+		Console.WriteLine($"{oldC} | {newC}");
+	}
+	Console.WriteLine("=========================================================================");
 
-    static int Check_LS1B_And_Reset(Position position)
-    {
-        int counter = 0;
+	static int Check_LS1B_And_Reset(Position position)
+	{
+		int counter = 0;
 
-        foreach (var bitboard in position.PieceBitBoards)
-        {
-            counter += CountBits_Naive(bitboard);
-        }
+		foreach (var bitboard in position.PieceBitBoards)
+		{
+			counter += CountBits_Naive(bitboard);
+		}
 
-        foreach (var bitboard in position.OccupancyBitBoards)
-        {
-            counter += CountBits_Naive(bitboard);
-        }
+		foreach (var bitboard in position.OccupancyBitBoards)
+		{
+			counter += CountBits_Naive(bitboard);
+		}
 
-        return counter;
-    }
+		return counter;
+	}
 
-    static int BitOperations_PopCount(Position position)
-    {
-        int counter = 0;
+	static int BitOperations_PopCount(Position position)
+	{
+		int counter = 0;
 
-        foreach (var bitboard in position.PieceBitBoards)
-        {
-            counter += CountBits_PopCount(bitboard);
-        }
+		foreach (var bitboard in position.PieceBitBoards)
+		{
+			counter += CountBits_PopCount(bitboard);
+		}
 
-        foreach (var bitboard in position.OccupancyBitBoards)
-        {
-            counter += CountBits_PopCount(bitboard);
-        }
+		foreach (var bitboard in position.OccupancyBitBoards)
+		{
+			counter += CountBits_PopCount(bitboard);
+		}
 
-        return counter;
-    }
+		return counter;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int CountBits_Naive(ulong bitboard)
-    {
-        int counter = 0;
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static int CountBits_Naive(ulong bitboard)
+	{
+		int counter = 0;
 
-        // Consecutively reset LSB
-        while (bitboard != default)
-        {
-            ++counter;
-            bitboard = ResetLS1B(bitboard);
-        }
+		// Consecutively reset LSB
+		while (bitboard != default)
+		{
+			++counter;
+			bitboard = ResetLS1B(bitboard);
+		}
 
-        return counter;
-    }
+		return counter;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int CountBits_PopCount(ulong bitboard) => BitOperations.PopCount(bitboard);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static int CountBits_PopCount(ulong bitboard) => BitOperations.PopCount(bitboard);
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static ulong ResetLS1B(ulong bitboard)
-    {
-        return bitboard & (bitboard - 1);
-    }
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static ulong ResetLS1B(ulong bitboard)
+	{
+		return bitboard & (bitboard - 1);
+	}
 }
 
 static void GetLS1BIndex()
 {
-    var Data = new[] {
-        new Position(Constants.InitialPositionFEN),
-        new Position(Constants.TrickyTestPositionFEN),
-        new Position(Constants.TrickyTestPositionReversedFEN),
-        new Position(Constants.CmkTestPositionFEN),
-        new Position(Constants.ComplexPositionFEN),
-        new Position(Constants.KillerTestPositionFEN),
-    };
+	var Data = new[] {
+		new Position(Constants.InitialPositionFEN),
+		new Position(Constants.TrickyTestPositionFEN),
+		new Position(Constants.TrickyTestPositionReversedFEN),
+		new Position(Constants.CmkTestPositionFEN),
+		new Position(Constants.ComplexPositionFEN),
+		new Position(Constants.KillerTestPositionFEN),
+	};
 
-    foreach (var position in Data)
-    {
-        var oldC = Original_GetLS1BIndex(position);
-        var newC = BitOperations_GetLS1BIndex(position);
+	foreach (var position in Data)
+	{
+		var oldC = Original_GetLS1BIndex(position);
+		var newC = BitOperations_GetLS1BIndex(position);
 
-        Console.WriteLine($"{oldC} | {newC}");
-    }
-    Console.WriteLine("=========================================================================");
+		Console.WriteLine($"{oldC} | {newC}");
+	}
+	Console.WriteLine("=========================================================================");
 
-    static int Original_GetLS1BIndex(Position position)
-    {
-        int counter = 0;
+	static int Original_GetLS1BIndex(Position position)
+	{
+		int counter = 0;
 
-        foreach (var bitboard in position.PieceBitBoards)
-        {
-            counter += Original_GetLS1BIndex_Impl(bitboard);
-        }
+		foreach (var bitboard in position.PieceBitBoards)
+		{
+			counter += Original_GetLS1BIndex_Impl(bitboard);
+		}
 
-        foreach (var bitboard in position.OccupancyBitBoards)
-        {
-            counter += Original_GetLS1BIndex_Impl(bitboard);
-        }
+		foreach (var bitboard in position.OccupancyBitBoards)
+		{
+			counter += Original_GetLS1BIndex_Impl(bitboard);
+		}
 
-        return counter;
-    }
+		return counter;
+	}
 
-    static int BitOperations_GetLS1BIndex(Position position)
-    {
-        int counter = 0;
+	static int BitOperations_GetLS1BIndex(Position position)
+	{
+		int counter = 0;
 
-        foreach (var bitboard in position.PieceBitBoards)
-        {
-            counter += BitOperations_GetLS1BIndex_Impl(bitboard);
-        }
+		foreach (var bitboard in position.PieceBitBoards)
+		{
+			counter += BitOperations_GetLS1BIndex_Impl(bitboard);
+		}
 
-        foreach (var bitboard in position.OccupancyBitBoards)
-        {
-            counter += BitOperations_GetLS1BIndex_Impl(bitboard);
-        }
+		foreach (var bitboard in position.OccupancyBitBoards)
+		{
+			counter += BitOperations_GetLS1BIndex_Impl(bitboard);
+		}
 
-        return counter;
-    }
+		return counter;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int Original_GetLS1BIndex_Impl(ulong bitboard)
-    {
-        if (bitboard == default)
-        {
-            return (int)BoardSquare.noSquare;
-        }
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static int Original_GetLS1BIndex_Impl(ulong bitboard)
+	{
+		if (bitboard == default)
+		{
+			return (int)BoardSquare.noSquare;
+		}
 
-        return CountBits(bitboard ^ (bitboard - 1)) - 1;
-    }
+		return CountBits(bitboard ^ (bitboard - 1)) - 1;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int BitOperations_GetLS1BIndex_Impl(ulong bitboard)
-    {
-        if (bitboard == default)
-        {
-            return (int)BoardSquare.noSquare;
-        }
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static int BitOperations_GetLS1BIndex_Impl(ulong bitboard)
+	{
+		if (bitboard == default)
+		{
+			return (int)BoardSquare.noSquare;
+		}
 
-        return BitOperations.TrailingZeroCount(bitboard);
-    }
+		return BitOperations.TrailingZeroCount(bitboard);
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    static int CountBits(ulong bitboard)
-    {
-        return BitOperations.PopCount(bitboard);
-    }
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static int CountBits(ulong bitboard)
+	{
+		return BitOperations.PopCount(bitboard);
+	}
 }
 
 static void FileAndRankMasks()
 {
-    const int square = (int)BoardSquare.e4;
+	const int square = (int)BoardSquare.e4;
 
-    Masks.RankMasks[square].Print();
-    Masks.IsolatedPawnMasks[square].Print();
-    Masks.WhitePassedPawnMasks[square].Print();
-    Masks.BlackPassedPawnMasks[square].Print();
+	Masks.RankMasks[square].Print();
+	Masks.IsolatedPawnMasks[square].Print();
+	Masks.WhitePassedPawnMasks[square].Print();
+	Masks.BlackPassedPawnMasks[square].Print();
 }
 
 static void EnhancedPawnEvaluation()
 {
-    var position = new Position("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1");
-    var eval = position.StaticEvaluation().Score;
-    position.Print();
-    Console.WriteLine(eval);
+	var position = new Position("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1");
+	var eval = position.StaticEvaluation().Score;
+	position.Print();
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp4pp/p7/8/8/P7/PPP3P1/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp4pp/p7/8/8/P7/PPP3P1/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp3pp1/p7/8/8/P7/PPP4P/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp3pp1/p7/8/8/P7/PPP4P/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp3pp1/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp3pp1/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp2pp2/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp2pp2/p7/8/8/P7/PP3P1P/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp2pp2/p7/8/7P/P7/PP3P2/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp2pp2/p7/8/7P/P7/PP3P2/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("4k3/pp2pp1P/p7/8/8/P7/PP3P2/4K3 w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("4k3/pp2pp1P/p7/8/8/P7/PP3P2/4K3 w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 }
 
 static void RookEvaluation()
 {
-    var position = new Position("r3k3/7p/8/8/8/8/7P/4K2R w - - 0 1");
-    position.Print();
-    var eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	var position = new Position("r3k3/7p/8/8/8/8/7P/4K2R w - - 0 1");
+	position.Print();
+	var eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("r3k3/1p6/8/8/8/8/7P/4K2R w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("r3k3/1p6/8/8/8/8/7P/4K2R w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 
-    position = new Position("r3k3/1P6/8/8/8/8/7p/4K2R w - - 0 1");
-    position.Print();
-    eval = position.StaticEvaluation().Score;
-    Console.WriteLine(eval);
+	position = new Position("r3k3/1P6/8/8/8/8/7p/4K2R w - - 0 1");
+	position.Print();
+	eval = position.StaticEvaluation().Score;
+	Console.WriteLine(eval);
 }
 
 static void TranspositionTableMethod()
 {
-    static void TesSize(int size)
-    {
-        Console.WriteLine("Hash: {0} MB", size);
-        var length = TranspositionTable.CalculateLength(size);
+	static void TesSize(int size)
+	{
+		Console.WriteLine("Hash: {0} MB", size);
+		var length = TranspositionTable.CalculateLength(size);
 
-        var lengthMb = length / 1024 / 1024;
+		var lengthMb = length / 1024 / 1024;
 
-        Console.WriteLine("TT memory: {0} MB", lengthMb * Marshal.SizeOf<TranspositionTableElement>());
-        Console.WriteLine("TT array length: {0}MB, (0x{1}, {2} items)", lengthMb, length.ToString("X"), length);
-        Console.WriteLine("TT mask: 0x{0} ({1})\n", (length - 1).ToString("X"), Convert.ToString(length - 1, 2));
-    }
+		Console.WriteLine("TT memory: {0} MB", lengthMb * Marshal.SizeOf<TranspositionTableElement>());
+		Console.WriteLine("TT array length: {0}MB, (0x{1}, {2} items)", lengthMb, length.ToString("X"), length);
+		Console.WriteLine("TT mask: 0x{0} ({1})\n", (length - 1).ToString("X"), Convert.ToString(length - 1, 2));
+	}
 
-    Console.WriteLine($"{nameof(TranspositionTableElement)} size: {Marshal.SizeOf<TranspositionTableElement>()} bytes\n");
+	Console.WriteLine($"{nameof(TranspositionTableElement)} size: {Marshal.SizeOf<TranspositionTableElement>()} bytes\n");
 
-    TesSize(2);
-    TesSize(4);
-    TesSize(16);
-    TesSize(32);
-    TesSize(64);
-    TesSize(128);
-    TesSize(256);
-    TesSize(512);
-    TesSize(1024);
+	TesSize(2);
+	TesSize(4);
+	TesSize(16);
+	TesSize(32);
+	TesSize(64);
+	TesSize(128);
+	TesSize(256);
+	TesSize(512);
+	TesSize(1024);
 
-    var ttLength = TranspositionTable.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
-    var transpositionTable = new TranspositionTable();
+	var ttLength = TranspositionTable.CalculateLength(Configuration.EngineSettings.TranspositionTableSize);
+	var transpositionTable = new TranspositionTable();
 
-    var position = new Position(Constants.InitialPositionFEN);
-    position.Print();
-    Console.WriteLine($"Hash: {position.UniqueIdentifier}");
+	var position = new Position(Constants.InitialPositionFEN);
+	position.Print();
+	Console.WriteLine($"Hash: {position.UniqueIdentifier}");
 
-    var hashKey = position.UniqueIdentifier % 0x400000;
-    Console.WriteLine(hashKey);
+	var hashKey = position.UniqueIdentifier % 0x400000;
+	Console.WriteLine(hashKey);
 
-    var hashKey2 = transpositionTable.CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove: 0);
-    Console.WriteLine(hashKey2);
+	var hashKey2 = transpositionTable.CalculateTTIndex(position.UniqueIdentifier, halfMovesWithoutCaptureOrPawnMove: 0);
+	Console.WriteLine(hashKey2);
 
-    transpositionTable.Clear();
+	transpositionTable.Clear();
 
-    //transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
-    //var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
+	//transpositionTable.RecordHash(position, depth: 3, maxDepth: 5, move: 1234, eval: +5, nodeType: NodeType.Alpha);
+	//var entry = transpositionTable.ProbeHash(position, maxDepth: 5, depth: 3, alpha: 1, beta: 2);
 
-    transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, false, move: 1234);
-    transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3, out var entry);
+	transpositionTable.RecordHash(position, halfMovesWithoutCaptureOrPawnMove: 0, position.StaticEvaluation().Score, depth: 5, ply: 3, score: +19, nodeType: NodeType.Alpha, false, move: 1234);
+	transpositionTable.ProbeHash(position, halfMovesWithoutCaptureOrPawnMove: 0, ply: 3, out var entry);
 }
 
 static void UnmakeMove()
 {
-    var pos = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq");
-    var a = Perft.PerftRecursiveImpl(pos, 1, default);
+	var pos = new Position("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq");
+	var a = Perft.PerftRecursiveImpl(pos, 1, default);
 
-    TestMoveGen(Constants.InitialPositionFEN);
-    TestMoveGen(Constants.TTPositionFEN);
-    TestMoveGen(Constants.CmkTestPositionFEN);
-    TestMoveGen(Constants.ComplexPositionFEN);
-    TestMoveGen(Constants.TrickyTestPositionFEN);
+	TestMoveGen(Constants.InitialPositionFEN);
+	TestMoveGen(Constants.TTPositionFEN);
+	TestMoveGen(Constants.CmkTestPositionFEN);
+	TestMoveGen(Constants.ComplexPositionFEN);
+	TestMoveGen(Constants.TrickyTestPositionFEN);
 
-    static void TestMoveGen(string fen)
-    {
-        var position = new Position(fen);
-        Console.WriteLine($"**Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}**");
+	static void TestMoveGen(string fen)
+	{
+		var position = new Position(fen);
+		Console.WriteLine($"**Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}**");
 
-        var allMoves = MoveGenerator.GenerateAllMoves(position);
+		var allMoves = MoveGenerator.GenerateAllMoves(position);
 
-        var oldZobristKey = position.UniqueIdentifier;
-        foreach (var move in allMoves)
-        {
-            var epdMoveString = move.ToEPDString(position);
-            Console.WriteLine($"Trying {epdMoveString} in\t{position.FEN()}");
+		var oldZobristKey = position.UniqueIdentifier;
+		foreach (var move in allMoves)
+		{
+			var epdMoveString = move.ToEPDString(position);
+			Console.WriteLine($"Trying {epdMoveString} in\t{position.FEN()}");
 
-            var newPosition = new Position(position);
-            newPosition.MakeMove(move);
-            var savedState = position.MakeMove(move);
+			var newPosition = new Position(position);
+			newPosition.MakeMove(move);
+			var savedState = position.MakeMove(move);
 
-            Console.WriteLine($"Position\t{newPosition.FEN()}, Zobrist key {newPosition.UniqueIdentifier}");
-            Console.WriteLine($"Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}");
+			Console.WriteLine($"Position\t{newPosition.FEN()}, Zobrist key {newPosition.UniqueIdentifier}");
+			Console.WriteLine($"Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}");
 
-            Console.WriteLine($"Unmaking {epdMoveString} in\t{position.FEN()}");
+			Console.WriteLine($"Unmaking {epdMoveString} in\t{position.FEN()}");
 
-            //position.UnmakeMove(move, savedState);
+			//position.UnmakeMove(move, savedState);
 
-            Console.WriteLine($"Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}");
+			Console.WriteLine($"Position\t{position.FEN()}, Zobrist key {position.UniqueIdentifier}");
 
-            if (oldZobristKey != position.UniqueIdentifier)
-            {
-                Console.WriteLine($"{oldZobristKey} != {position.UniqueIdentifier}");
-                throw new DirectoryNotFoundException();
-            }
+			if (oldZobristKey != position.UniqueIdentifier)
+			{
+				Console.WriteLine($"{oldZobristKey} != {position.UniqueIdentifier}");
+				throw new DirectoryNotFoundException();
+			}
 
-            Console.WriteLine("----------------------------------------------------------------------------");
-        }
-        Console.WriteLine();
-        Console.WriteLine();
-    }
+			Console.WriteLine("----------------------------------------------------------------------------");
+		}
+		Console.WriteLine();
+		Console.WriteLine();
+	}
 }
 
 static void PieceSquareTables()
 {
-    short[] middleGamePawnTableBlack = [.. MiddleGamePawnTable.Select((_, index) => (short)-MiddleGamePawnTable[0][index ^ 56])];
-    short[] endGamePawnTableBlack = [.. EndGamePawnTable.Select((_, index) => (short)-EndGamePawnTable[0][index ^ 56])];
+	short[] middleGamePawnTableBlack = [.. MiddleGamePawnTable.Select((_, index) => (short)-MiddleGamePawnTable[0][index ^ 56])];
+	short[] endGamePawnTableBlack = [.. EndGamePawnTable.Select((_, index) => (short)-EndGamePawnTable[0][index ^ 56])];
 
-    PrintBitBoard(MiddleGamePawnTable);
-    PrintBitBoard(middleGamePawnTableBlack);
+	PrintBitBoard(MiddleGamePawnTable);
+	PrintBitBoard(middleGamePawnTableBlack);
 
-    PrintBitBoard(EndGamePawnTable);
-    PrintBitBoard(endGamePawnTableBlack);
+	PrintBitBoard(EndGamePawnTable);
+	PrintBitBoard(endGamePawnTableBlack);
 
-    static void PrintBitBoard<T>(T[] bitboard)
-    {
-        for (var rank = 0; rank < 8; ++rank)
-        {
-            for (var file = 0; file < 8; ++file)
-            {
-                if (file == 0)
-                {
-                    Console.Write($"{8 - rank}  ");
-                }
+	static void PrintBitBoard<T>(T[] bitboard)
+	{
+		for (var rank = 0; rank < 8; ++rank)
+		{
+			for (var file = 0; file < 8; ++file)
+			{
+				if (file == 0)
+				{
+					Console.Write($"{8 - rank}  ");
+				}
 
-                var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
+				var squareIndex = BitBoardExtensions.SquareIndex(rank, file);
 
-                Console.Write($" {bitboard[squareIndex]}\t");
-            }
+				Console.Write($" {bitboard[squareIndex]}\t");
+			}
 
-            Console.WriteLine();
-        }
-        Console.Write("\n    a\tb\tc\td\te\tf\tg\th\n\n\n");
-    }
+			Console.WriteLine();
+		}
+		Console.Write("\n    a\tb\tc\td\te\tf\tg\th\n\n\n");
+	}
 }
 
 static void NewMasks()
 {
-    Masks.WhiteSidePassedPawnMasks[(int)BoardSquare.c4].Print();
-    Masks.BlackSidePassedPawnMasks[(int)BoardSquare.c5].Print();
+	Masks.WhiteSidePassedPawnMasks[(int)BoardSquare.c4].Print();
+	Masks.BlackSidePassedPawnMasks[(int)BoardSquare.c5].Print();
 
-    PrintBitBoardArray(Masks.WhitePassedPawnMasks);
-    PrintBitBoardArray(Masks.WhiteSidePassedPawnMasks);
-    PrintBitBoardArray(Masks.BlackSidePassedPawnMasks);
+	PrintBitBoardArray(Masks.WhitePassedPawnMasks);
+	PrintBitBoardArray(Masks.WhiteSidePassedPawnMasks);
+	PrintBitBoardArray(Masks.BlackSidePassedPawnMasks);
 
-    Masks.WhiteKnightOutpostMask.Print();
-    Masks.BlackKnightOutpostMask.Print();
+	Masks.WhiteKnightOutpostMask.Print();
+	Masks.BlackKnightOutpostMask.Print();
 
-    Masks.LightSquaresMask.Print();
-    Masks.DarkSquaresMask.Print();
-    (Masks.DarkSquaresMask ^ Masks.LightSquaresMask).Print();
+	Masks.LightSquaresMask.Print();
+	Masks.DarkSquaresMask.Print();
+	(Masks.DarkSquaresMask ^ Masks.LightSquaresMask).Print();
 
-    Console.WriteLine(((Masks.LightSquaresMask >> (int)BoardSquare.h1) & 1) != 0);
-    Console.WriteLine((((9 * (int)BoardSquare.h1) + 8) & 8) != 0);
-    Console.WriteLine(((Masks.LightSquaresMask >> (int)BoardSquare.a1) & 1) != 0);
-    Console.WriteLine((((9 * (int)BoardSquare.a1) + 8) & 8) != 0);
+	Console.WriteLine(((Masks.LightSquaresMask >> (int)BoardSquare.h1) & 1) != 0);
+	Console.WriteLine((((9 * (int)BoardSquare.h1) + 8) & 8) != 0);
+	Console.WriteLine(((Masks.LightSquaresMask >> (int)BoardSquare.a1) & 1) != 0);
+	Console.WriteLine((((9 * (int)BoardSquare.a1) + 8) & 8) != 0);
 }
 
 static void PrintBitBoardArray(ulong[] bb)
 {
-    for (int i = 0; i < 64; ++i)
-    {
-        Console.Write($"{bb[i]}UL, ");
+	for (int i = 0; i < 64; ++i)
+	{
+		Console.Write($"{bb[i]}UL, ");
 
-        if ((i + 1) % 8 == 0)
-        {
-            Console.WriteLine();
-        }
-    }
+		if ((i + 1) % 8 == 0)
+		{
+			Console.WriteLine();
+		}
+	}
 
-    Console.WriteLine();
+	Console.WriteLine();
 }
 
 static void DarkLightSquares()
 {
-    Constants.DarkSquaresBitBoard.Print();
-    Constants.LightSquaresBitBoard.Print();
+	Constants.DarkSquaresBitBoard.Print();
+	Constants.LightSquaresBitBoard.Print();
 
-    for (int i = 0; i < 64; ++i)
-    {
-        Debug.Assert(Constants.DarkSquaresBitBoard.GetBit(i) ^ Constants.LightSquaresBitBoard.GetBit(i));
-    }
+	for (int i = 0; i < 64; ++i)
+	{
+		Debug.Assert(Constants.DarkSquaresBitBoard.GetBit(i) ^ Constants.LightSquaresBitBoard.GetBit(i));
+	}
 }
 
 static void PawnIslands()
 {
-    PawnIslandsGenerator.GeneratePawnIslands();
+	PawnIslandsGenerator.GeneratePawnIslands();
 }
 
 static void PrintKingRing()
 {
-    Console.WriteLine(string.Join("UL,\n", KingRing));
+	Console.WriteLine(string.Join("UL,\n", KingRing));
 }

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -240,7 +240,7 @@ public sealed partial class Engine : IDisposable
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
         Dispose(disposing: true);
 
-        #pragma warning disable S3234, IDISP024 // "GC.SuppressFinalize" should not be invoked for types without destructors - https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose
+#pragma warning disable S3234, IDISP024 // "GC.SuppressFinalize" should not be invoked for types without destructors
         GC.SuppressFinalize(this);
 #pragma warning restore S3234, IDISP024 // "GC.SuppressFinalize" should not be invoked for types without destructors
     }

--- a/src/Lynx/Model/EvaluationContext.cs
+++ b/src/Lynx/Model/EvaluationContext.cs
@@ -1,19 +1,48 @@
-﻿namespace Lynx.Model;
+﻿using System.Buffers;
+
+namespace Lynx.Model;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public ref struct EvaluationContext
+public sealed class EvaluationContext : IDisposable
 {
-    public Span<BitBoard> Attacks;
-    public Span<BitBoard> AttacksBySide;
+    public BitBoard[] Attacks;
+    public BitBoard[] AttacksBySide;
 
-    public EvaluationContext(Span<BitBoard> attacks, Span<BitBoard> attacksBySide)
+    private bool _disposedValue;
+
+    public EvaluationContext()
     {
-        Attacks = attacks;
-        AttacksBySide = attacksBySide;
+        Attacks = ArrayPool<BitBoard>.Shared.Rent(12);
+        AttacksBySide = ArrayPool<BitBoard>.Shared.Rent(2);
 
-        Attacks.Clear();
-        AttacksBySide.Clear();
+        Array.Clear(Attacks, 0, 12);
+        AttacksBySide[0] = 0;
+        AttacksBySide[1] = 0;
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                ArrayPool<BitBoard>.Shared.Return(Attacks);
+                ArrayPool<BitBoard>.Shared.Return(AttacksBySide);
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+
+#pragma warning disable S3234, IDISP024 // "GC.SuppressFinalize" should not be invoked for types without destructors
+        GC.SuppressFinalize(this);
+#pragma warning restore S3234, IDISP024 // "GC.SuppressFinalize" should not be invoked for types without destructors
     }
 }
 

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -57,9 +57,7 @@ public sealed class Game : IDisposable
         MoveHistory = new(Constants.MaxNumberMovesInAGame);
 #endif
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
         for (int i = 0; i < rangeSpan.Length; ++i)
         {
@@ -68,7 +66,7 @@ public sealed class Game : IDisposable
                 break;
             }
             var moveString = rawMoves[rangeSpan[i]];
-            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, ref evaluationContext, movePool);
+            var moveList = MoveGenerator.GenerateAllMoves(CurrentPosition, evaluationContext, movePool);
 
             // TODO: consider creating moves on the fly
             if (!MoveExtensions.TryParseFromUCIString(moveString, moveList, out var parsedMove))
@@ -155,14 +153,14 @@ public sealed class Game : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition(ref EvaluationContext evaluationContext)
+    public bool Is50MovesRepetition(EvaluationContext evaluationContext)
     {
         if (HalfMovesWithoutCaptureOrPawnMove < 100)
         {
             return false;
         }
 
-        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, ref evaluationContext);
+        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, evaluationContext);
     }
 
     /// <summary>

--- a/src/Lynx/Model/Move.cs
+++ b/src/Lynx/Model/Move.cs
@@ -367,11 +367,9 @@ public static class MoveExtensions
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray();
+        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray();
 
         var movesWithSameSimpleRepresentation = pseudoLegalMoves
             .Where(m => m != move && m.Piece() == piece && m.TargetSquare() == targetSquare)

--- a/src/Lynx/Model/SearchConstraints.cs
+++ b/src/Lynx/Model/SearchConstraints.cs
@@ -10,9 +10,9 @@ public readonly struct SearchConstraints
     /// </summary>
     private const int DefaultTimeBound = 10_000_000;
 
-    public const int DefaultHardLimitTimeBound  = DefaultTimeBound;
+    public const int DefaultHardLimitTimeBound = DefaultTimeBound;
 
-    public const int DefaultSoftLimitTimeBound  = DefaultTimeBound;
+    public const int DefaultSoftLimitTimeBound = DefaultTimeBound;
 
     public readonly int HardLimitTimeBound;
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -7,687 +7,685 @@ namespace Lynx;
 public static class MoveGenerator
 {
 #if DEBUG
-    private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+	private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
 #endif
 
-    private const int TRUE = 1;
+	private const int TRUE = 1;
 
-    internal static int Init() => TRUE;
+	internal static int Init() => TRUE;
 
-    /// <summary>
-    /// Indexed by <see cref="Piece"/>.
-    /// Checks are not considered
-    /// </summary>
-    public static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
-    [
+	/// <summary>
+	/// Indexed by <see cref="Piece"/>.
+	/// Checks are not considered
+	/// </summary>
+	public static readonly Func<int, BitBoard, BitBoard>[] _pieceAttacks =
+	[
 #pragma warning disable IDE0350 // Use implicitly typed lambda
         (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.White][origin],
-        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
-        Attacks.BishopAttacks,
-        Attacks.RookAttacks,
-        Attacks.QueenAttacks,
-        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+		(int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+		Attacks.BishopAttacks,
+		Attacks.RookAttacks,
+		Attacks.QueenAttacks,
+		(int origin, BitBoard _) => Attacks.KingAttacks[origin],
 
-        (int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black][origin],
-        (int origin, BitBoard _) => Attacks.KnightAttacks[origin],
-        Attacks.BishopAttacks,
-        Attacks.RookAttacks,
-        Attacks.QueenAttacks,
-        (int origin, BitBoard _) => Attacks.KingAttacks[origin],
+		(int origin, BitBoard _) => Attacks.PawnAttacks[(int)Side.Black][origin],
+		(int origin, BitBoard _) => Attacks.KnightAttacks[origin],
+		Attacks.BishopAttacks,
+		Attacks.RookAttacks,
+		Attacks.QueenAttacks,
+		(int origin, BitBoard _) => Attacks.KingAttacks[origin],
 #pragma warning restore IDE0350 // Use implicitly typed lambda
     ];
 
-    /// <summary>
-    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-    /// </summary>
-    /// <param name="capturesOnly">Filters out all moves but captures</param>
-    [Obsolete("dev and test only")]
-    internal static Move[] GenerateAllMoves(Position position, bool capturesOnly = false)
-    {
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-
-        return (capturesOnly
-            ? GenerateAllCaptures(position, ref evaluationContext, moves)
-            : GenerateAllMoves(position, ref evaluationContext, moves)).ToArray();
-    }
-
-    /// <summary>
-    /// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Span<Move> GenerateAllMoves(Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
-    {
-        Debug.Assert(position.Side != Side.Both);
-
-        int localIndex = 0;
-
-        var offset = Utils.PieceOffset(position.Side);
-
-        GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
-        GenerateCastlingMoves(ref localIndex, movePool, position, ref evaluationContext);
-        GenerateKingMoves(ref localIndex, movePool, (int)Piece.K + offset, position, ref evaluationContext);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
-        GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
-
-        return movePool[..localIndex];
-    }
-
-    /// <summary>
-    /// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Span<Move> GenerateAllCaptures(Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
-    {
-        Debug.Assert(position.Side != Side.Both);
-
-        int localIndex = 0;
-
-        var offset = Utils.PieceOffset(position.Side);
-
-        GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
-        GenerateCastlingMoves(ref localIndex, movePool, position, ref evaluationContext);
-        GenerateKingCaptures(ref localIndex, movePool, (int)Piece.K + offset, position, ref evaluationContext);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
-        GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
-
-        return movePool[..localIndex];
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateAllPawnMoves(ref int localIndex, Span<Move> movePool, Position position, int offset)
-    {
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        var piece = (int)Piece.P + offset;
-        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-        var bitboard = position.PieceBitBoards[piece];
-
-        var pawnAttacks = Attacks.PawnAttacks[(int)position.Side];
-
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
-
-            var sourceRank = (sourceSquare >> 3) + 1;
-
-            Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
-
-            // Pawn pushes
-            var singlePushSquare = sourceSquare + pawnPush;
-            if (!occupancy.GetBit(singlePushSquare))
-            {
-                // Single pawn push
-                var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
-
-                var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
-                {
-                    var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.N + offset);
-
-                    movePool[localIndex] = knightPromo + 3;         // Q
-                    movePool[localIndex + 1] = knightPromo + 2;     // R
-                    movePool[localIndex + 2] = knightPromo;         // N
-                    movePool[localIndex + 3] = knightPromo + 1;     // B
-
-                    localIndex += 4;
-                }
-                else
-                {
-                    movePool[localIndex++] = singlePawnPush;
-
-                    // Double pawn push
-                    // Inside of the single pawn push if because singlePush square cannot be occupied either
-                    if ((sourceRank == 2)        // position.Side == Side.Black is always true, otherwise targetRank would be 1
-                        || (sourceRank == 7))    // position.Side == Side.White is always true, otherwise targetRank would be 8
-                    {
-                        var doublePushSquare = singlePushSquare + pawnPush;
-
-                        if (!occupancy.GetBit(doublePushSquare))
-                        {
-                            movePool[localIndex++] = MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece);
-                        }
-                    }
-                }
-            }
-
-            var attacks = pawnAttacks[sourceSquare];
-
-            // En passant
-            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
-            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-            {
-                movePool[localIndex++] = MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece, capturedPiece: (int)Piece.p - offset);
-            }
-
-            // Captures
-            var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
-            while (attackedSquares != default)
-            {
-                attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
-                var capturedPiece = position.Board[targetSquare];
-
-                var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
-
-                var targetRank = (targetSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-                {
-                    var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.N + offset);
-
-                    movePool[localIndex] = knightPromo + 3;         // Q
-                    movePool[localIndex + 1] = knightPromo + 2;     // R
-                    movePool[localIndex + 2] = knightPromo;         // N
-                    movePool[localIndex + 3] = knightPromo + 1;     // B;
-
-                    localIndex += 4;
-                }
-                else
-                {
-                    movePool[localIndex++] = pawnCapture;
-                }
-            }
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePawnCapturesAndPromotions(ref int localIndex, Span<Move> movePool, Position position, int offset)
-    {
-        var piece = (int)Piece.P + offset;
-        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-        var bitboard = position.PieceBitBoards[piece];
-
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
-
-        var pawnAttacks = Attacks.PawnAttacks[(int)position.Side];
-
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
-
-            var sourceRank = (sourceSquare >> 3) + 1;
-
-            Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
-
-            // Pawn pushes
-            var singlePushSquare = sourceSquare + pawnPush;
-            if (!occupancy.GetBit(singlePushSquare))
-            {
-                // Single pawn push
-                var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
-
-                var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
-                {
-                    var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.N + offset);
-
-                    movePool[localIndex] = knightPromo + 3;         // Q
-                    movePool[localIndex + 1] = knightPromo + 2;     // R
-                    movePool[localIndex + 2] = knightPromo;         // N
-                    movePool[localIndex + 3] = knightPromo + 1;     // B
-
-                    localIndex += 4;
-                }
-            }
-
-            var attacks = pawnAttacks[sourceSquare];
-
-            // En passant
-            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
-            // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-            {
-                movePool[localIndex++] = MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece, capturedPiece: (int)Piece.p - offset);
-            }
-
-            // Captures
-            var attackedSquares = attacks & oppositeSidePieces;
-            while (attackedSquares != default)
-            {
-                attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
-                var capturedPiece = position.Board[targetSquare];
-
-                var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
-
-                var targetRank = (targetSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-                {
-                    var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.N + offset);
-
-                    movePool[localIndex] = knightPromo + 3;         // Q
-                    movePool[localIndex + 1] = knightPromo + 2;     // R
-                    movePool[localIndex + 2] = knightPromo;         // N
-                    movePool[localIndex + 3] = knightPromo + 1;     // B
-
-                    localIndex += 4;
-                }
-                else
-                {
-                    movePool[localIndex++] = pawnCapture;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void GenerateCastlingMoves(ref int localIndex, Span<int> movePool, Position position, ref EvaluationContext evaluationContext)
-    {
-        // TODO: move to position?
-        var castlingRights = position.Castle;
-
-        if (castlingRights != default)
-        {
-            var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-
-            if (position.Side == Side.White)
-            {
-                if ((castlingRights & (int)CastlingRights.WK) != default
-                    && (occupancy & position.KingsideCastlingFreeSquares[(int)Side.White]) == 0
-                    && !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.White], Side.Black, ref evaluationContext))
-                {
-                    movePool[localIndex++] = position.WhiteShortCastle;
-                }
-
-                if ((castlingRights & (int)CastlingRights.WQ) != default
-                    && (occupancy & position.QueensideCastlingFreeSquares[(int)Side.White]) == 0
-                    && !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.White], Side.Black, ref evaluationContext))
-
-                {
-                    movePool[localIndex++] = position.WhiteLongCastle;
-                }
-            }
-            else
-            {
-                if ((castlingRights & (int)CastlingRights.BK) != default
-                    && (occupancy & position.KingsideCastlingFreeSquares[(int)Side.Black]) == 0
-                    && !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.Black], Side.White, ref evaluationContext))
-                {
-                    movePool[localIndex++] = position.BlackShortCastle;
-                }
-
-                if ((castlingRights & (int)CastlingRights.BQ) != default
-                    && (occupancy & position.QueensideCastlingFreeSquares[(int)Side.Black]) == 0
-                    && !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.Black], Side.White, ref evaluationContext))
-                {
-                    movePool[localIndex++] = position.BlackLongCastle;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateAllPieceMoves(ref int localIndex, Span<Move> movePool, int piece, Position position)
-    {
-        var bitboard = position.PieceBitBoards[piece];
-
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        ulong squaresNotOccupiedByUs = ~position.OccupancyBitBoards[(int)position.Side];
-
-        var pieceAttacks = _pieceAttacks[piece];
-
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
-
-            var attacks = pieceAttacks(sourceSquare, occupancy)
-                & squaresNotOccupiedByUs;
-
-            while (attacks != default)
-            {
-                attacks = attacks.WithoutLS1B(out int targetSquare);
-
-                Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
-
-                movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare]);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Generate King moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateKingMoves(ref int localIndex, Span<Move> movePool, int piece, Position position, ref EvaluationContext evaluationContext)
-    {
-        var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-
-        var attacks = _pieceAttacks[piece](sourceSquare, occupancy)
-            & ~position.OccupancyBitBoards[(int)position.Side]
-            & ~evaluationContext.AttacksBySide[Utils.OppositeSide(position.Side)];
-
-        while (attacks != default)
-        {
-            attacks = attacks.WithoutLS1B(out var targetSquare);
-
-            Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
-
-            movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare]);
-        }
-    }
-
-    /// <summary>
-    /// Generate Knight, Bishop, Rook and Queen capture moves.
-    /// Could also generate King captures, but <see cref="GenerateKingCaptures(ref int, Span{int}, int, Position)"/> is more efficient.
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GeneratePieceCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position)
-    {
-        var bitboard = position.PieceBitBoards[piece];
-        var oppositeSide = Utils.OppositeSide(position.Side);
-
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
-
-        var pieceAttacks = _pieceAttacks[piece];
-
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
-
-            var attacks = pieceAttacks(sourceSquare, occupancy)
-                & oppositeSidePieces;
-
-            while (attacks != default)
-            {
-                attacks = attacks.WithoutLS1B(out int targetSquare);
-                var capturedPiece = position.Board[targetSquare];
-                movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Generate King capture moves
-    /// </summary>
-    /// <param name="piece"><see cref="Piece"/></param>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void GenerateKingCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position, ref EvaluationContext evaluationContext)
-    {
-        var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
-        var oppositeSide = Utils.OppositeSide(position.Side);
-
-        var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
-            & position.OccupancyBitBoards[oppositeSide]
-            & ~evaluationContext.AttacksBySide[oppositeSide];
-
-        while (attacks != default)
-        {
-            attacks = attacks.WithoutLS1B(out var targetSquare);
-
-            var capturedPiece = position.Board[targetSquare];
-            movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
-        }
-    }
-
-    /// <summary>
-    /// Generates all psuedo-legal moves from <paramref name="position"/>
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool CanGenerateAtLeastAValidMove(Position position, ref EvaluationContext evaluationContext)
-    {
-        Debug.Assert(position.Side != Side.Both);
-
-        var offset = Utils.PieceOffset(position.Side);
+	/// <summary>
+	/// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+	/// </summary>
+	/// <param name="capturesOnly">Filters out all moves but captures</param>
+	[Obsolete("dev and test only")]
+	internal static Move[] GenerateAllMoves(Position position, bool capturesOnly = false)
+	{
+		Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+
+		using var evaluationContext = new EvaluationContext();
+
+		return (capturesOnly
+			? GenerateAllCaptures(position, evaluationContext, moves)
+			: GenerateAllMoves(position, evaluationContext, moves)).ToArray();
+	}
+
+	/// <summary>
+	/// Generates all psuedo-legal moves from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static Span<Move> GenerateAllMoves(Position position, EvaluationContext evaluationContext, Span<Move> movePool)
+	{
+		Debug.Assert(position.Side != Side.Both);
+
+		int localIndex = 0;
+
+		var offset = Utils.PieceOffset(position.Side);
+
+		GenerateAllPawnMoves(ref localIndex, movePool, position, offset);
+		GenerateCastlingMoves(ref localIndex, movePool, position, evaluationContext);
+		GenerateKingMoves(ref localIndex, movePool, (int)Piece.K + offset, position, evaluationContext);
+		GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.N + offset, position);
+		GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.B + offset, position);
+		GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.R + offset, position);
+		GenerateAllPieceMoves(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+		return movePool[..localIndex];
+	}
+
+	/// <summary>
+	/// Generates all psuedo-legal captures from <paramref name="position"/>, ordered by <see cref="Move.Score(Position)"/>
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static Span<Move> GenerateAllCaptures(Position position, EvaluationContext evaluationContext, Span<Move> movePool)
+	{
+		Debug.Assert(position.Side != Side.Both);
+
+		int localIndex = 0;
+
+		var offset = Utils.PieceOffset(position.Side);
+
+		GeneratePawnCapturesAndPromotions(ref localIndex, movePool, position, offset);
+		GenerateCastlingMoves(ref localIndex, movePool, position, evaluationContext);
+		GenerateKingCaptures(ref localIndex, movePool, (int)Piece.K + offset, position, evaluationContext);
+		GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.N + offset, position);
+		GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.B + offset, position);
+		GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.R + offset, position);
+		GeneratePieceCaptures(ref localIndex, movePool, (int)Piece.Q + offset, position);
+
+		return movePool[..localIndex];
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GenerateAllPawnMoves(ref int localIndex, Span<Move> movePool, Position position, int offset)
+	{
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		var piece = (int)Piece.P + offset;
+		var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+		int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+		var bitboard = position.PieceBitBoards[piece];
+
+		var pawnAttacks = Attacks.PawnAttacks[(int)position.Side];
+
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+
+			var sourceRank = (sourceSquare >> 3) + 1;
+
+			Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
+
+			// Pawn pushes
+			var singlePushSquare = sourceSquare + pawnPush;
+			if (!occupancy.GetBit(singlePushSquare))
+			{
+				// Single pawn push
+				var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+
+				var targetRank = (singlePushSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Promotion
+				{
+					var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.N + offset);
+
+					movePool[localIndex] = knightPromo + 3;         // Q
+					movePool[localIndex + 1] = knightPromo + 2;     // R
+					movePool[localIndex + 2] = knightPromo;         // N
+					movePool[localIndex + 3] = knightPromo + 1;     // B
+
+					localIndex += 4;
+				}
+				else
+				{
+					movePool[localIndex++] = singlePawnPush;
+
+					// Double pawn push
+					// Inside of the single pawn push if because singlePush square cannot be occupied either
+					if ((sourceRank == 2)        // position.Side == Side.Black is always true, otherwise targetRank would be 1
+						|| (sourceRank == 7))    // position.Side == Side.White is always true, otherwise targetRank would be 8
+					{
+						var doublePushSquare = singlePushSquare + pawnPush;
+
+						if (!occupancy.GetBit(doublePushSquare))
+						{
+							movePool[localIndex++] = MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece);
+						}
+					}
+				}
+			}
+
+			var attacks = pawnAttacks[sourceSquare];
+
+			// En passant
+			if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+			// We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+			{
+				movePool[localIndex++] = MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece, capturedPiece: (int)Piece.p - offset);
+			}
+
+			// Captures
+			var attackedSquares = attacks & position.OccupancyBitBoards[oppositeSide];
+			while (attackedSquares != default)
+			{
+				attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
+				var capturedPiece = position.Board[targetSquare];
+
+				var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
+
+				var targetRank = (targetSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+				{
+					var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.N + offset);
+
+					movePool[localIndex] = knightPromo + 3;         // Q
+					movePool[localIndex + 1] = knightPromo + 2;     // R
+					movePool[localIndex + 2] = knightPromo;         // N
+					movePool[localIndex + 3] = knightPromo + 1;     // B;
+
+					localIndex += 4;
+				}
+				else
+				{
+					movePool[localIndex++] = pawnCapture;
+				}
+			}
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GeneratePawnCapturesAndPromotions(ref int localIndex, Span<Move> movePool, Position position, int offset)
+	{
+		var piece = (int)Piece.P + offset;
+		var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+		int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+		var bitboard = position.PieceBitBoards[piece];
+
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
+
+		var pawnAttacks = Attacks.PawnAttacks[(int)position.Side];
+
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+
+			var sourceRank = (sourceSquare >> 3) + 1;
+
+			Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
+
+			// Pawn pushes
+			var singlePushSquare = sourceSquare + pawnPush;
+			if (!occupancy.GetBit(singlePushSquare))
+			{
+				// Single pawn push
+				var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+
+				var targetRank = (singlePushSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Promotion
+				{
+					var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.N + offset);
+
+					movePool[localIndex] = knightPromo + 3;         // Q
+					movePool[localIndex + 1] = knightPromo + 2;     // R
+					movePool[localIndex + 2] = knightPromo;         // N
+					movePool[localIndex + 3] = knightPromo + 1;     // B
+
+					localIndex += 4;
+				}
+			}
+
+			var attacks = pawnAttacks[sourceSquare];
+
+			// En passant
+			if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant))
+			// We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+			{
+				movePool[localIndex++] = MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece, capturedPiece: (int)Piece.p - offset);
+			}
+
+			// Captures
+			var attackedSquares = attacks & oppositeSidePieces;
+			while (attackedSquares != default)
+			{
+				attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
+				var capturedPiece = position.Board[targetSquare];
+
+				var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
+
+				var targetRank = (targetSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+				{
+					var knightPromo = MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.N + offset);
+
+					movePool[localIndex] = knightPromo + 3;         // Q
+					movePool[localIndex + 1] = knightPromo + 2;     // R
+					movePool[localIndex + 2] = knightPromo;         // N
+					movePool[localIndex + 3] = knightPromo + 1;     // B
+
+					localIndex += 4;
+				}
+				else
+				{
+					movePool[localIndex++] = pawnCapture;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+	/// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static void GenerateCastlingMoves(ref int localIndex, Span<int> movePool, Position position, EvaluationContext evaluationContext)
+	{
+		// TODO: move to position?
+		var castlingRights = position.Castle;
+
+		if (castlingRights != default)
+		{
+			var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+
+			if (position.Side == Side.White)
+			{
+				if ((castlingRights & (int)CastlingRights.WK) != default
+					&& (occupancy & position.KingsideCastlingFreeSquares[(int)Side.White]) == 0
+					&& !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.White], Side.Black, evaluationContext))
+				{
+					movePool[localIndex++] = position.WhiteShortCastle;
+				}
+
+				if ((castlingRights & (int)CastlingRights.WQ) != default
+					&& (occupancy & position.QueensideCastlingFreeSquares[(int)Side.White]) == 0
+					&& !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.White], Side.Black, evaluationContext))
+
+				{
+					movePool[localIndex++] = position.WhiteLongCastle;
+				}
+			}
+			else
+			{
+				if ((castlingRights & (int)CastlingRights.BK) != default
+					&& (occupancy & position.KingsideCastlingFreeSquares[(int)Side.Black]) == 0
+					&& !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.Black], Side.White, evaluationContext))
+				{
+					movePool[localIndex++] = position.BlackShortCastle;
+				}
+
+				if ((castlingRights & (int)CastlingRights.BQ) != default
+					&& (occupancy & position.QueensideCastlingFreeSquares[(int)Side.Black]) == 0
+					&& !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.Black], Side.White, evaluationContext))
+				{
+					movePool[localIndex++] = position.BlackLongCastle;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Generate Knight, Bishop, Rook and Queen moves
+	/// </summary>
+	/// <param name="piece"><see cref="Piece"/></param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GenerateAllPieceMoves(ref int localIndex, Span<Move> movePool, int piece, Position position)
+	{
+		var bitboard = position.PieceBitBoards[piece];
+
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		ulong squaresNotOccupiedByUs = ~position.OccupancyBitBoards[(int)position.Side];
+
+		var pieceAttacks = _pieceAttacks[piece];
+
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+
+			var attacks = pieceAttacks(sourceSquare, occupancy)
+				& squaresNotOccupiedByUs;
+
+			while (attacks != default)
+			{
+				attacks = attacks.WithoutLS1B(out int targetSquare);
+
+				Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
+
+				movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare]);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Generate King moves
+	/// </summary>
+	/// <param name="piece"><see cref="Piece"/></param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GenerateKingMoves(ref int localIndex, Span<Move> movePool, int piece, Position position, EvaluationContext evaluationContext)
+	{
+		var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+
+		var attacks = _pieceAttacks[piece](sourceSquare, occupancy)
+			& ~position.OccupancyBitBoards[(int)position.Side]
+			& ~evaluationContext.AttacksBySide[Utils.OppositeSide(position.Side)];
+
+		while (attacks != default)
+		{
+			attacks = attacks.WithoutLS1B(out var targetSquare);
+
+			Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
+
+			movePool[localIndex++] = MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare]);
+		}
+	}
+
+	/// <summary>
+	/// Generate Knight, Bishop, Rook and Queen capture moves.
+	/// Could also generate King captures, but <see cref="GenerateKingCaptures(ref int, Span{int}, int, Position)"/> is more efficient.
+	/// </summary>
+	/// <param name="piece"><see cref="Piece"/></param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GeneratePieceCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position)
+	{
+		var bitboard = position.PieceBitBoards[piece];
+		var oppositeSide = Utils.OppositeSide(position.Side);
+
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
+
+		var pieceAttacks = _pieceAttacks[piece];
+
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+
+			var attacks = pieceAttacks(sourceSquare, occupancy)
+				& oppositeSidePieces;
+
+			while (attacks != default)
+			{
+				attacks = attacks.WithoutLS1B(out int targetSquare);
+				var capturedPiece = position.Board[targetSquare];
+				movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Generate King capture moves
+	/// </summary>
+	/// <param name="piece"><see cref="Piece"/></param>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static void GenerateKingCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position, EvaluationContext evaluationContext)
+	{
+		var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
+		var oppositeSide = Utils.OppositeSide(position.Side);
+
+		var attacks = _pieceAttacks[piece](sourceSquare, position.OccupancyBitBoards[(int)Side.Both])
+			& position.OccupancyBitBoards[oppositeSide]
+			& ~evaluationContext.AttacksBySide[oppositeSide];
+
+		while (attacks != default)
+		{
+			attacks = attacks.WithoutLS1B(out var targetSquare);
+
+			var capturedPiece = position.Board[targetSquare];
+			movePool[localIndex++] = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
+		}
+	}
+
+	/// <summary>
+	/// Generates all psuedo-legal moves from <paramref name="position"/>
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool CanGenerateAtLeastAValidMove(Position position, EvaluationContext evaluationContext)
+	{
+		Debug.Assert(position.Side != Side.Both);
+
+		var offset = Utils.PieceOffset(position.Side);
 
 #if DEBUG
-        try
-        {
+		try
+		{
 #endif
-            return IsAnyPawnMoveValid(position, offset)
-                || IsAnyKingMoveValid((int)Piece.K + offset, position, ref evaluationContext)    // in?
-                || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
-                || IsAnyPieceMoveValid((int)Piece.B + offset, position)
-                || IsAnyPieceMoveValid((int)Piece.N + offset, position)
-                || IsAnyPieceMoveValid((int)Piece.R + offset, position)
-                || IsAnyCastlingMoveValid(position, ref evaluationContext);
+			return IsAnyPawnMoveValid(position, offset)
+				|| IsAnyKingMoveValid((int)Piece.K + offset, position, evaluationContext)    // in?
+				|| IsAnyPieceMoveValid((int)Piece.Q + offset, position)
+				|| IsAnyPieceMoveValid((int)Piece.B + offset, position)
+				|| IsAnyPieceMoveValid((int)Piece.N + offset, position)
+				|| IsAnyPieceMoveValid((int)Piece.R + offset, position)
+				|| IsAnyCastlingMoveValid(position, evaluationContext);
 #if DEBUG
-        }
-        catch (Exception e)
-        {
-            _logger.Error(e, $"Error in {nameof(CanGenerateAtLeastAValidMove)}");
-            return false;
-        }
+		}
+		catch (Exception e)
+		{
+			_logger.Error(e, $"Error in {nameof(CanGenerateAtLeastAValidMove)}");
+			return false;
+		}
 #endif
-    }
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyPawnMoveValid(Position position, int offset)
-    {
-        var piece = (int)Piece.P + offset;
-        var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
-        int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
-        var bitboard = position.PieceBitBoards[piece];
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool IsAnyPawnMoveValid(Position position, int offset)
+	{
+		var piece = (int)Piece.P + offset;
+		var pawnPush = +8 - ((int)position.Side * 16);          // position.Side == Side.White ? -8 : +8
+		int oppositeSide = Utils.OppositeSide(position.Side);   // position.Side == Side.White ? (int)Side.Black : (int)Side.White
+		var bitboard = position.PieceBitBoards[piece];
 
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		var oppositeSidePieces = position.OccupancyBitBoards[oppositeSide];
 
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
 
-            var sourceRank = (sourceSquare >> 3) + 1;
+			var sourceRank = (sourceSquare >> 3) + 1;
 
-            Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
+			Debug.Assert(sourceRank != 1 && sourceRank != 8, $"There's a non-promoted {position.Side} pawn in rank {sourceRank})");
 
-            // Pawn pushes
-            var singlePushSquare = sourceSquare + pawnPush;
-            if (!occupancy.GetBit(singlePushSquare))
-            {
-                // Single pawn push
-                var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
+			// Pawn pushes
+			var singlePushSquare = sourceSquare + pawnPush;
+			if (!occupancy.GetBit(singlePushSquare))
+			{
+				// Single pawn push
+				var singlePawnPush = MoveExtensions.Encode(sourceSquare, singlePushSquare, piece);
 
-                var targetRank = (singlePushSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Promotion
-                {
-                    // If any of the promotions isn't valid, it means that the pawn move unveils a discovered check, or that the promoted piece doesn't stop an existing check in the 8th rank
-                    // Therefore none of the other promotions will be valid either
-                    if (IsValidMove(position, MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.Q + offset)))
-                    {
-                        return true;
-                    }
-                }
-                else
-                {
-                    if (IsValidMove(position, singlePawnPush))
-                    {
-                        return true;
-                    }
+				var targetRank = (singlePushSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Promotion
+				{
+					// If any of the promotions isn't valid, it means that the pawn move unveils a discovered check, or that the promoted piece doesn't stop an existing check in the 8th rank
+					// Therefore none of the other promotions will be valid either
+					if (IsValidMove(position, MoveExtensions.EncodePromotionFromPawnMove(singlePawnPush, promotedPiece: (int)Piece.Q + offset)))
+					{
+						return true;
+					}
+				}
+				else
+				{
+					if (IsValidMove(position, singlePawnPush))
+					{
+						return true;
+					}
 
-                    // Double pawn push
-                    // Inside of the if because singlePush square cannot be occupied either
-                    var doublePushSquare = singlePushSquare + pawnPush;
-                    if (!occupancy.GetBit(doublePushSquare)
-                        && (sourceRank == 2         // position.Side == Side.Black is always true, otherwise targetRank would be 1
-                            || sourceRank == 7)     // position.Side == Side.White is always true, otherwise targetRank would be 8
-                        && IsValidMove(position, MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece)))
-                    {
-                        return true;
-                    }
-                }
-            }
+					// Double pawn push
+					// Inside of the if because singlePush square cannot be occupied either
+					var doublePushSquare = singlePushSquare + pawnPush;
+					if (!occupancy.GetBit(doublePushSquare)
+						&& (sourceRank == 2         // position.Side == Side.Black is always true, otherwise targetRank would be 1
+							|| sourceRank == 7)     // position.Side == Side.White is always true, otherwise targetRank would be 8
+						&& IsValidMove(position, MoveExtensions.EncodeDoublePawnPush(sourceSquare, doublePushSquare, piece)))
+					{
+						return true;
+					}
+				}
+			}
 
-            var attacks = Attacks.PawnAttacks[(int)position.Side][sourceSquare];
+			var attacks = Attacks.PawnAttacks[(int)position.Side][sourceSquare];
 
-            // En passant
-            if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
-                // We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
-                && IsValidMove(position, MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece))) // Could add here capturedPiece: (int)Piece.p - offset
-            {
-                return true;
-            }
+			// En passant
+			if (position.EnPassant != BoardSquare.noSquare && attacks.GetBit(position.EnPassant)
+				// We assume that position.OccupancyBitBoards[oppositeOccupancy].GetBit(targetSquare + singlePush) == true
+				&& IsValidMove(position, MoveExtensions.EncodeEnPassant(sourceSquare, (int)position.EnPassant, piece))) // Could add here capturedPiece: (int)Piece.p - offset
+			{
+				return true;
+			}
 
-            // Captures
-            var attackedSquares = attacks & oppositeSidePieces;
-            while (attackedSquares != default)
-            {
-                attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
-                var capturedPiece = position.Board[targetSquare];
+			// Captures
+			var attackedSquares = attacks & oppositeSidePieces;
+			while (attackedSquares != default)
+			{
+				attackedSquares = attackedSquares.WithoutLS1B(out int targetSquare);
+				var capturedPiece = position.Board[targetSquare];
 
-                var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
+				var pawnCapture = MoveExtensions.EncodeCapture(sourceSquare, targetSquare, piece, capturedPiece);
 
-                var targetRank = (targetSquare >> 3) + 1;
-                if (targetRank == 1 || targetRank == 8)  // Capture with promotion
-                {
-                    // If any of the promotions that capture the same piece isn't valid, it means that the pawn move unveils a discovered check, or that the capture doesn't stop an existing check in the 8th rank
-                    // Therefore none of the other promotions capturing the same piece will be valid either
-                    if (IsValidMove(position, MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.Q + offset)))
-                    {
-                        return true;
-                    }
-                }
-                else if (IsValidMove(position, pawnCapture))
-                {
-                    return true;
-                }
-            }
-        }
+				var targetRank = (targetSquare >> 3) + 1;
+				if (targetRank == 1 || targetRank == 8)  // Capture with promotion
+				{
+					// If any of the promotions that capture the same piece isn't valid, it means that the pawn move unveils a discovered check, or that the capture doesn't stop an existing check in the 8th rank
+					// Therefore none of the other promotions capturing the same piece will be valid either
+					if (IsValidMove(position, MoveExtensions.EncodePromotionFromPawnMove(pawnCapture, promotedPiece: (int)Piece.Q + offset)))
+					{
+						return true;
+					}
+				}
+				else if (IsValidMove(position, pawnCapture))
+				{
+					return true;
+				}
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /// <summary>
-    /// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
-    /// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool IsAnyCastlingMoveValid(Position position, ref EvaluationContext evaluationContext)
-    {
-        // TODO: move to position?
+	/// <summary>
+	/// Obvious moves that put the king in check have been discarded, but the rest still need to be discarded
+	/// see FEN position "8/8/8/2bbb3/2bKb3/2bbb3/8/8 w - - 0 1", where 4 legal moves (corners) are found
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool IsAnyCastlingMoveValid(Position position, EvaluationContext evaluationContext)
+	{
+		// TODO: move to position?
 
-        var castlingRights = position.Castle;
+		var castlingRights = position.Castle;
 
-        if (castlingRights != default)
-        {
-            var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		if (castlingRights != default)
+		{
+			var occupancy = position.OccupancyBitBoards[(int)Side.Both];
 
-            if (position.Side == Side.White)
-            {
-                if ((castlingRights & (int)CastlingRights.WK) != default
-                    && (occupancy & position.KingsideCastlingFreeSquares[(int)Side.White]) == 0
-                    && !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.White], Side.Black, ref evaluationContext)
-                    && IsValidMove(position, position.WhiteShortCastle))
-                {
-                    return true;
-                }
+			if (position.Side == Side.White)
+			{
+				if ((castlingRights & (int)CastlingRights.WK) != default
+					&& (occupancy & position.KingsideCastlingFreeSquares[(int)Side.White]) == 0
+					&& !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.White], Side.Black, evaluationContext)
+					&& IsValidMove(position, position.WhiteShortCastle))
+				{
+					return true;
+				}
 
-                if ((castlingRights & (int)CastlingRights.WQ) != default
-                    && (occupancy & position.QueensideCastlingFreeSquares[(int)Side.White]) == 0
-                    && !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.White], Side.Black, ref evaluationContext)
-                    && IsValidMove(position, position.WhiteLongCastle))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                if ((castlingRights & (int)CastlingRights.BK) != default
-                    && (occupancy & position.KingsideCastlingFreeSquares[(int)Side.Black]) == 0
-                    && !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.Black], Side.White, ref evaluationContext)
-                    && IsValidMove(position, position.BlackShortCastle))
-                {
-                    return true;
-                }
+				if ((castlingRights & (int)CastlingRights.WQ) != default
+					&& (occupancy & position.QueensideCastlingFreeSquares[(int)Side.White]) == 0
+					&& !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.White], Side.Black, evaluationContext)
+					&& IsValidMove(position, position.WhiteLongCastle))
+				{
+					return true;
+				}
+			}
+			else
+			{
+				if ((castlingRights & (int)CastlingRights.BK) != default
+					&& (occupancy & position.KingsideCastlingFreeSquares[(int)Side.Black]) == 0
+					&& !position.AreSquaresAttacked(position.KingsideCastlingNonAttackedSquares[(int)Side.Black], Side.White, evaluationContext)
+					&& IsValidMove(position, position.BlackShortCastle))
+				{
+					return true;
+				}
 
-                if ((castlingRights & (int)CastlingRights.BQ) != default
-                    && (occupancy & position.QueensideCastlingFreeSquares[(int)Side.Black]) == 0
-                    && !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.Black], Side.White, ref evaluationContext)
-                    && IsValidMove(position, position.BlackLongCastle))
-                {
-                    return true;
-                }
-            }
-        }
+				if ((castlingRights & (int)CastlingRights.BQ) != default
+					&& (occupancy & position.QueensideCastlingFreeSquares[(int)Side.Black]) == 0
+					&& !position.AreSquaresAttacked(position.QueensideCastlingNonAttackedSquares[(int)Side.Black], Side.White, evaluationContext)
+					&& IsValidMove(position, position.BlackLongCastle))
+				{
+					return true;
+				}
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /// <summary>
-    /// Also valid for Kings, but less performant than <see cref="IsAnyKingMoveValid(int, Position)"/>
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyPieceMoveValid(int piece, Position position)
-    {
-        var bitboard = position.PieceBitBoards[piece];
+	/// <summary>
+	/// Also valid for Kings, but less performant than <see cref="IsAnyKingMoveValid(int, Position)"/>
+	/// </summary>
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool IsAnyPieceMoveValid(int piece, Position position)
+	{
+		var bitboard = position.PieceBitBoards[piece];
 
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
-        var squaresNotOccupiedByUs = ~position.OccupancyBitBoards[(int)position.Side];
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+		var squaresNotOccupiedByUs = ~position.OccupancyBitBoards[(int)position.Side];
 
-        var pieceAttacks = _pieceAttacks[piece];
+		var pieceAttacks = _pieceAttacks[piece];
 
-        while (bitboard != default)
-        {
-            bitboard = bitboard.WithoutLS1B(out int sourceSquare);
+		while (bitboard != default)
+		{
+			bitboard = bitboard.WithoutLS1B(out int sourceSquare);
 
-            var attacks = pieceAttacks(sourceSquare, occupancy)
-                & squaresNotOccupiedByUs;
+			var attacks = pieceAttacks(sourceSquare, occupancy)
+				& squaresNotOccupiedByUs;
 
-            while (attacks != default)
-            {
-                attacks = attacks.WithoutLS1B(out int targetSquare);
+			while (attacks != default)
+			{
+				attacks = attacks.WithoutLS1B(out int targetSquare);
 
-                Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
+				Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
 
-                if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare])))
-                {
-                    return true;
-                }
-            }
-        }
+				if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare])))
+				{
+					return true;
+				}
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsAnyKingMoveValid(int piece, Position position, ref EvaluationContext evaluationContext)
-    {
-        var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
-        var occupancy = position.OccupancyBitBoards[(int)Side.Both];
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private static bool IsAnyKingMoveValid(int piece, Position position, EvaluationContext evaluationContext)
+	{
+		var sourceSquare = position.PieceBitBoards[piece].GetLS1BIndex();
+		var occupancy = position.OccupancyBitBoards[(int)Side.Both];
 
-        var attacks = _pieceAttacks[piece](sourceSquare, occupancy)
-            & ~position.OccupancyBitBoards[(int)position.Side]
-            & ~evaluationContext.AttacksBySide[Utils.OppositeSide(position.Side)];
+		var attacks = _pieceAttacks[piece](sourceSquare, occupancy)
+			& ~position.OccupancyBitBoards[(int)position.Side]
+			& ~evaluationContext.AttacksBySide[Utils.OppositeSide(position.Side)];
 
-        while (attacks != default)
-        {
-            attacks = attacks.WithoutLS1B(out var targetSquare);
+		while (attacks != default)
+		{
+			attacks = attacks.WithoutLS1B(out var targetSquare);
 
-            Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
+			Debug.Assert(occupancy.GetBit(targetSquare) == (position.Board[targetSquare] != (int)Piece.None));
 
-            if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare])))
-            {
-                return true;
-            }
-        }
+			if (IsValidMove(position, MoveExtensions.Encode(sourceSquare, targetSquare, piece, capturedPiece: position.Board[targetSquare])))
+			{
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static bool IsValidMove(Position position, Move move)
-    {
-        var gameState = position.MakeMove(move);
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal static bool IsValidMove(Position position, Move move)
+	{
+		var gameState = position.MakeMove(move);
 
-        bool result = position.WasProduceByAValidMove();
-        position.UnmakeMove(move, gameState);
+		bool result = position.WasProduceByAValidMove();
+		position.UnmakeMove(move, gameState);
 
-        return result;
-    }
+		return result;
+	}
 }

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -40,11 +40,9 @@ public static class Perft
         {
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            using var evaluationContext = new EvaluationContext();
 
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves))
+            foreach (var move in MoveGenerator.GenerateAllMoves(position, evaluationContext, moves))
             {
                 var state = position.MakeMove(move);
 
@@ -68,11 +66,9 @@ public static class Perft
         {
             Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            using var evaluationContext = new EvaluationContext();
 
-            foreach (var move in MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves))
+            foreach (var move in MoveGenerator.GenerateAllMoves(position, evaluationContext, moves))
             {
                 var state = position.MakeMove(move);
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -49,7 +49,7 @@ public sealed partial class Engine
     /// [12][64][2][2]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref int QuietHistoryEntry(Position position, Move move, ref EvaluationContext evaluationContext)
+    private ref int QuietHistoryEntry(Position position, Move move, EvaluationContext evaluationContext)
     {
         const int pieceOffset = 64 * 2 * 2;
         const int targetSquareOffset = 2 * 2;
@@ -328,13 +328,11 @@ public sealed partial class Engine
         {
             Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            using var evaluationContext = new EvaluationContext();
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),
-               MoveGenerator.GenerateAllMoves(position, ref evaluationContext, movePool),
+               MoveGenerator.GenerateAllMoves(position, evaluationContext, movePool),
                out _))
             {
                 var message = $"Unexpected PV move {i}: {move.UCIString()} from position {position.FEN()}";

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -8,633 +8,629 @@ namespace Lynx;
 
 public sealed partial class Engine
 {
-    private readonly Stopwatch _stopWatch = new();
-    private readonly Move[] _pVTable = GC.AllocateArray<Move>(Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1 + Constants.ArrayDepthMargin) / 2, pinned: true);
+	private readonly Stopwatch _stopWatch = new();
+	private readonly Move[] _pVTable = GC.AllocateArray<Move>(Configuration.EngineSettings.MaxDepth * (Configuration.EngineSettings.MaxDepth + 1 + Constants.ArrayDepthMargin) / 2, pinned: true);
 
-    /// <summary>
-    /// 2 x (<see cref="Configuration.EngineSettings.MaxDepth"/> + <see cref="Constants.ArrayDepthMargin"/>)
-    /// </summary>
-    private readonly int[] _killerMoves = GC.AllocateArray<int>(2 * (Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin), pinned: true);
+	/// <summary>
+	/// 2 x (<see cref="Configuration.EngineSettings.MaxDepth"/> + <see cref="Constants.ArrayDepthMargin"/>)
+	/// </summary>
+	private readonly int[] _killerMoves = GC.AllocateArray<int>(2 * (Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin), pinned: true);
 
-    /// <summary>
-    /// 12 x 64
-    /// </summary>
-    private readonly int[] _counterMoves = GC.AllocateArray<int>(12 * 64, pinned: true);
+	/// <summary>
+	/// 12 x 64
+	/// </summary>
+	private readonly int[] _counterMoves = GC.AllocateArray<int>(12 * 64, pinned: true);
 
-    /// <summary>
-    /// 12 x 64 x 2 x 2
-    /// piece x target square x source is attacked x target is attacked
-    /// </summary>
-    private readonly int[] _quietHistory = GC.AllocateArray<int>(12 * 64 * 2 * 2, pinned: true);
+	/// <summary>
+	/// 12 x 64 x 2 x 2
+	/// piece x target square x source is attacked x target is attacked
+	/// </summary>
+	private readonly int[] _quietHistory = GC.AllocateArray<int>(12 * 64 * 2 * 2, pinned: true);
 
-    /// <summary>
-    /// 12 x 64 x 12,
-    /// piece x target square x captured piece
-    /// </summary>
-    private readonly int[] _captureHistory = GC.AllocateArray<int>(12 * 64 * 12, pinned: true);
+	/// <summary>
+	/// 12 x 64 x 12,
+	/// piece x target square x captured piece
+	/// </summary>
+	private readonly int[] _captureHistory = GC.AllocateArray<int>(12 * 64 * 12, pinned: true);
 
-    /// <summary>
-    /// 12 x 64 x 12 x 64 x <see cref="EvaluationConstants.ContinuationHistoryPlyCount"/>
-    /// piece x target square x last piece x last target square x plies back
-    /// ply 0 -> Continuation move history
-    /// ply 1 -> Follow-up move history
-    /// </summary>
-    private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
+	/// <summary>
+	/// 12 x 64 x 12 x 64 x <see cref="EvaluationConstants.ContinuationHistoryPlyCount"/>
+	/// piece x target square x last piece x last target square x plies back
+	/// ply 0 -> Continuation move history
+	/// ply 1 -> Follow-up move history
+	/// </summary>
+	private readonly int[] _continuationHistory = GC.AllocateArray<int>(12 * 64 * 12 * 64 * EvaluationConstants.ContinuationHistoryPlyCount, pinned: true);
 
-    /// <summary>
-    /// <see cref="Constants.PawnCorrHistoryHashSize"/> x 2
-    /// Pawn hash x side to move
-    /// </summary>
-    private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistoryHashSize * 2, pinned: true);
+	/// <summary>
+	/// <see cref="Constants.PawnCorrHistoryHashSize"/> x 2
+	/// Pawn hash x side to move
+	/// </summary>
+	private readonly int[] _pawnCorrHistory = GC.AllocateArray<int>(Constants.PawnCorrHistoryHashSize * 2, pinned: true);
 
-    /// <summary>
-    /// <see cref="Constants.NonPawnCorrHistoryHashMask"/> x 2 x 2
-    /// Non-pawn side hash x side to move x piece hash side
-    /// </summary>
-    private readonly int[] _nonPawnCorrHistory = GC.AllocateArray<int>(Constants.NonPawnCorrHistoryHashSize * 2 * 2, pinned: true);
+	/// <summary>
+	/// <see cref="Constants.NonPawnCorrHistoryHashMask"/> x 2 x 2
+	/// Non-pawn side hash x side to move x piece hash side
+	/// </summary>
+	private readonly int[] _nonPawnCorrHistory = GC.AllocateArray<int>(Constants.NonPawnCorrHistoryHashSize * 2 * 2, pinned: true);
 
-    /// <summary>
-    /// <see cref="Constants.MinorCorrHistoryHashSize"/> x 2
-    /// Minor hash x side to move
-    /// </summary>
-    private readonly int[] _minorCorrHistory = GC.AllocateArray<int>(Constants.MinorCorrHistoryHashSize * 2, pinned: true);
+	/// <summary>
+	/// <see cref="Constants.MinorCorrHistoryHashSize"/> x 2
+	/// Minor hash x side to move
+	/// </summary>
+	private readonly int[] _minorCorrHistory = GC.AllocateArray<int>(Constants.MinorCorrHistoryHashSize * 2, pinned: true);
 
-    /// <summary>
-    /// <see cref="Constants.MajorCorrHistoryHashSize"/> x 2
-    /// Major hash x side to move
-    /// </summary>
-    private readonly int[] _majorCorrHistory = GC.AllocateArray<int>(Constants.MajorCorrHistoryHashSize * 2, pinned: true);
+	/// <summary>
+	/// <see cref="Constants.MajorCorrHistoryHashSize"/> x 2
+	/// Major hash x side to move
+	/// </summary>
+	private readonly int[] _majorCorrHistory = GC.AllocateArray<int>(Constants.MajorCorrHistoryHashSize * 2, pinned: true);
 
-    /// <summary>
-    /// 12 x 64
-    /// piece x target square
-    /// </summary>
-    private readonly ulong[][] _moveNodeCount;
+	/// <summary>
+	/// 12 x 64
+	/// piece x target square
+	/// </summary>
+	private readonly ulong[][] _moveNodeCount;
 
-    private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
+	private readonly int[] _maxDepthReached = GC.AllocateArray<int>(Configuration.EngineSettings.MaxDepth + Constants.ArrayDepthMargin, pinned: true);
 
-    /// <summary>
-    /// <see cref="Constants.KingPawnHashSize"/>
-    /// </summary>
-    private readonly PawnTableElement[] _pawnEvalTable = GC.AllocateArray<PawnTableElement>(Constants.KingPawnHashSize, pinned: true);
+	/// <summary>
+	/// <see cref="Constants.KingPawnHashSize"/>
+	/// </summary>
+	private readonly PawnTableElement[] _pawnEvalTable = GC.AllocateArray<PawnTableElement>(Constants.KingPawnHashSize, pinned: true);
 
-    private ulong _nodes;
+	private ulong _nodes;
 
-    private SearchResult? _previousSearchResult;
+	private SearchResult? _previousSearchResult;
 
 #pragma warning disable CA1805 // Do not initialize unnecessarily - Interferes with S3459
-    private readonly Move _defaultMove = 0;
+	private readonly Move _defaultMove = 0;
 #pragma warning restore CA1805 // Do not initialize unnecessarily
 
-    private int _bestMoveStability;
-    private int _scoreDelta;
+	private int _bestMoveStability;
+	private int _scoreDelta;
 
-    /// <summary>
-    /// Iterative Deepening Depth-First Search (IDDFS) using alpha-beta pruning.
-    /// Requires <see cref="_searchConstraints"/> to be populated before invoking it
-    /// </summary>
-    /// <returns>Not null <see cref="SearchResult"/>, although made nullable in order to match online tb probing signature</returns>
-    [SkipLocalsInit]
-    private SearchResult IDDFS(bool isPondering, CancellationToken cancellationToken)
-    {
-        // Cleanup
-        _nodes = 0;
+	/// <summary>
+	/// Iterative Deepening Depth-First Search (IDDFS) using alpha-beta pruning.
+	/// Requires <see cref="_searchConstraints"/> to be populated before invoking it
+	/// </summary>
+	/// <returns>Not null <see cref="SearchResult"/>, although made nullable in order to match online tb probing signature</returns>
+	[SkipLocalsInit]
+	private SearchResult IDDFS(bool isPondering, CancellationToken cancellationToken)
+	{
+		// Cleanup
+		_nodes = 0;
 
-        Array.Clear(_pVTable);
-        Array.Clear(_maxDepthReached);
-        for (int i = 0; i < 12; ++i)
-        {
-            Array.Clear(_moveNodeCount[i]);
-        }
+		Array.Clear(_pVTable);
+		Array.Clear(_maxDepthReached);
+		for (int i = 0; i < 12; ++i)
+		{
+			Array.Clear(_moveNodeCount[i]);
+		}
 
-        int bestScore = 0;
-        int alpha = EvaluationConstants.MinEval;
-        int beta = EvaluationConstants.MaxEval;
-        SearchResult? lastSearchResult = null;
-        int depth = 1;
-        Move firstLegalMove = default;
+		int bestScore = 0;
+		int alpha = EvaluationConstants.MinEval;
+		int beta = EvaluationConstants.MaxEval;
+		SearchResult? lastSearchResult = null;
+		int depth = 1;
+		Move firstLegalMove = default;
 
-        _stopWatch.Restart();
+		_stopWatch.Restart();
 
-        var logLevel = IsMainEngine
-            ? LogLevel.Debug
+		var logLevel = IsMainEngine
+			? LogLevel.Debug
 #if MULTITHREAD_DEBUG
             : LogLevel.Trace;
 #else
-            : LogLevel.Off;
+			: LogLevel.Off;
 #endif
 
-        try
-        {
-            if (!isPondering && OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
-            {
-                _engineWriter.TryWrite(onlyOneLegalMoveSearchResult);
+		try
+		{
+			if (!isPondering && OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
+			{
+				_engineWriter.TryWrite(onlyOneLegalMoveSearchResult);
 
-                return onlyOneLegalMoveSearchResult;
-            }
+				return onlyOneLegalMoveSearchResult;
+			}
 
-            Array.Clear(_killerMoves);
-            // Not clearing _quietHistory on purpose
-            // Not clearing _captureHistory on purpose
+			Array.Clear(_killerMoves);
+			// Not clearing _quietHistory on purpose
+			// Not clearing _captureHistory on purpose
 
-            int mate = 0;
+			int mate = 0;
 
-            do
-            {
-                cancellationToken.ThrowIfCancellationRequested();
+			do
+			{
+				cancellationToken.ThrowIfCancellationRequested();
 
-                if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
-                    || lastSearchResult?.Score is null)
-                {
-                    bestScore = NegaMax(depth: depth, ply: 0, alpha, beta, cutnode: false, cancellationToken);
-                }
-                else
-                {
-                    // 🔍 Aspiration windows - search using a window around an expected score (the previous search one)
-                    // If the resulting score doesn't fall inside of the window, it is widened it until it does
-                    var window = Configuration.EngineSettings.AspirationWindow_Base;
+				if (depth < Configuration.EngineSettings.AspirationWindow_MinDepth
+					|| lastSearchResult?.Score is null)
+				{
+					bestScore = NegaMax(depth: depth, ply: 0, alpha, beta, cutnode: false, cancellationToken);
+				}
+				else
+				{
+					// 🔍 Aspiration windows - search using a window around an expected score (the previous search one)
+					// If the resulting score doesn't fall inside of the window, it is widened it until it does
+					var window = Configuration.EngineSettings.AspirationWindow_Base;
 
-                    // A temporary reduction is used for fail highs, because the verification for those 'too good' lines
-                    // are expected to happen at lower depths
-                    int failHighReduction = 0;
+					// A temporary reduction is used for fail highs, because the verification for those 'too good' lines
+					// are expected to happen at lower depths
+					int failHighReduction = 0;
 
-                    alpha = Math.Clamp(lastSearchResult.Score - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                    beta = Math.Clamp(lastSearchResult.Score + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
+					alpha = Math.Clamp(lastSearchResult.Score - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
+					beta = Math.Clamp(lastSearchResult.Score + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
 
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
-                        _id, depth, alpha, beta, lastSearchResult.Score, _nodes);
+					_logger.Log(logLevel,
+						"[#{EngineId}] Depth {Depth}: asp-win [{Alpha}, {Beta}] for previous search score {Score}, nodes {Nodes}",
+						_id, depth, alpha, beta, lastSearchResult.Score, _nodes);
 
-                    Debug.Assert(
-                        lastSearchResult.Mate == 0
-                            ? lastSearchResult.Score < EvaluationConstants.PositiveCheckmateDetectionLimit && lastSearchResult.Score > EvaluationConstants.NegativeCheckmateDetectionLimit
-                            : Math.Abs(lastSearchResult.Score) < EvaluationConstants.CheckMateBaseEvaluation && (lastSearchResult.Score > EvaluationConstants.PositiveCheckmateDetectionLimit || lastSearchResult.Score < EvaluationConstants.NegativeCheckmateDetectionLimit));
+					Debug.Assert(
+						lastSearchResult.Mate == 0
+							? lastSearchResult.Score < EvaluationConstants.PositiveCheckmateDetectionLimit && lastSearchResult.Score > EvaluationConstants.NegativeCheckmateDetectionLimit
+							: Math.Abs(lastSearchResult.Score) < EvaluationConstants.CheckMateBaseEvaluation && (lastSearchResult.Score > EvaluationConstants.PositiveCheckmateDetectionLimit || lastSearchResult.Score < EvaluationConstants.NegativeCheckmateDetectionLimit));
 
-                    while (true)
-                    {
-                        var depthToSearch = depth - failHighReduction;
-                        Debug.Assert(depthToSearch > 0);
+					while (true)
+					{
+						var depthToSearch = depth - failHighReduction;
+						Debug.Assert(depthToSearch > 0);
 
-                        _logger.Log(logLevel,
-                        "[#{EngineId}] Asp-win depth {Depth} ({DepthWithoutReduction} - {Reduction}), window {Window}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
-                        _id, depthToSearch, depth, failHighReduction, window, alpha, beta, bestScore, _nodes);
+						_logger.Log(logLevel,
+						"[#{EngineId}] Asp-win depth {Depth} ({DepthWithoutReduction} - {Reduction}), window {Window}: [{Alpha}, {Beta}] for score {Score}, nodes {Nodes}",
+						_id, depthToSearch, depth, failHighReduction, window, alpha, beta, bestScore, _nodes);
 
-                        bestScore = NegaMax(depth: depthToSearch, ply: 0, alpha, beta, cutnode: false, cancellationToken);
-                        Debug.Assert(bestScore > EvaluationConstants.MinEval && bestScore < EvaluationConstants.MaxEval);
+						bestScore = NegaMax(depth: depthToSearch, ply: 0, alpha, beta, cutnode: false, cancellationToken);
+						Debug.Assert(bestScore > EvaluationConstants.MinEval && bestScore < EvaluationConstants.MaxEval);
 
-                        // 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, EvaluationConstants.MaxEval
-                        window = Math.Min(EvaluationConstants.MaxEval, (int)(window * Configuration.EngineSettings.AspirationWindow_Multiplier));
+						// 13, 19, 28, 42, 63, 94, 141, 211, 316, 474, 711, 1066, 1599, 2398, 3597, 5395, 8092, 12138, 18207, 27310, EvaluationConstants.MaxEval
+						window = Math.Min(EvaluationConstants.MaxEval, (int)(window * Configuration.EngineSettings.AspirationWindow_Multiplier));
 
-                        // Depth change: https://github.com/lynx-chess/Lynx/pull/440
-                        if (alpha >= bestScore)     // Fail low
-                        {
-                            alpha = Math.Clamp(bestScore - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                            beta = (alpha + beta) >> 1;  // (alpha + beta) / 2
-                            failHighReduction = 0;
-                        }
-                        else if (beta <= bestScore)     // Fail high
-                        {
-                            beta = Math.Clamp(bestScore + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
-                            if (failHighReduction < 3)
-                            {
-                                ++failHighReduction;
-                            }
-                        }
-                        else
-                        {
-                            break;
-                        }
+						// Depth change: https://github.com/lynx-chess/Lynx/pull/440
+						if (alpha >= bestScore)     // Fail low
+						{
+							alpha = Math.Clamp(bestScore - window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
+							beta = (alpha + beta) >> 1;  // (alpha + beta) / 2
+							failHighReduction = 0;
+						}
+						else if (beta <= bestScore)     // Fail high
+						{
+							beta = Math.Clamp(bestScore + window, EvaluationConstants.MinEval, EvaluationConstants.MaxEval);
+							if (failHighReduction < 3)
+							{
+								++failHighReduction;
+							}
+						}
+						else
+						{
+							break;
+						}
 
-                        if (bestScore > EvaluationConstants.CheckMateBaseEvaluation)
-                        {
-                            _logger.Warn(
-                                "[#{EngineId}] Depth {Depth}: potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
-                                _id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore);
+						if (bestScore > EvaluationConstants.CheckMateBaseEvaluation)
+						{
+							_logger.Warn(
+								"[#{EngineId}] Depth {Depth}: potential +X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
+								_id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore);
 
-                            bestScore = EvaluationConstants.PositiveCheckmateDetectionLimit + 1;
+							bestScore = EvaluationConstants.PositiveCheckmateDetectionLimit + 1;
 
-                            break;
-                        }
+							break;
+						}
 
-                        if (bestScore < -EvaluationConstants.CheckMateBaseEvaluation)
-                        {
-                            // TODO bug
-                            _logger.Warn(
-                            //_logger.Info(
-                                "[#{EngineId}] Depth {Depth}: potential -X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
-                                _id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore);
+						if (bestScore < -EvaluationConstants.CheckMateBaseEvaluation)
+						{
+							// TODO bug
+							_logger.Warn(
+								//_logger.Info(
+								"[#{EngineId}] Depth {Depth}: potential -X checkmate detected in position {Position}, but score {BestScore} outside of the limits",
+								_id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore);
 
-                            bestScore = EvaluationConstants.NegativeCheckmateDetectionLimit - 1;
+							bestScore = EvaluationConstants.NegativeCheckmateDetectionLimit - 1;
 
-                            break;
-                        }
-                    }
-                }
+							break;
+						}
+					}
+				}
 
-                //PrintPvTable(depth: depth);
-                ValidatePVTable();
-                Debug.Assert(bestScore != EvaluationConstants.MinEval);
+				//PrintPvTable(depth: depth);
+				ValidatePVTable();
+				Debug.Assert(bestScore != EvaluationConstants.MinEval);
 
-                var bestScoreAbs = Math.Abs(bestScore);
-                bool isMateDetected = bestScoreAbs > EvaluationConstants.PositiveCheckmateDetectionLimit && bestScoreAbs < EvaluationConstants.CheckMateBaseEvaluation;
-                mate = isMateDetected
-                    ? Utils.CalculateMateInX(bestScore, bestScoreAbs)
-                    : 0;
+				var bestScoreAbs = Math.Abs(bestScore);
+				bool isMateDetected = bestScoreAbs > EvaluationConstants.PositiveCheckmateDetectionLimit && bestScoreAbs < EvaluationConstants.CheckMateBaseEvaluation;
+				mate = isMateDetected
+					? Utils.CalculateMateInX(bestScore, bestScoreAbs)
+					: 0;
 
-                var oldBestMove = lastSearchResult?.BestMove;
-                var oldScore = lastSearchResult?.Score ?? 0;
-                var lastSearchResultCandidate = UpdateLastSearchResult(lastSearchResult, bestScore, depth, mate);
+				var oldBestMove = lastSearchResult?.BestMove;
+				var oldScore = lastSearchResult?.Score ?? 0;
+				var lastSearchResultCandidate = UpdateLastSearchResult(lastSearchResult, bestScore, depth, mate);
 
-                if (lastSearchResultCandidate.BestMove == default)
-                {
-                    _logger.Warn(
-                        "[#{EngineId}] Depth {Depth}: search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}?) detected",
-                        _id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore, mate);
+				if (lastSearchResultCandidate.BestMove == default)
+				{
+					_logger.Warn(
+						"[#{EngineId}] Depth {Depth}: search didn't produce a best move for position {Position}. Score {Score} (mate in {Mate}?) detected",
+						_id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove), bestScore, mate);
 
-                    _bestMoveStability = 0;
-                    _scoreDelta = 0;
+					_bestMoveStability = 0;
+					_scoreDelta = 0;
 
-                    continue;
-                }
+					continue;
+				}
 
-                lastSearchResult = lastSearchResultCandidate;
+				lastSearchResult = lastSearchResultCandidate;
 
-                if (oldBestMove == lastSearchResult.BestMove)
-                {
-                    ++_bestMoveStability;
-                }
-                else
-                {
-                    _bestMoveStability = 0;
-                }
+				if (oldBestMove == lastSearchResult.BestMove)
+				{
+					++_bestMoveStability;
+				}
+				else
+				{
+					_bestMoveStability = 0;
+				}
 
-                _scoreDelta = oldScore - lastSearchResult.Score;
+				_scoreDelta = oldScore - lastSearchResult.Score;
 
-                _engineWriter.TryWrite(lastSearchResult);
-            } while (StopSearchCondition(lastSearchResult?.BestMove, ++depth, mate, bestScore, isPondering));
-        }
-        catch (OperationCanceledException)
-        {
-            // One degree higher than log level, but can't add 1 to Off
-            var higherLogLevel = IsMainEngine
-                ? LogLevel.Info
+				_engineWriter.TryWrite(lastSearchResult);
+			} while (StopSearchCondition(lastSearchResult?.BestMove, ++depth, mate, bestScore, isPondering));
+		}
+		catch (OperationCanceledException)
+		{
+			// One degree higher than log level, but can't add 1 to Off
+			var higherLogLevel = IsMainEngine
+				? LogLevel.Info
 #if MULTITHREAD_DEBUG
                 : LogLevel.Debug;
 #else
-                : LogLevel.Off;
+				: LogLevel.Off;
 #endif
 
 #pragma warning disable S6667 // Logging in a catch clause should pass the caught exception as a parameter - expected exception we want to ignore
-            _logger.Log(higherLogLevel,
-                "[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
-                _id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
+			_logger.Log(higherLogLevel,
+				"[#{EngineId}] Depth {Depth}: main search cancellation requested after {Time}ms (>= {HardLimitTime}ms). Nodes {Nodes}, best move will be returned",
+				_id, depth, _stopWatch.ElapsedMilliseconds, _searchConstraints.HardLimitTimeBound, _nodes);
 #pragma warning restore S6667 // Logging in a catch clause should pass the caught exception as a parameter.
 
-            for (int i = 0; i < lastSearchResult?.Moves.Length; ++i)
-            {
-                _pVTable[i] = lastSearchResult.Moves[i];
-            }
-        }
-        catch (Exception e) when (e is not LynxException)
-        {
-            _logger.Error(e,
-                "[#{EngineId}] Depth {Depth}: unexpected error ocurred during the search of position {Position}, best move will be returned\n",
-                _id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
-        }
-        finally
-        {
-            _stopWatch.Stop();
-        }
+			for (int i = 0; i < lastSearchResult?.Moves.Length; ++i)
+			{
+				_pVTable[i] = lastSearchResult.Moves[i];
+			}
+		}
+		catch (Exception e) when (e is not LynxException)
+		{
+			_logger.Error(e,
+				"[#{EngineId}] Depth {Depth}: unexpected error ocurred during the search of position {Position}, best move will be returned\n",
+				_id, depth, Game.PositionBeforeLastSearch.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
+		}
+		finally
+		{
+			_stopWatch.Stop();
+		}
 
-        //TODO revisit
-        //if (Configuration.EngineSettings.UseOnlineTablebaseInRootPositions
-        //    && isMateDetected
-        //    && (finalSearchResult.Mate * 2) + Game.HalfMovesWithoutCaptureOrPawnMove < Constants.MaxMateDistanceToStopSearching)
-        //{
-        //    _searchCancellationToken.Cancel();
-        //    _logger.Info("Engine search found a short enough mate, cancelling online tb probing if still active");
-        //}
+		//TODO revisit
+		//if (Configuration.EngineSettings.UseOnlineTablebaseInRootPositions
+		//    && isMateDetected
+		//    && (finalSearchResult.Mate * 2) + Game.HalfMovesWithoutCaptureOrPawnMove < Constants.MaxMateDistanceToStopSearching)
+		//{
+		//    _searchCancellationToken.Cancel();
+		//    _logger.Info("Engine search found a short enough mate, cancelling online tb probing if still active");
+		//}
 
-        return GenerateFinalSearchResult(lastSearchResult, bestScore, depth, firstLegalMove, isPondering);
-    }
+		return GenerateFinalSearchResult(lastSearchResult, bestScore, depth, firstLegalMove, isPondering);
+	}
 
-    private bool StopSearchCondition(Move? bestMove, int depth, int mate, int bestScore, bool isPondering)
-    {
-        if (bestMove is null || bestMove == 0)
-        {
-            _logger.Warn(
-                "[#{EngineId}] Depth {Depth}: search continues, due to lack of best move", _id, depth - 1);
+	private bool StopSearchCondition(Move? bestMove, int depth, int mate, int bestScore, bool isPondering)
+	{
+		if (bestMove is null || bestMove == 0)
+		{
+			_logger.Warn(
+				"[#{EngineId}] Depth {Depth}: search continues, due to lack of best move", _id, depth - 1);
 
-            return true;
-        }
+			return true;
+		}
 
-        var logLevel = IsMainEngine
-            ? LogLevel.Info
+		var logLevel = IsMainEngine
+			? LogLevel.Info
 #if MULTITHREAD_DEBUG
             : LogLevel.Debug;
 #else
-                : LogLevel.Off;
+				: LogLevel.Off;
 #endif
 
-        if (mate != 0)
-        {
-            if (mate == EvaluationConstants.MaxMate || mate == EvaluationConstants.MinMate)
-            {
-                //_logger.Warn( // TODO bug
-                _logger.Info(
-                    "[#{EngineId}] Depth {Depth}: mate {Mate} outside of range detected, stopping search and playing best move so far: {BestMove}",
-                    _id, depth - 1, mate, bestMove.Value.UCIString());
+		if (mate != 0)
+		{
+			if (mate == EvaluationConstants.MaxMate || mate == EvaluationConstants.MinMate)
+			{
+				//_logger.Warn( // TODO bug
+				_logger.Info(
+					"[#{EngineId}] Depth {Depth}: mate {Mate} outside of range detected, stopping search and playing best move so far: {BestMove}",
+					_id, depth - 1, mate, bestMove.Value.UCIString());
 
-                return false;
-            }
+				return false;
+			}
 
-            var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
+			var winningMateThreshold = (100 - Game.HalfMovesWithoutCaptureOrPawnMove) / 2;
 
-            _logger.Log(logLevel,
-                "[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
-                _id, depth - 1, mate, bestScore, winningMateThreshold);
+			_logger.Log(logLevel,
+				"[#{EngineId}] Depth {Depth}: mate in {Mate} detected (score {Score}, {MateThreshold} moves until draw by repetition)",
+				_id, depth - 1, mate, bestScore, winningMateThreshold);
 
-            if (!isPondering && (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold))
-            {
-                if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
-                {
-                    _logger.Log(logLevel,
-                        "[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
-                        _id, _searchConstraints.SoftLimitTimeBound);
+			if (!isPondering && (mate < 0 || mate + Constants.MateDistanceMarginToStopSearching < winningMateThreshold))
+			{
+				if (_searchConstraints.SoftLimitTimeBound < Configuration.EngineSettings.SoftTimeBoundLimitOnMate)
+				{
+					_logger.Log(logLevel,
+						"[#{EngineId}] Stopping, since mate is short enough and we're short on time: soft limit {SoftLimit}ms",
+						_id, _searchConstraints.SoftLimitTimeBound);
 
-                    return false;
-                }
+					return false;
+				}
 
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Could stop search, since mate is short enough",
-                    _id, _searchConstraints.SoftLimitTimeBound);
-            }
+				_logger.Log(logLevel,
+					"[#{EngineId}] Could stop search, since mate is short enough",
+					_id, _searchConstraints.SoftLimitTimeBound);
+			}
 
-            _logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
-        }
+			_logger.Log(logLevel, "[#{EngineId}] Search continues, hoping to find a faster mate", _id);
+		}
 
-        if (depth >= Configuration.EngineSettings.MaxDepth)
-        {
-            _logger.Log(logLevel,
-                "[#{EngineId}] Max depth reached: {MaxDepth}",
-                _id, Configuration.EngineSettings.MaxDepth);
+		if (depth >= Configuration.EngineSettings.MaxDepth)
+		{
+			_logger.Log(logLevel,
+				"[#{EngineId}] Max depth reached: {MaxDepth}",
+				_id, Configuration.EngineSettings.MaxDepth);
 
-            return false;
-        }
+			return false;
+		}
 
-        var maxDepth = _searchConstraints.MaxDepth;
-        if (maxDepth > 0)
-        {
-            var shouldContinue = depth <= maxDepth;
+		var maxDepth = _searchConstraints.MaxDepth;
+		if (maxDepth > 0)
+		{
+			var shouldContinue = depth <= maxDepth;
 
-            if (!shouldContinue)
-            {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
-                    _id, depth - 1);
-            }
+			if (!shouldContinue)
+			{
+				_logger.Log(logLevel,
+					"[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
+					_id, depth - 1);
+			}
 
-            return shouldContinue;
-        }
+			return shouldContinue;
+		}
 
-        if (!isPondering)
-        {
-            var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
+		if (!isPondering)
+		{
+			var elapsedMilliseconds = _stopWatch.ElapsedMilliseconds;
 
-            var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
-            var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
+			var bestMoveNodeCount = _moveNodeCount[bestMove.Value.Piece()][bestMove.Value.TargetSquare()];
+			var scaledSoftLimitTimeBound = TimeManager.SoftLimit(_searchConstraints, depth - 1, bestMoveNodeCount, _nodes, _bestMoveStability, _scoreDelta);
 
-            _logger.Log(logLevel,
-                "[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
-                _id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
+			_logger.Log(logLevel,
+				"[#{EngineId}] [TM] {ElapsedMilliseconds}ms | Depth {Depth}: hard limit {HardLimit}, base soft limit {BaseSoftLimit}ms, scaled soft limit {ScaledSoftLimit}ms",
+				_id, elapsedMilliseconds, depth - 1, _searchConstraints.HardLimitTimeBound, _searchConstraints.SoftLimitTimeBound, scaledSoftLimitTimeBound);
 
-            if (elapsedMilliseconds > scaledSoftLimitTimeBound)
-            {
-                _logger.Log(logLevel,
-                    "[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
-                    _id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
+			if (elapsedMilliseconds > scaledSoftLimitTimeBound)
+			{
+				_logger.Log(logLevel,
+					"[#{EngineId}] [TM] Stopping at depth {0} (nodes {1}): {2}ms > {3}ms",
+					_id, depth - 1, _nodes, elapsedMilliseconds, scaledSoftLimitTimeBound);
 
-                return false;
-            }
-        }
+				return false;
+			}
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    [SkipLocalsInit]
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private bool OnlyOneLegalMove(ref Move firstLegalMove, [NotNullWhen(true)] out SearchResult? result)
-    {
-        bool onlyOneLegalMove = false;
+	[SkipLocalsInit]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private bool OnlyOneLegalMove(ref Move firstLegalMove, [NotNullWhen(true)] out SearchResult? result)
+	{
+		bool onlyOneLegalMove = false;
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+		Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		using var evaluationContext = new EvaluationContext();
 
-        foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, ref evaluationContext, moves))
-        {
-            var gameState = Game.CurrentPosition.MakeMove(move);
-            bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
-            Game.CurrentPosition.UnmakeMove(move, gameState);
+		foreach (var move in MoveGenerator.GenerateAllMoves(Game.CurrentPosition, evaluationContext, moves))
+		{
+			var gameState = Game.CurrentPosition.MakeMove(move);
+			bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
+			Game.CurrentPosition.UnmakeMove(move, gameState);
 
-            if (isPositionValid)
-            {
-                // We save the first legal move and check if there's at least another one
-                if (firstLegalMove == default)
-                {
-                    firstLegalMove = move;
-                    onlyOneLegalMove = true;
-                }
-                // If there's a second legal move, we exit and let the search continue
-                else
-                {
-                    onlyOneLegalMove = false;
-                    break;
-                }
-            }
-        }
+			if (isPositionValid)
+			{
+				// We save the first legal move and check if there's at least another one
+				if (firstLegalMove == default)
+				{
+					firstLegalMove = move;
+					onlyOneLegalMove = true;
+				}
+				// If there's a second legal move, we exit and let the search continue
+				else
+				{
+					onlyOneLegalMove = false;
+					break;
+				}
+			}
+		}
 
-        // Detect if there was only one legal move
-        if (onlyOneLegalMove)
-        {
-            _logger.Debug("One single move found");
+		// Detect if there was only one legal move
+		if (onlyOneLegalMove)
+		{
+			_logger.Debug("One single move found");
 
-            // We don't have or need any eval, and we return a fake but recognizable one
-            // See constant XML for details
-            var score = Game.CurrentPosition.Side == Side.White
-                ? +EvaluationConstants.SingleMoveScore
-                : -EvaluationConstants.SingleMoveScore;
+			// We don't have or need any eval, and we return a fake but recognizable one
+			// See constant XML for details
+			var score = Game.CurrentPosition.Side == Side.White
+				? +EvaluationConstants.SingleMoveScore
+				: -EvaluationConstants.SingleMoveScore;
 
-            result = new SearchResult(
+			result = new SearchResult(
 #if MULTITHREAD_DEBUG
                 _id,
 #endif
-                firstLegalMove, score, 0, [firstLegalMove])
-            {
-                DepthReached = 0,
-                Nodes = 0,
-                Time = 0,
-                NodesPerSecond = 0
-            };
+				firstLegalMove, score, 0, [firstLegalMove])
+			{
+				DepthReached = 0,
+				Nodes = 0,
+				Time = 0,
+				NodesPerSecond = 0
+			};
 
-            return true;
-        }
+			return true;
+		}
 
-        result = null;
-        return false;
-    }
+		result = null;
+		return false;
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SearchResult UpdateLastSearchResult(SearchResult? lastSearchResult,
-        int bestScore, int depth, int mate)
-    {
-        var pvTableSpan = _pVTable.AsSpan();
-        var pvMoves = pvTableSpan[..pvTableSpan.IndexOf(0)].ToArray();
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private SearchResult UpdateLastSearchResult(SearchResult? lastSearchResult,
+		int bestScore, int depth, int mate)
+	{
+		var pvTableSpan = _pVTable.AsSpan();
+		var pvMoves = pvTableSpan[..pvTableSpan.IndexOf(0)].ToArray();
 
-        var maxDepthReached = _maxDepthReached.Max();
+		var maxDepthReached = _maxDepthReached.Max();
 
-        var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
+		var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
 
-        _previousSearchResult = lastSearchResult;
-        return new SearchResult(
+		_previousSearchResult = lastSearchResult;
+		return new SearchResult(
 #if MULTITHREAD_DEBUG
                 _id,
 #endif
-            pvMoves.FirstOrDefault(), bestScore, depth, pvMoves, mate)
-        {
-            DepthReached = maxDepthReached,
-            Nodes = _nodes,
-            Time = Utils.CalculateUCITime(elapsedSeconds),
-            NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds)
-        };
-    }
+			pvMoves.FirstOrDefault(), bestScore, depth, pvMoves, mate)
+		{
+			DepthReached = maxDepthReached,
+			Nodes = _nodes,
+			Time = Utils.CalculateUCITime(elapsedSeconds),
+			NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds)
+		};
+	}
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SearchResult GenerateFinalSearchResult(SearchResult? lastSearchResult,
-        int bestScore, int depth, Move firstLegalMove, bool isPondering)
-    {
-        SearchResult finalSearchResult;
-        if (lastSearchResult is null)
-        {
-            var noDepth1Message =
-                $"[#{_id}] Depth {depth}: search cancelled with no result for position {Game.PositionBeforeLastSearch.FEN()} (hard limit {_searchConstraints.HardLimitTimeBound}ms, soft limit {_searchConstraints.SoftLimitTimeBound}ms). Choosing an emergency move";
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	private SearchResult GenerateFinalSearchResult(SearchResult? lastSearchResult,
+		int bestScore, int depth, Move firstLegalMove, bool isPondering)
+	{
+		SearchResult finalSearchResult;
+		if (lastSearchResult is null)
+		{
+			var noDepth1Message =
+				$"[#{_id}] Depth {depth}: search cancelled with no result for position {Game.PositionBeforeLastSearch.FEN()} (hard limit {_searchConstraints.HardLimitTimeBound}ms, soft limit {_searchConstraints.SoftLimitTimeBound}ms). Choosing an emergency move";
 
-            // In the event of a quick ponderhit/stop while pondering because the opponent moved quickly, we don't want no warning triggered here
-            //  when cancelling the pondering search
-            // The other condition reflects what happens in helper engines when a mate is quickly detected in the main:
-            //  search in helper engines sometimes get cancelled before any meaningful result is found, so we don't want a warning either
-            if (isPondering || !IsMainEngine)
-            {
-                _logger.Info(noDepth1Message);
-            }
-            else
-            {
-                _logger.Warn(noDepth1Message);
-            }
+			// In the event of a quick ponderhit/stop while pondering because the opponent moved quickly, we don't want no warning triggered here
+			//  when cancelling the pondering search
+			// The other condition reflects what happens in helper engines when a mate is quickly detected in the main:
+			//  search in helper engines sometimes get cancelled before any meaningful result is found, so we don't want a warning either
+			if (isPondering || !IsMainEngine)
+			{
+				_logger.Info(noDepth1Message);
+			}
+			else
+			{
+				_logger.Warn(noDepth1Message);
+			}
 
-            finalSearchResult = BestMoveRoot(firstLegalMove);
-        }
-        else
-        {
-            finalSearchResult = _previousSearchResult = lastSearchResult;
-        }
+			finalSearchResult = BestMoveRoot(firstLegalMove);
+		}
+		else
+		{
+			finalSearchResult = _previousSearchResult = lastSearchResult;
+		}
 
-        var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
+		var elapsedSeconds = Utils.CalculateElapsedSeconds(_stopWatch);
 
-        finalSearchResult.DepthReached = Math.Max(finalSearchResult.DepthReached, _maxDepthReached.LastOrDefault(item => item != default));
-        finalSearchResult.Nodes = _nodes;
-        finalSearchResult.Time = Utils.CalculateUCITime(elapsedSeconds);
-        finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds);
-        finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
-        if (Configuration.EngineSettings.ShowWDL)
-        {
-            finalSearchResult.WDL = WDL.WDLModel(bestScore, depth);
-        }
+		finalSearchResult.DepthReached = Math.Max(finalSearchResult.DepthReached, _maxDepthReached.LastOrDefault(item => item != default));
+		finalSearchResult.Nodes = _nodes;
+		finalSearchResult.Time = Utils.CalculateUCITime(elapsedSeconds);
+		finalSearchResult.NodesPerSecond = Utils.CalculateNps(_nodes, elapsedSeconds);
+		finalSearchResult.HashfullPermill = _tt.HashfullPermillApprox();
+		if (Configuration.EngineSettings.ShowWDL)
+		{
+			finalSearchResult.WDL = WDL.WDLModel(bestScore, depth);
+		}
 
-        return finalSearchResult;
-    }
+		return finalSearchResult;
+	}
 
-    /// <summary>
-    /// Find the best move without searching, based on TT and <see cref="ScoreMove(int, int, short)"/>
-    /// </summary>
-    private SearchResult BestMoveRoot(Move firstLegalMove)
-    {
-        var score = 0;
-        ShortMove ttBestMove = default;
+	/// <summary>
+	/// Find the best move without searching, based on TT and <see cref="ScoreMove(int, int, short)"/>
+	/// </summary>
+	private SearchResult BestMoveRoot(Move firstLegalMove)
+	{
+		var score = 0;
+		ShortMove ttBestMove = default;
 
-        using var position = new Position(Game.PositionBeforeLastSearch);
-        var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, out var ttEntry);
+		using var position = new Position(Game.PositionBeforeLastSearch);
+		var ttHit = _tt.ProbeHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, ply: 0, out var ttEntry);
 
-        if (ttHit)
-        {
-            ttBestMove = ttEntry.BestMove;
-            score = ttEntry.Score;
+		if (ttHit)
+		{
+			ttBestMove = ttEntry.BestMove;
+			score = ttEntry.Score;
 
-            if (ttEntry.Score == EvaluationConstants.NoScore)
-            {
-                score = ttEntry.StaticEval;
-            }
-        }
+			if (ttEntry.Score == EvaluationConstants.NoScore)
+			{
+				score = ttEntry.StaticEval;
+			}
+		}
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		using var evaluationContext = new EvaluationContext();
 
-        Span<Move> pseudoLegalMoves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, pseudoLegalMoves);
+		Span<Move> pseudoLegalMoves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+		pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, evaluationContext, pseudoLegalMoves);
 
-        Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
-        for (int i = 0; i < pseudoLegalMoves.Length; ++i)
-        {
-            moveScores[i] = ScoreMove(position, pseudoLegalMoves[i], 0, ref evaluationContext, ttBestMove);
-        }
+		Span<int> moveScores = stackalloc int[pseudoLegalMoves.Length];
+		for (int i = 0; i < pseudoLegalMoves.Length; ++i)
+		{
+			moveScores[i] = ScoreMove(position, pseudoLegalMoves[i], 0, evaluationContext, ttBestMove);
+		}
 
-        for (int i = 0; i < pseudoLegalMoves.Length; ++i)
-        {
-            // Incremental move sorting
-            for (int j = i + 1; j < pseudoLegalMoves.Length; j++)
-            {
-                if (moveScores[j] > moveScores[i])
-                {
-                    (moveScores[i], moveScores[j], pseudoLegalMoves[i], pseudoLegalMoves[j]) = (moveScores[j], moveScores[i], pseudoLegalMoves[j], pseudoLegalMoves[i]);
-                }
-            }
+		for (int i = 0; i < pseudoLegalMoves.Length; ++i)
+		{
+			// Incremental move sorting
+			for (int j = i + 1; j < pseudoLegalMoves.Length; j++)
+			{
+				if (moveScores[j] > moveScores[i])
+				{
+					(moveScores[i], moveScores[j], pseudoLegalMoves[i], pseudoLegalMoves[j]) = (moveScores[j], moveScores[i], pseudoLegalMoves[j], pseudoLegalMoves[i]);
+				}
+			}
 
-            var move = pseudoLegalMoves[i];
+			var move = pseudoLegalMoves[i];
 
-            var gameState = position.MakeMove(move);
-            if (!position.WasProduceByAValidMove())
-            {
-                position.UnmakeMove(move, gameState);
-                continue;
-            }
+			var gameState = position.MakeMove(move);
+			if (!position.WasProduceByAValidMove())
+			{
+				position.UnmakeMove(move, gameState);
+				continue;
+			}
 
-            // We don't have or need any eval, and we don't want to return 0 or a negative eval that
-            // could make the GUI resign or take a draw from this position.
-            // Since this only happens in root, we don't really care about being more precise for raising
-            // alphas or betas of parent moves, so let's just return +-2 pawns depending on the side to move
-            var singleMoveEval = Game.CurrentPosition.Side == Side.White
-                ? EvaluationConstants.EmergencyMoveScore        // -0.66
-                : -EvaluationConstants.EmergencyMoveScore;      // +0.66
+			// We don't have or need any eval, and we don't want to return 0 or a negative eval that
+			// could make the GUI resign or take a draw from this position.
+			// Since this only happens in root, we don't really care about being more precise for raising
+			// alphas or betas of parent moves, so let's just return +-2 pawns depending on the side to move
+			var singleMoveEval = Game.CurrentPosition.Side == Side.White
+				? EvaluationConstants.EmergencyMoveScore        // -0.66
+				: -EvaluationConstants.EmergencyMoveScore;      // +0.66
 
-            return new SearchResult(
+			return new SearchResult(
 #if MULTITHREAD_DEBUG
                 _id,
 #endif
-                move, singleMoveEval, 0, [move])
-            {
-                DepthReached = 0
-            };
-        }
+				move, singleMoveEval, 0, [move])
+			{
+				DepthReached = 0
+			};
+		}
 
-        _logger.Error("No valid move found while looking for an emergency move for position {Fen}", position.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
+		_logger.Error("No valid move found while looking for an emergency move for position {Fen}", position.FEN(Game.HalfMovesWithoutCaptureOrPawnMove));
 
-        return new(
+		return new(
 #if MULTITHREAD_DEBUG
                 _id,
 #endif
-            firstLegalMove, 0, 0, [firstLegalMove]);
-    }
+			firstLegalMove, 0, 0, [firstLegalMove]);
+	}
 }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -12,7 +12,7 @@ public sealed partial class Engine
     /// Returns the score evaluation of a move taking into account <paramref name="bestMoveTTCandidate"/>, <see cref="MostValueableVictimLeastValuableAttacker"/>, <see cref="_killerMoves"/> and <see cref="_quietHistory"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMove(Position position, Move move, int ply, ref EvaluationContext evaluationContext, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMove(Position position, Move move, int ply, EvaluationContext evaluationContext, ShortMove bestMoveTTCandidate = default)
     {
         if ((ShortMove)move == bestMoveTTCandidate)
         {
@@ -50,13 +50,13 @@ public sealed partial class Engine
 
                 // Counter move history
                 return BaseMoveScore
-                    + QuietHistoryEntry(position, move, ref evaluationContext)
+                    + QuietHistoryEntry(position, move, evaluationContext)
                     + ContinuationHistoryEntry(move.Piece(), move.TargetSquare(), ply - 1);
             }
 
             // History move or 0 if not found
             return BaseMoveScore
-                + QuietHistoryEntry(position, move, ref evaluationContext);
+                + QuietHistoryEntry(position, move, evaluationContext);
         }
 
         // Queen promotion
@@ -157,7 +157,7 @@ public sealed partial class Engine
     /// Quiet history, contination history, killers and counter moves
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(Position position, int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot, bool pvNode, ref EvaluationContext evaluationContext)
+    private void UpdateMoveOrderingHeuristicsOnQuietBetaCutoff(Position position, int depth, int ply, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, bool isRoot, bool pvNode, EvaluationContext evaluationContext)
     {
         var piece = move.Piece();
         var targetSquare = move.TargetSquare();
@@ -170,8 +170,8 @@ public sealed partial class Engine
             int rawHistoryBonus = HistoryBonus[depth];
             int rawHistoryMalus = HistoryMalus[depth];
 
-        ref var quietHistoryEntry = ref QuietHistoryEntry(position, move, ref evaluationContext);
-        quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, rawHistoryBonus);
+            ref var quietHistoryEntry = ref QuietHistoryEntry(position, move, evaluationContext);
+            quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, rawHistoryBonus);
 
             if (!isRoot)
             {
@@ -191,10 +191,10 @@ public sealed partial class Engine
                     var visitedMovePiece = visitedMove.Piece();
                     var visitedMoveTargetSquare = visitedMove.TargetSquare();
 
-                // 🔍 Quiet history penalty / malus
-                // When a quiet move fails high, penalize previous visited quiet moves
-                quietHistoryEntry = ref QuietHistoryEntry(position, visitedMove, ref evaluationContext);
-                quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryMalus);
+                    // 🔍 Quiet history penalty / malus
+                    // When a quiet move fails high, penalize previous visited quiet moves
+                    quietHistoryEntry = ref QuietHistoryEntry(position, visitedMove, evaluationContext);
+                    quietHistoryEntry = ScoreHistoryMove(quietHistoryEntry, -rawHistoryMalus);
 
                     if (!isRoot)
                     {

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -688,7 +688,7 @@ public sealed class Searcher : IDisposable
             {
                 _mainEngine.Dispose();
 
-                foreach(var engine in _extraEngines)
+                foreach (var engine in _extraEngines)
                 {
                     engine.Dispose();
                 }

--- a/src/Lynx/UCI/Commands/GUI/DebugCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/DebugCommand.cs
@@ -24,7 +24,7 @@ public sealed class DebugCommand
     public static bool Parse(ReadOnlySpan<char> command)
     {
         const string on = "on";
-        const string off= "off";
+        const string off = "off";
 
         Span<Range> items = stackalloc Range[2];
         command.Split(items, ' ', StringSplitOptions.RemoveEmptyEntries);

--- a/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/PositionCommand.cs
@@ -66,13 +66,11 @@ public sealed class PositionCommand
 
         Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
         if (!MoveExtensions.TryParseFromUCIString(
             moveString,
-            MoveGenerator.GenerateAllMoves(game.CurrentPosition, ref evaluationContext, movePool),
+            MoveGenerator.GenerateAllMoves(game.CurrentPosition, evaluationContext, movePool),
             out lastMove))
         {
             _logger.Warn("Error parsing last move {0} from position command {1}", lastMove, positionCommand);

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -6,534 +6,532 @@ namespace Lynx.Test.BestMove;
 
 public class RegressionTest : BaseTest
 {
-    [TestCase("r2k3r/p1p2ppp/2p5/2P5/6nq/2NB4/PPPP2PP/R1BQR1K1 w - - 0 13", null, new[] { "g2h3" },
-        Description = "Avoid Mate in 2, fails with initial implementation of MiniMax depth 4")]
-
-    [TestCase("r2k3r/p1p2ppp/2p5/2P5/6nq/2NB4/PPPP2PP/R1BQR1K1 w - - 0 13", null, new[] { "g2h3", "e1e4" },
-        Description = "Avoid Mate in 4, fails with MiniMax depth 4")]
-
-    [TestCase("q5k1/2p5/1bb1pQ2/1p6/1P6/5N2/P4PPP/3RK2R b K - 0 1", null, new[] { "a8a2" },
-        Description = "Avoid Mate in 3, seen with NegaMax depth 4 (but weirdly not with AlphaBeta depth 4)")]
-
-    [TestCase("r2qr1k1/ppp2ppp/5n2/2nPp3/1b4b1/P1NPP1P1/1P2NPBP/R1BQ1RK1 b - - 0 1", new[] { "b4c3", "g4e2" }, new[] { "b4a5" },
-        Description = "Fails with simple MiniMax depth 3 and 4: b4a5 is played")]
-
-    [TestCase("r2qkb1r/ppp2ppp/2n2n2/3pp3/8/PPP3Pb/3PPP1P/RNBQK1NR w KQkq - 0 1", new[] { "g1h3" },
-        Description = "Used to fail")]
-
-    [TestCase("8/n2k4/bpr4p/1q1p4/4pp1b/P3P1Pr/R2K4/1r2n1Nr w - - 0 1", new[]
-    {
-                "a3a4",
-                "a2a1", "a2b2", "a2c2",
-                "e3f4", "f3g4",
-                "g3f4", "g3g4", "g3h4",
-                "g3f4", "g3g4", "g3h4",
-                "g1h3", "g1f3", "g1e2"
-            }, Description = "Used to return an illegal move in the very first versions")]
-
-    [TestCase("7k/1Q4r1/2q1B3/1P2QNN1/8/R7/nN6/K1R5 b - - 0 1", new[] { "c6c1" },
-        Description = "Get stalemated vs winning a queen")]
-
-    public void GeneralRegression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
-    }
-
-    [TestCase("r1bq2k1/1pp1n2p/2nppr1Q/p7/2PP2P1/5N2/PP3P1P/2KR1B1R w - - 0 15", new[] { "h6f6" },
-        Description = "AlphaBeta/NegaMax depth 5 spends almost 3 minutes with a simple retake")]
-    public void SlowRecapture(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
-    }
-
-    [Explicit]
-    [Category(Categories.NotGoodEnough)]
-    [TestCase("6k1/1R6/5Kn1/3p1N2/1P6/8/8/3r4 b - - 10 37", new[] { "g6f8" }, new[] { "g6f4" },
-        Description = "Avoid mate in 4 https://lichess.org/XkZsoXLA#74")]
-    public void AvoidMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
-    }
-
-    [TestCase(5)]
-    [TestCase(6)]
-    public void KeepNonGoodQuiescenceMoves(int depth)
-    {
-        const string fen = Constants.InitialPositionFEN;
-        var engine = GetEngine(fen);
-        var goCommand = new GoCommand($"go depth {depth}");
-
-        var bestResult = engine.BestMove(goCommand);
-
-        switch (depth)
-        {
-            case 5 when bestResult.Moves.Length >= 5:
-                Assert.AreNotEqual("f6e4", bestResult.Moves[4].UCIString());
-                break;
-            case 6 when bestResult.Moves.Length >= 6:
-                Assert.AreNotEqual("f3e5", bestResult.Moves[5].UCIString());
-                break;
-        }
-    }
-
-    [TestCase(5, Constants.InitialPositionFEN, "d8d5")]
-    [TestCase(5, "rq2k2r/ppp2pb1/2n1pnpp/1Q1p1b2/3P1B2/2N1PNP1/PPP2PBP/R3K2R w KQkq - 0 1", "e5f4")]
-    public void TrashInPVTable(int depth, string fen, string notExpectedMove)
-    {
-        var goCommand = new GoCommand($"go depth {depth}");
-
-        var engine = GetEngine(fen);
-        var bestResult = engine.BestMove(goCommand);
-
-        if (bestResult.Moves.Length > depth)
-        {
-            Assert.AreNotEqual(notExpectedMove, bestResult.Moves[depth].UCIString());
-        }
-    }
-
-    [Test]
-    public void TrashInPV()
-    {
-        const string positionCommand = "position startpos moves c2c4";
-        var goCommand = new GoCommand("go depth 5");
-
-        var engine = GetEngine();
-
-        engine.AdjustPosition(positionCommand);
-        Assert.DoesNotThrow(() => engine.BestMove(goCommand));
-    }
-
-    [Explicit]
-    [Category(Categories.NotGoodEnough)]
-    [TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
-        Description = "At depth 3 White takes the pawn")]
-    [TestCase("r1bqk2r/ppp2ppp/2n1p3/8/Q1pP4/2b2NP1/P3PPBP/1RB2RK1 b kq - 1 10", null, new[] { "c3d4" },
-        Description = "It failed at depth 6 in https://lichess.org/nZVw6G5D/black#19")]
-    [TestCase("r1bqkb1r/ppp2ppp/2n1p3/3pP3/3Pn3/5P2/PPP1N1PP/R1BQKBNR b KQkq - 0 1", null, new[] { "f8b4" },
-        Description = "It failed at depth 5 in https://lichess.org/rtTsj9Sr/black")]
-    public void GeneralFailures(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
-    }
-
-    /// <summary>
-    /// Verifies that with both <see cref="Configuration.EngineSettings.MinDepth"/>
-    /// and <see cref="Configuration.EngineSettings.DepthWhenLessThanMinMoveTime"/>
-    /// the positions that result as a consequence of the given position commands
-    /// aren't considered as drawn
-    /// </summary>
-    [TestCase("position startpos moves" +
-        " c2c4 e7e5 b1c3 g8f6 g1f3 b8c6 e2e4 f8b4 d2d3 d7d6 a2a3 b4c5 b2b4 c5b6 c1e3" +
-        " b6e3 f2e3 a7a6 b4b5 a6b5 c4b5 c6a7 d3d4 e5d4 d1d4 c7c5 d4d2 e8g8 e1c1 f8e8" +
-        " e4e5 f6g4 e5d6 g4e3 d6d7 c8d7 d2d7 d8a5 d7d2 e3d1 c3d1 a7b5 d2a5 a8a5 a3a4" +
-        " b5d4 f3d4 c5d4 f1b5 e8e5 d1f2 e5f5 h1e1 a5a8 f2e4 f5d5 g2g4 d4d3 c1d2 h7h5" +
-        " g4h5 d5h5 e1h1 a8d8 d2c3 h5h3 e4f2 d8c8 c3d4 d3d2 f2h3 c8c1 h3f2 c1h1 b5e2" +
-        " h1h2 d4e3 f7f5 f2d1 f5f4 e3d3 g7g5 d1c3 f4f3 e2f3 h2h3 d3e2 g8g7 c3d1 h3h2" +
-        " e2e3 h2h3 e3e2 b7b6 f3g2 h3a3 g2c6 a3a2 d1e3 g7f6 e3c4 g5g4 c4b6 f6e5 c6a8" +
-        " e5d4 a8d5 a2a1 e2d2 d4c5 d5e6 c5b6 e6g4 a1a4 g4e6 b6c5 d2d3 a4a1 e6f5 c5d6" +
-        " d3e4 a1d1 f5c8 d1e1 e4f4 d6d5 c8b7 d5d4 b7g2 e1e2 f4f3 e2a2 f3g3 d4c5 g3f3" +
-        " c5d5 f3g3 d5d6 g3f3 d6e5 f3g3 e5d6 g3f3 d6e5 g2h3 a2b2 f3g3 e5d5 g3f3 d5d4" +
-        " h3g2 d4d5 f3g3 d5d6 g3f3 d6e6 f3g3 e6d6 g2a8 b2a2 a8b7 a2b2 b7a8 d6c7 g3f4" +
-        " c7b8 f4e5 b8a8 e5d6 a8a7 d6c7 a7a8 c7c8 a8a7 c8c7")]
-
-    [TestCase("position startpos moves" +
-        " e2e4 e7e5 g1f3 b8c6 f1c4 f8c5 e1g1 g8f6 d2d3 d7d6 c2c3 a7a5 f1e1 e8g8 b1d2" +
-        " c5b6 b2b3 f8e8 c1b2 c8g4 h2h3 g4h5 g2g4 h5g6 g4g5 d6d5 g5f6 d5c4 d2c4 d8f6" +
-        " c4b6 c7b6 c3c4 g6h5 e1e3 c6d4 g1g2 f6g6 g2h2 d4f3 e3f3 g6d6 a1c1 a8d8 c1c3" +
-        " f7f5 d1e2 h5f3 e2f3 f5e4 f3e4 d6h6 c3c2 h6f4 e4f4 e5f4 d3d4 e8e1 c2d2 g7g5" +
-        " d4d5 d8d6 a2a4 h7h5 f2f3 e1e3 b2a3 d6d7 d2g2 e3b3 a3c1 d7g7 c1b2 g7g6 h3h4" +
-        " b3f3 h4g5 f3e3 b2f6 f4f3 g2f2 e3e4 f2f3 e4c4 f3b3 c4a4 d5d6 a4h4 b3h3 h4e4" +
-        " h3h5 e4e2 h2g1 e2e1 g1g2 e1d1 h5h8 g8f7 h8h7 f7e6 h7b7 d1d6 g2f3 e6d5 f3f4" +
-        " d5c6 b7b8 c6d7 f4f5 d7c7 b8e8 d6f6 g5f6 g6g2 f6f7 g2f2 f5g6 f2g2 g6f5 g2f2" +
-        " f5e6 a5a4 f7f8q f2f8 e8f8 b6b5 e6e5 c7b7 f8f7 b7a6 f7f8 b5b4 e5d5 b4b3 f8b8" +
-        " a6a5 d5c5 a5a6 b8a8 a6b7 a8a4 b7c8 a4b4 c8d7 b4b3 d7e6 b3b8 e6f5 b8a8 f5e6" +
-        " c5c4 e6d6 a8d8 d6c7 d8e8 c7d6 e8a8 d6e6 c4c5 e6f5 c5d5 f5f6 a8e8 f6f7 e8a8" +
-        " f7g7 d5d4 g7f7 d4e5 f7e7 e5d5 e7f6 a8e8 f6f7 e8b8 f7f6 b8a8 f6g7 a8b8 g7f6" +
-        " b8d8 f6f7 d5d6 f7g6 d6d5 g6f7 d5e5 f7e7 d8d6 e7f7 d6d8 f7e7")]
-
-    [TestCase("position startpos moves" +
-        " g1f3 d7d5 d2d4 g8f6 c1f4 c8f5 e2e3 e7e6 f1d3 f5g6 b1c3 f8d6 e1g1 e8g8 h2h3" +
-        " g6h5 f4g5 d6e7 g2g4 h5g6 d3g6 f7g6 f1e1 b8c6 g5f4 f8e8 f3e5 c6e5 d4e5 f6e4" +
-        " c3e4 d5e4 d1e2 c7c5 a1d1 d8b6 c2c4 g6g5 f4g3 a8d8 d1d8 e7d8 e1d1 b6c6 d1d6" +
-        " c6c8 f2f3 d8c7 d6d2 c8b8 f3e4 c7e5 g3e5 b8e5 e2g2 e5c7 b2b3 e6e5 g2e2 b7b6" +
-        " a2a4 a7a5 e2d3 c7c8 d3d6 h7h5 d6d5 g8h7 d5d7 c8d7 d2d7 h5g4 h3g4 e8e6 d7d5" +
-        " g7g6 g1g2 h7g7 g2g1 g7g8 d5d7 g8f8 g1f2 f8e8 d7b7 e8d8 b7g7 e6d6 f2g1 d6d1" +
-        " g1g2 d1d6 g2g1 d6d1 g1f2 d1d2 f2g3 d2d3 g3f3 d3d6 f3g2 d6d2 g2f3 d2d6 g7f7" +
-        " d8e8 f7a7 d6d7 a7a8 d7d8 a8a7 d8d7 a7a8 d7d8 a8a6 d8d6 f3e2 e8e7 a6a8 e7d7" +
-        " e2f3 d7e6 f3g3 e6d7 g3f3 d6f6 f3g3 d7c7 a8a5 b6a5 b3b4 a5b4 a4a5 b4b3 a5a6" +
-        " f6a6 g3f3 c7b8 f3g3 b3b2 g3h3 b2b1q h3g3 b1e4 g3h3 e4c4 h3g3 c4g4 g3g4 c5c4" +
-        " g4g5 e5e4 g5g4 g6g5 g4g5 c4c3 g5f5 b8a8 f5e4 c3c2 e4d5")]
-
-    [TestCase("position startpos moves" +
-        " e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 c1g5 e7e6 f2f4 d8b6 d1d2" +
-        " b6b2 a1b1 b2a3 e4e5 d6e5 f4e5 f6d5 c3d5 e6d5 c2c4 b8d7 e5e6 d7f6 g5f6 g7f6" +
-        " c4d5 a3c5 e6f7 e8f7 d4e6 c5e7 d2e2 b7b5 e6f8 e7f8 b1c1 f8d8 e2h5 f7g8 c1d1" +
-        " c8b7 h5g4 g8f8 g4b4 f8f7 d5d6 h8e8 e1f2 d8b6 b4d4 b6d4 d1d4 a8d8 f1d3 e8e6" +
-        " d6d7 b7c6 h1d1 e6e7 d3f5 h7h6 d4d6 e7e5 d6c6 e5f5 f2g1 f7e7 c6c7 f5e5 g1f2" +
-        " a6a5 g2g4 e5e4 f2f3 e4c4 c7a7 c4c3 f3e4 c3c2 a7a5 d8d7 d1d7 e7d7 h2h4 d7c7" +
-        " a5b5 c2e2 e4f5 e2f2 f5e6 f2a2 e6f6 a2g2 b5h5 g2g4 h5h6 g4g2 f6e5 g2e2 e5d5" +
-        " e2d2 d5e5 d2e2 e5d5 e2d2 d5e4 d2e2 e4d4 e2d2 d4e4 d2e2 e4d4 e2c2 h6h8 c2d2" +
-        " d4e5 d2e2 e5d5 e2d2 d5e5 d2e2 e5d4 c7d6 h4h5 e2d2 d4e4 d2e2 e4f5 e2f2 f5e4" +
-        " f2e2 e4d4 e2d2 d4c4 d6e5 h8e8 e5f5 e8h8 d2h2 c4d5 f5g5 h8g8 g5h6 d5d6 h2h5" +
-        " g8a8 h6g7 d6e6 g7g6 e6d6 h5h2 d6d5 g6g7 d5d6 g7f6 d6d5 h2d2 d5e4 f6e6 e4e3" +
-        " d2b2 e3d4 e6d6 d4e4 d6c5 a8c8 c5d6 c8a8 d6c7 e4e5 b2d2 a8f8 c7b7 e5e6 b7c7" +
-        " e6e5 d2e2 e5d4 c7d6 f8a8 e2d2 d4c3 d2f2 c3d4 f2d2 d4c4 d6c7 c4c5 c7b7 a8e8" +
-        " b7a6 c5c6 a6a5 c6c7 a5a6 c7b8 a6b6 b8a8 b6c7 a8a7 c7d7 a7a8 d7e8 a8b8 e8d8" +
-        " b8a8")]
-
-    [TestCase("position startpos moves" +
-        " g1f3 d7d5 d2d4 g8f6 g2g3 b8c6 f1g2 e7e6 b1c3 f8d6 e1g1 e8g8 f1e1 a8b8 e2e4 d5e4 c3e4 f6e4 e1e4 d6e7" +
-        " b2b3 b7b5 c1b2 c8b7 e4e3 e7f6 f3e5 c6e7 g2b7 b8b7 e5g4 e7f5 g4f6 d8f6 e3e5 f5e7 d1f1 e7c6 f1g2 b7b6" +
-        " e5e4 f8d8 c2c3 f6f5 g3g4 f5g6 a1e1 b6a6 a2a3 c6a5 g2g3 d8c8 g3d3 a6b6 d3d1 f7f5 e4e5 g6g4 d1g4 f5g4" +
-        " e5e6 b6e6 e1e6 a5b3 e6e5 c7c5 e5e2 b3a5 d4c5 c8c5 e2e8 g8f7 e8a8 c5c7 a8b8 a7a6 g1g2 c7c6 b8h8 a5c4" +
-        " b2c1 h7h6 h8a8 g7g5 a8a7 f7g6 a7a8 c6f6 a8g8 g6h5 g8e8 f6f3 c1e3 c4a3 e8d8 a3c2 e3d2 h5g6 g2g1 f3f6" +
-        " d8g8 g6f5 g8d8 c2a3 d2e3 a3c4 e3d4 c4e5 g1g2 h6h5 h2h3 g4h3 g2h3 f6e6 h3g2 f5e4 d4e3 g5g4 d8h8 e6c6" +
-        " e3d4 e5g6 h8e8 e4f5 g2g1 h5h4 g1h2 c6e6 e8a8 f5f4 d4e3 f4f3 h2g1 g4g3 a8a7 g6e7 a7a8 e7d5 a8f8 f3g4" +
-        " f8g8 g4h3 g1f1 d5e3 f2e3 e6e3 g8g5 e3c3 f1e2 g3g2 e2f2 b5b4 g5g2 c3c2 f2e3 c2g2 e3d4 b4b3 d4d5 b3b2" +
-        " d5e5 b2b1q e5f4 b1d3 f4e5 g2g6 e5f4 d3e2 f4f5 e2e6 f5f4 g6g4 f4f3 e6e8 f3f2 g4f4 f2g1 f4f6 g1h1 e8e6" +
-        " h1g1 e6e5 g1h1 e5d5 h1g1 d5d4 g1h1 d4e4 h1g1 f6g6 g1f1 e4d3 f1e1 g6g1 e1f2 g1g2 f2e1 g2g6 e1f2 d3d2" +
-        " f2f3 d2e1 f3f4 e1e2 f4f5 e2e6 f5f4 g6g4 f4f3 e6e8 f3f2 g4f4 f2g1 f4f6 g1h1 e8e6 h1g1 e6e5 g1h1 e5d5",
-        Ignore = "Now that we detect 2 move repetitions, this should fail")]
-    public void FalseDrawnPositions(string positionCommand)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition(positionCommand);
-
-        var bestMove = engine.BestMove(new GoCommand($"go depth {Engine.DefaultMaxDepth}"));
-        Assert.NotZero(bestMove.Score);
-
-        //engine.AdjustPosition(positionCommand);
-        //bestMove = engine.BestMove(new GoCommand($"go depth {Configuration.EngineSettings.DepthWhenLessThanMinMoveTime}"));
-        //Assert.NotZero(bestMove.Evaluation);
-    }
-
-    [TestCase("position startpos moves" +
-        " c2c4 e7e6 b1c3 g8f6 g1f3 f8b4 e2e3 e8g8 d2d4 c7c5 f1d3 d7d5 e1g1 b8c6 c4d5" +
-        " e6d5 d4c5 b4c5 b2b3 f8e8 c1b2 b7b6 f1e1 c8b7 d1b1 h7h5 a2a3 a7a5 e3e4 f6g4" +
-        " e1e2 d5d4 c3d5 g4e5 f3e5 c6e5 d3b5 e8e6 d5f4 e6h6 f4d3 e5d3 b1d3 h6d6 e4e5" +
-        " d6g6 f2f3 d8d5 a1e1 d5f3 d3g6 f3e2 b5e2 f7g6 e2d3 g6g5 a3a4 a8d8 e5e6 d8e8" +
-        " e1e5 h5h4 d3g6 e8e7 g6f7 g8f8 e5g5 b7c8 g5g6 e7a7 g2g3 h4h3 g6g5 a7f7 e6f7" +
-        " f8f7 g5h5 d4d3 h5c5 b6c5 g1f2 c8e6 f2e3 f7g8 e3d3 e6b3 b2c3 c5c4 d3d4 b3a4" +
-        " d4c4 a4d7 c3a5 g7g5 c4d4 g5g4 d4e5 d7c8 e5f4 c8e6 a5c7 e6c8 f4e4 g8g7 c7e5" +
-        " g7f7 e5b2 f7e6 e4f4 e6d5 f4e3 c8d7 e3f4 d7e6 f4e3 d5d6 e3e4 e6d5 e4f4 d5e6" +
-        " f4e3 e6d5 e3f4 d5f3 f4f5 d6d5 f5f4 d5d6 f4f5 d6d5 f5f4 f3d1 f4f5 d1e2 f5f4" +
-        " d5d6 f4e4 d6e6 e4f4 e6d5 f4f5 d5c5 f5f6 c5b6 f6e7 b6a7 e7d8 a7a8 d8e7 a8b8" +
-        " e7f8 b8a8 f8e7 a8b8 e7f8 b8a8")]
-    public void FalseDrawnPositionBy50MovesRule(string positionCommand)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition(positionCommand);
-
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-
-        Assert.False(engine.Game.Is50MovesRepetition(ref evaluationContext));
-        var bestMove = engine.BestMove(new GoCommand("go depth 1"));
-
-        engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.UCIString());
-        Assert.IsFalse(engine.Game.Is50MovesRepetition(ref evaluationContext));
-    }
-
-    // 8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1 - || PV Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6, with b1=Q as the first invalid move there
-    [TestCase("position startpos moves d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1f4 e8g8" +
-        " e2e3 c7c5 d4c5 e7c5 a2a3 a7a6 d1d2 d5c4 f1c4 b7b5 c4d3 c8b7 b2b4 b7f3 b4c5 f3g2" +
-        " h1g1 g2f3 g1g3 f3c6 f4h6 g7g6 h6f8 d8f8 a3a4 b5b4 c3a2 b4b3 a2c1 f8c5 c1b3 c5d5" +
-        " b3a5 d5h1 d3f1 c6d5 d2c3 b8d7 c3c7 h1e4 f1c4 e4c2 a1a2 c2c1 e1e2 d7e5 c7e5 d5c4" +
-        " a5c4 c1c4 e2f3 c4a2 e5f6 a2a4 f3g2 a8c8 g3f3 a4d7 f6e5 d7b5 e5d6 a6a5 d6e7 c8f8" +
-        " e7d6 a5a4 e3e4 b5c4 f3e3 f8c8 h2h3 c4b5 e3f3 b5g5 f3g3 g5a5 g3d3 a5g5 d3g3 g5b5" +
-        " g3f3 b5a5 f3d3 a5a8 d6b4 c8b8 b4c4 a4a3 d3d2 b8b2 d2b2 a3b2 c4b4 a8a2 b4b8 g8g7" +
-        " b8e5 g7g8 e5b8 g8g7 b8e5 f7f6 e5c7 g7g8 c7b8 g8f7 b8c7 f7g8 c7b8 g8g7")]
-    public void InvalidPV(string positionCommand)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition(positionCommand);
-
-        var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
-        Assert.Zero(bestMove.Score);
-        Assert.AreEqual(1, bestMove.Moves.Length);
-        Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
-    }
-
-    // pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
-    [TestCase("position startpos moves e2e4 c7c6 d2d4 d7d5 e4e5 c8f5 g1f3 e7e6 f1e2 c6c5 c1e3" +
-        " c5d4 f3d4 g8e7 b1c3 f5g6 h2h4 h7h5 e2b5 b8d7 e3f4 a7a6 b5d3 g6d3 d1d3 e7g6 d4e6 g6f4" +
-        " e6f4 d7e5 d3e2 d8d6 c3d5 g7g6 e1c1 f8h6 h1e1 f7f6 d5f6 d6f6 e2e5 f6e5 e1e5 e8f8 g2g3" +
-        " a8e8 e5e3 h6f4 g3f4 h8h7 d1d6 h7f7 e3e8 f8e8 d6g6 f7f4 g6g8 e8f7 g8b8 b7b5 b8b6 f4a4" +
-        " f2f3 a4h4 b6a6 h4h1 c1d2 h1h2 d2c3 h2f2 b2b3 h5h4 a6h6 f2f3 c3b4 f3f4 b4b5 f7g7 h6h5" +
-        " g7f6 c2c4 f4f5 h5f5 f6f5 c4c5 f5e6 a2a4 h4h3 b5b6 h3h2 b3b4 h2h1q a4a5")]
-
-    public void InvalidPV2(string positionCommand)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition(positionCommand.AsSpan()[..^10]);  // 8/8/1K2k3/2P5/PP6/8/7p/8 b - - 0 46, ready to promote
-
-        var bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
-        Assert.AreEqual("h2h1q", bestMove.BestMove.UCIString());
-
-        engine.AdjustPosition(positionCommand);
-        bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
-        Assert.AreNotEqual("h2h1q", bestMove.BestMove.UCIString());
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase(Constants.KillerTestPositionFEN)]
-    [TestCase(Constants.TrickyTestPositionFEN)]
-    public void PVTableCrash(string fen)
-    {
-        const int depthWhenMaxDepthInQuiescenceIsReached = 7;
-        var engine = GetEngine(fen);
-
-        var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
-        Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.Depth);
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [Test]
-    public void PonderingCrash()
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition("position startpos moves" +
-            " e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 f2f3 e7e5 d4b3 c8e6 c1e3 h7h5 c3d5 e6d5 e4d5 b8d7" +
-            " f1e2 g7g6 d1d2 f8g7 c2c4 d8c7 e1c1 e8c8 h1e1 d7b6 d2c2 h5h4 a2a3 h4h3 g2h3 h8h3 e2f1 h3h5 h2h3 c8b8" +
-            " c2c3 h5f5 b3d2 d8c8 c1b1 b6d5 c4d5 c7c3 b2c3 f6d5 d2e4 d5c3 e4c3 c8c3 b1b2 c3c6 b2b3 b8c8 a3a4 f5f6" +
-            " h3h4 c6c7 f1h3 c8b8 h3g4 c7c6 e3g5 f6e6 g4e6 f7e6 g5e7 d6d5 e1g1 g7h6 g1g6 h6e3 a4a5 e3d4 f3f4 b7b6" +
-            " a5b6 c6b6 b3a4 b6c6 e7b4 b8b7 f4e5 d4e5 d1e1 e5c7 e1e6 c6c4 e6a6 c4h4 a6e6 h4h1 a4b5 d5d4 g6g7 h1c1" +
-            " g7d7 b7c8 d7d4 c1a1 e6e8 c8b7 d4d7 a1c1 b4a3 c1c2 b5a4 b7c6 d7e7 c2d2 a3c1 d2c2 c1g5 c2c5 g5e3 c5d5" +
-            " e8a8 d5d3 a8a6 c6d5 e7d7 d5e4 d7c7 d3e3 a6a8 e4d5 a8d8 d5e6 a4b5 e3b3 b5c4 b3b1 d8e8 e6f6 c4d3 b1d1" +
-            " d3c2 d1a1 c7d7 f6f5 d7f7 f5g6 e8e7 g6g5 c2d3 a1a2 d3d4 a2a4 d4e5 a4a5 e5d6 a5a2 f7g7 g5f4 g7f7 f4g4" +
-            " f7g7 g4f4 g7f7 f4g4 e7b7 g4g5 d6e5 g5g4 f7f4 g4g5 b7g7 g5h5 f4f7 a2e2 e5d5 h5h6 g7h7 h6g5 h7g7 g5h5" +
-            " d5d4 h5h6 f7a7 h6h5 d4d5 h5h6 d5d6 h6h5 a7f7 h5h6 d6d5 h6h5 f7a7 h5h6 d5d4 h6h5 g7g8 h5h6 d4d5 e2b2" +
-            " d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8");
-
-        var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
-
-        engine.AdjustPosition("position startpos moves" +
-            " e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 f2f3 e7e5 d4b3 c8e6 c1e3 h7h5 c3d5 e6d5 e4d5 b8d7" +
-            " f1e2 g7g6 d1d2 f8g7 c2c4 d8c7 e1c1 e8c8 h1e1 d7b6 d2c2 h5h4 a2a3 h4h3 g2h3 h8h3 e2f1 h3h5 h2h3 c8b8" +
-            " c2c3 h5f5 b3d2 d8c8 c1b1 b6d5 c4d5 c7c3 b2c3 f6d5 d2e4 d5c3 e4c3 c8c3 b1b2 c3c6 b2b3 b8c8 a3a4 f5f6" +
-            " h3h4 c6c7 f1h3 c8b8 h3g4 c7c6 e3g5 f6e6 g4e6 f7e6 g5e7 d6d5 e1g1 g7h6 g1g6 h6e3 a4a5 e3d4 f3f4 b7b6" +
-            " a5b6 c6b6 b3a4 b6c6 e7b4 b8b7 f4e5 d4e5 d1e1 e5c7 e1e6 c6c4 e6a6 c4h4 a6e6 h4h1 a4b5 d5d4 g6g7 h1c1" +
-            " g7d7 b7c8 d7d4 c1a1 e6e8 c8b7 d4d7 a1c1 b4a3 c1c2 b5a4 b7c6 d7e7 c2d2 a3c1 d2c2 c1g5 c2c5 g5e3 c5d5" +
-            " e8a8 d5d3 a8a6 c6d5 e7d7 d5e4 d7c7 d3e3 a6a8 e4d5 a8d8 d5e6 a4b5 e3b3 b5c4 b3b1 d8e8 e6f6 c4d3 b1d1" +
-            " d3c2 d1a1 c7d7 f6f5 d7f7 f5g6 e8e7 g6g5 c2d3 a1a2 d3d4 a2a4 d4e5 a4a5 e5d6 a5a2 f7g7 g5f4 g7f7 f4g4" +
-            " f7g7 g4f4 g7f7 f4g4 e7b7 g4g5 d6e5 g5g4 f7f4 g4g5 b7g7 g5h5 f4f7 a2e2 e5d5 h5h6 g7h7 h6g5 h7g7 g5h5" +
-            " d5d4 h5h6 f7a7 h6h5 d4d5 h5h6 d5d6 h6h5 a7f7 h5h6 d6d5 h6h5 f7a7 h5h6 d5d4 h6h5 g7g8 h5h6 d4d5 e2b2" +
-            " d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8" +
-            $" {searchResult.BestMove.UCIString()} {searchResult.Moves[1].UCIString()}");
-
-        searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
-
-        Assert.NotZero(searchResult.BestMove);
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("position fen r1bq1rk1/pp1nppbp/2p2np1/8/2QPP3/2N2N2/PP2BPPP/R1B1K2R w KQ - 0 1" +
-    " moves c1f4 d7b6 c4b4 c8e6 e1g1 a7a5 b4c5 b6d7 c5a3 d8b6 e4e5 f6d5 c3d5 e6d5 f1d1 a8d8 f4d2 d8a8" +
-    " a3e7 f8d8 d2c3 a5a4 d1d2 g7h6 d2c2 h6g7 c2c1 c6c5 c1d1 a8c8 e7d6 d5c6 d4c5 d7c5 d6e7 d8e8 e7h4" +
-    " c6f3 e2f3 g7e5 c3e5 e8e5 h4d4 b6f6 d4b4 g8g7 d1d2 c8e8 a1f1 b7b6 d2d1 h7h6 b4c4 e5e7 b2b4 a4b3" +
-    " a2b3 c5e4 b3b4 e4c3 d1d3 c3e4 b4b5 f6b2 c4d4 b2d4 d3d4 e7e5 f3e4 e5e4 d4e4 e8e4 f1b1 g7f6 f2f3" +
-    " e4e5 g1f2 h6h5 b1b4 f6f5 h2h4 e5d5 f2e3 d5e5 e3f2 f7f6 g2g4 f5e6 f3f4 e5c5 f4f5 e6f7 f5g6 f7g6" +
-    " g4h5 g6h5 f2e3 f6f5 e3d3 c5d5 d3e3 h5g6 b4b2 g6f6 b2b4 f6e5 e3e2 f5f4 h4h5 e5f5 h5h6 d5d6 b4c4" +
-    " d6h6 c4c6 h6c6 b5c6 f5e6 e2d3 b6b5 d3e4 b5b4 c6c7 e6d7 c7c8q d7c8 e4f4 b4b3 f4e4 b3b2 e4f3" +
-    " b2b1q f3f2 c8c7 f2e2 b1a2 e2d1 a2f2 d1c1 f2e2 c1b1 e2d3 b1a2 d3d2 a2b3 c7c6 b3c4 d2e3 c4b4 e3d3" +
-    " b4a4 d3e3", Description = "FEN 8/8/2k5/8/K7/4q3/8/8 w - - 0 1")]
-
-    [TestCase("position fen r2qk1nr/1ppb2bp/p1np1pp1/4p3/B2PP3/2P2N2/PP3PPP/RNBQR1K1 w kq - 0 1 moves c1e3" +
-    " b7b5 a4c2 g8h6 h2h3 e8g8 b1d2 h6f7 d1e2 e5d4 c3d4 d8e7 a1c1 a8e8 c2b3 e7d8 e2d3 c6e7 c1c2 d6d5" +
-    " c2c5 d7c6 e4d5 c6d5 a2a4 d5b3 d3b3 c7c6 b3d3 f7e5 d3c2 e5d7 c2b3 f8f7 c5c2 d7b6 a4b5 a6b5 e3f4" +
-    " e7d5 e1e8 d8e8 f4d6 e8d7 b3a3 b6c8 d6c5 d7b7 d2e4 f7d7 a3b3 g8h8 c2e2 d7d8 e4c3 c8b6 h3h4 f6f5" +
-    " f3e5 d5c3 b2c3 b6d5 c3c4 d5f4 e2a2 g7e5 d4e5 f4d3 a2d2 b7a6 c4b5 a6a1 b3d1 a1d1 d2d1 d8d5 e5e6" +
-    " h8g7 b5c6 d5c5 d1d3 g7f6 e6e7 f6e7 d3d7 e7e6 d7h7 c5c6 h7a7 e6e5 a7e7 e5f6 e7b7 c6c2 g2g3 c2a2" +
-    " g1g2 a2c2 g2f3 c2c4 f3e3 c4c3 e3f4 c3c4 f4f3 c4c3 f3e2 c3c2 e2e1 f6e6 e1f1 e6f6 f1g2 f6e6 b7a7" +
-    " e6f6 g2f3 c2b2 a7c7 b2a2 f3e3 a2a3 e3d4 a3a2 c7c6 f6g7 d4e3 a2a3 e3f4 a3a4 f4f3 g7f7 h4h5 g6h5" +
-    " c6h6 a4a2 h6h5 f7f6 f3e3 a2b2 h5h7 f6e6 e3f3 e6d5 h7e7 d5d6 e7e8 b2a2 f3e3 a2b2 f2f4 b2c2 e8e5" +
-    " c2c5 e5c5 d6c5 e3f3 c5d6 g3g4 f5g4 f3g4 d6c6 f4f5 c6d7 g4g5 d7e7 g5g6 e7f8 g6f6 f8e8 f6g7 e8d7" +
-    " f5f6 d7e6 f6f7 e6f5 f7f8q f5g5 f8c5 g5g4 g7f7 g4f4 c5b4 f4e3 b4c3 e3e4 c3b4 e4e3 f7f6 e3f3 b4d2" +
-    " f3g4 f6f7 g4f3 d2d3 f3f2 f7f8 f2g1 d3e3 g1g2 e3e2 g2g3 f8e7 g3h3 e7d7 h3h4 e2g2 h4h5 d7e6 h5h6 e6d7",
-    Description = "FEN 8/3K4/7k/8/8/8/6Q1/8 b - - 0 1")]
-    public void DepthOverflow(string positionCommand)
-    {
-        var engine = GetEngine();
-
-        engine.AdjustPosition(positionCommand);
-
-        var result = engine.BestMove(new("go wtime 3600000 btime 3600000"));
-        Assert.Less(result.DepthReached, Configuration.EngineSettings.MaxDepth);
-    }
-
-    [TestCase("4r3/5P1k/5K2/5N2/8/8/8/8 w - - 0 1", new[] { "f7e8b" },
-        Description = "Position by Alex Brunetti, https://www.talkchess.com/forum3/viewtopic.php?f=2&t=31150&start=28")]
-    public void BishopUnderpromotion(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
-    }
-
-    /// <summary>
-    /// Unfortunately or not, it doesn't crash IDDFS, so the test is mostly useless, but let's have it in place just in case
-    /// </summary>
-    [Test]
-    public void MaxDepthCrash()
-    {
-        var engine = GetEngine();
-
-        engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3");
-
-        engine.BestMove(new("go wtime 10000 btime 10000 winc 80 binc 80"));
-
-        engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3 f6f7 d3c3");
-
-        Assert.DoesNotThrow(() => engine.BestMove(new("go wtime 100000 btime 100000 winc 80 binc 80")));
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("8/8/4k3/3n1n2/5P2/8/3K4/8 b - - 0 12", null, new[] { "d5f4" },
-    Description = "NN vs P, where knights can't take the pawn")]
-    [TestCase("8/5R2/1n2RK2/8/8/7k/4r3/8 b - - 0 1", null, new[] { "e2e6" },
-    Description = "RR vs RB, where if the side with the bishop exchanges the rooks, they lose")]
-    public void PawnlessEndgames(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
-    {
-        TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 20);
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("8/5pk1/6n1/3N4/4Q3/6P1/1q3PK1/8 b - - 0 1", 25)]
-    [TestCase("8/p3k3/1b3p2/5Kp1/1p5p/1P2P2P/P3BP2/8 w - - 0 1", 20)]
-    [TestCase("6k1/4Np2/8/5PP1/2n3K1/8/8/8 b - - 0 1", 20)]
-    [TestCase("8/4Np1k/8/5PPK/2n5/8/8/8 b - - 0 1", 20)]
-    [TestCase("1R6/8/8/5p2/5k2/r7/5K2/8 w - - 0 1", 20)]
-    [TestCase("8/8/5k2/5p2/1R6/r7/6K1/8 w - - 0 1", 20)]
-    [TestCase("8/8/5n2/7k/7p/5P2/6P1/4BK2 w - - 0 1", 20)]
-    [TestCase("3B4/8/8/7k/7p/5P2/4n1PK/8 w - - 0 1", 20)]
-    public void PVTableOverflow(string fen, int depth)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition($"position fen {fen}");
-
-        var result = engine.BestMove(new($"go depth {depth}"));
-
-        Assert.AreEqual(depth, result.Depth);
-    }
-
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("8/1p1k3b/p1n1pp2/P1B4p/BPP2p2/5P2/3K2PP/8 b - c3 1 1", 30)]
-    public void NegativeDepth(string fen, int depth)
-    {
-        var engine = GetEngine();
-        engine.AdjustPosition($"position fen {fen}");
-
-        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
-    }
-
-    [Test]
-    public void HighSeldepthAtDepth2()
-    {
-        var engine = GetEngine();
-
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
-        Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
-
-        // It used to happen at the second repetition, info depth 2 seldepth 127
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
-        Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
-
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
-        Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
-    }
-
-    [Test]
-    public void HighSeldepthAtDepth2_FixedDepth()
-    {
-        var engine = GetEngine();
-
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
-        Assert.Less(result.DepthReached, 5 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
-
-        // It used to happen at the second repetition, info depth 2 seldepth 127
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        result = engine.BestMove(new("go depth 3"));
-        Assert.Less(result.DepthReached, 32, $"depth {result.Depth}, seldepth {result.DepthReached}");
-
-        engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
-        result = engine.BestMove(new("go depth 3"));
-        Assert.Less(result.DepthReached, 32, $"depth {result.Depth}, seldepth {result.DepthReached}");
-    }
+	[TestCase("r2k3r/p1p2ppp/2p5/2P5/6nq/2NB4/PPPP2PP/R1BQR1K1 w - - 0 13", null, new[] { "g2h3" },
+		Description = "Avoid Mate in 2, fails with initial implementation of MiniMax depth 4")]
+
+	[TestCase("r2k3r/p1p2ppp/2p5/2P5/6nq/2NB4/PPPP2PP/R1BQR1K1 w - - 0 13", null, new[] { "g2h3", "e1e4" },
+		Description = "Avoid Mate in 4, fails with MiniMax depth 4")]
+
+	[TestCase("q5k1/2p5/1bb1pQ2/1p6/1P6/5N2/P4PPP/3RK2R b K - 0 1", null, new[] { "a8a2" },
+		Description = "Avoid Mate in 3, seen with NegaMax depth 4 (but weirdly not with AlphaBeta depth 4)")]
+
+	[TestCase("r2qr1k1/ppp2ppp/5n2/2nPp3/1b4b1/P1NPP1P1/1P2NPBP/R1BQ1RK1 b - - 0 1", new[] { "b4c3", "g4e2" }, new[] { "b4a5" },
+		Description = "Fails with simple MiniMax depth 3 and 4: b4a5 is played")]
+
+	[TestCase("r2qkb1r/ppp2ppp/2n2n2/3pp3/8/PPP3Pb/3PPP1P/RNBQK1NR w KQkq - 0 1", new[] { "g1h3" },
+		Description = "Used to fail")]
+
+	[TestCase("8/n2k4/bpr4p/1q1p4/4pp1b/P3P1Pr/R2K4/1r2n1Nr w - - 0 1", new[]
+	{
+				"a3a4",
+				"a2a1", "a2b2", "a2c2",
+				"e3f4", "f3g4",
+				"g3f4", "g3g4", "g3h4",
+				"g3f4", "g3g4", "g3h4",
+				"g1h3", "g1f3", "g1e2"
+			}, Description = "Used to return an illegal move in the very first versions")]
+
+	[TestCase("7k/1Q4r1/2q1B3/1P2QNN1/8/R7/nN6/K1R5 b - - 0 1", new[] { "c6c1" },
+		Description = "Get stalemated vs winning a queen")]
+
+	public void GeneralRegression(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
+	}
+
+	[TestCase("r1bq2k1/1pp1n2p/2nppr1Q/p7/2PP2P1/5N2/PP3P1P/2KR1B1R w - - 0 15", new[] { "h6f6" },
+		Description = "AlphaBeta/NegaMax depth 5 spends almost 3 minutes with a simple retake")]
+	public void SlowRecapture(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 5);
+	}
+
+	[Explicit]
+	[Category(Categories.NotGoodEnough)]
+	[TestCase("6k1/1R6/5Kn1/3p1N2/1P6/8/8/3r4 b - - 10 37", new[] { "g6f8" }, new[] { "g6f4" },
+		Description = "Avoid mate in 4 https://lichess.org/XkZsoXLA#74")]
+	public void AvoidMate(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+	}
+
+	[TestCase(5)]
+	[TestCase(6)]
+	public void KeepNonGoodQuiescenceMoves(int depth)
+	{
+		const string fen = Constants.InitialPositionFEN;
+		var engine = GetEngine(fen);
+		var goCommand = new GoCommand($"go depth {depth}");
+
+		var bestResult = engine.BestMove(goCommand);
+
+		switch (depth)
+		{
+			case 5 when bestResult.Moves.Length >= 5:
+				Assert.AreNotEqual("f6e4", bestResult.Moves[4].UCIString());
+				break;
+			case 6 when bestResult.Moves.Length >= 6:
+				Assert.AreNotEqual("f3e5", bestResult.Moves[5].UCIString());
+				break;
+		}
+	}
+
+	[TestCase(5, Constants.InitialPositionFEN, "d8d5")]
+	[TestCase(5, "rq2k2r/ppp2pb1/2n1pnpp/1Q1p1b2/3P1B2/2N1PNP1/PPP2PBP/R3K2R w KQkq - 0 1", "e5f4")]
+	public void TrashInPVTable(int depth, string fen, string notExpectedMove)
+	{
+		var goCommand = new GoCommand($"go depth {depth}");
+
+		var engine = GetEngine(fen);
+		var bestResult = engine.BestMove(goCommand);
+
+		if (bestResult.Moves.Length > depth)
+		{
+			Assert.AreNotEqual(notExpectedMove, bestResult.Moves[depth].UCIString());
+		}
+	}
+
+	[Test]
+	public void TrashInPV()
+	{
+		const string positionCommand = "position startpos moves c2c4";
+		var goCommand = new GoCommand("go depth 5");
+
+		var engine = GetEngine();
+
+		engine.AdjustPosition(positionCommand);
+		Assert.DoesNotThrow(() => engine.BestMove(goCommand));
+	}
+
+	[Explicit]
+	[Category(Categories.NotGoodEnough)]
+	[TestCase("3rk2r/ppq1pp2/2p1n1pp/7n/4P3/2P1BQP1/P1P2PBP/R3R1K1 w k - 0 18", null, new[] { "e3a7" },
+		Description = "At depth 3 White takes the pawn")]
+	[TestCase("r1bqk2r/ppp2ppp/2n1p3/8/Q1pP4/2b2NP1/P3PPBP/1RB2RK1 b kq - 1 10", null, new[] { "c3d4" },
+		Description = "It failed at depth 6 in https://lichess.org/nZVw6G5D/black#19")]
+	[TestCase("r1bqkb1r/ppp2ppp/2n1p3/3pP3/3Pn3/5P2/PPP1N1PP/R1BQKBNR b KQkq - 0 1", null, new[] { "f8b4" },
+		Description = "It failed at depth 5 in https://lichess.org/rtTsj9Sr/black")]
+	public void GeneralFailures(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+	}
+
+	/// <summary>
+	/// Verifies that with both <see cref="Configuration.EngineSettings.MinDepth"/>
+	/// and <see cref="Configuration.EngineSettings.DepthWhenLessThanMinMoveTime"/>
+	/// the positions that result as a consequence of the given position commands
+	/// aren't considered as drawn
+	/// </summary>
+	[TestCase("position startpos moves" +
+		" c2c4 e7e5 b1c3 g8f6 g1f3 b8c6 e2e4 f8b4 d2d3 d7d6 a2a3 b4c5 b2b4 c5b6 c1e3" +
+		" b6e3 f2e3 a7a6 b4b5 a6b5 c4b5 c6a7 d3d4 e5d4 d1d4 c7c5 d4d2 e8g8 e1c1 f8e8" +
+		" e4e5 f6g4 e5d6 g4e3 d6d7 c8d7 d2d7 d8a5 d7d2 e3d1 c3d1 a7b5 d2a5 a8a5 a3a4" +
+		" b5d4 f3d4 c5d4 f1b5 e8e5 d1f2 e5f5 h1e1 a5a8 f2e4 f5d5 g2g4 d4d3 c1d2 h7h5" +
+		" g4h5 d5h5 e1h1 a8d8 d2c3 h5h3 e4f2 d8c8 c3d4 d3d2 f2h3 c8c1 h3f2 c1h1 b5e2" +
+		" h1h2 d4e3 f7f5 f2d1 f5f4 e3d3 g7g5 d1c3 f4f3 e2f3 h2h3 d3e2 g8g7 c3d1 h3h2" +
+		" e2e3 h2h3 e3e2 b7b6 f3g2 h3a3 g2c6 a3a2 d1e3 g7f6 e3c4 g5g4 c4b6 f6e5 c6a8" +
+		" e5d4 a8d5 a2a1 e2d2 d4c5 d5e6 c5b6 e6g4 a1a4 g4e6 b6c5 d2d3 a4a1 e6f5 c5d6" +
+		" d3e4 a1d1 f5c8 d1e1 e4f4 d6d5 c8b7 d5d4 b7g2 e1e2 f4f3 e2a2 f3g3 d4c5 g3f3" +
+		" c5d5 f3g3 d5d6 g3f3 d6e5 f3g3 e5d6 g3f3 d6e5 g2h3 a2b2 f3g3 e5d5 g3f3 d5d4" +
+		" h3g2 d4d5 f3g3 d5d6 g3f3 d6e6 f3g3 e6d6 g2a8 b2a2 a8b7 a2b2 b7a8 d6c7 g3f4" +
+		" c7b8 f4e5 b8a8 e5d6 a8a7 d6c7 a7a8 c7c8 a8a7 c8c7")]
+
+	[TestCase("position startpos moves" +
+		" e2e4 e7e5 g1f3 b8c6 f1c4 f8c5 e1g1 g8f6 d2d3 d7d6 c2c3 a7a5 f1e1 e8g8 b1d2" +
+		" c5b6 b2b3 f8e8 c1b2 c8g4 h2h3 g4h5 g2g4 h5g6 g4g5 d6d5 g5f6 d5c4 d2c4 d8f6" +
+		" c4b6 c7b6 c3c4 g6h5 e1e3 c6d4 g1g2 f6g6 g2h2 d4f3 e3f3 g6d6 a1c1 a8d8 c1c3" +
+		" f7f5 d1e2 h5f3 e2f3 f5e4 f3e4 d6h6 c3c2 h6f4 e4f4 e5f4 d3d4 e8e1 c2d2 g7g5" +
+		" d4d5 d8d6 a2a4 h7h5 f2f3 e1e3 b2a3 d6d7 d2g2 e3b3 a3c1 d7g7 c1b2 g7g6 h3h4" +
+		" b3f3 h4g5 f3e3 b2f6 f4f3 g2f2 e3e4 f2f3 e4c4 f3b3 c4a4 d5d6 a4h4 b3h3 h4e4" +
+		" h3h5 e4e2 h2g1 e2e1 g1g2 e1d1 h5h8 g8f7 h8h7 f7e6 h7b7 d1d6 g2f3 e6d5 f3f4" +
+		" d5c6 b7b8 c6d7 f4f5 d7c7 b8e8 d6f6 g5f6 g6g2 f6f7 g2f2 f5g6 f2g2 g6f5 g2f2" +
+		" f5e6 a5a4 f7f8q f2f8 e8f8 b6b5 e6e5 c7b7 f8f7 b7a6 f7f8 b5b4 e5d5 b4b3 f8b8" +
+		" a6a5 d5c5 a5a6 b8a8 a6b7 a8a4 b7c8 a4b4 c8d7 b4b3 d7e6 b3b8 e6f5 b8a8 f5e6" +
+		" c5c4 e6d6 a8d8 d6c7 d8e8 c7d6 e8a8 d6e6 c4c5 e6f5 c5d5 f5f6 a8e8 f6f7 e8a8" +
+		" f7g7 d5d4 g7f7 d4e5 f7e7 e5d5 e7f6 a8e8 f6f7 e8b8 f7f6 b8a8 f6g7 a8b8 g7f6" +
+		" b8d8 f6f7 d5d6 f7g6 d6d5 g6f7 d5e5 f7e7 d8d6 e7f7 d6d8 f7e7")]
+
+	[TestCase("position startpos moves" +
+		" g1f3 d7d5 d2d4 g8f6 c1f4 c8f5 e2e3 e7e6 f1d3 f5g6 b1c3 f8d6 e1g1 e8g8 h2h3" +
+		" g6h5 f4g5 d6e7 g2g4 h5g6 d3g6 f7g6 f1e1 b8c6 g5f4 f8e8 f3e5 c6e5 d4e5 f6e4" +
+		" c3e4 d5e4 d1e2 c7c5 a1d1 d8b6 c2c4 g6g5 f4g3 a8d8 d1d8 e7d8 e1d1 b6c6 d1d6" +
+		" c6c8 f2f3 d8c7 d6d2 c8b8 f3e4 c7e5 g3e5 b8e5 e2g2 e5c7 b2b3 e6e5 g2e2 b7b6" +
+		" a2a4 a7a5 e2d3 c7c8 d3d6 h7h5 d6d5 g8h7 d5d7 c8d7 d2d7 h5g4 h3g4 e8e6 d7d5" +
+		" g7g6 g1g2 h7g7 g2g1 g7g8 d5d7 g8f8 g1f2 f8e8 d7b7 e8d8 b7g7 e6d6 f2g1 d6d1" +
+		" g1g2 d1d6 g2g1 d6d1 g1f2 d1d2 f2g3 d2d3 g3f3 d3d6 f3g2 d6d2 g2f3 d2d6 g7f7" +
+		" d8e8 f7a7 d6d7 a7a8 d7d8 a8a7 d8d7 a7a8 d7d8 a8a6 d8d6 f3e2 e8e7 a6a8 e7d7" +
+		" e2f3 d7e6 f3g3 e6d7 g3f3 d6f6 f3g3 d7c7 a8a5 b6a5 b3b4 a5b4 a4a5 b4b3 a5a6" +
+		" f6a6 g3f3 c7b8 f3g3 b3b2 g3h3 b2b1q h3g3 b1e4 g3h3 e4c4 h3g3 c4g4 g3g4 c5c4" +
+		" g4g5 e5e4 g5g4 g6g5 g4g5 c4c3 g5f5 b8a8 f5e4 c3c2 e4d5")]
+
+	[TestCase("position startpos moves" +
+		" e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 c1g5 e7e6 f2f4 d8b6 d1d2" +
+		" b6b2 a1b1 b2a3 e4e5 d6e5 f4e5 f6d5 c3d5 e6d5 c2c4 b8d7 e5e6 d7f6 g5f6 g7f6" +
+		" c4d5 a3c5 e6f7 e8f7 d4e6 c5e7 d2e2 b7b5 e6f8 e7f8 b1c1 f8d8 e2h5 f7g8 c1d1" +
+		" c8b7 h5g4 g8f8 g4b4 f8f7 d5d6 h8e8 e1f2 d8b6 b4d4 b6d4 d1d4 a8d8 f1d3 e8e6" +
+		" d6d7 b7c6 h1d1 e6e7 d3f5 h7h6 d4d6 e7e5 d6c6 e5f5 f2g1 f7e7 c6c7 f5e5 g1f2" +
+		" a6a5 g2g4 e5e4 f2f3 e4c4 c7a7 c4c3 f3e4 c3c2 a7a5 d8d7 d1d7 e7d7 h2h4 d7c7" +
+		" a5b5 c2e2 e4f5 e2f2 f5e6 f2a2 e6f6 a2g2 b5h5 g2g4 h5h6 g4g2 f6e5 g2e2 e5d5" +
+		" e2d2 d5e5 d2e2 e5d5 e2d2 d5e4 d2e2 e4d4 e2d2 d4e4 d2e2 e4d4 e2c2 h6h8 c2d2" +
+		" d4e5 d2e2 e5d5 e2d2 d5e5 d2e2 e5d4 c7d6 h4h5 e2d2 d4e4 d2e2 e4f5 e2f2 f5e4" +
+		" f2e2 e4d4 e2d2 d4c4 d6e5 h8e8 e5f5 e8h8 d2h2 c4d5 f5g5 h8g8 g5h6 d5d6 h2h5" +
+		" g8a8 h6g7 d6e6 g7g6 e6d6 h5h2 d6d5 g6g7 d5d6 g7f6 d6d5 h2d2 d5e4 f6e6 e4e3" +
+		" d2b2 e3d4 e6d6 d4e4 d6c5 a8c8 c5d6 c8a8 d6c7 e4e5 b2d2 a8f8 c7b7 e5e6 b7c7" +
+		" e6e5 d2e2 e5d4 c7d6 f8a8 e2d2 d4c3 d2f2 c3d4 f2d2 d4c4 d6c7 c4c5 c7b7 a8e8" +
+		" b7a6 c5c6 a6a5 c6c7 a5a6 c7b8 a6b6 b8a8 b6c7 a8a7 c7d7 a7a8 d7e8 a8b8 e8d8" +
+		" b8a8")]
+
+	[TestCase("position startpos moves" +
+		" g1f3 d7d5 d2d4 g8f6 g2g3 b8c6 f1g2 e7e6 b1c3 f8d6 e1g1 e8g8 f1e1 a8b8 e2e4 d5e4 c3e4 f6e4 e1e4 d6e7" +
+		" b2b3 b7b5 c1b2 c8b7 e4e3 e7f6 f3e5 c6e7 g2b7 b8b7 e5g4 e7f5 g4f6 d8f6 e3e5 f5e7 d1f1 e7c6 f1g2 b7b6" +
+		" e5e4 f8d8 c2c3 f6f5 g3g4 f5g6 a1e1 b6a6 a2a3 c6a5 g2g3 d8c8 g3d3 a6b6 d3d1 f7f5 e4e5 g6g4 d1g4 f5g4" +
+		" e5e6 b6e6 e1e6 a5b3 e6e5 c7c5 e5e2 b3a5 d4c5 c8c5 e2e8 g8f7 e8a8 c5c7 a8b8 a7a6 g1g2 c7c6 b8h8 a5c4" +
+		" b2c1 h7h6 h8a8 g7g5 a8a7 f7g6 a7a8 c6f6 a8g8 g6h5 g8e8 f6f3 c1e3 c4a3 e8d8 a3c2 e3d2 h5g6 g2g1 f3f6" +
+		" d8g8 g6f5 g8d8 c2a3 d2e3 a3c4 e3d4 c4e5 g1g2 h6h5 h2h3 g4h3 g2h3 f6e6 h3g2 f5e4 d4e3 g5g4 d8h8 e6c6" +
+		" e3d4 e5g6 h8e8 e4f5 g2g1 h5h4 g1h2 c6e6 e8a8 f5f4 d4e3 f4f3 h2g1 g4g3 a8a7 g6e7 a7a8 e7d5 a8f8 f3g4" +
+		" f8g8 g4h3 g1f1 d5e3 f2e3 e6e3 g8g5 e3c3 f1e2 g3g2 e2f2 b5b4 g5g2 c3c2 f2e3 c2g2 e3d4 b4b3 d4d5 b3b2" +
+		" d5e5 b2b1q e5f4 b1d3 f4e5 g2g6 e5f4 d3e2 f4f5 e2e6 f5f4 g6g4 f4f3 e6e8 f3f2 g4f4 f2g1 f4f6 g1h1 e8e6" +
+		" h1g1 e6e5 g1h1 e5d5 h1g1 d5d4 g1h1 d4e4 h1g1 f6g6 g1f1 e4d3 f1e1 g6g1 e1f2 g1g2 f2e1 g2g6 e1f2 d3d2" +
+		" f2f3 d2e1 f3f4 e1e2 f4f5 e2e6 f5f4 g6g4 f4f3 e6e8 f3f2 g4f4 f2g1 f4f6 g1h1 e8e6 h1g1 e6e5 g1h1 e5d5",
+		Ignore = "Now that we detect 2 move repetitions, this should fail")]
+	public void FalseDrawnPositions(string positionCommand)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition(positionCommand);
+
+		var bestMove = engine.BestMove(new GoCommand($"go depth {Engine.DefaultMaxDepth}"));
+		Assert.NotZero(bestMove.Score);
+
+		//engine.AdjustPosition(positionCommand);
+		//bestMove = engine.BestMove(new GoCommand($"go depth {Configuration.EngineSettings.DepthWhenLessThanMinMoveTime}"));
+		//Assert.NotZero(bestMove.Evaluation);
+	}
+
+	[TestCase("position startpos moves" +
+		" c2c4 e7e6 b1c3 g8f6 g1f3 f8b4 e2e3 e8g8 d2d4 c7c5 f1d3 d7d5 e1g1 b8c6 c4d5" +
+		" e6d5 d4c5 b4c5 b2b3 f8e8 c1b2 b7b6 f1e1 c8b7 d1b1 h7h5 a2a3 a7a5 e3e4 f6g4" +
+		" e1e2 d5d4 c3d5 g4e5 f3e5 c6e5 d3b5 e8e6 d5f4 e6h6 f4d3 e5d3 b1d3 h6d6 e4e5" +
+		" d6g6 f2f3 d8d5 a1e1 d5f3 d3g6 f3e2 b5e2 f7g6 e2d3 g6g5 a3a4 a8d8 e5e6 d8e8" +
+		" e1e5 h5h4 d3g6 e8e7 g6f7 g8f8 e5g5 b7c8 g5g6 e7a7 g2g3 h4h3 g6g5 a7f7 e6f7" +
+		" f8f7 g5h5 d4d3 h5c5 b6c5 g1f2 c8e6 f2e3 f7g8 e3d3 e6b3 b2c3 c5c4 d3d4 b3a4" +
+		" d4c4 a4d7 c3a5 g7g5 c4d4 g5g4 d4e5 d7c8 e5f4 c8e6 a5c7 e6c8 f4e4 g8g7 c7e5" +
+		" g7f7 e5b2 f7e6 e4f4 e6d5 f4e3 c8d7 e3f4 d7e6 f4e3 d5d6 e3e4 e6d5 e4f4 d5e6" +
+		" f4e3 e6d5 e3f4 d5f3 f4f5 d6d5 f5f4 d5d6 f4f5 d6d5 f5f4 f3d1 f4f5 d1e2 f5f4" +
+		" d5d6 f4e4 d6e6 e4f4 e6d5 f4f5 d5c5 f5f6 c5b6 f6e7 b6a7 e7d8 a7a8 d8e7 a8b8" +
+		" e7f8 b8a8 f8e7 a8b8 e7f8 b8a8")]
+	public void FalseDrawnPositionBy50MovesRule(string positionCommand)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition(positionCommand);
+
+		using var evaluationContext = new EvaluationContext();
+
+		Assert.False(engine.Game.Is50MovesRepetition(evaluationContext));
+		var bestMove = engine.BestMove(new GoCommand("go depth 1"));
+
+		engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.UCIString());
+		Assert.IsFalse(engine.Game.Is50MovesRepetition(evaluationContext));
+	}
+
+	// 8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1 - || PV Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6, with b1=Q as the first invalid move there
+	[TestCase("position startpos moves d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1f4 e8g8" +
+		" e2e3 c7c5 d4c5 e7c5 a2a3 a7a6 d1d2 d5c4 f1c4 b7b5 c4d3 c8b7 b2b4 b7f3 b4c5 f3g2" +
+		" h1g1 g2f3 g1g3 f3c6 f4h6 g7g6 h6f8 d8f8 a3a4 b5b4 c3a2 b4b3 a2c1 f8c5 c1b3 c5d5" +
+		" b3a5 d5h1 d3f1 c6d5 d2c3 b8d7 c3c7 h1e4 f1c4 e4c2 a1a2 c2c1 e1e2 d7e5 c7e5 d5c4" +
+		" a5c4 c1c4 e2f3 c4a2 e5f6 a2a4 f3g2 a8c8 g3f3 a4d7 f6e5 d7b5 e5d6 a6a5 d6e7 c8f8" +
+		" e7d6 a5a4 e3e4 b5c4 f3e3 f8c8 h2h3 c4b5 e3f3 b5g5 f3g3 g5a5 g3d3 a5g5 d3g3 g5b5" +
+		" g3f3 b5a5 f3d3 a5a8 d6b4 c8b8 b4c4 a4a3 d3d2 b8b2 d2b2 a3b2 c4b4 a8a2 b4b8 g8g7" +
+		" b8e5 g7g8 e5b8 g8g7 b8e5 f7f6 e5c7 g7g8 c7b8 g8f7 b8c7 f7g8 c7b8 g8g7")]
+	public void InvalidPV(string positionCommand)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition(positionCommand);
+
+		var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
+		Assert.Zero(bestMove.Score);
+		Assert.AreEqual(1, bestMove.Moves.Length);
+		Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
+	}
+
+	// pv h2h1q a5a6 d5c4 a6a7 c4b4 c5c6 h1g1 b6a6, playing h2h1q again
+	[TestCase("position startpos moves e2e4 c7c6 d2d4 d7d5 e4e5 c8f5 g1f3 e7e6 f1e2 c6c5 c1e3" +
+		" c5d4 f3d4 g8e7 b1c3 f5g6 h2h4 h7h5 e2b5 b8d7 e3f4 a7a6 b5d3 g6d3 d1d3 e7g6 d4e6 g6f4" +
+		" e6f4 d7e5 d3e2 d8d6 c3d5 g7g6 e1c1 f8h6 h1e1 f7f6 d5f6 d6f6 e2e5 f6e5 e1e5 e8f8 g2g3" +
+		" a8e8 e5e3 h6f4 g3f4 h8h7 d1d6 h7f7 e3e8 f8e8 d6g6 f7f4 g6g8 e8f7 g8b8 b7b5 b8b6 f4a4" +
+		" f2f3 a4h4 b6a6 h4h1 c1d2 h1h2 d2c3 h2f2 b2b3 h5h4 a6h6 f2f3 c3b4 f3f4 b4b5 f7g7 h6h5" +
+		" g7f6 c2c4 f4f5 h5f5 f6f5 c4c5 f5e6 a2a4 h4h3 b5b6 h3h2 b3b4 h2h1q a4a5")]
+
+	public void InvalidPV2(string positionCommand)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition(positionCommand.AsSpan()[..^10]);  // 8/8/1K2k3/2P5/PP6/8/7p/8 b - - 0 46, ready to promote
+
+		var bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+		Assert.AreEqual("h2h1q", bestMove.BestMove.UCIString());
+
+		engine.AdjustPosition(positionCommand);
+		bestMove = engine.BestMove(new GoCommand($"go depth {7}"));
+		Assert.AreNotEqual("h2h1q", bestMove.BestMove.UCIString());
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase(Constants.KillerTestPositionFEN)]
+	[TestCase(Constants.TrickyTestPositionFEN)]
+	public void PVTableCrash(string fen)
+	{
+		const int depthWhenMaxDepthInQuiescenceIsReached = 7;
+		var engine = GetEngine(fen);
+
+		var bestMove = engine.BestMove(new GoCommand($"go depth {depthWhenMaxDepthInQuiescenceIsReached}"));
+		Assert.AreEqual(depthWhenMaxDepthInQuiescenceIsReached, bestMove.Depth);
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[Test]
+	public void PonderingCrash()
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition("position startpos moves" +
+			" e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 f2f3 e7e5 d4b3 c8e6 c1e3 h7h5 c3d5 e6d5 e4d5 b8d7" +
+			" f1e2 g7g6 d1d2 f8g7 c2c4 d8c7 e1c1 e8c8 h1e1 d7b6 d2c2 h5h4 a2a3 h4h3 g2h3 h8h3 e2f1 h3h5 h2h3 c8b8" +
+			" c2c3 h5f5 b3d2 d8c8 c1b1 b6d5 c4d5 c7c3 b2c3 f6d5 d2e4 d5c3 e4c3 c8c3 b1b2 c3c6 b2b3 b8c8 a3a4 f5f6" +
+			" h3h4 c6c7 f1h3 c8b8 h3g4 c7c6 e3g5 f6e6 g4e6 f7e6 g5e7 d6d5 e1g1 g7h6 g1g6 h6e3 a4a5 e3d4 f3f4 b7b6" +
+			" a5b6 c6b6 b3a4 b6c6 e7b4 b8b7 f4e5 d4e5 d1e1 e5c7 e1e6 c6c4 e6a6 c4h4 a6e6 h4h1 a4b5 d5d4 g6g7 h1c1" +
+			" g7d7 b7c8 d7d4 c1a1 e6e8 c8b7 d4d7 a1c1 b4a3 c1c2 b5a4 b7c6 d7e7 c2d2 a3c1 d2c2 c1g5 c2c5 g5e3 c5d5" +
+			" e8a8 d5d3 a8a6 c6d5 e7d7 d5e4 d7c7 d3e3 a6a8 e4d5 a8d8 d5e6 a4b5 e3b3 b5c4 b3b1 d8e8 e6f6 c4d3 b1d1" +
+			" d3c2 d1a1 c7d7 f6f5 d7f7 f5g6 e8e7 g6g5 c2d3 a1a2 d3d4 a2a4 d4e5 a4a5 e5d6 a5a2 f7g7 g5f4 g7f7 f4g4" +
+			" f7g7 g4f4 g7f7 f4g4 e7b7 g4g5 d6e5 g5g4 f7f4 g4g5 b7g7 g5h5 f4f7 a2e2 e5d5 h5h6 g7h7 h6g5 h7g7 g5h5" +
+			" d5d4 h5h6 f7a7 h6h5 d4d5 h5h6 d5d6 h6h5 a7f7 h5h6 d6d5 h6h5 f7a7 h5h6 d5d4 h6h5 g7g8 h5h6 d4d5 e2b2" +
+			" d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8");
+
+		var searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+
+		engine.AdjustPosition("position startpos moves" +
+			" e2e4 c7c5 g1f3 d7d6 d2d4 c5d4 f3d4 g8f6 b1c3 a7a6 f2f3 e7e5 d4b3 c8e6 c1e3 h7h5 c3d5 e6d5 e4d5 b8d7" +
+			" f1e2 g7g6 d1d2 f8g7 c2c4 d8c7 e1c1 e8c8 h1e1 d7b6 d2c2 h5h4 a2a3 h4h3 g2h3 h8h3 e2f1 h3h5 h2h3 c8b8" +
+			" c2c3 h5f5 b3d2 d8c8 c1b1 b6d5 c4d5 c7c3 b2c3 f6d5 d2e4 d5c3 e4c3 c8c3 b1b2 c3c6 b2b3 b8c8 a3a4 f5f6" +
+			" h3h4 c6c7 f1h3 c8b8 h3g4 c7c6 e3g5 f6e6 g4e6 f7e6 g5e7 d6d5 e1g1 g7h6 g1g6 h6e3 a4a5 e3d4 f3f4 b7b6" +
+			" a5b6 c6b6 b3a4 b6c6 e7b4 b8b7 f4e5 d4e5 d1e1 e5c7 e1e6 c6c4 e6a6 c4h4 a6e6 h4h1 a4b5 d5d4 g6g7 h1c1" +
+			" g7d7 b7c8 d7d4 c1a1 e6e8 c8b7 d4d7 a1c1 b4a3 c1c2 b5a4 b7c6 d7e7 c2d2 a3c1 d2c2 c1g5 c2c5 g5e3 c5d5" +
+			" e8a8 d5d3 a8a6 c6d5 e7d7 d5e4 d7c7 d3e3 a6a8 e4d5 a8d8 d5e6 a4b5 e3b3 b5c4 b3b1 d8e8 e6f6 c4d3 b1d1" +
+			" d3c2 d1a1 c7d7 f6f5 d7f7 f5g6 e8e7 g6g5 c2d3 a1a2 d3d4 a2a4 d4e5 a4a5 e5d6 a5a2 f7g7 g5f4 g7f7 f4g4" +
+			" f7g7 g4f4 g7f7 f4g4 e7b7 g4g5 d6e5 g5g4 f7f4 g4g5 b7g7 g5h5 f4f7 a2e2 e5d5 h5h6 g7h7 h6g5 h7g7 g5h5" +
+			" d5d4 h5h6 f7a7 h6h5 d4d5 h5h6 d5d6 h6h5 a7f7 h5h6 d6d5 h6h5 f7a7 h5h6 d5d4 h6h5 g7g8 h5h6 d4d5 e2b2" +
+			" d5d6 b2f2 a7a8 h6h7 d6d5 h7h6 d5e5 h6h7 e5d5 h7h6 d5e6 h6h5 g8g1 f2e2 e6f7 e2f2 f7g7 f2f8" +
+			$" {searchResult.BestMove.UCIString()} {searchResult.Moves[1].UCIString()}");
+
+		searchResult = engine.BestMove(new($"go depth {Engine.DefaultMaxDepth}"));
+
+		Assert.NotZero(searchResult.BestMove);
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("position fen r1bq1rk1/pp1nppbp/2p2np1/8/2QPP3/2N2N2/PP2BPPP/R1B1K2R w KQ - 0 1" +
+	" moves c1f4 d7b6 c4b4 c8e6 e1g1 a7a5 b4c5 b6d7 c5a3 d8b6 e4e5 f6d5 c3d5 e6d5 f1d1 a8d8 f4d2 d8a8" +
+	" a3e7 f8d8 d2c3 a5a4 d1d2 g7h6 d2c2 h6g7 c2c1 c6c5 c1d1 a8c8 e7d6 d5c6 d4c5 d7c5 d6e7 d8e8 e7h4" +
+	" c6f3 e2f3 g7e5 c3e5 e8e5 h4d4 b6f6 d4b4 g8g7 d1d2 c8e8 a1f1 b7b6 d2d1 h7h6 b4c4 e5e7 b2b4 a4b3" +
+	" a2b3 c5e4 b3b4 e4c3 d1d3 c3e4 b4b5 f6b2 c4d4 b2d4 d3d4 e7e5 f3e4 e5e4 d4e4 e8e4 f1b1 g7f6 f2f3" +
+	" e4e5 g1f2 h6h5 b1b4 f6f5 h2h4 e5d5 f2e3 d5e5 e3f2 f7f6 g2g4 f5e6 f3f4 e5c5 f4f5 e6f7 f5g6 f7g6" +
+	" g4h5 g6h5 f2e3 f6f5 e3d3 c5d5 d3e3 h5g6 b4b2 g6f6 b2b4 f6e5 e3e2 f5f4 h4h5 e5f5 h5h6 d5d6 b4c4" +
+	" d6h6 c4c6 h6c6 b5c6 f5e6 e2d3 b6b5 d3e4 b5b4 c6c7 e6d7 c7c8q d7c8 e4f4 b4b3 f4e4 b3b2 e4f3" +
+	" b2b1q f3f2 c8c7 f2e2 b1a2 e2d1 a2f2 d1c1 f2e2 c1b1 e2d3 b1a2 d3d2 a2b3 c7c6 b3c4 d2e3 c4b4 e3d3" +
+	" b4a4 d3e3", Description = "FEN 8/8/2k5/8/K7/4q3/8/8 w - - 0 1")]
+
+	[TestCase("position fen r2qk1nr/1ppb2bp/p1np1pp1/4p3/B2PP3/2P2N2/PP3PPP/RNBQR1K1 w kq - 0 1 moves c1e3" +
+	" b7b5 a4c2 g8h6 h2h3 e8g8 b1d2 h6f7 d1e2 e5d4 c3d4 d8e7 a1c1 a8e8 c2b3 e7d8 e2d3 c6e7 c1c2 d6d5" +
+	" c2c5 d7c6 e4d5 c6d5 a2a4 d5b3 d3b3 c7c6 b3d3 f7e5 d3c2 e5d7 c2b3 f8f7 c5c2 d7b6 a4b5 a6b5 e3f4" +
+	" e7d5 e1e8 d8e8 f4d6 e8d7 b3a3 b6c8 d6c5 d7b7 d2e4 f7d7 a3b3 g8h8 c2e2 d7d8 e4c3 c8b6 h3h4 f6f5" +
+	" f3e5 d5c3 b2c3 b6d5 c3c4 d5f4 e2a2 g7e5 d4e5 f4d3 a2d2 b7a6 c4b5 a6a1 b3d1 a1d1 d2d1 d8d5 e5e6" +
+	" h8g7 b5c6 d5c5 d1d3 g7f6 e6e7 f6e7 d3d7 e7e6 d7h7 c5c6 h7a7 e6e5 a7e7 e5f6 e7b7 c6c2 g2g3 c2a2" +
+	" g1g2 a2c2 g2f3 c2c4 f3e3 c4c3 e3f4 c3c4 f4f3 c4c3 f3e2 c3c2 e2e1 f6e6 e1f1 e6f6 f1g2 f6e6 b7a7" +
+	" e6f6 g2f3 c2b2 a7c7 b2a2 f3e3 a2a3 e3d4 a3a2 c7c6 f6g7 d4e3 a2a3 e3f4 a3a4 f4f3 g7f7 h4h5 g6h5" +
+	" c6h6 a4a2 h6h5 f7f6 f3e3 a2b2 h5h7 f6e6 e3f3 e6d5 h7e7 d5d6 e7e8 b2a2 f3e3 a2b2 f2f4 b2c2 e8e5" +
+	" c2c5 e5c5 d6c5 e3f3 c5d6 g3g4 f5g4 f3g4 d6c6 f4f5 c6d7 g4g5 d7e7 g5g6 e7f8 g6f6 f8e8 f6g7 e8d7" +
+	" f5f6 d7e6 f6f7 e6f5 f7f8q f5g5 f8c5 g5g4 g7f7 g4f4 c5b4 f4e3 b4c3 e3e4 c3b4 e4e3 f7f6 e3f3 b4d2" +
+	" f3g4 f6f7 g4f3 d2d3 f3f2 f7f8 f2g1 d3e3 g1g2 e3e2 g2g3 f8e7 g3h3 e7d7 h3h4 e2g2 h4h5 d7e6 h5h6 e6d7",
+	Description = "FEN 8/3K4/7k/8/8/8/6Q1/8 b - - 0 1")]
+	public void DepthOverflow(string positionCommand)
+	{
+		var engine = GetEngine();
+
+		engine.AdjustPosition(positionCommand);
+
+		var result = engine.BestMove(new("go wtime 3600000 btime 3600000"));
+		Assert.Less(result.DepthReached, Configuration.EngineSettings.MaxDepth);
+	}
+
+	[TestCase("4r3/5P1k/5K2/5N2/8/8/8/8 w - - 0 1", new[] { "f7e8b" },
+		Description = "Position by Alex Brunetti, https://www.talkchess.com/forum3/viewtopic.php?f=2&t=31150&start=28")]
+	public void BishopUnderpromotion(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString);
+	}
+
+	/// <summary>
+	/// Unfortunately or not, it doesn't crash IDDFS, so the test is mostly useless, but let's have it in place just in case
+	/// </summary>
+	[Test]
+	public void MaxDepthCrash()
+	{
+		var engine = GetEngine();
+
+		engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3");
+
+		engine.BestMove(new("go wtime 10000 btime 10000 winc 80 binc 80"));
+
+		engine.AdjustPosition("position startpos moves e2e4 c7c5 g1f3 g7g6 d2d4 f8g7 d4d5 d7d6 f1e2 c8g4 f3d2 g4e2 d1e2 g8f6 b1c3 f6d7 d2f3 d8b6 e1g1 b8a6 a2a4 a6c7 c3b5 c7b5 a4b5 h7h6 c2c4 e8g8 c1d2 a7a5 h2h3 g7b2 d2a5 a8a5 e2b2 f8a8 e4e5 a5a1 f1a1 a8a1 b2a1 d6e5 f3e5 d7e5 a1e5 b6d6 e5d6 e7d6 f2f4 f7f5 g1h2 g8f7 h2g3 f7f6 h3h4 g6g5 h4h5 f6g7 b5b6 g7f6 g3f3 g5g4 f3e3 f6f7 e3d2 f7e7 d2e2 e7f6 e2d3 f6g7 d3c2 g7f6 c2b3 f6f7 b3c3 f7f6 c3c2 f6e7 c2b2 e7f7 b2b1 f7f6 b1a1 f6e7 a1a2 e7f6 a2b1 f6e7 b1a1 e7f7 a1b2 f7f6 b2a2 f6e7 g2g3 e7f6 a2b2 f6e7 b2c3 e7f6 c3d3 f6f7 d3c3");
+
+		Assert.DoesNotThrow(() => engine.BestMove(new("go wtime 100000 btime 100000 winc 80 binc 80")));
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("8/8/4k3/3n1n2/5P2/8/3K4/8 b - - 0 12", null, new[] { "d5f4" },
+	Description = "NN vs P, where knights can't take the pawn")]
+	[TestCase("8/5R2/1n2RK2/8/8/7k/4r3/8 b - - 0 1", null, new[] { "e2e6" },
+	Description = "RR vs RB, where if the side with the bishop exchanges the rooks, they lose")]
+	public void PawnlessEndgames(string fen, string[]? allowedUCIMoveString, string[]? excludedUCIMoveString = null)
+	{
+		TestBestMove(fen, allowedUCIMoveString, excludedUCIMoveString, depth: 20);
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("8/5pk1/6n1/3N4/4Q3/6P1/1q3PK1/8 b - - 0 1", 25)]
+	[TestCase("8/p3k3/1b3p2/5Kp1/1p5p/1P2P2P/P3BP2/8 w - - 0 1", 20)]
+	[TestCase("6k1/4Np2/8/5PP1/2n3K1/8/8/8 b - - 0 1", 20)]
+	[TestCase("8/4Np1k/8/5PPK/2n5/8/8/8 b - - 0 1", 20)]
+	[TestCase("1R6/8/8/5p2/5k2/r7/5K2/8 w - - 0 1", 20)]
+	[TestCase("8/8/5k2/5p2/1R6/r7/6K1/8 w - - 0 1", 20)]
+	[TestCase("8/8/5n2/7k/7p/5P2/6P1/4BK2 w - - 0 1", 20)]
+	[TestCase("3B4/8/8/7k/7p/5P2/4n1PK/8 w - - 0 1", 20)]
+	public void PVTableOverflow(string fen, int depth)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition($"position fen {fen}");
+
+		var result = engine.BestMove(new($"go depth {depth}"));
+
+		Assert.AreEqual(depth, result.Depth);
+	}
+
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("8/1p1k3b/p1n1pp2/P1B4p/BPP2p2/5P2/3K2PP/8 b - c3 1 1", 30)]
+	public void NegativeDepth(string fen, int depth)
+	{
+		var engine = GetEngine();
+		engine.AdjustPosition($"position fen {fen}");
+
+		Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+	}
+
+	[Test]
+	public void HighSeldepthAtDepth2()
+	{
+		var engine = GetEngine();
+
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+		Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+		// It used to happen at the second repetition, info depth 2 seldepth 127
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+		Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+		Assert.Less(result.DepthReached, 4 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+	}
+
+	[Test]
+	public void HighSeldepthAtDepth2_FixedDepth()
+	{
+		var engine = GetEngine();
+
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		var result = engine.BestMove(new("go wtime 6000 btime 6000 winc 3000 binc 3000"));
+		Assert.Less(result.DepthReached, 5 * result.Depth, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+		// It used to happen at the second repetition, info depth 2 seldepth 127
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		result = engine.BestMove(new("go depth 3"));
+		Assert.Less(result.DepthReached, 32, $"depth {result.Depth}, seldepth {result.DepthReached}");
+
+		engine.AdjustPosition("position fen 8/4kpN1/8/4p1PK/1b2P3/5P2/8/8 b - - 60 109");
+		result = engine.BestMove(new("go depth 3"));
+		Assert.Less(result.DepthReached, 32, $"depth {result.Depth}, seldepth {result.DepthReached}");
+	}
 
 #pragma warning disable S4144 // Methods should not have identical implementations
 
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNNK1B1 w - - 0 1", 50)]  // 216 legal moves
-    [TestCase("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1", 50)]  // 218 legal moves
-    [TestCase("QQQQQQBk/Q6B/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1", 50)]   // 265 pseudolegal moves at the time of writing this
-    [TestCase("kBQQQQQQ/BR5Q/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1", 50)]  // 270 pseudolegal and legal moves at the time of writing this
-    public void PositionWithMoreThan256PseudolegalMoves(string fen, int depth)
-    {
-        var engine = GetEngine();
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNNK1B1 w - - 0 1", 50)]  // 216 legal moves
+	[TestCase("R6R/3Q4/1Q4Q1/4Q3/2Q4Q/Q4Q2/pp1Q4/kBNN1KB1 w - - 0 1", 50)]  // 218 legal moves
+	[TestCase("QQQQQQBk/Q6B/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1", 50)]   // 265 pseudolegal moves at the time of writing this
+	[TestCase("kBQQQQQQ/BR5Q/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1", 50)]  // 270 pseudolegal and legal moves at the time of writing this
+	public void PositionWithMoreThan256PseudolegalMoves(string fen, int depth)
+	{
+		var engine = GetEngine();
 
-        engine.AdjustPosition($"position fen {fen}");
-        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
-    }
+		engine.AdjustPosition($"position fen {fen}");
+		Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+	}
 
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("qqqqkqqq/1p1p1p1p/pPpPpPpP/P1P1P1P1/8/P6P/PP2K1PP/QQRQ1RQQ b - - 4 1", 20)]
-    [TestCase("qqqq2kq/1p1p1p1p/pPpPpPpQ/P1P5/8/P6P/PP2KQPP/3R1R1Q b - - 1 1", 20)]
-    [TestCase("8/1p1k1p1p/pPpP1P1P/P1P1P1PP/1P4P1/P1QQ1Q1P/PR2K3/8 b - - 1 1", 20)]
-    [TestCase("8/1p1k1p1p/pPpP1P1P/P1P1P1P1/1P5P/PR1Q1QP1/P3K2P/2Q5 b - - 1 1", 20)]
-    [TestCase("4k3/1p3p1Q/pPpP1P1P/P1P1P1PP/1P4P1/P1QQ3P/PR2K3/8 b - - 1 1", 20)]
-    [TestCase("2k5/1p3QPP/pPpPPPP1/P1P2Q1P/1P5P/P1Q5/PR2K3/8 b - - 1 1", 20)]
-    [TestCase("3k4/1p3p1p/pPpP1P1P/P1P1P1PP/1P4P1/P2Q1Q1P/PRQ1K3/8 b - - 0 1", 20)]
-    [TestCase("k7/1p1p1p1p/pPpPpPpP/P1P1PRP1/1P5P/P2Q2P1/PR2KQ1P/Q1Q4Q b - - 1 1", 20)]
-    [TestCase("rnbqkbnr/pppppppp/pPpPpPpP/PpPpPpPp/pPpPpPpP/PpPpPpPp/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 20)]
-    [TestCase("1k6/3Q4/1p1p1p1p/pPpPpPpP/P1P1P1P1/8/PPPPPPPP/RRRRKRRR w - - 0 1", 20)]
-    public void PositionWithMoreThan8Pawns(string fen, int depth)
-    {
-        var engine = GetEngine();
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("qqqqkqqq/1p1p1p1p/pPpPpPpP/P1P1P1P1/8/P6P/PP2K1PP/QQRQ1RQQ b - - 4 1", 20)]
+	[TestCase("qqqq2kq/1p1p1p1p/pPpPpPpQ/P1P5/8/P6P/PP2KQPP/3R1R1Q b - - 1 1", 20)]
+	[TestCase("8/1p1k1p1p/pPpP1P1P/P1P1P1PP/1P4P1/P1QQ1Q1P/PR2K3/8 b - - 1 1", 20)]
+	[TestCase("8/1p1k1p1p/pPpP1P1P/P1P1P1P1/1P5P/PR1Q1QP1/P3K2P/2Q5 b - - 1 1", 20)]
+	[TestCase("4k3/1p3p1Q/pPpP1P1P/P1P1P1PP/1P4P1/P1QQ3P/PR2K3/8 b - - 1 1", 20)]
+	[TestCase("2k5/1p3QPP/pPpPPPP1/P1P2Q1P/1P5P/P1Q5/PR2K3/8 b - - 1 1", 20)]
+	[TestCase("3k4/1p3p1p/pPpP1P1P/P1P1P1PP/1P4P1/P2Q1Q1P/PRQ1K3/8 b - - 0 1", 20)]
+	[TestCase("k7/1p1p1p1p/pPpPpPpP/P1P1PRP1/1P5P/P2Q2P1/PR2KQ1P/Q1Q4Q b - - 1 1", 20)]
+	[TestCase("rnbqkbnr/pppppppp/pPpPpPpP/PpPpPpPp/pPpPpPpP/PpPpPpPp/PPPPPPPP/RNBQKBNR w KQkq - 0 1", 20)]
+	[TestCase("1k6/3Q4/1p1p1p1p/pPpPpPpP/P1P1P1P1/8/PPPPPPPP/RRRRKRRR w - - 0 1", 20)]
+	public void PositionWithMoreThan8Pawns(string fen, int depth)
+	{
+		var engine = GetEngine();
 
-        engine.AdjustPosition($"position fen {fen}");
-        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
-    }
+		engine.AdjustPosition($"position fen {fen}");
+		Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+	}
 
-    [Explicit]
-    [Category(Categories.LongRunning)]
-    [TestCase("NNNNNNNk/N6N/N2N3N/N1NNN2N/N2NNN1N/N3N2N/N6N/KNNNNNNN w - - 0 1", 20)]
-    [TestCase("BBBBBBBk/B5pB/B2B3B/B1BBB2B/B2BBB1B/B3B2B/B6B/KBBBBBBB w - - 0 1", 20)]
-    [TestCase("RRRRRRnk/R6n/R2R3R/R1RRR2R/R2RRR1R/R3R2R/R6R/KRRRRRRR w - - 0 1", 20)]
-    [TestCase("QQQQQQnk/Q5nn/Q2Q3Q/Q1QQQ2Q/Q2QQQ1Q/Q3Q2Q/Q6Q/KQQQQQQQ w - - 0 1", 20)]
-    public void PositionWithMoreThan10Pieces(string fen, int depth)
-    {
-        var engine = GetEngine();
+	[Explicit]
+	[Category(Categories.LongRunning)]
+	[TestCase("NNNNNNNk/N6N/N2N3N/N1NNN2N/N2NNN1N/N3N2N/N6N/KNNNNNNN w - - 0 1", 20)]
+	[TestCase("BBBBBBBk/B5pB/B2B3B/B1BBB2B/B2BBB1B/B3B2B/B6B/KBBBBBBB w - - 0 1", 20)]
+	[TestCase("RRRRRRnk/R6n/R2R3R/R1RRR2R/R2RRR1R/R3R2R/R6R/KRRRRRRR w - - 0 1", 20)]
+	[TestCase("QQQQQQnk/Q5nn/Q2Q3Q/Q1QQQ2Q/Q2QQQ1Q/Q3Q2Q/Q6Q/KQQQQQQQ w - - 0 1", 20)]
+	public void PositionWithMoreThan10Pieces(string fen, int depth)
+	{
+		var engine = GetEngine();
 
-        engine.AdjustPosition($"position fen {fen}");
-        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
-    }
+		engine.AdjustPosition($"position fen {fen}");
+		Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+	}
 
-    /// <summary>
-    /// They won't get understood as FRC, rather as empty castling rights.
-    /// Too slow in debug mode (~30s), but interested in any failing asserts,
-    /// so will have to live with that for now.
-    /// </summary>
-    [TestCase("rnkrbbqn/pppp1ppp/8/4p3/4P3/3P4/PPP2PPP/NNQRKRBB b KQkq - 0 1", 15)]
-    [TestCase("bnqbrnkr/p1p2pp1/1p6/4p3/4N2p/3P4/PPPB1PPP/RQ1K1RNB w kq e6 1 1", 17)]
-    public void XFENParsingWhenNoFRCEnabled(string fen, int depth)
-    {
-        var engine = GetEngine();
+	/// <summary>
+	/// They won't get understood as FRC, rather as empty castling rights.
+	/// Too slow in debug mode (~30s), but interested in any failing asserts,
+	/// so will have to live with that for now.
+	/// </summary>
+	[TestCase("rnkrbbqn/pppp1ppp/8/4p3/4P3/3P4/PPP2PPP/NNQRKRBB b KQkq - 0 1", 15)]
+	[TestCase("bnqbrnkr/p1p2pp1/1p6/4p3/4N2p/3P4/PPPB1PPP/RQ1K1RNB w kq e6 1 1", 17)]
+	public void XFENParsingWhenNoFRCEnabled(string fen, int depth)
+	{
+		var engine = GetEngine();
 
-        engine.AdjustPosition($"position fen {fen}");
+		engine.AdjustPosition($"position fen {fen}");
 
-        Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
-    }
+		Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
+	}
 
 #pragma warning restore S4144 // Methods should not have identical implementations
 }

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -45,7 +45,7 @@ public class EvaluationConstantsTest
     [Test]
     public void CheckmateDepthFactorTest()
     {
-        const int maxCheckmateValue = CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth ;
+        const int maxCheckmateValue = CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth;
         Assert.Less(maxCheckmateValue, MaxEval);
         Assert.Greater(maxCheckmateValue, MinEval);
 

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -187,11 +187,9 @@ public class GameTest : BaseTest
 
         // If the checkmate is in the move when it's claimed, checkmate remains
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition(evaluationContext));
     }
 
     [Test]
@@ -219,11 +217,9 @@ public class GameTest : BaseTest
 #endif
         Assert.AreEqual(100 + 1, game.PositionHashHistoryLength());
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        Assert.True(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.True(game.Is50MovesRepetition(evaluationContext));
     }
 
     [Test]
@@ -255,10 +251,8 @@ public class GameTest : BaseTest
 #endif
         Assert.AreEqual(51 + 1, game.PositionHashHistoryLength());
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition(evaluationContext));
     }
 }

--- a/tests/Lynx.Test/IncrementalEvalTest.cs
+++ b/tests/Lynx.Test/IncrementalEvalTest.cs
@@ -23,11 +23,9 @@ public class IncrementalEvalTest
             Span<Move> moveSpan = stackalloc Move[2];
             var index = 0;
 
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+            using var evaluationContext = new EvaluationContext();
 
-            MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, ref evaluationContext);
+            MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, evaluationContext);
 
             foreach (var move in moveSpan[..index])
             {

--- a/tests/Lynx.Test/Model/MoveScoreTest.cs
+++ b/tests/Lynx.Test/Model/MoveScoreTest.cs
@@ -5,81 +5,74 @@ namespace Lynx.Test.Model;
 
 public class MoveScoreTest : BaseTest
 {
-    /// <summary>
-    /// 'Tricky position'
-    /// 8   r . . . k . . r
-    /// 7   p . p p q p b .
-    /// 6   b n . . p n p .
-    /// 5   . . . P N . . .
-    /// 4   . p . . P . . .
-    /// 3   . . N . . Q . p
-    /// 2   P P P B B P P P
-    /// 1   R . . . K . . R
-    ///     a b c d e f g h
-    /// This tests indirectly <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
-    /// </summary>
-    [TestCase(Constants.TrickyTestPositionFEN)]
-    public void MoveScore(string fen)
-    {
-        var engine = GetEngine(fen);
+	/// <summary>
+	/// 'Tricky position'
+	/// 8   r . . . k . . r
+	/// 7   p . p p q p b .
+	/// 6   b n . . p n p .
+	/// 5   . . . P N . . .
+	/// 4   . p . . P . . .
+	/// 3   . . N . . Q . p
+	/// 2   P P P B B P P P
+	/// 1   R . . . K . . R
+	///     a b c d e f g h
+	/// This tests indirectly <see cref="EvaluationConstants.MostValueableVictimLeastValuableAttacker"/>
+	/// </summary>
+	[TestCase(Constants.TrickyTestPositionFEN)]
+	public void MoveScore(string fen)
+	{
+		var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move =>
-        {
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-            return engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext);
-        }).ToList();
+		var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move =>
+		{
+			using var evaluationContext = new EvaluationContext();
+			return engine.ScoreMove(engine.Game.CurrentPosition, move, default, evaluationContext);
+		}).ToList();
 
-        Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
-        Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
-        Assert.AreEqual("g2h3", allMoves[2].UCIString());     // PxP
-        Assert.AreEqual("f3f6", allMoves[3].UCIString());     // QxN
-        Assert.AreEqual("e5d7", allMoves[4].UCIString());     // NxP
-        Assert.AreEqual("e5f7", allMoves[5].UCIString());     // NxP
-        Assert.AreEqual("e5g6", allMoves[6].UCIString());     // NxP
-        Assert.AreEqual("f3h3", allMoves[7].UCIString());     // QxP
+		Assert.AreEqual("e2a6", allMoves[0].UCIString());     // BxB
+		Assert.AreEqual("d5e6", allMoves[1].UCIString());     // PxP
+		Assert.AreEqual("g2h3", allMoves[2].UCIString());     // PxP
+		Assert.AreEqual("f3f6", allMoves[3].UCIString());     // QxN
+		Assert.AreEqual("e5d7", allMoves[4].UCIString());     // NxP
+		Assert.AreEqual("e5f7", allMoves[5].UCIString());     // NxP
+		Assert.AreEqual("e5g6", allMoves[6].UCIString());     // NxP
+		Assert.AreEqual("f3h3", allMoves[7].UCIString());     // QxP
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		using var evaluationContext = new EvaluationContext();
 
-        foreach (var move in allMoves.Where(move => move.CapturedPiece() == (int)Piece.None && !move.IsCastle()))
-        {
-            Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext));
-        }
-    }
+		foreach (var move in allMoves.Where(move => move.CapturedPiece() == (int)Piece.None && !move.IsCastle()))
+		{
+			Assert.AreEqual(EvaluationConstants.BaseMoveScore, engine.ScoreMove(engine.Game.CurrentPosition, move, default, evaluationContext));
+		}
+	}
 
-    /// <summary>
-    /// Only one capture, en passant, both sides
-    /// 8   r n b q k b n r
-    /// 7   p p p . p p p p
-    /// 6   . . . . . . . .
-    /// 5   . . . p P . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P P P . P P P
-    /// 1   R N B Q K B N R
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1", "e5d6")]
-    [TestCase("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", "d4e3")]
-    public void MoveScoreEnPassant(string fen, string moveWithHighestScore)
-    {
-        var engine = GetEngine(fen);
+	/// <summary>
+	/// Only one capture, en passant, both sides
+	/// 8   r n b q k b n r
+	/// 7   p p p . p p p p
+	/// 6   . . . . . . . .
+	/// 5   . . . p P . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P P P . P P P
+	/// 1   R N B Q K B N R
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("rnbqkbnr/ppp1pppp/8/3pP3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6 0 1", "e5d6")]
+	[TestCase("rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1", "d4e3")]
+	public void MoveScoreEnPassant(string fen, string moveWithHighestScore)
+	{
+		var engine = GetEngine(fen);
 
-        var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move =>
-        {
-            Span<BitBoard> attacks = stackalloc BitBoard[12];
-            Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-            var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-            return engine.ScoreMove(engine.Game.CurrentPosition, move, default, ref evaluationContext);
-        }).ToList();
+		var allMoves = MoveGenerator.GenerateAllMoves(engine.Game.CurrentPosition).OrderByDescending(move =>
+		{
+			using var evaluationContext = new EvaluationContext();
+			return engine.ScoreMove(engine.Game.CurrentPosition, move, default, evaluationContext);
+		}).ToList();
 
-        Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0][6], engine.ScoreMove(engine.Game.CurrentPosition, allMoves[0], default, ref evaluationContext));
-    }
+		Assert.AreEqual(moveWithHighestScore, allMoves[0].UCIString());
+
+		using var evaluationContext = new EvaluationContext();
+		Assert.AreEqual(EvaluationConstants.GoodCaptureMoveBaseScoreValue + EvaluationConstants.MostValueableVictimLeastValuableAttacker[0][6], engine.ScoreMove(engine.Game.CurrentPosition, allMoves[0], default, evaluationContext));
+	}
 }

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -94,11 +94,9 @@ public class MoveToEPDStringTest
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray();
+        var pseudoLegalMoves = MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray();
 
         var ambiguousMoves = pseudoLegalMoves
             .Where(m => m.Piece() == (int)piece && m.TargetSquare() == (int)targetSquare)

--- a/tests/Lynx.Test/Model/PositionTest.cs
+++ b/tests/Lynx.Test/Model/PositionTest.cs
@@ -9,1081 +9,1077 @@ namespace Lynx.Test.Model;
 
 public class PositionTest
 {
-    [TestCase(Constants.InitialPositionFEN)]
-    [TestCase(Constants.TrickyTestPositionFEN)]
-    [TestCase(Constants.TrickyTestPositionReversedFEN)]
-    [TestCase(Constants.KillerTestPositionFEN)]
-    [TestCase("r2q1rk1/ppp2ppp/2n1bn2/2b1p3/3pP3/3P1NPP/PPP1NPB1/R1BQ1RK1 b - - 0 1")]
-    public void FEN(string fen)
-    {
-        var position = new Position(fen);
-        Assert.AreEqual(fen, position.FEN());
+	[TestCase(Constants.InitialPositionFEN)]
+	[TestCase(Constants.TrickyTestPositionFEN)]
+	[TestCase(Constants.TrickyTestPositionReversedFEN)]
+	[TestCase(Constants.KillerTestPositionFEN)]
+	[TestCase("r2q1rk1/ppp2ppp/2n1bn2/2b1p3/3pP3/3P1NPP/PPP1NPB1/R1BQ1RK1 b - - 0 1")]
+	public void FEN(string fen)
+	{
+		var position = new Position(fen);
+		Assert.AreEqual(fen, position.FEN());
 
-        var newPosition = new Position(position);
-        Assert.AreEqual(fen, newPosition.FEN());
-    }
+		var newPosition = new Position(position);
+		Assert.AreEqual(fen, newPosition.FEN());
+	}
 
-    [TestCase(Constants.InitialPositionFEN)]
-    [TestCase(Constants.TrickyTestPositionFEN)]
-    [TestCase(Constants.TrickyTestPositionReversedFEN)]
-    [TestCase(Constants.KillerTestPositionFEN)]
-    [TestCase(Constants.CmkTestPositionFEN)]
-    public void CloneConstructor(string fen)
-    {
-        // Arrange
-        var position = new Position(fen);
+	[TestCase(Constants.InitialPositionFEN)]
+	[TestCase(Constants.TrickyTestPositionFEN)]
+	[TestCase(Constants.TrickyTestPositionReversedFEN)]
+	[TestCase(Constants.KillerTestPositionFEN)]
+	[TestCase(Constants.CmkTestPositionFEN)]
+	public void CloneConstructor(string fen)
+	{
+		// Arrange
+		var position = new Position(fen);
 
-        // Act
-        var clonedPosition = new Position(position);
+		// Act
+		var clonedPosition = new Position(position);
 
-        // Assert
-        Assert.AreEqual(position.FEN(), clonedPosition.FEN());
-        Assert.AreEqual(position.UniqueIdentifier, clonedPosition.UniqueIdentifier);
-        Assert.AreEqual(position.Side, clonedPosition.Side);
-        Assert.AreEqual(position.Castle, clonedPosition.Castle);
-        Assert.AreEqual(position.EnPassant, clonedPosition.EnPassant);
+		// Assert
+		Assert.AreEqual(position.FEN(), clonedPosition.FEN());
+		Assert.AreEqual(position.UniqueIdentifier, clonedPosition.UniqueIdentifier);
+		Assert.AreEqual(position.Side, clonedPosition.Side);
+		Assert.AreEqual(position.Castle, clonedPosition.Castle);
+		Assert.AreEqual(position.EnPassant, clonedPosition.EnPassant);
 
-        for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
-        {
-            Assert.AreEqual(position.PieceBitBoards[piece], clonedPosition.PieceBitBoards[piece]);
-        }
+		for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
+		{
+			Assert.AreEqual(position.PieceBitBoards[piece], clonedPosition.PieceBitBoards[piece]);
+		}
 
-        for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
-        {
-            Assert.AreEqual(position.OccupancyBitBoards[occupancy], clonedPosition.OccupancyBitBoards[occupancy]);
-        }
+		for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
+		{
+			Assert.AreEqual(position.OccupancyBitBoards[occupancy], clonedPosition.OccupancyBitBoards[occupancy]);
+		}
 
-        // Act: modify original, to ensure they're not sharing references to the same memory object
-        for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
-        {
-            position.PieceBitBoards[piece].ResetLS1B();
-            position.PieceBitBoards[piece].SetBit((int)BoardSquare.e5 + piece);
-        }
+		// Act: modify original, to ensure they're not sharing references to the same memory object
+		for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
+		{
+			position.PieceBitBoards[piece].ResetLS1B();
+			position.PieceBitBoards[piece].SetBit((int)BoardSquare.e5 + piece);
+		}
 
-        for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
-        {
-            position.OccupancyBitBoards[occupancy].ResetLS1B();
-            position.OccupancyBitBoards[occupancy].SetBit((int)BoardSquare.g7 + occupancy);
-        }
+		for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
+		{
+			position.OccupancyBitBoards[occupancy].ResetLS1B();
+			position.OccupancyBitBoards[occupancy].SetBit((int)BoardSquare.g7 + occupancy);
+		}
 
-        // Assert
-        for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
-        {
-            Assert.AreNotEqual(position.PieceBitBoards[piece], clonedPosition.PieceBitBoards[piece]);
-        }
+		// Assert
+		for (int piece = 0; piece < position.PieceBitBoards.Length; ++piece)
+		{
+			Assert.AreNotEqual(position.PieceBitBoards[piece], clonedPosition.PieceBitBoards[piece]);
+		}
 
-        for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
-        {
-            Assert.AreNotEqual(position.OccupancyBitBoards[occupancy], clonedPosition.OccupancyBitBoards[occupancy]);
-        }
-    }
+		for (int occupancy = 0; occupancy < position.OccupancyBitBoards.Length; ++occupancy)
+		{
+			Assert.AreNotEqual(position.OccupancyBitBoards[occupancy], clonedPosition.OccupancyBitBoards[occupancy]);
+		}
+	}
 
-    [TestCase(Constants.EmptyBoardFEN)]
-    [TestCase("K/8/8/8/8/8/8/8 w - - 0 1")]
-    [TestCase("K/8/8/8/8/8/8/8 b - - 0 1")]
-    [TestCase("k/8/8/8/8/8/8/8 w - - 0 1")]
-    [TestCase("k/8/8/8/8/8/8/8 b - - 0 1")]
-    public void MissingKings(string fen)
-    {
-        Assert.Throws<LynxException>(() => new Position(fen));
-    }
+	[TestCase(Constants.EmptyBoardFEN)]
+	[TestCase("K/8/8/8/8/8/8/8 w - - 0 1")]
+	[TestCase("K/8/8/8/8/8/8/8 b - - 0 1")]
+	[TestCase("k/8/8/8/8/8/8/8 w - - 0 1")]
+	[TestCase("k/8/8/8/8/8/8/8 b - - 0 1")]
+	public void MissingKings(string fen)
+	{
+		Assert.Throws<LynxException>(() => new Position(fen));
+	}
 
-    [Explicit]
-    [Category(Categories.LongRunning)]  // Can't run on debug due to position validation
-    [TestCase(Constants.InitialPositionFEN, true)]
-    [TestCase("r1k5/1K6/8/8/8/8/8/8 w - - 0 1", false)]
-    [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1", false)]
-    [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 1", true)]
-    [TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR b KQkq - 0 1", false)]
-    [TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR w KQkq - 0 1", true)]
-    [TestCase("r1k5/1K6/8/8/8/8/8/8 w - - 0 1", false)]
-    public void IsValid(string fen, bool shouldBeValid)
-    {
-        Assert.AreEqual(shouldBeValid, new Position(fen).IsValid());
-    }
+	[Explicit]
+	[Category(Categories.LongRunning)]  // Can't run on debug due to position validation
+	[TestCase(Constants.InitialPositionFEN, true)]
+	[TestCase("r1k5/1K6/8/8/8/8/8/8 w - - 0 1", false)]
+	[TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1", false)]
+	[TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 1", true)]
+	[TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR b KQkq - 0 1", false)]
+	[TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR w KQkq - 0 1", true)]
+	[TestCase("r1k5/1K6/8/8/8/8/8/8 w - - 0 1", false)]
+	public void IsValid(string fen, bool shouldBeValid)
+	{
+		Assert.AreEqual(shouldBeValid, new Position(fen).IsValid());
+	}
 
-    [Explicit]
-    [Category(Categories.LongRunning)]  // Can't run on debug due to position validation
-    [TestCase(Constants.EmptyBoardFEN, false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
-    [TestCase("K/8/8/8/8/8/8/8 w - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
-    [TestCase("K/8/8/8/8/8/8/8 b - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
-    [TestCase("k/8/8/8/8/8/8/8 w - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
-    [TestCase("k/8/8/8/8/8/8/8 b - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
-    [TestCase(Constants.InitialPositionFEN, true)]
-    [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1", false)]
-    [TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 1", true)]
-    [TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR b KQkq - 0 1", false)]
-    [TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR w KQkq - 0 1", true)]
-    public void WasProduceByAValidMove(string fen, bool shouldBeValid)
-    {
-        Assert.AreEqual(shouldBeValid, new Position(fen).WasProduceByAValidMove());
-    }
+	[Explicit]
+	[Category(Categories.LongRunning)]  // Can't run on debug due to position validation
+	[TestCase(Constants.EmptyBoardFEN, false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
+	[TestCase("K/8/8/8/8/8/8/8 w - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
+	[TestCase("K/8/8/8/8/8/8/8 b - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
+	[TestCase("k/8/8/8/8/8/8/8 w - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
+	[TestCase("k/8/8/8/8/8/8/8 b - - 0 1", false, Ignore = "WasProduceByAValidMove doesn't check the presence of both kings on the board")]
+	[TestCase(Constants.InitialPositionFEN, true)]
+	[TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR w KQkq - 0 1", false)]
+	[TestCase("r1bqkbnr/pppp2pp/2n2p2/4p2Q/2B1P3/8/PPPP1PPP/RNB1K1NR b KQkq - 0 1", true)]
+	[TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR b KQkq - 0 1", false)]
+	[TestCase("r1bqk1nr/pppp2pp/2n2p2/4p3/1bB1P3/3P4/PPP2PPP/RNBQK1NR w KQkq - 0 1", true)]
+	public void WasProduceByAValidMove(string fen, bool shouldBeValid)
+	{
+		Assert.AreEqual(shouldBeValid, new Position(fen).WasProduceByAValidMove());
+	}
 
-    [Explicit]
-    [Category(Categories.LongRunning)]  // Can't run on debug due to position validation
-    [TestCase("rnbqkbnr/ppp1pppp/3p4/1B6/8/4P3/PPPP1PPP/RNBQK1NR b KQkq - 1 2", true)]
-    [TestCase("rnbqkbnr/ppp1pppp/3p4/1B6/8/4P3/PPPP1PPP/RNBQK1NR w KQkq - 1 2", false)]
-    [TestCase("rnbqk1nr/pppp1ppp/4p3/8/1b6/3P1N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3", true)]
-    [TestCase("rnbqk1nr/pppp1ppp/4p3/8/1b6/3P1N2/PPP1PPPP/RNBQKB1R b KQkq - 2 3", false)]
+	[Explicit]
+	[Category(Categories.LongRunning)]  // Can't run on debug due to position validation
+	[TestCase("rnbqkbnr/ppp1pppp/3p4/1B6/8/4P3/PPPP1PPP/RNBQK1NR b KQkq - 1 2", true)]
+	[TestCase("rnbqkbnr/ppp1pppp/3p4/1B6/8/4P3/PPPP1PPP/RNBQK1NR w KQkq - 1 2", false)]
+	[TestCase("rnbqk1nr/pppp1ppp/4p3/8/1b6/3P1N2/PPP1PPPP/RNBQKB1R w KQkq - 2 3", true)]
+	[TestCase("rnbqk1nr/pppp1ppp/4p3/8/1b6/3P1N2/PPP1PPPP/RNBQKB1R b KQkq - 2 3", false)]
 
-    [TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR w KQkq - 1 3", true)]
-    [TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR b KQkq - 1 3", false)]
-    [TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR w KQkq - 1 3", true)]
-    [TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR b KQkq - 1 3", false)]
-    public void IsInCheck(string fen, bool positionInCheck)
-    {
-        var position = new Position(fen);
+	[TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR w KQkq - 1 3", true)]
+	[TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR b KQkq - 1 3", false)]
+	[TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR w KQkq - 1 3", true)]
+	[TestCase("rnb1k1nr/pppp1ppp/4p3/8/1b6/3P3P/PPP1PPP1/RNB1KBNR b KQkq - 1 3", false)]
+	public void IsInCheck(string fen, bool positionInCheck)
+	{
+		var position = new Position(fen);
 
-        Assert.AreEqual(positionInCheck, position.IsInCheck());
-    }
+		Assert.AreEqual(positionInCheck, position.IsInCheck());
+	}
 
-    [TestCase("7k/8/8/8/8/3B4/1K6/6Q1 b - - 0 1", 0)]
-    [TestCase("7K/8/8/8/8/3b4/1k6/6q1 w - - 0 1", 0)]
-    [TestCase("8/5K2/7p/6pk/6p1/6P1/7P/8 b - - 0 1", 0)]
-    [TestCase("8/7p/6p1/6P1/6PK/5k1P/8/8 w - - 0 1", 0)]
-    [TestCase("7k/8/8/8/8/8/1K5R/6R1 b - - 0 1", -CheckMateBaseEvaluation)]
-    [TestCase("7K/8/8/8/8/8/1k5r/6r1 w - - 0 1", -CheckMateBaseEvaluation)]
-    public void EvaluateFinalPosition(string fen, int expectedEvaluationValue)
-    {
-        // Arrange
-        var position = new Position(fen);
-        Assert.IsEmpty(MoveGenerator.GenerateAllMoves(position).Where(move =>
-        {
-            var newPosition = new Position(position);
-            newPosition.MakeMove(move);
-            return newPosition.IsValid();
-        }));
-        var isInCheck = position.IsInCheck();
+	[TestCase("7k/8/8/8/8/3B4/1K6/6Q1 b - - 0 1", 0)]
+	[TestCase("7K/8/8/8/8/3b4/1k6/6q1 w - - 0 1", 0)]
+	[TestCase("8/5K2/7p/6pk/6p1/6P1/7P/8 b - - 0 1", 0)]
+	[TestCase("8/7p/6p1/6P1/6PK/5k1P/8/8 w - - 0 1", 0)]
+	[TestCase("7k/8/8/8/8/8/1K5R/6R1 b - - 0 1", -CheckMateBaseEvaluation)]
+	[TestCase("7K/8/8/8/8/8/1k5r/6r1 w - - 0 1", -CheckMateBaseEvaluation)]
+	public void EvaluateFinalPosition(string fen, int expectedEvaluationValue)
+	{
+		// Arrange
+		var position = new Position(fen);
+		Assert.IsEmpty(MoveGenerator.GenerateAllMoves(position).Where(move =>
+		{
+			var newPosition = new Position(position);
+			newPosition.MakeMove(move);
+			return newPosition.IsValid();
+		}));
+		var isInCheck = position.IsInCheck();
 
-        // Act
-        var noDepthResult = Position.EvaluateFinalPosition(default, isInCheck);
-        var depthOneResult = Position.EvaluateFinalPosition(1, isInCheck);
-        var depthTwoResult = Position.EvaluateFinalPosition(2, isInCheck);
+		// Act
+		var noDepthResult = Position.EvaluateFinalPosition(default, isInCheck);
+		var depthOneResult = Position.EvaluateFinalPosition(1, isInCheck);
+		var depthTwoResult = Position.EvaluateFinalPosition(2, isInCheck);
 
-        if (expectedEvaluationValue < 0)
-        {
-            Assert.AreEqual(expectedEvaluationValue, noDepthResult);
+		if (expectedEvaluationValue < 0)
+		{
+			Assert.AreEqual(expectedEvaluationValue, noDepthResult);
 
-            Assert.True(noDepthResult < depthOneResult);
-            Assert.True(depthOneResult < depthTwoResult);
-        }
-    }
+			Assert.True(noDepthResult < depthOneResult);
+			Assert.True(depthOneResult < depthTwoResult);
+		}
+	}
 
-    [TestCase("8/k7/8/3B4/8/8/8/7K w - - 0 1", Description = "B")]
-    [TestCase("8/k7/8/3b4/8/8/8/7K w - - 0 1", Description = "b")]
-    [TestCase("k7/8/8/3N4/8/8/8/7K w - - 0 1", Description = "N")]
-    [TestCase("k7/8/8/3N4/8/8/8/7K w - - 0 1", Description = "n")]
-    [TestCase("k7/8/8/2NN4/8/8/8/7K w - - 0 1", Description = "N+N")]
-    [TestCase("k7/8/8/2nn4/8/8/8/7K w - - 0 1", Description = "n+n")]
-    [TestCase("k7/8/8/3B4/8/8/8/6K1 b - - 0 1", Description = "B")]
-    [TestCase("k7/8/8/3b4/8/8/8/6K1 b - - 0 1", Description = "b")]
-    [TestCase("k7/8/8/3N4/8/8/8/7K b - - 0 1", Description = "N")]
-    [TestCase("k7/8/8/3N4/8/8/8/7K b - - 0 1", Description = "n")]
-    [TestCase("k7/8/8/2NN4/8/8/8/7K b - - 0 1", Description = "N+N")]
-    [TestCase("k7/8/8/2nn4/8/8/8/7K b - - 0 1", Description = "n+n")]
-    public void StaticEvaluation_DrawDueToLackOfMaterial(string fen)
-    {
-        var position = new Position(fen);
+	[TestCase("8/k7/8/3B4/8/8/8/7K w - - 0 1", Description = "B")]
+	[TestCase("8/k7/8/3b4/8/8/8/7K w - - 0 1", Description = "b")]
+	[TestCase("k7/8/8/3N4/8/8/8/7K w - - 0 1", Description = "N")]
+	[TestCase("k7/8/8/3N4/8/8/8/7K w - - 0 1", Description = "n")]
+	[TestCase("k7/8/8/2NN4/8/8/8/7K w - - 0 1", Description = "N+N")]
+	[TestCase("k7/8/8/2nn4/8/8/8/7K w - - 0 1", Description = "n+n")]
+	[TestCase("k7/8/8/3B4/8/8/8/6K1 b - - 0 1", Description = "B")]
+	[TestCase("k7/8/8/3b4/8/8/8/6K1 b - - 0 1", Description = "b")]
+	[TestCase("k7/8/8/3N4/8/8/8/7K b - - 0 1", Description = "N")]
+	[TestCase("k7/8/8/3N4/8/8/8/7K b - - 0 1", Description = "n")]
+	[TestCase("k7/8/8/2NN4/8/8/8/7K b - - 0 1", Description = "N+N")]
+	[TestCase("k7/8/8/2nn4/8/8/8/7K b - - 0 1", Description = "n+n")]
+	public void StaticEvaluation_DrawDueToLackOfMaterial(string fen)
+	{
+		var position = new Position(fen);
 
-        Assert.AreEqual(0, position.StaticEvaluation().Score);
-    }
+		Assert.AreEqual(0, position.StaticEvaluation().Score);
+	}
 
-    [TestCase("4k3/8/8/7Q/7q/8/4K3/8 w - - 0 1", "4k3/8/8/7Q/7q/8/8/4K3 w - - 0 1", Description = "King in 7th rank with queens > King in 8th rank with queens", IgnoreReason = "Can't understand PSQT any more")]
-    [TestCase("4k3/p7/8/8/8/8/P3K3/8 w - - 0 1", "4k3/p7/8/8/8/8/P7/4K3 w - - 0 1", Description = "King in 7th rank without queens > King in 8th rank without queens", IgnoreReason = "Can't understand PSQT any more")]
-    [TestCase("4k3/7p/8/8/4K3/8/7P/8 w - - 0 1", "4k3/7p/8/q7/4K3/Q7/7P/8 w - - 0 1", Description = "King in the center without queens > King in the center with queens", IgnoreReason = "Can't understand PSQT any more")]
-    public void StaticEvaluation_KingEndgame(string fen1, string fen2)
-    {
-        Assert.Greater(new Position(fen1).StaticEvaluation().Score, new Position(fen2).StaticEvaluation().Score);
-    }
+	[TestCase("4k3/8/8/7Q/7q/8/4K3/8 w - - 0 1", "4k3/8/8/7Q/7q/8/8/4K3 w - - 0 1", Description = "King in 7th rank with queens > King in 8th rank with queens", IgnoreReason = "Can't understand PSQT any more")]
+	[TestCase("4k3/p7/8/8/8/8/P3K3/8 w - - 0 1", "4k3/p7/8/8/8/8/P7/4K3 w - - 0 1", Description = "King in 7th rank without queens > King in 8th rank without queens", IgnoreReason = "Can't understand PSQT any more")]
+	[TestCase("4k3/7p/8/8/4K3/8/7P/8 w - - 0 1", "4k3/7p/8/q7/4K3/Q7/7P/8 w - - 0 1", Description = "King in the center without queens > King in the center with queens", IgnoreReason = "Can't understand PSQT any more")]
+	public void StaticEvaluation_KingEndgame(string fen1, string fen2)
+	{
+		Assert.Greater(new Position(fen1).StaticEvaluation().Score, new Position(fen2).StaticEvaluation().Score);
+	}
 
-    /// <summary>
-    /// 8   . . . . k . . .
-    /// 7   . p p p . . . .
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . P . . . .
-    /// 1   . . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("7k/1ppp2pp/8/8/8/8/PP1P2PP/7K w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("3k4/3p2pp/8/8/8/8/4PPP1/3K4 b - - 0 1")]
-    public void StaticEvaluation_IsolatedPawnPenalty(string fen)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-            - AdditionalPieceEvaluation(position, Piece.p);
+	/// <summary>
+	/// 8   . . . . k . . .
+	/// 7   . p p p . . . .
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . P . . . .
+	/// 1   . . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("7k/1ppp2pp/8/8/8/8/PP1P2PP/7K w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("3k4/3p2pp/8/8/8/8/4PPP1/3K4 b - - 0 1")]
+	public void StaticEvaluation_IsolatedPawnPenalty(string fen)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.P)
+			- AdditionalPieceEvaluation(position, Piece.p);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        var expectedEval = UnpackMG(IsolatedPawnPenalty[Constants.File[(int)BoardSquare.d3]]) - UnpackMG(PawnPhalanxBonus[1]);
+		var expectedEval = UnpackMG(IsolatedPawnPenalty[Constants.File[(int)BoardSquare.d3]]) - UnpackMG(PawnPhalanxBonus[1]);
 
-        Assert.AreEqual(expectedEval, evaluation);
-    }
+		Assert.AreEqual(expectedEval, evaluation);
+	}
 
-    /// <summary>
-    /// 8   . . . . k . . .
-    /// 7   p p p . . . . .
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   P . . . . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    //[TestCase("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1")]
-    ///// <summary>
-    ///// Previous one mirrored
-    ///// </summary>
-    ///// <param name="fen"></param>
-    //[TestCase("3k4/6pp/7p/8/8/8/5PPP/3K4 b - - 0 1")]
-    //public void StaticEvaluation_DoublePawnPenalty(string fen)
-    //{
-    //    Position position = new Position(fen);
-    //    int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-    //        - AdditionalPieceEvaluation(position, Piece.p);
+	/// <summary>
+	/// 8   . . . . k . . .
+	/// 7   p p p . . . . .
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   P . . . . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	//[TestCase("4k3/ppp5/8/8/8/P7/PP6/4K3 w - - 0 1")]
+	///// <summary>
+	///// Previous one mirrored
+	///// </summary>
+	///// <param name="fen"></param>
+	//[TestCase("3k4/6pp/7p/8/8/8/5PPP/3K4 b - - 0 1")]
+	//public void StaticEvaluation_DoublePawnPenalty(string fen)
+	//{
+	//    Position position = new Position(fen);
+	//    int evaluation = AdditionalPieceEvaluation(position, Piece.P)
+	//        - AdditionalPieceEvaluation(position, Piece.p);
 
-    //    if (position.Side == Side.Black)
-    //    {
-    //        evaluation = -evaluation;
-    //    }
+	//    if (position.Side == Side.Black)
+	//    {
+	//        evaluation = -evaluation;
+	//    }
 
-    //    Assert.AreEqual(4 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
-    //}
+	//    Assert.AreEqual(4 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
+	//}
 
-    /// <summary>
-    /// Illegal position, but avoids any positional bonuses
-    /// 8   . . . . k . . .
-    /// 7   p p p . . p p p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   P . . . . . . .
-    /// 2   P P . . . . P P
-    /// 1   P . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    //[TestCase("7k/ppp2ppp/8/8/8/P7/PP4PP/P6K w - - 0 1")]
-    ///// <summary>
-    ///// Previous one mirrored
-    ///// </summary>
-    ///// <param name="fen"></param>
-    //[TestCase("k6p/pp4pp/7p/8/8/8/PPP2PPP/K7 b - - 0 1")]
-    //public void StaticEvaluation_TriplePawnPenalty(string fen)
-    //{
-    //    Position position = new Position(fen);
-    //    int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-    //        - AdditionalPieceEvaluation(position, Piece.p);
+	/// <summary>
+	/// Illegal position, but avoids any positional bonuses
+	/// 8   . . . . k . . .
+	/// 7   p p p . . p p p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   P . . . . . . .
+	/// 2   P P . . . . P P
+	/// 1   P . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	//[TestCase("7k/ppp2ppp/8/8/8/P7/PP4PP/P6K w - - 0 1")]
+	///// <summary>
+	///// Previous one mirrored
+	///// </summary>
+	///// <param name="fen"></param>
+	//[TestCase("k6p/pp4pp/7p/8/8/8/PPP2PPP/K7 b - - 0 1")]
+	//public void StaticEvaluation_TriplePawnPenalty(string fen)
+	//{
+	//    Position position = new Position(fen);
+	//    int evaluation = AdditionalPieceEvaluation(position, Piece.P)
+	//        - AdditionalPieceEvaluation(position, Piece.p);
 
-    //    if (position.Side == Side.Black)
-    //    {
-    //        evaluation = -evaluation;
-    //    }
+	//    if (position.Side == Side.Black)
+	//    {
+	//        evaluation = -evaluation;
+	//    }
 
-    //    Assert.AreEqual(9 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
-    //}
+	//    Assert.AreEqual(9 * Configuration.EngineSettings.DoubledPawnPenalty.MG, evaluation);
+	//}
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . . . . . .
-    /// 6   p . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . P . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp6/p7/8/8/8/PP1P4/6K1 w - - 0 1", BoardSquare.d2)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/3p2pp/8/8/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d7)]
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . . . . . .
+	/// 6   p . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . P . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp6/p7/8/8/8/PP1P4/6K1 w - - 0 1", BoardSquare.d2)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/3p2pp/8/8/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d7)]
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . . . . . .
-    /// 6   p . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . P . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp6/p7/8/8/3P4/PP6/6K1 w - - 0 1", BoardSquare.d3)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/6pp/3p4/8/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d6)]
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . . . . . .
+	/// 6   p . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . P . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp6/p7/8/8/3P4/PP6/6K1 w - - 0 1", BoardSquare.d3)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/6pp/3p4/8/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d6)]
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . . . . . .
-    /// 6   p . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . P . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp6/p7/8/3P4/8/PP6/6K1 w - - 0 1", BoardSquare.d4)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/6pp/8/3p4/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d5)]
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . . . . . .
+	/// 6   p . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . P . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp6/p7/8/3P4/8/PP6/6K1 w - - 0 1", BoardSquare.d4)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/6pp/8/3p4/8/7P/6PP/1K6 b - - 0 1", BoardSquare.d5)]
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . . . . . .
-    /// 6   p . . . . . . .
-    /// 5   . . . P . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp6/p7/3P4/8/8/PP6/6K1 w - - 0 1", BoardSquare.d5)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/6pp/8/8/3p4/7P/6PP/1K6 b - - 0 1", BoardSquare.d4)]
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . . . . . .
+	/// 6   p . . . . . . .
+	/// 5   . . . P . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp6/p7/3P4/8/8/PP6/6K1 w - - 0 1", BoardSquare.d5)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/6pp/8/8/3p4/7P/6PP/1K6 b - - 0 1", BoardSquare.d4)]
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . . . . . .
-    /// 6   p . . P . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp6/p2P4/8/8/8/PP6/6K1 w - - 0 1", BoardSquare.d6)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/6pp/8/8/8/3p3P/6PP/1K6 b - - 0 1", BoardSquare.d3)]
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . . . . . .
+	/// 6   p . . P . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp6/p2P4/8/8/8/PP6/6K1 w - - 0 1", BoardSquare.d6)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/6pp/8/8/8/3p3P/6PP/1K6 b - - 0 1", BoardSquare.d3)]
 
-    /// <summary>
-    /// 8   . . . . . . k .
-    /// 7   p p . P . . . .
-    /// 6   p . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P . . . . . .
-    /// 1   . . . . . . K .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp1P4/p7/8/8/8/PP6/6K1 w - - 0 1", BoardSquare.d7)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("1k6/6pp/8/8/8/7P/3p2PP/1K6 b - - 0 1", BoardSquare.d2)]
-    public void StaticEvaluation_PassedPawnBonus(string fen, BoardSquare square)
-    {
-        var position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.P)
-            - AdditionalPieceEvaluation(position, Piece.p);
+	/// <summary>
+	/// 8   . . . . . . k .
+	/// 7   p p . P . . . .
+	/// 6   p . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P . . . . . .
+	/// 1   . . . . . . K .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp1P4/p7/8/8/8/PP6/6K1 w - - 0 1", BoardSquare.d7)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("1k6/6pp/8/8/8/7P/3p2PP/1K6 b - - 0 1", BoardSquare.d2)]
+	public void StaticEvaluation_PassedPawnBonus(string fen, BoardSquare square)
+	{
+		var position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.P)
+			- AdditionalPieceEvaluation(position, Piece.p);
 
-        var rank = Constants.Rank[(int)square];
-        var passedPawnsMask = Masks.WhitePassedPawnMasks[(int)square];
+		var rank = Constants.Rank[(int)square];
+		var passedPawnsMask = Masks.WhitePassedPawnMasks[(int)square];
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-            rank = 7 - rank;
-            passedPawnsMask = Masks.BlackPassedPawnMasks[(int)square];
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+			rank = 7 - rank;
+			passedPawnsMask = Masks.BlackPassedPawnMasks[(int)square];
+		}
 
-        var whiteKingDistance = Constants.ChebyshevDistance[(int)square][position.PieceBitBoards[(int)Piece.K].GetLS1BIndex()];
-        var blackKingDistance = Constants.ChebyshevDistance[(int)square][position.PieceBitBoards[(int)Piece.k].GetLS1BIndex()];
+		var whiteKingDistance = Constants.ChebyshevDistance[(int)square][position.PieceBitBoards[(int)Piece.K].GetLS1BIndex()];
+		var blackKingDistance = Constants.ChebyshevDistance[(int)square][position.PieceBitBoards[(int)Piece.k].GetLS1BIndex()];
 
-        var friendlyKingDistance = position.Side == Side.White
-            ? whiteKingDistance
-            : blackKingDistance;
+		var friendlyKingDistance = position.Side == Side.White
+			? whiteKingDistance
+			: blackKingDistance;
 
-        var enemyKingDistance = position.Side == Side.White
-            ? blackKingDistance
-            : whiteKingDistance;
+		var enemyKingDistance = position.Side == Side.White
+			? blackKingDistance
+			: whiteKingDistance;
 
-        var expectedEval = 0;
-        if ((passedPawnsMask & position.OccupancyBitBoards[OppositeSide(position.Side)]) == 0)
-        {
-            expectedEval += UnpackMG(PassedPawnBonusNoEnemiesAheadBonus[0][rank]);
-            expectedEval += UnpackMG(PassedPawnBonusNoEnemiesAheadEnemyBonus[0][rank]);
-        }
+		var expectedEval = 0;
+		if ((passedPawnsMask & position.OccupancyBitBoards[OppositeSide(position.Side)]) == 0)
+		{
+			expectedEval += UnpackMG(PassedPawnBonusNoEnemiesAheadBonus[0][rank]);
+			expectedEval += UnpackMG(PassedPawnBonusNoEnemiesAheadEnemyBonus[0][rank]);
+		}
 
-        Assert.AreEqual(
-            expectedEval
-            //(-4 * Configuration.EngineSettings.DoubledPawnPenalty.MG)
-            + UnpackMG(IsolatedPawnPenalty[Constants.File[(int)square]])
-            + UnpackMG(PassedPawnBonus[0][rank])
-            + UnpackMG(PassedPawnEnemyBonus[0][rank])
-            + UnpackMG(FriendlyKingDistanceToPassedPawnBonus[friendlyKingDistance])
-            + UnpackMG(EnemyKingDistanceToPassedPawnPenalty[enemyKingDistance]),
+		Assert.AreEqual(
+			expectedEval
+			//(-4 * Configuration.EngineSettings.DoubledPawnPenalty.MG)
+			+ UnpackMG(IsolatedPawnPenalty[Constants.File[(int)square]])
+			+ UnpackMG(PassedPawnBonus[0][rank])
+			+ UnpackMG(PassedPawnEnemyBonus[0][rank])
+			+ UnpackMG(FriendlyKingDistanceToPassedPawnBonus[friendlyKingDistance])
+			+ UnpackMG(EnemyKingDistanceToPassedPawnPenalty[enemyKingDistance]),
 
-            evaluation);
-    }
+			evaluation);
+	}
 
-    /// <summary>
-    /// 8   . . . . k . . r
-    /// 7   p . . . . . . p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   . . P . . . . P
-    /// 1   R . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("4k2r/p6p/8/8/8/8/2P4P/R3K3 w - - 0 1", 10, 3, 0)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("3k3r/p4p2/8/8/8/8/P6P/R2K4 b - - 0 1", 10, 3, 7)]
-    public void StaticEvaluation_SemiOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int semiopenFile)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+	/// <summary>
+	/// 8   . . . . k . . r
+	/// 7   p . . . . . . p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   . . P . . . . P
+	/// 1   R . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("4k2r/p6p/8/8/8/8/2P4P/R3K3 w - - 0 1", 10, 3, 0)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("3k3r/p4p2/8/8/8/8/P6P/R2K4 b - - 0 1", 10, 3, 7)]
+	public void StaticEvaluation_SemiOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int semiopenFile)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.R)
+			- AdditionalPieceEvaluation(position, Piece.r);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(
-            UnpackMG(SemiOpenFileRookBonus[0][semiopenFile])
-                + UnpackMG(SemiOpenFileRookEnemyBonus[0][semiopenFile])
-                + UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
-            evaluation);
-    }
+		Assert.AreEqual(
+			UnpackMG(SemiOpenFileRookBonus[0][semiopenFile])
+				+ UnpackMG(SemiOpenFileRookEnemyBonus[0][semiopenFile])
+				+ UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
+			evaluation);
+	}
 
-    /// <summary>
-    /// 8   . . . . k . . r
-    /// 7   p . . . . . . p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   . . P . . . . P
-    /// 1   . R . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("7r/2p1k2p/8/8/8/8/2P1K2P/1R6 w - - 0 1", 13, 7, 1)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("6r1/p2k1p2/8/8/8/8/P2K1P2/R7 b - - 0 1", 13, 7, 6)]
-    public void StaticEvaluation_OpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int openFile)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+	/// <summary>
+	/// 8   . . . . k . . r
+	/// 7   p . . . . . . p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   . . P . . . . P
+	/// 1   . R . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("7r/2p1k2p/8/8/8/8/2P1K2P/1R6 w - - 0 1", 13, 7, 1)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("6r1/p2k1p2/8/8/8/8/P2K1P2/R7 b - - 0 1", 13, 7, 6)]
+	public void StaticEvaluation_OpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int openFile)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.R)
+			- AdditionalPieceEvaluation(position, Piece.r);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(
-            UnpackMG(OpenFileRookBonus[0][openFile])
-            + UnpackMG(OpenFileRookEnemyBonus[0][openFile])
-            + UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
-            evaluation);
-    }
+		Assert.AreEqual(
+			UnpackMG(OpenFileRookBonus[0][openFile])
+			+ UnpackMG(OpenFileRookEnemyBonus[0][openFile])
+			+ UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
+			evaluation);
+	}
 
-    /// <summary>
-    /// 8   . . . . k. .r
-    /// 7   p. . . . . .r
-    /// 6   . . . . . . . p
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   R. .P. . .P
-    /// 1   R. .K. . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("4k2r/p6r/7p/8/8/8/R2P3P/R2K4 w - - 0 1", 10, 9, 0)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("4k2r/p3p2r/8/8/8/P7/R6P/R2K4 b - - 0 1", 10, 9, 7)]
-    public void StaticEvaluation_DoubleSemiOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int semiopenFile)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+	/// <summary>
+	/// 8   . . . . k. .r
+	/// 7   p. . . . . .r
+	/// 6   . . . . . . . p
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   R. .P. . .P
+	/// 1   R. .K. . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("4k2r/p6r/7p/8/8/8/R2P3P/R2K4 w - - 0 1", 10, 9, 0)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("4k2r/p3p2r/8/8/8/P7/R6P/R2K4 b - - 0 1", 10, 9, 7)]
+	public void StaticEvaluation_DoubleSemiOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int semiopenFile)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.R)
+			- AdditionalPieceEvaluation(position, Piece.r);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(
-            (2 * UnpackMG(SemiOpenFileRookBonus[0][semiopenFile]))
-            + (2 * UnpackMG(SemiOpenFileRookEnemyBonus[0][semiopenFile]))
-            + UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
-        evaluation);
-    }
+		Assert.AreEqual(
+			(2 * UnpackMG(SemiOpenFileRookBonus[0][semiopenFile]))
+			+ (2 * UnpackMG(SemiOpenFileRookEnemyBonus[0][semiopenFile]))
+			+ UnpackMG(RookMobilityBonus[rookMobilitySideToMove]) - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
+		evaluation);
+	}
 
-    /// <summary>
-    /// 8   . r . . . . . k
-    /// 7   . r . . . . . p
-    /// 6   . . p . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . P . . . . .
-    /// 2   . . R . . . . P
-    /// 1   . . R . . . . K
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("1r5k/1r5p/2p5/8/8/2P5/2R4P/2R4K w - - 0 1", 7, 12, 1)]   // Counting only second rank rooks
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("k4r2/p4r2/5p2/8/8/5P2/P5R1/K5R1 b - - 0 1", 7, 12, 6)]
-    public void StaticEvaluation_DoubleOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int openFile)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.R)
-            - AdditionalPieceEvaluation(position, Piece.r);
+	/// <summary>
+	/// 8   . r . . . . . k
+	/// 7   . r . . . . . p
+	/// 6   . . p . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . P . . . . .
+	/// 2   . . R . . . . P
+	/// 1   . . R . . . . K
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("1r5k/1r5p/2p5/8/8/2P5/2R4P/2R4K w - - 0 1", 7, 12, 1)]   // Counting only second rank rooks
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("k4r2/p4r2/5p2/8/8/5P2/P5R1/K5R1 b - - 0 1", 7, 12, 6)]
+	public void StaticEvaluation_DoubleOpenFileRookBonus(string fen, int rookMobilitySideToMove, int rookMobilitySideNotToMove, int openFile)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.R)
+			- AdditionalPieceEvaluation(position, Piece.r);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(
-            (-2 * UnpackMG(OpenFileRookBonus[0][openFile]))
-            + (-2 * UnpackMG(OpenFileRookEnemyBonus[0][openFile]))
-            + UnpackMG(RookMobilityBonus[rookMobilitySideToMove])
-            - UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
-            evaluation);
-    }
+		Assert.AreEqual(
+			(-2 * UnpackMG(OpenFileRookBonus[0][openFile]))
+			+ (-2 * UnpackMG(OpenFileRookEnemyBonus[0][openFile]))
+			+ UnpackMG(RookMobilityBonus[rookMobilitySideToMove])
+			- UnpackMG(RookMobilityBonus[rookMobilitySideNotToMove]),
+			evaluation);
+	}
 
-    /// <summary>
-    /// No rooks = no bonus or penalty
-    /// 8   . . . . . . k .
-    /// 7   p . p . . . p p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P . P . . . P P
-    /// 1   . K . . . . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/p1p3pp/8/8/8/8/P1P3PP/1K6 w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("6k1/pp3p1p/8/8/8/8/PP3P1P/1K6 b - - 0 1")]
-    [Ignore("Broken by virtual king mobility")]
-    public void StaticEvaluation_NoOpenFileKingPenalty(string fen)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+	/// <summary>
+	/// No rooks = no bonus or penalty
+	/// 8   . . . . . . k .
+	/// 7   p . p . . . p p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P . P . . . P P
+	/// 1   . K . . . . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/p1p3pp/8/8/8/8/P1P3PP/1K6 w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("6k1/pp3p1p/8/8/8/8/PP3P1P/1K6 b - - 0 1")]
+	[Ignore("Broken by virtual king mobility")]
+	public void StaticEvaluation_NoOpenFileKingPenalty(string fen)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalKingEvaluation(position, Piece.K)
+			- AdditionalKingEvaluation(position, Piece.k);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(0, evaluation);
-    }
+		Assert.AreEqual(0, evaluation);
+	}
 
 #pragma warning disable S4144 // Methods should not have identical implementations
-    /// <summary>
-    /// No rooks = no bonus or penalty
-    /// 8   . . . . . . k .
-    /// 7   p . p . . . p p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P . P . . . P P
-    /// 1   . K . . . . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("6k1/pp1p2pp/8/8/8/8/P1PP2PP/1K6 w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("6k1/pp2pp1p/8/8/8/8/PP2P1PP/1K6 b - - 0 1")]
-    public void StaticEvaluation_NoSemiOpenFileKingPenalty(string fen)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+	/// <summary>
+	/// No rooks = no bonus or penalty
+	/// 8   . . . . . . k .
+	/// 7   p . p . . . p p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P . P . . . P P
+	/// 1   . K . . . . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("6k1/pp1p2pp/8/8/8/8/P1PP2PP/1K6 w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("6k1/pp2pp1p/8/8/8/8/PP2P1PP/1K6 b - - 0 1")]
+	public void StaticEvaluation_NoSemiOpenFileKingPenalty(string fen)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalKingEvaluation(position, Piece.K)
+			- AdditionalKingEvaluation(position, Piece.k);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(0, evaluation);
-    }
+		Assert.AreEqual(0, evaluation);
+	}
 #pragma warning restore S4144 // Methods should not have identical implementations
 
-    /// <summary>
-    /// 8   . k . . . . . n
-    /// 7   . . . . . p p p
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   P P P . . . . .
-    /// 1   . K . . . . . N
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("1k5n/5ppp/8/8/8/8/PPP5/1K5N w - - 0 1", 3)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("n5k1/5ppp/8/8/8/8/PPP5/N5K1 b - - 0 1", 3)]
-    /// <summary>
-    /// 8   . k . . . b . b
-    /// 7   . . . . . n n n
-    /// 6   . . . . . . . .
-    /// 5   . . . . . . . .
-    /// 4   . . . . . . . .
-    /// 3   . . . . . . . .
-    /// 2   N N N . . . . .
-    /// 1   B K B . . . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("1k3b1b/5nnn/8/8/8/8/NNN5/BKB5 w - - 0 1", 5)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("5bkb/5nnn/8/8/8/8/NNN5/B1B3K1 b - - 0 1", 5)]
-    [Ignore("Broken by virtual king mobility")]
-    public void StaticEvaluation_KingShieldBonus(string fen, int surroundingPieces)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalKingEvaluation(position, Piece.K)
-            - AdditionalKingEvaluation(position, Piece.k);
+	/// <summary>
+	/// 8   . k . . . . . n
+	/// 7   . . . . . p p p
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   P P P . . . . .
+	/// 1   . K . . . . . N
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("1k5n/5ppp/8/8/8/8/PPP5/1K5N w - - 0 1", 3)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("n5k1/5ppp/8/8/8/8/PPP5/N5K1 b - - 0 1", 3)]
+	/// <summary>
+	/// 8   . k . . . b . b
+	/// 7   . . . . . n n n
+	/// 6   . . . . . . . .
+	/// 5   . . . . . . . .
+	/// 4   . . . . . . . .
+	/// 3   . . . . . . . .
+	/// 2   N N N . . . . .
+	/// 1   B K B . . . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("1k3b1b/5nnn/8/8/8/8/NNN5/BKB5 w - - 0 1", 5)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("5bkb/5nnn/8/8/8/8/NNN5/B1B3K1 b - - 0 1", 5)]
+	[Ignore("Broken by virtual king mobility")]
+	public void StaticEvaluation_KingShieldBonus(string fen, int surroundingPieces)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalKingEvaluation(position, Piece.K)
+			- AdditionalKingEvaluation(position, Piece.k);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(surroundingPieces * UnpackEG(KingShieldBonus), evaluation);
-    }
+		Assert.AreEqual(surroundingPieces * UnpackEG(KingShieldBonus), evaluation);
+	}
 
-    /// <summary>
-    /// 8   n . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . . . . . . . .
-    /// 5   . . . b . . . .
-    /// 4   . . . B . . . .
-    /// 3   . . . . . . . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . N
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("n3k3/1n6/8/3b4/3B4/8/6N1/4K2N w - - 0 1", 13, 11)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("n2k4/1n6/8/4b3/4B3/8/6N1/3K3N b - - 0 1", 13, 11)]
-    /// <summary>
-    /// 8   . . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . .  p. . . . .
-    /// 5   . . . b . . . .
-    /// 4   . . . B . . . .
-    /// 3   . . . . . P . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("4k3/1n6/2n5/3b4/3B4/5N2/6N1/4K3 w - - 0 1", 13, 9)]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("3k4/1n6/2n5/4b3/4B3/5N2/6N1/3K4 b - - 0 1", 13, 9)]
-    public void StaticEvaluation_BishopMobility(string fen, int sideToMoveMobilityCount, int nonSideToMoveMobilityCount)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.B)
-            - AdditionalPieceEvaluation(position, Piece.b);
+	/// <summary>
+	/// 8   n . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . . . . . . . .
+	/// 5   . . . b . . . .
+	/// 4   . . . B . . . .
+	/// 3   . . . . . . . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . N
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("n3k3/1n6/8/3b4/3B4/8/6N1/4K2N w - - 0 1", 13, 11)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("n2k4/1n6/8/4b3/4B3/8/6N1/3K3N b - - 0 1", 13, 11)]
+	/// <summary>
+	/// 8   . . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . .  p. . . . .
+	/// 5   . . . b . . . .
+	/// 4   . . . B . . . .
+	/// 3   . . . . . P . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("4k3/1n6/2n5/3b4/3B4/5N2/6N1/4K3 w - - 0 1", 13, 9)]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("3k4/1n6/2n5/4b3/4B3/5N2/6N1/3K4 b - - 0 1", 13, 9)]
+	public void StaticEvaluation_BishopMobility(string fen, int sideToMoveMobilityCount, int nonSideToMoveMobilityCount)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.B)
+			- AdditionalPieceEvaluation(position, Piece.b);
 
-        if (position.Side == Side.Black)
-        {
-            evaluation = -evaluation;
-        }
+		if (position.Side == Side.Black)
+		{
+			evaluation = -evaluation;
+		}
 
-        Assert.AreEqual(UnpackMG(BishopMobilityBonus[sideToMoveMobilityCount]) - UnpackMG(BishopMobilityBonus[nonSideToMoveMobilityCount]), evaluation);
-    }
+		Assert.AreEqual(UnpackMG(BishopMobilityBonus[sideToMoveMobilityCount]) - UnpackMG(BishopMobilityBonus[nonSideToMoveMobilityCount]), evaluation);
+	}
 
-    /// <summary>
-    /// 8   n . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . . . . . . . .
-    /// 5   . . . q . . . .
-    /// 4   . . . Q . . . .
-    /// 3   . . . . . . . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . N
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("n7/1p6/3k4/3q4/3Q4/3K4/6P1/7N w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("n7/1p6/4k3/4q3/4Q3/4K3/6P1/7N b - - 0 1")]
-    /// <summary>
-    /// 8   . . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . . p . . . . .
-    /// 5   . . . q . . . .
-    /// 4   . . . Q . . . .
-    /// 3   . . . . . P . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("4k3/1p6/2p5/3q4/3Q4/5P2/6P1/4K3 w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("3k4/1p6/2p5/4q3/4Q3/5P2/6P1/3K4 b - - 0 1")]
-    /// <summary>
-    /// 8   n . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . . . . . . . .
-    /// 5   . . . q . . . .
-    /// 4   . . . Q . . . .
-    /// 3   . . . . . . . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . N
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("n7/1p6/3k4/3q4/3Q4/3K4/6P1/7N w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("n7/1p6/4k3/4q3/4Q3/4K3/6P1/7N b - - 0 1")]
-    /// <summary>
-    /// 8   . . . . k . . .
-    /// 7   . p . . . . . .
-    /// 6   . . p . . . . .
-    /// 5   . . . q . . . .
-    /// 4   . . . Q . . . .
-    /// 3   . . . . . P . .
-    /// 2   . . . . . . P .
-    /// 1   . . . . K . . .
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("4k3/1p6/2p5/3q4/3Q4/5P2/6P1/4K3 w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("3k4/1p6/2p5/4q3/4Q3/5P2/6P1/3K4 b - - 0 1")]
-    /// <summary>
-    /// 8   n . . . k . . .
-    /// 7   . . . . . . . .
-    /// 6   . . p . . . . .
-    /// 5   . r . q . . . R
-    /// 4   . . . Q . . . .
-    /// 3   . . . . . P . .
-    /// 2   . . . . . . . .
-    /// 1   . . . . K . . N
-    ///     a b c d e f g h
-    /// </summary>
-    [TestCase("2n1kn2/4n3/2p5/1r1q3R/3Q4/5P2/6NN/7K w - - 0 1")]
-    /// <summary>
-    /// Previous one mirrored
-    /// </summary>
-    [TestCase("n7/k7/2p5/4q3/r3Q1R1/5P2/8/3K3N b - - 0 1")]
-    public void StaticEvaluation_QueenMobility(string fen)
-    {
-        Position position = new Position(fen);
-        int evaluation = AdditionalPieceEvaluation(position, Piece.Q)
-            - AdditionalPieceEvaluation(position, Piece.q);
+	/// <summary>
+	/// 8   n . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . . . . . . . .
+	/// 5   . . . q . . . .
+	/// 4   . . . Q . . . .
+	/// 3   . . . . . . . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . N
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("n7/1p6/3k4/3q4/3Q4/3K4/6P1/7N w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("n7/1p6/4k3/4q3/4Q3/4K3/6P1/7N b - - 0 1")]
+	/// <summary>
+	/// 8   . . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . . p . . . . .
+	/// 5   . . . q . . . .
+	/// 4   . . . Q . . . .
+	/// 3   . . . . . P . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("4k3/1p6/2p5/3q4/3Q4/5P2/6P1/4K3 w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("3k4/1p6/2p5/4q3/4Q3/5P2/6P1/3K4 b - - 0 1")]
+	/// <summary>
+	/// 8   n . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . . . . . . . .
+	/// 5   . . . q . . . .
+	/// 4   . . . Q . . . .
+	/// 3   . . . . . . . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . N
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("n7/1p6/3k4/3q4/3Q4/3K4/6P1/7N w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("n7/1p6/4k3/4q3/4Q3/4K3/6P1/7N b - - 0 1")]
+	/// <summary>
+	/// 8   . . . . k . . .
+	/// 7   . p . . . . . .
+	/// 6   . . p . . . . .
+	/// 5   . . . q . . . .
+	/// 4   . . . Q . . . .
+	/// 3   . . . . . P . .
+	/// 2   . . . . . . P .
+	/// 1   . . . . K . . .
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("4k3/1p6/2p5/3q4/3Q4/5P2/6P1/4K3 w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("3k4/1p6/2p5/4q3/4Q3/5P2/6P1/3K4 b - - 0 1")]
+	/// <summary>
+	/// 8   n . . . k . . .
+	/// 7   . . . . . . . .
+	/// 6   . . p . . . . .
+	/// 5   . r . q . . . R
+	/// 4   . . . Q . . . .
+	/// 3   . . . . . P . .
+	/// 2   . . . . . . . .
+	/// 1   . . . . K . . N
+	///     a b c d e f g h
+	/// </summary>
+	[TestCase("2n1kn2/4n3/2p5/1r1q3R/3Q4/5P2/6NN/7K w - - 0 1")]
+	/// <summary>
+	/// Previous one mirrored
+	/// </summary>
+	[TestCase("n7/k7/2p5/4q3/r3Q1R1/5P2/8/3K3N b - - 0 1")]
+	public void StaticEvaluation_QueenMobility(string fen)
+	{
+		Position position = new Position(fen);
+		int evaluation = AdditionalPieceEvaluation(position, Piece.Q)
+			- AdditionalPieceEvaluation(position, Piece.q);
 
-        BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
-        BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
+		BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
+		BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
 
-        var whiteMobility =
-            (Attacks.QueenAttacks(position.PieceBitBoards[(int)Piece.Q].GetLS1BIndex(), position.OccupancyBitBoards[(int)Side.Both])
-                & (~(position.PieceBitBoards[(int)Piece.P] | blackPawnAttacks)))
-            .CountBits();
+		var whiteMobility =
+			(Attacks.QueenAttacks(position.PieceBitBoards[(int)Piece.Q].GetLS1BIndex(), position.OccupancyBitBoards[(int)Side.Both])
+				& (~(position.PieceBitBoards[(int)Piece.P] | blackPawnAttacks)))
+			.CountBits();
 
-        var blackMobility =
-            (Attacks.QueenAttacks(position.PieceBitBoards[(int)Piece.q].GetLS1BIndex(), position.OccupancyBitBoards[(int)Side.Both])
-                & (~(position.PieceBitBoards[(int)Piece.p] | whitePawnAttacks)))
-            .CountBits();
+		var blackMobility =
+			(Attacks.QueenAttacks(position.PieceBitBoards[(int)Piece.q].GetLS1BIndex(), position.OccupancyBitBoards[(int)Side.Both])
+				& (~(position.PieceBitBoards[(int)Piece.p] | whitePawnAttacks)))
+			.CountBits();
 
-        var expectedEvaluation = QueenMobilityBonus[whiteMobility] - QueenMobilityBonus[blackMobility];
+		var expectedEvaluation = QueenMobilityBonus[whiteMobility] - QueenMobilityBonus[blackMobility];
 
-        Assert.AreEqual(UnpackMG(expectedEvaluation), evaluation);
-    }
+		Assert.AreEqual(UnpackMG(expectedEvaluation), evaluation);
+	}
 
-    /// <summary>
-    /// https://github.com/lynx-chess/Lynx/pull/510
-    /// </summary>
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", MinStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
-    [TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
-    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K6k b - - 0 1", MinStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
-    [TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
-    public void StaticEvaluation_Clamp(string fen, int expectedStaticEvaluation)
-    {
-        var position = new Position(fen);
+	/// <summary>
+	/// https://github.com/lynx-chess/Lynx/pull/510
+	/// </summary>
+	[TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K6k b - - 0 1", MinStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+	[TestCase("QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QPPPPPPP/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "Packed eval reduces max eval to a short, so over Short.MaxValue it overflows and produces unexpected results")]
+	[TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K6k b - - 0 1", MinStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
+	[TestCase("8/QQQQQQ1/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQQQQQQQ/QQ6/K5k1 w - - 0 1", MaxStaticEval, IgnoreReason = "It's just a pain to maintain this with bucketed PSQT tuning")]
+	public void StaticEvaluation_Clamp(string fen, int expectedStaticEvaluation)
+	{
+		var position = new Position(fen);
 
-        Assert.AreEqual(expectedStaticEvaluation, position.StaticEvaluation().Score);
-    }
+		Assert.AreEqual(expectedStaticEvaluation, position.StaticEvaluation().Score);
+	}
 
-    [TestCase("k7/8/8/3K4/8/8/8/8 w - - 0 1", true, "K vs k")]
-    [TestCase("8/8/8/8/3k4/8/8/K7 w - - 0 1", true, "K vs k")]
-    public void StaticEvaluation_PawnlessEndgames_KingVsKing(string fen, bool isDrawExpected, string _)
-    {
-        EvaluateDrawOrNotDraw(fen, isDrawExpected, 0);
-    }
+	[TestCase("k7/8/8/3K4/8/8/8/8 w - - 0 1", true, "K vs k")]
+	[TestCase("8/8/8/8/3k4/8/8/K7 w - - 0 1", true, "K vs k")]
+	public void StaticEvaluation_PawnlessEndgames_KingVsKing(string fen, bool isDrawExpected, string _)
+	{
+		EvaluateDrawOrNotDraw(fen, isDrawExpected, 0);
+	}
 
-    [TestCase("1k6/8/8/8/8/8/1B6/1K6 w - - 0 1", true, 1, "B")]
-    [TestCase("1k6/1b6/8/8/8/8/8/1K6 w - - 0 1", true, 1, "b")]
-    [TestCase("1k6/8/8/8/8/8/1N6/1K6 w - - 0 1", true, 1, "N")]
-    [TestCase("1k6/1n6/8/8/8/8/8/1K6 w - - 0 1", true, 1, "n")]
-    [TestCase("2k5/8/8/8/8/8/1R6/1K6 w - - 0 1", false, 2, "R")]
-    [TestCase("rk6/8/8/8/8/8/8/1K6 w - - 0 1", false, 2, "r")]
-    [TestCase("2k5/8/8/8/8/8/1Q6/1K6 w - - 0 1", false, 4, "Q")]
-    [TestCase("qk6/8/8/8/8/8/8/1K6 w - - 0 1", false, 4, "q")]
-    public void StaticEvaluation_PawnlessEndgames_SinglePiece(string fen, bool isDrawExpected, int expectedPhase, string _)
-    {
-        EvaluateDrawOrNotDraw(fen, isDrawExpected, expectedPhase);
-    }
+	[TestCase("1k6/8/8/8/8/8/1B6/1K6 w - - 0 1", true, 1, "B")]
+	[TestCase("1k6/1b6/8/8/8/8/8/1K6 w - - 0 1", true, 1, "b")]
+	[TestCase("1k6/8/8/8/8/8/1N6/1K6 w - - 0 1", true, 1, "N")]
+	[TestCase("1k6/1n6/8/8/8/8/8/1K6 w - - 0 1", true, 1, "n")]
+	[TestCase("2k5/8/8/8/8/8/1R6/1K6 w - - 0 1", false, 2, "R")]
+	[TestCase("rk6/8/8/8/8/8/8/1K6 w - - 0 1", false, 2, "r")]
+	[TestCase("2k5/8/8/8/8/8/1Q6/1K6 w - - 0 1", false, 4, "Q")]
+	[TestCase("qk6/8/8/8/8/8/8/1K6 w - - 0 1", false, 4, "q")]
+	public void StaticEvaluation_PawnlessEndgames_SinglePiece(string fen, bool isDrawExpected, int expectedPhase, string _)
+	{
+		EvaluateDrawOrNotDraw(fen, isDrawExpected, expectedPhase);
+	}
 
-    [TestCase("1k6/n7/8/8/8/8/N7/1K6 w - - 0 1", true, "N vs n")]
-    [TestCase("1k6/b7/8/8/8/8/B7/1K6 w - - 0 1", true, "B vs b")]
-    [TestCase("1k6/n7/8/8/8/8/B7/1K6 w - - 0 1", true, "B vs n")]
-    [TestCase("1k6/b7/8/8/8/8/N7/1K6 w - - 0 1", true, "N vs b")]
-    [TestCase("1k6/8/8/8/8/8/NB6/1K6 w - - 0 1", false, "BN")]
-    [TestCase("1k6/8/8/8/8/8/BB6/1K6 w - - 0 1", false, "BB")]
-    [TestCase("1k6/bb6/8/8/8/8/8/1K6 w - - 0 1", false, "bb")]
-    [TestCase("1k6/bn6/8/8/8/8/8/1K6 w - - 0 1", false, "bn")]
-    [TestCase("1k6/8/8/8/8/8/NN6/1K6 w - - 0 1", true, "NN")]
-    [TestCase("1k6/nn6/8/8/8/8/8/1K6 w - - 0 1", true, "nn")]
-    public void StaticEvaluation_PawnlessEndgames_TwoMinorPieces(string fen, bool isDrawExpected, string _)
-    {
-        EvaluateDrawOrNotDraw(fen, isDrawExpected, 2);
-    }
+	[TestCase("1k6/n7/8/8/8/8/N7/1K6 w - - 0 1", true, "N vs n")]
+	[TestCase("1k6/b7/8/8/8/8/B7/1K6 w - - 0 1", true, "B vs b")]
+	[TestCase("1k6/n7/8/8/8/8/B7/1K6 w - - 0 1", true, "B vs n")]
+	[TestCase("1k6/b7/8/8/8/8/N7/1K6 w - - 0 1", true, "N vs b")]
+	[TestCase("1k6/8/8/8/8/8/NB6/1K6 w - - 0 1", false, "BN")]
+	[TestCase("1k6/8/8/8/8/8/BB6/1K6 w - - 0 1", false, "BB")]
+	[TestCase("1k6/bb6/8/8/8/8/8/1K6 w - - 0 1", false, "bb")]
+	[TestCase("1k6/bn6/8/8/8/8/8/1K6 w - - 0 1", false, "bn")]
+	[TestCase("1k6/8/8/8/8/8/NN6/1K6 w - - 0 1", true, "NN")]
+	[TestCase("1k6/nn6/8/8/8/8/8/1K6 w - - 0 1", true, "nn")]
+	public void StaticEvaluation_PawnlessEndgames_TwoMinorPieces(string fen, bool isDrawExpected, string _)
+	{
+		EvaluateDrawOrNotDraw(fen, isDrawExpected, 2);
+	}
 
-    [TestCase("8/8/3kb3/8/8/2NN4/3K4/8 w - - 0 1", true, "NN vs b")]
-    [TestCase("8/8/3knn2/8/8/3B4/3K4/8 w - - 0 1", true, "B vs nn")]
-    [TestCase("8/8/3kn3/8/8/2NN4/3K4/8 w - - 0 1", true, "NN vs n")]
-    [TestCase("8/8/3knn2/8/8/3N4/3K4/8 w - - 0 1", true, "N vs nn")]
-    public void StaticEvaluation_PawnlessEndgames_TwoMinorPiecesVsOne(string fen, bool isDrawExpected, string _)
-    {
-        EvaluateDrawOrNotDraw(fen, isDrawExpected, 3);
-    }
+	[TestCase("8/8/3kb3/8/8/2NN4/3K4/8 w - - 0 1", true, "NN vs b")]
+	[TestCase("8/8/3knn2/8/8/3B4/3K4/8 w - - 0 1", true, "B vs nn")]
+	[TestCase("8/8/3kn3/8/8/2NN4/3K4/8 w - - 0 1", true, "NN vs n")]
+	[TestCase("8/8/3knn2/8/8/3N4/3K4/8 w - - 0 1", true, "N vs nn")]
+	public void StaticEvaluation_PawnlessEndgames_TwoMinorPiecesVsOne(string fen, bool isDrawExpected, string _)
+	{
+		EvaluateDrawOrNotDraw(fen, isDrawExpected, 3);
+	}
 
-    [TestCase(0, 0)]
-    [TestCase(0, 100)]
-    [TestCase(100, 100)]
-    [TestCase(100, 200)]
-    public void TaperedEvaluation(int mg, int eg)
-    {
-        Assert.AreEqual(mg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 24));
-        Assert.AreEqual(eg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 0));
-    }
+	[TestCase(0, 0)]
+	[TestCase(0, 100)]
+	[TestCase(100, 100)]
+	[TestCase(100, 200)]
+	public void TaperedEvaluation(int mg, int eg)
+	{
+		Assert.AreEqual(mg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 24));
+		Assert.AreEqual(eg, Position.TaperedEvaluation(Pack((short)mg, (short)eg), 0));
+	}
 
-    [Test]
-    public void ScaleEvalWith50MovesDrawDistance()
-    {
-        const string queenVsRookPosition = "8/4k3/4r3/3Q4/3K4/8/8/8 w - - 0 1";
+	[Test]
+	public void ScaleEvalWith50MovesDrawDistance()
+	{
+		const string queenVsRookPosition = "8/4k3/4r3/3Q4/3K4/8/8/8 w - - 0 1";
 
-        var position = new Position(queenVsRookPosition);
+		var position = new Position(queenVsRookPosition);
 
-        Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
-        Assert.AreEqual((int)(0.5 * position.StaticEvaluation(0).Score), position.StaticEvaluation(100).Score);
-        Assert.AreEqual((int)(0.75 * position.StaticEvaluation(0).Score), position.StaticEvaluation(50).Score);
-    }
+		Assert.Greater(position.StaticEvaluation(0), position.StaticEvaluation(10));
+		Assert.AreEqual((int)(0.5 * position.StaticEvaluation(0).Score), position.StaticEvaluation(100).Score);
+		Assert.AreEqual((int)(0.75 * position.StaticEvaluation(0).Score), position.StaticEvaluation(50).Score);
+	}
 
-    [Test]
-    public void FreeAndNonAttackedSquares()
-    {
-        /// <summary>
-        /// 8   0 0 0 0 0 0 0 0
-        /// 7   0 0 0 0 0 0 0 0
-        /// 6   0 0 0 0 0 0 0 0
-        /// 5   0 0 0 0 0 0 0 0
-        /// 4   0 0 0 0 0 0 0 0
-        /// 3   0 0 0 0 0 0 0 0
-        /// 2   0 0 0 0 0 0 0 0
-        /// 1   0 0 0 0 0 1 1 0
-        ///     a b c d e f g h
-        /// </summary>
-        const BitBoard WhiteShortCastleFreeSquares = 0x6000000000000000;
+	[Test]
+	public void FreeAndNonAttackedSquares()
+	{
+		/// <summary>
+		/// 8   0 0 0 0 0 0 0 0
+		/// 7   0 0 0 0 0 0 0 0
+		/// 6   0 0 0 0 0 0 0 0
+		/// 5   0 0 0 0 0 0 0 0
+		/// 4   0 0 0 0 0 0 0 0
+		/// 3   0 0 0 0 0 0 0 0
+		/// 2   0 0 0 0 0 0 0 0
+		/// 1   0 0 0 0 0 1 1 0
+		///     a b c d e f g h
+		/// </summary>
+		const BitBoard WhiteShortCastleFreeSquares = 0x6000000000000000;
 
-        /// <summary>
-        /// 8   0 0 0 0 0 0 0 0
-        /// 7   0 0 0 0 0 0 0 0
-        /// 6   0 0 0 0 0 0 0 0
-        /// 5   0 0 0 0 0 0 0 0
-        /// 4   0 0 0 0 0 0 0 0
-        /// 3   0 0 0 0 0 0 0 0
-        /// 2   0 0 0 0 0 0 0 0
-        /// 1   0 1 1 1 0 0 0 0
-        ///     a b c d e f g h
-        /// </summary>
-        const BitBoard WhiteLongCastleFreeSquares = 0xe00000000000000;
+		/// <summary>
+		/// 8   0 0 0 0 0 0 0 0
+		/// 7   0 0 0 0 0 0 0 0
+		/// 6   0 0 0 0 0 0 0 0
+		/// 5   0 0 0 0 0 0 0 0
+		/// 4   0 0 0 0 0 0 0 0
+		/// 3   0 0 0 0 0 0 0 0
+		/// 2   0 0 0 0 0 0 0 0
+		/// 1   0 1 1 1 0 0 0 0
+		///     a b c d e f g h
+		/// </summary>
+		const BitBoard WhiteLongCastleFreeSquares = 0xe00000000000000;
 
-        /// <summary>
-        /// 8   0 0 0 0 0 1 1 0
-        /// 7   0 0 0 0 0 0 0 0
-        /// 6   0 0 0 0 0 0 0 0
-        /// 5   0 0 0 0 0 0 0 0
-        /// 4   0 0 0 0 0 0 0 0
-        /// 3   0 0 0 0 0 0 0 0
-        /// 2   0 0 0 0 0 0 0 0
-        /// 1   0 0 0 0 0 0 0 0
-        ///     a b c d e f g h
-        /// </summary>
-        const BitBoard BlackShortCastleFreeSquares = 0x60;
+		/// <summary>
+		/// 8   0 0 0 0 0 1 1 0
+		/// 7   0 0 0 0 0 0 0 0
+		/// 6   0 0 0 0 0 0 0 0
+		/// 5   0 0 0 0 0 0 0 0
+		/// 4   0 0 0 0 0 0 0 0
+		/// 3   0 0 0 0 0 0 0 0
+		/// 2   0 0 0 0 0 0 0 0
+		/// 1   0 0 0 0 0 0 0 0
+		///     a b c d e f g h
+		/// </summary>
+		const BitBoard BlackShortCastleFreeSquares = 0x60;
 
-        /// <summary>
-        /// 8   0 1 1 1 0 0 0 0
-        /// 7   0 0 0 0 0 0 0 0
-        /// 6   0 0 0 0 0 0 0 0
-        /// 5   0 0 0 0 0 0 0 0
-        /// 4   0 0 0 0 0 0 0 0
-        /// 3   0 0 0 0 0 0 0 0
-        /// 2   0 0 0 0 0 0 0 0
-        /// 1   0 0 0 0 0 0 0 0
-        ///     a b c d e f g h
-        /// </summary>
-        const BitBoard BlackLongCastleFreeSquares = 0xe;
+		/// <summary>
+		/// 8   0 1 1 1 0 0 0 0
+		/// 7   0 0 0 0 0 0 0 0
+		/// 6   0 0 0 0 0 0 0 0
+		/// 5   0 0 0 0 0 0 0 0
+		/// 4   0 0 0 0 0 0 0 0
+		/// 3   0 0 0 0 0 0 0 0
+		/// 2   0 0 0 0 0 0 0 0
+		/// 1   0 0 0 0 0 0 0 0
+		///     a b c d e f g h
+		/// </summary>
+		const BitBoard BlackLongCastleFreeSquares = 0xe;
 
-        var position = new Position(Constants.InitialPositionFEN);
+		var position = new Position(Constants.InitialPositionFEN);
 
-        Assert.AreEqual(WhiteShortCastleFreeSquares, position.KingsideCastlingFreeSquares[(int)Side.White]);
-        Assert.AreEqual(BlackShortCastleFreeSquares, position.KingsideCastlingFreeSquares[(int)Side.Black]);
-        Assert.AreEqual(WhiteLongCastleFreeSquares, position.QueensideCastlingFreeSquares[(int)Side.White]);
-        Assert.AreEqual(BlackLongCastleFreeSquares, position.QueensideCastlingFreeSquares[(int)Side.Black]);
+		Assert.AreEqual(WhiteShortCastleFreeSquares, position.KingsideCastlingFreeSquares[(int)Side.White]);
+		Assert.AreEqual(BlackShortCastleFreeSquares, position.KingsideCastlingFreeSquares[(int)Side.Black]);
+		Assert.AreEqual(WhiteLongCastleFreeSquares, position.QueensideCastlingFreeSquares[(int)Side.White]);
+		Assert.AreEqual(BlackLongCastleFreeSquares, position.QueensideCastlingFreeSquares[(int)Side.Black]);
 
-        var nonAttackedWhiteShortCastleSquares = position.KingsideCastlingFreeSquares[(int)Side.White];
-        nonAttackedWhiteShortCastleSquares.SetBit(Constants.InitialWhiteKingSquare);
-        nonAttackedWhiteShortCastleSquares.SetBit(Constants.WhiteKingShortCastleSquare);
+		var nonAttackedWhiteShortCastleSquares = position.KingsideCastlingFreeSquares[(int)Side.White];
+		nonAttackedWhiteShortCastleSquares.SetBit(Constants.InitialWhiteKingSquare);
+		nonAttackedWhiteShortCastleSquares.SetBit(Constants.WhiteKingShortCastleSquare);
 
-        var nonAttackedWhiteLongCastleSquares = position.QueensideCastlingFreeSquares[(int)Side.White];
-        nonAttackedWhiteLongCastleSquares.PopBit(BoardSquare.b1);
-        nonAttackedWhiteLongCastleSquares.SetBit(Constants.InitialWhiteKingSquare);
-        nonAttackedWhiteLongCastleSquares.SetBit(Constants.WhiteKingLongCastleSquare);
+		var nonAttackedWhiteLongCastleSquares = position.QueensideCastlingFreeSquares[(int)Side.White];
+		nonAttackedWhiteLongCastleSquares.PopBit(BoardSquare.b1);
+		nonAttackedWhiteLongCastleSquares.SetBit(Constants.InitialWhiteKingSquare);
+		nonAttackedWhiteLongCastleSquares.SetBit(Constants.WhiteKingLongCastleSquare);
 
-        var nonAttackedBlackShortCastleSquares = position.KingsideCastlingFreeSquares[(int)Side.Black];
-        nonAttackedBlackShortCastleSquares.SetBit(Constants.InitialBlackKingSquare);
-        nonAttackedBlackShortCastleSquares.SetBit(Constants.BlackKingShortCastleSquare);
+		var nonAttackedBlackShortCastleSquares = position.KingsideCastlingFreeSquares[(int)Side.Black];
+		nonAttackedBlackShortCastleSquares.SetBit(Constants.InitialBlackKingSquare);
+		nonAttackedBlackShortCastleSquares.SetBit(Constants.BlackKingShortCastleSquare);
 
-        var nonAttackedBlackLongCastleSquares = position.QueensideCastlingFreeSquares[(int)Side.Black];
-        nonAttackedBlackLongCastleSquares.PopBit(BoardSquare.b8);
-        nonAttackedBlackLongCastleSquares.SetBit(Constants.InitialBlackKingSquare);
-        nonAttackedBlackLongCastleSquares.SetBit(Constants.BlackKingLongCastleSquare);
+		var nonAttackedBlackLongCastleSquares = position.QueensideCastlingFreeSquares[(int)Side.Black];
+		nonAttackedBlackLongCastleSquares.PopBit(BoardSquare.b8);
+		nonAttackedBlackLongCastleSquares.SetBit(Constants.InitialBlackKingSquare);
+		nonAttackedBlackLongCastleSquares.SetBit(Constants.BlackKingLongCastleSquare);
 
-        Assert.AreEqual(nonAttackedWhiteShortCastleSquares, position.KingsideCastlingNonAttackedSquares[(int)Side.White]);
-        Assert.AreEqual(nonAttackedWhiteLongCastleSquares, position.QueensideCastlingNonAttackedSquares[(int)Side.White]);
-        Assert.AreEqual(nonAttackedBlackShortCastleSquares, position.KingsideCastlingNonAttackedSquares[(int)Side.Black]);
-        Assert.AreEqual(nonAttackedBlackLongCastleSquares, position.QueensideCastlingNonAttackedSquares[(int)Side.Black]);
-    }
+		Assert.AreEqual(nonAttackedWhiteShortCastleSquares, position.KingsideCastlingNonAttackedSquares[(int)Side.White]);
+		Assert.AreEqual(nonAttackedWhiteLongCastleSquares, position.QueensideCastlingNonAttackedSquares[(int)Side.White]);
+		Assert.AreEqual(nonAttackedBlackShortCastleSquares, position.KingsideCastlingNonAttackedSquares[(int)Side.Black]);
+		Assert.AreEqual(nonAttackedBlackLongCastleSquares, position.QueensideCastlingNonAttackedSquares[(int)Side.Black]);
+	}
 
-    private static int AdditionalPieceEvaluation(Position position, Piece piece)
-    {
-        var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();
-        var blackKing = position.PieceBitBoards[(int)Piece.k].GetLS1BIndex();
+	private static int AdditionalPieceEvaluation(Position position, Piece piece)
+	{
+		var whiteKing = position.PieceBitBoards[(int)Piece.K].GetLS1BIndex();
+		var blackKing = position.PieceBitBoards[(int)Piece.k].GetLS1BIndex();
 
-        var sameSideKingSquare = piece <= Piece.K
-            ? whiteKing
-            : blackKing;
+		var sameSideKingSquare = piece <= Piece.K
+			? whiteKing
+			: blackKing;
 
-        var oppositeSideKingSquare = piece <= Piece.K
-            ? blackKing
-            : whiteKing;
+		var oppositeSideKingSquare = piece <= Piece.K
+			? blackKing
+			: whiteKing;
 
-        BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
-        BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
+		BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
+		BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
 
-        var oppositeSidePawnAttacks = piece <= Piece.K
-            ? blackPawnAttacks
-            : whitePawnAttacks;
+		var oppositeSidePawnAttacks = piece <= Piece.K
+			? blackPawnAttacks
+			: whitePawnAttacks;
 
-        var pieceSide = (int)piece <= (int)Piece.K
-            ? (int)Side.White
-            : (int)Side.Black;
+		var pieceSide = (int)piece <= (int)Piece.K
+			? (int)Side.White
+			: (int)Side.Black;
 
-        var bitBoard = position.PieceBitBoards[(int)piece];
-        int eval = 0;
+		var bitBoard = position.PieceBitBoards[(int)piece];
+		int eval = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		using var evaluationContext = new EvaluationContext();
 
-        while (!bitBoard.Empty())
-        {
-            var pieceSquareIndex = bitBoard.GetLS1BIndex();
-            bitBoard.ResetLS1B();
-            eval += UnpackMG(position.AdditionalPieceEvaluation(ref evaluationContext, 0, 0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
-        }
+		while (!bitBoard.Empty())
+		{
+			var pieceSquareIndex = bitBoard.GetLS1BIndex();
+			bitBoard.ResetLS1B();
+			eval += UnpackMG(position.AdditionalPieceEvaluation(evaluationContext, 0, 0, pieceSquareIndex, (int)piece, pieceSide, sameSideKingSquare, oppositeSideKingSquare, oppositeSidePawnAttacks));
+		}
 
-        return eval;
-    }
+		return eval;
+	}
 
-    private static int AdditionalKingEvaluation(Position position, Piece piece)
-    {
-        for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.k; ++pieceIndex)
-        {
-            var bitboard = position.PieceBitBoards[pieceIndex];
+	private static int AdditionalKingEvaluation(Position position, Piece piece)
+	{
+		for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.k; ++pieceIndex)
+		{
+			var bitboard = position.PieceBitBoards[pieceIndex];
 
-            while (bitboard != default)
-            {
-                bitboard.ResetLS1B();
-            }
-        }
+			while (bitboard != default)
+			{
+				bitboard.ResetLS1B();
+			}
+		}
 
-        BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
-        BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
+		BitBoard whitePawnAttacks = position.PieceBitBoards[(int)Piece.P].ShiftUpRight() | position.PieceBitBoards[(int)Piece.P].ShiftUpLeft();
+		BitBoard blackPawnAttacks = position.PieceBitBoards[(int)Piece.p].ShiftDownRight() | position.PieceBitBoards[(int)Piece.p].ShiftDownLeft();
 
-        var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
+		var bitBoard = position.PieceBitBoards[(int)piece].GetLS1BIndex();
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		using var evaluationContext = new EvaluationContext();
 
-        return UnpackEG(piece == Piece.K
-            ? position.KingAdditionalEvaluation(ref evaluationContext, bitBoard, 0, (int)Side.White, blackPawnAttacks)
-            : position.KingAdditionalEvaluation(ref evaluationContext, bitBoard, 0, (int)Side.Black, whitePawnAttacks));
-    }
+		return UnpackEG(piece == Piece.K
+			? position.KingAdditionalEvaluation(evaluationContext, bitBoard, 0, (int)Side.White, blackPawnAttacks)
+			: position.KingAdditionalEvaluation(evaluationContext, bitBoard, 0, (int)Side.Black, whitePawnAttacks));
+	}
 
-    private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)
-    {
-        var position = new Position(fen);
-        var (score, phase) = position.StaticEvaluation();
+	private static void EvaluateDrawOrNotDraw(string fen, bool isDrawExpected, int expectedPhase)
+	{
+		var position = new Position(fen);
+		var (score, phase) = position.StaticEvaluation();
 
-        Assert.AreEqual(expectedPhase, phase);
+		Assert.AreEqual(expectedPhase, phase);
 
-        if (isDrawExpected)
-        {
-            Assert.AreEqual(0, score);
-        }
-        else
-        {
-            Assert.AreNotEqual(0, score);
-        }
-    }
+		if (isDrawExpected)
+		{
+			Assert.AreEqual(0, score);
+		}
+		else
+		{
+			Assert.AreNotEqual(0, score);
+		}
+	}
 }

--- a/tests/Lynx.Test/MoveGeneration/CastlingMoveTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/CastlingMoveTest.cs
@@ -18,11 +18,9 @@ public class CastlingMoveTest
         Span<Move> moveSpan = stackalloc Move[2];
         var index = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, ref evaluationContext);
+        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, evaluationContext);
 
         var move = moveSpan[0];
         Assert.IsTrue(move.IsCastle());
@@ -37,11 +35,9 @@ public class CastlingMoveTest
         Span<Move> moveSpan = stackalloc Move[2];
         var index = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, ref evaluationContext);
+        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, evaluationContext);
 
         var move = moveSpan[0];
         Assert.IsTrue(move.IsCastle());
@@ -56,11 +52,9 @@ public class CastlingMoveTest
         Span<Move> moveSpan = stackalloc Move[2];
         var index = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, ref evaluationContext);
+        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, evaluationContext);
 
         var move = moveSpan[0];
         Assert.IsTrue(move.IsCastle());
@@ -75,11 +69,9 @@ public class CastlingMoveTest
         Span<Move> moveSpan = stackalloc Move[2];
         var index = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, ref evaluationContext);
+        MoveGenerator.GenerateCastlingMoves(ref index, moveSpan, position, evaluationContext);
 
         var move = moveSpan[0];
         Assert.IsTrue(move.IsCastle());

--- a/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneralMoveGeneratorTest.cs
@@ -5,49 +5,45 @@ namespace Lynx.Test.MoveGeneration;
 
 public class GeneralMoveGeneratorTest
 {
-    /// <summary>
-    /// http://www.talkchess.com/forum3/viewtopic.php?f=7&t=78241&sid=c0f623952408bbd4a891bd36adcc132d&start=10#p907063
-    /// </summary>
-    [Test]
-    public void DiscoveredCheckAfterEnPassantCapture()
-    {
-        var originalPosition = new Position("8/8/8/k1pP3R/8/8/8/n4K2 w - c6 0 1");
+	/// <summary>
+	/// http://www.talkchess.com/forum3/viewtopic.php?f=7&t=78241&sid=c0f623952408bbd4a891bd36adcc132d&start=10#p907063
+	/// </summary>
+	[Test]
+	public void DiscoveredCheckAfterEnPassantCapture()
+	{
+		var originalPosition = new Position("8/8/8/k1pP3R/8/8/8/n4K2 w - c6 0 1");
 
-        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+		using var evaluationContext = new EvaluationContext();
 
-        var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition, ref evaluationContext, moves).ToArray().Single(m => m.IsEnPassant());
-        var positionAfterEnPassant = new Position(originalPosition);
-        positionAfterEnPassant.MakeMove(enPassantMove);
+		var enPassantMove = MoveGenerator.GenerateAllMoves(originalPosition, evaluationContext, moves).ToArray().Single(m => m.IsEnPassant());
+		var positionAfterEnPassant = new Position(originalPosition);
+		positionAfterEnPassant.MakeMove(enPassantMove);
 
-        moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        foreach (var move in MoveGenerator.GenerateAllMoves(positionAfterEnPassant, ref evaluationContext, moves))
-        {
-            var newPosition = new Position(positionAfterEnPassant);
-            newPosition.MakeMove(move);
-            if (newPosition.IsValid())
-            {
-                Assert.AreNotEqual(Piece.n, (Piece)move.Piece());
-                Assert.AreEqual(Piece.k, (Piece)move.Piece());
-            }
-        }
-    }
+		moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+		foreach (var move in MoveGenerator.GenerateAllMoves(positionAfterEnPassant, evaluationContext, moves))
+		{
+			var newPosition = new Position(positionAfterEnPassant);
+			newPosition.MakeMove(move);
+			if (newPosition.IsValid())
+			{
+				Assert.AreNotEqual(Piece.n, (Piece)move.Piece());
+				Assert.AreEqual(Piece.k, (Piece)move.Piece());
+			}
+		}
+	}
 
-    [TestCase("QQQQQQBk/Q6B/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1")]   // 265 pseudolegal moves at the time of writing this
-    public void PositionWithMoreThan256PseudolegalMoves(string fen)
-    {
-        // 265 pseudolegal moves at the time of writing this
-        var position = new Position(fen);
+	[TestCase("QQQQQQBk/Q6B/Q6Q/Q6Q/Q6Q/Q6Q/Q6Q/KQQQQQQQ w - - 0 1")]   // 265 pseudolegal moves at the time of writing this
+	public void PositionWithMoreThan256PseudolegalMoves(string fen)
+	{
+		// 265 pseudolegal moves at the time of writing this
+		var position = new Position(fen);
 
-        Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+		Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+		using var evaluationContext = new EvaluationContext();
 
-        var allMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moveSpan);
+		var allMoves = MoveGenerator.GenerateAllMoves(position, evaluationContext, moveSpan);
 
-        Assert.LessOrEqual(allMoves.Length, Constants.MaxNumberOfPseudolegalMovesInAPosition);
-    }
+		Assert.LessOrEqual(allMoves.Length, Constants.MaxNumberOfPseudolegalMovesInAPosition);
+	}
 }

--- a/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateBishopMovesTest.cs
@@ -8,21 +8,17 @@ public class GenerateBishopMovesTest
     private static IEnumerable<Move> GenerateBishopMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }
 
     private static IEnumerable<Move> GenerateBishopCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.B || m.Piece() == (int)Piece.b);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateCastlingMovesTest.cs
@@ -173,11 +173,9 @@ public class GenerateCastlingMovesTest
     {
         int index = 0;
 
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, ref evaluationContext);
+        MoveGenerator.GenerateCastlingMoves(ref index, moves, position, evaluationContext);
     }
 
 #pragma warning restore RCS1098, S4144 // Methods should not have identical implementations

--- a/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKingMovesTest.cs
@@ -8,21 +8,17 @@ public class GenerateKingMovesTest
     private static IEnumerable<Move> GenerateKingMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }
 
     private static IEnumerable<Move> GenerateKingCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.K || m.Piece() == (int)Piece.k);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateKnightMovesTest.cs
@@ -8,21 +8,17 @@ public class GenerateKnightMovesTest
     private static IEnumerable<Move> GenerateKnightMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }
 
     private static IEnumerable<Move> GenerateKnightCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.N || m.Piece() == (int)Piece.n);
     }
 
     [TestCase(Constants.InitialPositionFEN, 4)]

--- a/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GeneratePawnMovesTest.cs
@@ -9,21 +9,17 @@ public class GeneratePawnMovesTest
     private static IEnumerable<Move> GeneratePawnMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
+        using var evaluationContext = new EvaluationContext();
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 
     private static IEnumerable<Move> GeneratePawnCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
+        using var evaluationContext = new EvaluationContext();
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() % (int)Piece.p == 0);
     }
 
     [Test]

--- a/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateQueenMovesTest.cs
@@ -8,21 +8,17 @@ public class GenerateQueenMovesTest
     private static IEnumerable<Move> GenerateQueenMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
+        using var evaluationContext = new EvaluationContext();
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 
     private static IEnumerable<Move> GenerateQueenCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
+        using var evaluationContext = new EvaluationContext();
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.Q || m.Piece() == (int)Piece.q);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/GenerateRookMovesTest.cs
@@ -8,21 +8,17 @@ public class GenerateRookMovesTest
     private static IEnumerable<Move> GenerateRookMoves(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        return MoveGenerator.GenerateAllMoves(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
+        return MoveGenerator.GenerateAllMoves(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
 
     private static IEnumerable<Move> GenerateRookCaptures(Position position)
     {
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
 
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
-        return MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
+        using var evaluationContext = new EvaluationContext();
+        return MoveGenerator.GenerateAllCaptures(position, evaluationContext, moves).ToArray().Where(m => m.Piece() == (int)Piece.R || m.Piece() == (int)Piece.r);
     }
 
     [TestCase(Constants.InitialPositionFEN, 0)]

--- a/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
+++ b/tests/Lynx.Test/MoveGeneration/RegressionTest.cs
@@ -20,11 +20,9 @@ public class MoveGeneratorRegressionTest : BaseTest
         Assert.True(moves.Exists(m => m.IsDoublePawnPush()));
 
         Span<Move> moveSpan = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-        Span<BitBoard> attacks = stackalloc BitBoard[12];
-        Span<BitBoard> attacksBySide = stackalloc BitBoard[2];
-        var evaluationContext = new EvaluationContext(attacks, attacksBySide);
+        using var evaluationContext = new EvaluationContext();
 
-        var captures = MoveGenerator.GenerateAllCaptures(position, ref evaluationContext, moveSpan).ToArray().ToList();
+        var captures = MoveGenerator.GenerateAllCaptures(position, evaluationContext, moveSpan).ToArray().ToList();
 
         Assert.True(moves.Exists(m => m.IsShortCastle()));
         Assert.True(moves.Exists(m => m.IsLongCastle()));


### PR DESCRIPTION
The idea was to better be able to have rented arrays without passing them via constructor

benches even timed out xD

```
Test  | refactor/evaluationcontext-class
Elo   | -1199.83 +- 0.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.05 (-2.25, 2.89) [-3.00, 1.00]
Games | 6: +0 -6 =0
Penta | [3, 0, 0, 0, 0]
https://openbench.lynx-chess.com/test/2195/
```