### PR TITLE
🔍 QS fail medium

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -976,6 +976,16 @@ public sealed partial class Engine
             staticEval = bestScore;
         }
 
+        // QS fail medium
+        if (!pvNode
+            && bestScore >= beta
+            && bestScore < EvaluationConstants.PositiveCheckmateDetectionLimit
+            && beta < EvaluationConstants.PositiveCheckmateDetectionLimit
+            && beta > EvaluationConstants.NegativeCheckmateDetectionLimit)
+        {
+            bestScore = (bestScore + beta) / 2;
+        }
+
         _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, 0, ply, bestScore, nodeType, ttPv, bestMove);
 
         return bestScore;


### PR DESCRIPTION
```
Test  | search/qs-fail-medium
Elo   | -0.00 +- 1.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.16 (-2.25, 2.89) [0.00, 3.00]
Games | 57984: +16048 -16048 =25888
Penta | [1173, 7082, 12506, 7034, 1197]
https://openbench.lynx-chess.com/test/2189/
```