### PR TITLE
🔍 Move ordering: add bonus for moves that involve or create a passed pawn

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -205,6 +205,8 @@ public static class EvaluationConstants
 
     public const int BadCaptureMoveBaseScoreValue = 16_384;
 
+    public const int PassedPawnPushBonus = 1024;
+
     //public const int MaxHistoryMoveValue => Configuration.EngineSettings.MaxHistoryMoveValue;
 
     /// <summary>

--- a/src/Lynx/Masks.cs
+++ b/src/Lynx/Masks.cs
@@ -65,6 +65,11 @@ public static class Masks
     public static BitBoard[] BlackPassedPawnMasks { get; } = new BitBoard[64];
 
     /// <summary>
+    /// [2][64]
+    /// </summary>
+    public static BitBoard[][] PassedPawnMasks { get; } = [BlackPassedPawnMasks, WhitePassedPawnMasks];
+
+    /// <summary>
     /// Passed 'side' pawn mask for square c4
     /// 8  0 1 0 1 0 0 0 0
     /// 7  0 1 0 1 0 0 0 0


### PR DESCRIPTION
Too slow?

```
Test  | moveordering/passedpawns
Elo   | -2.05 +- 3.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 19020: +5097 -5209 =8714
Penta | [383, 2302, 4202, 2290, 333]
https://openbench.lynx-chess.com/test/2265/
```