### PR TITLE
⚡ Replace every pair of friend-enemy PQST() calls by a single one

### DIFF
--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -468,11 +468,8 @@ public class Position : IDisposable
                 (sameSideBucket, opposideSideBucket) = (opposideSideBucket, sameSideBucket);
             }
 
-            _incrementalEvalAccumulator -= PSQT(0, sameSideBucket, piece, sourceSquare);
-            _incrementalEvalAccumulator -= PSQT(1, opposideSideBucket, piece, sourceSquare);
-
-            _incrementalEvalAccumulator += PSQT(0, sameSideBucket, newPiece, targetSquare);
-            _incrementalEvalAccumulator += PSQT(1, opposideSideBucket, newPiece, targetSquare);
+            _incrementalEvalAccumulator -= PSQT(sameSideBucket, opposideSideBucket, piece, sourceSquare);
+            _incrementalEvalAccumulator += PSQT(sameSideBucket, opposideSideBucket, newPiece, targetSquare);
 
             _incrementalPhaseAccumulator += extraPhaseIfIncremental;
 
@@ -511,8 +508,7 @@ public class Position : IDisposable
                                 }
                             }
 
-                            _incrementalEvalAccumulator -= PSQT(0, opposideSideBucket, capturedPiece, capturedSquare);
-                            _incrementalEvalAccumulator -= PSQT(1, sameSideBucket, capturedPiece, capturedSquare);
+                            _incrementalEvalAccumulator -= PSQT(opposideSideBucket, sameSideBucket, capturedPiece, capturedSquare);
 
                             _incrementalPhaseAccumulator -= GamePhaseByPiece[capturedPiece];
                         }
@@ -546,8 +542,7 @@ public class Position : IDisposable
                         _uniqueIdentifier ^= capturedPawnHash;
                         _kingPawnUniqueIdentifier ^= capturedPawnHash;
 
-                        _incrementalEvalAccumulator -= PSQT(0, opposideSideBucket, capturedPiece, capturedSquare);
-                        _incrementalEvalAccumulator -= PSQT(1, sameSideBucket, capturedPiece, capturedSquare);
+                        _incrementalEvalAccumulator -= PSQT(opposideSideBucket, sameSideBucket, capturedPiece, capturedSquare);
 
                         //_incrementalPhaseAccumulator -= GamePhaseByPiece[capturedPiece];
                         break;
@@ -1375,8 +1370,7 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, (int)Piece.P, pieceSquareIndex)
-                                                + PSQT(1, blackBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore += AdditionalPieceEvaluation(...);
                 }
@@ -1390,8 +1384,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, blackBucket, (int)Piece.p, pieceSquareIndex)
-                                                + PSQT(1, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore -= AdditionalPieceEvaluation(...);
                 }
@@ -1415,8 +1408,7 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, (int)Piece.P, pieceSquareIndex)
-                                                + PSQT(1, blackBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
 
                     pawnScore += PawnAdditionalEvaluation(ref evaluationContext, whiteBucket, blackBucket, pieceSquareIndex, (int)Piece.P, whiteKing, blackKing);
                 }
@@ -1435,8 +1427,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, blackBucket, (int)Piece.p, pieceSquareIndex)
-                                                + PSQT(1, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
                     pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, blackBucket, whiteBucket, pieceSquareIndex, (int)Piece.p, blackKing, whiteKing);
                 }
@@ -1460,8 +1451,7 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, whiteBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, blackBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
@@ -1482,8 +1472,7 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(0, blackBucket, pieceIndex, pieceSquareIndex)
-                                                + PSQT(1, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
@@ -1498,10 +1487,8 @@ public class Position : IDisposable
 
         // Kings - they can't be incremental due to the king buckets
         packedScore +=
-            PSQT(0, whiteBucket, (int)Piece.K, whiteKing)
-            + PSQT(1, blackBucket, (int)Piece.K, whiteKing)
-            + PSQT(0, blackBucket, (int)Piece.k, blackKing)
-            + PSQT(1, whiteBucket, (int)Piece.k, blackKing);
+            PSQT(whiteBucket, blackBucket, (int)Piece.K, whiteKing)
+            + PSQT(blackBucket, whiteBucket, (int)Piece.k, blackKing);
 
         packedScore +=
             KingAdditionalEvaluation(whiteKing, whiteBucket, (int)Side.White, blackPawnAttacks)

--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+
 using static Lynx.TunableEvalParameters;
 
 namespace Lynx;

--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -25,9 +25,9 @@ public static class EvaluationPSQTs
 #pragma warning restore S4663 // Comments should not be empty
 
     /// <summary>
-    /// 2 x PSQTBucketCount x 12 x 64
+    /// 2 x PSQTBucketCount x PSQTBucketCount x 12 x 64
     /// </summary>
-    internal static readonly int[] _packedPSQT = GC.AllocateArray<int>(2 * PSQTBucketCount * 12 * 64, pinned: true);
+    internal static readonly int[] _packedPSQT = GC.AllocateArray<int>(2 * PSQTBucketCount * PSQTBucketCount * 12 * 64, pinned: true);
 
     static EvaluationPSQTs()
     {
@@ -72,21 +72,32 @@ public static class EvaluationPSQTs
             ]
         ];
 
-        for (int friendEnemy = 0; friendEnemy < 2; ++friendEnemy)
+        for (int friendBucket = 0; friendBucket < PSQTBucketCount; ++friendBucket)
         {
-            for (int bucket = 0; bucket < PSQTBucketCount; ++bucket)
+            for (int enemyBucket = 0; enemyBucket < PSQTBucketCount; ++enemyBucket)
             {
                 for (int piece = (int)Piece.P; piece <= (int)Piece.K; ++piece)
                 {
                     for (int sq = 0; sq < 64; ++sq)
                     {
-                        _packedPSQT[PSQTIndex(friendEnemy, bucket, piece, sq)] = Utils.Pack(
-                            (short)(MiddleGamePieceValues[friendEnemy][bucket][piece] + mgPositionalTables[friendEnemy][piece][bucket][sq]),
-                            (short)(EndGamePieceValues[friendEnemy][bucket][piece] + egPositionalTables[friendEnemy][piece][bucket][sq]));
+                        const int Friend = 0;
+                        const int Enemy = 1;
 
-                        _packedPSQT[PSQTIndex(friendEnemy, bucket, piece + 6, sq)] = Utils.Pack(
-                            (short)(MiddleGamePieceValues[friendEnemy][bucket][piece + 6] - mgPositionalTables[friendEnemy][piece][bucket][sq ^ 56]),
-                            (short)(EndGamePieceValues[friendEnemy][bucket][piece + 6] - egPositionalTables[friendEnemy][piece][bucket][sq ^ 56]));
+                        _packedPSQT[PSQTIndex(friendBucket, enemyBucket, piece, sq)] =
+                            Utils.Pack(
+                                (short)(MiddleGamePieceValues[Friend][friendBucket][piece] + mgPositionalTables[Friend][piece][friendBucket][sq]),
+                                (short)(EndGamePieceValues[Friend][friendBucket][piece] + egPositionalTables[Friend][piece][friendBucket][sq]))
+                            + Utils.Pack(
+                                (short)(MiddleGamePieceValues[Enemy][enemyBucket][piece] + mgPositionalTables[Enemy][piece][enemyBucket][sq]),
+                                (short)(EndGamePieceValues[Enemy][enemyBucket][piece] + egPositionalTables[Enemy][piece][enemyBucket][sq]));
+
+                        _packedPSQT[PSQTIndex(friendBucket, enemyBucket, piece + 6, sq)] =
+                            Utils.Pack(
+                                (short)(MiddleGamePieceValues[Friend][friendBucket][piece + 6] - mgPositionalTables[Friend][piece][friendBucket][sq ^ 56]),
+                                (short)(EndGamePieceValues[Friend][friendBucket][piece + 6] - egPositionalTables[Friend][piece][friendBucket][sq ^ 56]))
+                            + Utils.Pack(
+                                (short)(MiddleGamePieceValues[Enemy][enemyBucket][piece + 6] - mgPositionalTables[Enemy][piece][enemyBucket][sq ^ 56]),
+                                (short)(EndGamePieceValues[Enemy][enemyBucket][piece + 6] - egPositionalTables[Enemy][piece][enemyBucket][sq ^ 56]));
                     }
                 }
             }
@@ -97,26 +108,26 @@ public static class EvaluationPSQTs
     /// [2][PSQTBucketCount][12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int PSQT(int friendEnemy, int bucket, int piece, int square)
+    public static int PSQT(int friendBucket, int enemyBucket, int piece, int square)
     {
-        var index = PSQTIndex(friendEnemy, bucket, piece, square);
+        var index = PSQTIndex(friendBucket, enemyBucket, piece, square);
         Debug.Assert(index >= 0 && index < _packedPSQT.Length);
 
         return Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(_packedPSQT), index);
     }
 
     /// <summary>
-    /// [2][PSQTBucketCount][12][64]
+    /// [PSQTBucketCount][PSQTBucketCount][12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static int PSQTIndex(int friendEnemy, int bucket, int piece, int square)
+    public static int PSQTIndex(int friendBucket, int enemyBucket, int piece, int square)
     {
-        const int friendEnemyOffset = PSQTBucketCount * 12 * 64;
-        const int bucketOffset = 12 * 64;
+        const int friendBucketOffset = PSQTBucketCount * 12 * 64;
+        const int enemyBucketOffset = 12 * 64;
         const int pieceOffset = 64;
 
-        return (friendEnemy * friendEnemyOffset)
-            + (bucket * bucketOffset)
+        return (friendBucket * friendBucketOffset)
+            + (enemyBucket * enemyBucketOffset)
             + (piece * pieceOffset)
             + square;
     }

--- a/src/Lynx/PSQT.cs
+++ b/src/Lynx/PSQT.cs
@@ -49,7 +49,6 @@ public static class EvaluationPSQTs
                 MiddleGameEnemyQueenTable,
                 MiddleGameEnemyKingTable
             ]
-
         ];
 
         short[][][][] egPositionalTables =

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -1,12 +1,13 @@
 ﻿using Lynx.Model;
 using NUnit.Framework;
+
 using static Lynx.EvaluationConstants;
 using static Lynx.EvaluationParams;
-using static Lynx.EvaluationPSQTs;
 using static Lynx.TunableEvalParameters;
 using static Lynx.Utils;
 
 namespace Lynx.Test;
+
 public class EvaluationConstantsTest
 {
     /// <summary>
@@ -265,93 +266,6 @@ public class EvaluationConstantsTest
         Assert.NotZero(EmergencyMoveScore);
         Assert.Less(EmergencyMoveScore, -50);
         Assert.Greater(EmergencyMoveScore, -200);
-    }
-
-    [Test]
-    public void PackedEvaluation()
-    {
-        short[][][] mgFriend =
-        [
-            MiddleGamePawnTable,
-            MiddleGameKnightTable,
-            MiddleGameBishopTable,
-            MiddleGameRookTable,
-            MiddleGameQueenTable,
-            MiddleGameKingTable
-        ];
-
-        short[][][] egFriend =
-        [
-            EndGamePawnTable,
-            EndGameKnightTable,
-            EndGameBishopTable,
-            EndGameRookTable,
-            EndGameQueenTable,
-            EndGameKingTable
-        ];
-
-        short[][][] mgEnemy =
-        [
-            MiddleGameEnemyPawnTable,
-            MiddleGameEnemyKnightTable,
-            MiddleGameEnemyBishopTable,
-            MiddleGameEnemyRookTable,
-            MiddleGameEnemyQueenTable,
-            MiddleGameEnemyKingTable
-        ];
-
-        short[][][] egEnemy =
-        [
-            EndGameEnemyPawnTable,
-            EndGameEnemyKnightTable,
-            EndGameEnemyBishopTable,
-            EndGameEnemyRookTable,
-            EndGameEnemyQueenTable,
-            EndGameEnemyKingTable
-        ];
-
-        for (int friendBucket = 0; friendBucket < PSQTBucketCount; ++friendBucket)
-        {
-            for (int enemyBucket = 0; enemyBucket < PSQTBucketCount; ++enemyBucket)
-            {
-                for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
-                {
-                    for (int sq = 0; sq < 64; ++sq)
-                    {
-                        int mg, eg;
-
-                        if (piece < (int)Piece.p) // white piece
-                        {
-                            mg =
-                                MiddleGamePieceValues[0][friendBucket][piece] + mgFriend[piece][friendBucket][sq]
-                                + MiddleGamePieceValues[1][enemyBucket][piece] + mgEnemy[piece][enemyBucket][sq];
-
-                            eg =
-                                EndGamePieceValues[0][friendBucket][piece] + egFriend[piece][friendBucket][sq]
-                                + EndGamePieceValues[1][enemyBucket][piece] + egEnemy[piece][enemyBucket][sq];
-                        }
-                        else // black piece
-                        {
-                            int basePiece = piece - 6;
-                            // Mirror square and subtract (equivalent to adding the pre-negated table)
-                            var mirror = sq ^ 56;
-
-                            mg =
-                                MiddleGamePieceValues[0][friendBucket][piece] - mgFriend[basePiece][friendBucket][mirror]
-                                + MiddleGamePieceValues[1][enemyBucket][piece] - mgEnemy[basePiece][enemyBucket][mirror];
-
-                            eg =
-                                EndGamePieceValues[0][friendBucket][piece] - egFriend[basePiece][friendBucket][mirror]
-                                + EndGamePieceValues[1][enemyBucket][piece] - egEnemy[basePiece][enemyBucket][mirror];
-                        }
-
-                        var packed = PSQT(friendBucket, enemyBucket, piece, sq);
-                        Assert.AreEqual(mg, Utils.UnpackMG(packed), $"MG mismatch piece {piece} sq {sq} fb {friendBucket} eb {enemyBucket}");
-                        Assert.AreEqual(eg, Utils.UnpackEG(packed), $"EG mismatch piece {piece} sq {sq} fb {friendBucket} eb {enemyBucket}");
-                    }
-                }
-            }
-        }
     }
 
     /// <summary>

--- a/tests/Lynx.Test/EvaluationConstantsTest.cs
+++ b/tests/Lynx.Test/EvaluationConstantsTest.cs
@@ -45,7 +45,7 @@ public class EvaluationConstantsTest
     [Test]
     public void CheckmateDepthFactorTest()
     {
-        const int maxCheckmateValue = CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth ;
+        const int maxCheckmateValue = CheckMateBaseEvaluation - Constants.AbsoluteMaxDepth;
         Assert.Less(maxCheckmateValue, MaxEval);
         Assert.Greater(maxCheckmateValue, MinEval);
 
@@ -322,17 +322,25 @@ public class EvaluationConstantsTest
             endGameKingTableBlack
         ];
 
-        for (int bucket = 0; bucket < PSQTBucketCount; ++bucket)
+        for (int friendBucket = 0; friendBucket < PSQTBucketCount; ++friendBucket)
         {
-            for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
+            for (int enemyBucket = 0; enemyBucket < PSQTBucketCount; ++enemyBucket)
             {
-                for (int sq = 0; sq < 64; ++sq)
+                for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
                 {
-                    var mg = (short)(MiddleGamePieceValues[0][bucket][piece] + mgPositionalTables[piece][bucket][sq]);
-                    var eg = (short)(EndGamePieceValues[0][bucket][piece] + egPositionalTables[piece][bucket][sq]);
+                    for (int sq = 0; sq < 64; ++sq)
+                    {
+                        var mg = (short)(MiddleGamePieceValues[0][friendBucket][piece] + mgPositionalTables[piece][friendBucket][sq]
+                            + MiddleGamePieceValues[1][enemyBucket][piece] + mgPositionalTables[piece][enemyBucket][sq]);
 
-                    Assert.AreEqual(Utils.UnpackEG(PSQT(0, bucket, piece, sq)), eg);
-                    Assert.AreEqual(Utils.UnpackMG(PSQT(0, bucket, piece, sq)), mg);
+                        var eg = (short)(EndGamePieceValues[0][friendBucket][piece] + egPositionalTables[piece][friendBucket][sq]
+                            + EndGamePieceValues[1][enemyBucket][piece] + egPositionalTables[piece][enemyBucket][sq]);
+
+                        var psqt = PSQT(friendBucket, enemyBucket, piece, sq);
+
+                        Assert.AreEqual(Utils.UnpackEG(psqt), eg);
+                        Assert.AreEqual(Utils.UnpackMG(psqt), mg);
+                    }
                 }
             }
         }

--- a/tests/Lynx.Test/PSQTTest.cs
+++ b/tests/Lynx.Test/PSQTTest.cs
@@ -1,0 +1,97 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+using static Lynx.EvaluationPSQTs;
+using static Lynx.TunableEvalParameters;
+
+namespace Lynx.Test;
+
+public class PSQTTest
+{
+    [Test]
+    public void PackedEvaluation()
+    {
+        short[][][] mgFriend =
+        [
+            MiddleGamePawnTable,
+            MiddleGameKnightTable,
+            MiddleGameBishopTable,
+            MiddleGameRookTable,
+            MiddleGameQueenTable,
+            MiddleGameKingTable
+        ];
+
+        short[][][] egFriend =
+        [
+            EndGamePawnTable,
+            EndGameKnightTable,
+            EndGameBishopTable,
+            EndGameRookTable,
+            EndGameQueenTable,
+            EndGameKingTable
+        ];
+
+        short[][][] mgEnemy =
+        [
+            MiddleGameEnemyPawnTable,
+            MiddleGameEnemyKnightTable,
+            MiddleGameEnemyBishopTable,
+            MiddleGameEnemyRookTable,
+            MiddleGameEnemyQueenTable,
+            MiddleGameEnemyKingTable
+        ];
+
+        short[][][] egEnemy =
+        [
+            EndGameEnemyPawnTable,
+            EndGameEnemyKnightTable,
+            EndGameEnemyBishopTable,
+            EndGameEnemyRookTable,
+            EndGameEnemyQueenTable,
+            EndGameEnemyKingTable
+        ];
+
+        for (int friendBucket = 0; friendBucket < PSQTBucketCount; ++friendBucket)
+        {
+            for (int enemyBucket = 0; enemyBucket < PSQTBucketCount; ++enemyBucket)
+            {
+                for (int piece = (int)Piece.P; piece <= (int)Piece.k; ++piece)
+                {
+                    for (int sq = 0; sq < 64; ++sq)
+                    {
+                        int mg, eg;
+
+                        if (piece < (int)Piece.p) // white piece
+                        {
+                            mg =
+                                MiddleGamePieceValues[0][friendBucket][piece] + mgFriend[piece][friendBucket][sq]
+                                + MiddleGamePieceValues[1][enemyBucket][piece] + mgEnemy[piece][enemyBucket][sq];
+
+                            eg =
+                                EndGamePieceValues[0][friendBucket][piece] + egFriend[piece][friendBucket][sq]
+                                + EndGamePieceValues[1][enemyBucket][piece] + egEnemy[piece][enemyBucket][sq];
+                        }
+                        else // black piece
+                        {
+                            int basePiece = piece - 6;
+                            // Mirror square and subtract (equivalent to adding the pre-negated table)
+                            var mirror = sq ^ 56;
+
+                            mg =
+                                MiddleGamePieceValues[0][friendBucket][piece] - mgFriend[basePiece][friendBucket][mirror]
+                                + MiddleGamePieceValues[1][enemyBucket][piece] - mgEnemy[basePiece][enemyBucket][mirror];
+
+                            eg =
+                                EndGamePieceValues[0][friendBucket][piece] - egFriend[basePiece][friendBucket][mirror]
+                                + EndGamePieceValues[1][enemyBucket][piece] - egEnemy[basePiece][enemyBucket][mirror];
+                        }
+
+                        var packed = PSQT(friendBucket, enemyBucket, piece, sq);
+                        Assert.AreEqual(mg, Utils.UnpackMG(packed), $"MG mismatch piece {piece} sq {sq} fb {friendBucket} eb {enemyBucket}");
+                        Assert.AreEqual(eg, Utils.UnpackEG(packed), $"EG mismatch piece {piece} sq {sq} fb {friendBucket} eb {enemyBucket}");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
```
Test  | perf/psqt-friendenemy-together
Elo   | 3.66 +- 3.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | 12434: +3436 -3305 =5693
Penta | [214, 1356, 2940, 1499, 208]
https://openbench.lynx-chess.com/test/2277/
```