### PR TITLE
⚡ `Position` minor speedups

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1016,28 +1016,28 @@ public class Position : IDisposable
 
         Debug.Assert(Side != Side.Both, failureMessage, "Side == Side.Both");
 
-        var whitePawns = PieceBitBoards[(int)Piece.P];
-        var blackPawns = PieceBitBoards[(int)Piece.p];
-        var whiteKnights = PieceBitBoards[(int)Piece.N];
-        var whiteBishops = PieceBitBoards[(int)Piece.B];
-        var whiteRooks = PieceBitBoards[(int)Piece.R];
-        var whiteQueens = PieceBitBoards[(int)Piece.Q];
-        var whiteKings = PieceBitBoards[(int)Piece.K];
-        var blackKnights = PieceBitBoards[(int)Piece.n];
-        var blackBishops = PieceBitBoards[(int)Piece.b];
-        var blackRooks = PieceBitBoards[(int)Piece.r];
-        var blackQueens = PieceBitBoards[(int)Piece.q];
-        var blackKings = PieceBitBoards[(int)Piece.k];
+        var whitePawns = _pieceBitBoards[(int)Piece.P];
+        var blackPawns = _pieceBitBoards[(int)Piece.p];
+        var whiteKnights = _pieceBitBoards[(int)Piece.N];
+        var whiteBishops = _pieceBitBoards[(int)Piece.B];
+        var whiteRooks = _pieceBitBoards[(int)Piece.R];
+        var whiteQueens = _pieceBitBoards[(int)Piece.Q];
+        var whiteKings = _pieceBitBoards[(int)Piece.K];
+        var blackKnights = _pieceBitBoards[(int)Piece.n];
+        var blackBishops = _pieceBitBoards[(int)Piece.b];
+        var blackRooks = _pieceBitBoards[(int)Piece.r];
+        var blackQueens = _pieceBitBoards[(int)Piece.q];
+        var blackKings = _pieceBitBoards[(int)Piece.k];
 
         // No pawns in 1 and 8 ranks
         Debug.Assert((whitePawns & Constants.PawnSquares) == whitePawns, failureMessage, "White pawn(s) un 1-8");
         Debug.Assert((blackPawns & Constants.PawnSquares) == blackPawns, failureMessage, "Black pawn(s) un 1-8");
 
         // No side occupancy overlap
-        Debug.Assert((OccupancyBitBoards[(int)Side.White] & OccupancyBitBoards[(int)Side.Black]) == 0, failureMessage, "White and Black overlap");
+        Debug.Assert((_occupancyBitBoards[(int)Side.White] & _occupancyBitBoards[(int)Side.Black]) == 0, failureMessage, "White and Black overlap");
 
         // Side.Both occupancy overlap
-        Debug.Assert((OccupancyBitBoards[(int)Side.White] | OccupancyBitBoards[(int)Side.Black]) == OccupancyBitBoards[(int)Side.Both], failureMessage, "Occupancy not correct");
+        Debug.Assert((_occupancyBitBoards[(int)Side.White] | _occupancyBitBoards[(int)Side.Black]) == _occupancyBitBoards[(int)Side.Both], failureMessage, "Occupancy not correct");
 
         // No piece overlap
         const string pieceOverlapMessage = "Piece overlap";
@@ -1178,7 +1178,7 @@ public class Position : IDisposable
         // En-passant and pawn to be captured position
         if (_enPassant != BoardSquare.noSquare)
         {
-            Debug.Assert(!OccupancyBitBoards[(int)Side.Both].GetBit(_enPassant), failureMessage, $"Non-empty en passant square {_enPassant}");
+            Debug.Assert(!_occupancyBitBoards[(int)Side.Both].GetBit(_enPassant), failureMessage, $"Non-empty en passant square {_enPassant}");
 
             var rank = Constants.Rank[(int)_enPassant];
             Debug.Assert(rank == 2 || rank == 5, failureMessage, $"Wrong en-passant rank for {_enPassant}");
@@ -2139,13 +2139,14 @@ public class Position : IDisposable
         KingThreatsBonus
     ];
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void CalculateThreats(ref EvaluationContext evaluationContext)
     {
-        var occupancy = OccupancyBitBoards[(int)Side.Both];
+        var occupancy = _occupancyBitBoards[(int)Side.Both];
 
         for (int pieceIndex = (int)Piece.P; pieceIndex <= (int)Piece.K; ++pieceIndex)
         {
-            var board = PieceBitBoards[pieceIndex];
+            var board = _pieceBitBoards[pieceIndex];
             var attacks = MoveGenerator._pieceAttacks[pieceIndex];
 
             while (board != 0)
@@ -2159,7 +2160,7 @@ public class Position : IDisposable
 
         for (int pieceIndex = (int)Piece.p; pieceIndex <= (int)Piece.k; ++pieceIndex)
         {
-            var board = PieceBitBoards[pieceIndex];
+            var board = _pieceBitBoards[pieceIndex];
             var attacks = MoveGenerator._pieceAttacks[pieceIndex];
 
             while (board != 0)
@@ -2218,9 +2219,9 @@ public class Position : IDisposable
         int packedBonus = 0;
 
         var offset = Utils.PieceOffset(side);
-        var occupancy = OccupancyBitBoards[(int)Side.Both];
+        var occupancy = _occupancyBitBoards[(int)Side.Both];
 
-        var oppositeSideKingSquare = PieceBitBoards[(int)Piece.k - offset].GetLS1BIndex();
+        var oppositeSideKingSquare = _pieceBitBoards[(int)Piece.k - offset].GetLS1BIndex();
         var oppositeSideAttacks = evaluationContext.AttacksBySide[oppositeSide];
 
         Span<BitBoard> checkThreats = stackalloc BitBoard[5];
@@ -2718,19 +2719,19 @@ public class Position : IDisposable
     {
         var attacks = evaluationContext.Attacks;
 
-        Debug.Assert(PieceBitBoards[(int)Piece.P] == 0 || attacks[(int)Piece.P] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.N] == 0 || attacks[(int)Piece.N] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.B] == 0 || attacks[(int)Piece.B] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.R] == 0 || attacks[(int)Piece.R] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.Q] == 0 || attacks[(int)Piece.Q] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.P] == 0 || attacks[(int)Piece.P] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.N] == 0 || attacks[(int)Piece.N] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.B] == 0 || attacks[(int)Piece.B] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.R] == 0 || attacks[(int)Piece.R] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.Q] == 0 || attacks[(int)Piece.Q] != 0);
         Debug.Assert(attacks[(int)Piece.K] != 0);
         Debug.Assert(evaluationContext.AttacksBySide[(int)Side.White] != 0);
 
-        Debug.Assert(PieceBitBoards[(int)Piece.p] == 0 || attacks[(int)Piece.p] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.n] == 0 || attacks[(int)Piece.n] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.b] == 0 || attacks[(int)Piece.b] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.r] == 0 || attacks[(int)Piece.r] != 0);
-        Debug.Assert(PieceBitBoards[(int)Piece.q] == 0 || attacks[(int)Piece.q] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.p] == 0 || attacks[(int)Piece.p] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.n] == 0 || attacks[(int)Piece.n] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.b] == 0 || attacks[(int)Piece.b] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.r] == 0 || attacks[(int)Piece.r] != 0);
+        Debug.Assert(_pieceBitBoards[(int)Piece.q] == 0 || attacks[(int)Piece.q] != 0);
         Debug.Assert(attacks[(int)Piece.k] != 0);
         Debug.Assert(evaluationContext.AttacksBySide[(int)Side.Black] != 0);
     }


### PR DESCRIPTION
- Add missing inline suggestion for `Position.CalculateThreats()`
- Use fields instead of properties inside of `Position`