### PR TITLE
🔍 LMR: reduce more when previous moves raised alpha - 75

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,6 +245,12 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
+    public int LMR_AlphaRaiseCounter { get; set; } = 50;
+
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(25, 300, 30)]
     public int LMR_Corrplexity { get; set; } = 197;
 
     [SPSA<int>(25, 300, 30)]

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -245,7 +245,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>
     /// </summary>
     [SPSA<int>(25, 300, 30)]
-    public int LMR_AlphaRaiseCounter { get; set; } = 50;
+    public int LMR_AlphaRaiseCounter { get; set; } = 75;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.LMRScaleFactor"/>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -334,6 +334,7 @@ public sealed partial class Engine
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
         int visitedMovesCounter = 0;
+        int alphaRaiseCounter = 0;
 
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
@@ -579,6 +580,8 @@ public sealed partial class Engine
                                     reduction += Configuration.EngineSettings.LMR_TTCapture;
                                 }
 
+                                reduction += alphaRaiseCounter * Configuration.EngineSettings.LMR_AlphaRaiseCounter;
+
                                 if (pvNode)
                                 {
                                     reduction -= Configuration.EngineSettings.LMR_PVNode;
@@ -695,6 +698,7 @@ public sealed partial class Engine
                     }
 
                     nodeType = NodeType.Exact;
+                    ++alphaRaiseCounter;
                 }
 
                 // Beta-cutoff - refutation found, no need to keep searching this line


### PR DESCRIPTION
50: https://github.com/lynx-chess/Lynx/pull/2089
25: https://github.com/lynx-chess/Lynx/pull/2106

```
Test  | search/lmr-alpha-raises-2
Elo   | -1.49 +- 3.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.53 (-2.25, 2.89) [0.00, 3.00]
Games | 16070: +4381 -4450 =7239
Penta | [345, 1956, 3493, 1905, 336]
https://openbench.lynx-chess.com/test/2216/
```