### PR TITLE
⚡ Cache kings squares and buckets in `Position` - in `GameState` 

### DIFF
--- a/src/Lynx.Benchmark/MoveGenerator_SpanUnsafeAdd_Benchmark.cs
+++ b/src/Lynx.Benchmark/MoveGenerator_SpanUnsafeAdd_Benchmark.cs
@@ -825,7 +825,7 @@ public class MoveGenerator_SpanUnsafeAdd_Benchmark : BaseBenchmark
             var gameState = position.MakeMove(move);
 
             bool result = position.WasProduceByAValidMove();
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMove(move, in gameState);
 
             return result;
         }
@@ -1502,7 +1502,7 @@ public class MoveGenerator_SpanUnsafeAdd_Benchmark : BaseBenchmark
             var gameState = position.MakeMove(move);
 
             bool result = position.WasProduceByAValidMove();
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMove(move, in gameState);
 
             return result;
         }

--- a/src/Lynx.Benchmark/ParseGame_Benchmark.cs
+++ b/src/Lynx.Benchmark/ParseGame_Benchmark.cs
@@ -537,7 +537,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
             else
             {
                 _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
+                CurrentPosition.UnmakeMove(moveToPlay, in gameState);
             }
 
             PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
@@ -618,7 +618,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
             else
             {
                 _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
+                CurrentPosition.UnmakeMove(moveToPlay, in gameState);
             }
 
             PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);
@@ -703,7 +703,7 @@ public partial class ParseGame_Benchmark : BaseBenchmark
             else
             {
                 _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
+                CurrentPosition.UnmakeMove(moveToPlay, in gameState);
             }
 
             PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);

--- a/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
+++ b/src/Lynx.Benchmark/TryParseFromUCIString_Benchmark.cs
@@ -243,7 +243,7 @@ public class TryParseFromUCIString_Benchmark : BaseBenchmark
             else
             {
                 _logger.Warn("Error trying to play {0}", moveToPlay.UCIString());
-                CurrentPosition.UnmakeMove(moveToPlay, gameState);
+                CurrentPosition.UnmakeMove(moveToPlay, in gameState);
             }
 
             PositionHashHistory.Add(CurrentPosition.UniqueIdentifier);

--- a/src/Lynx.Dev/Program.cs
+++ b/src/Lynx.Dev/Program.cs
@@ -537,7 +537,7 @@ static void _32_Make_Move()
             Console.WriteLine("Black occupancy:");
             game.CurrentPosition.OccupancyBitBoards[(int)Side.Black].Print();
 
-            game.CurrentPosition.UnmakeMove(move, gameState);
+            game.CurrentPosition.UnmakeMove(move, in gameState);
         }
     }
 
@@ -553,7 +553,7 @@ static void _32_Make_Move()
                 Console.WriteLine(move.ToEPDString(game.CurrentPosition));
                 var gameState = game.MakeMove(move);
                 game.CurrentPosition.Print();
-                game.CurrentPosition.UnmakeMove(move, gameState);
+                game.CurrentPosition.UnmakeMove(move, in gameState);
             }
         }
     }

--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -20,6 +20,14 @@ public readonly struct GameState
 
     public readonly int IncrementalPhaseAccumulator;
 
+    public readonly int WhiteKing;
+
+    public readonly int BlackKing;
+
+    public readonly int WhiteKingBucket;
+
+    public readonly int BlackKingBucket;
+
     public readonly BoardSquare EnPassant;
 
     public readonly byte Castle;
@@ -40,6 +48,11 @@ public readonly struct GameState
         Castle = position.Castle;
         IncrementalEvalAccumulator = position._incrementalEvalAccumulator;
         IncrementalPhaseAccumulator = position._incrementalPhaseAccumulator;
+
+        WhiteKing = position.WhiteKing;
+        BlackKing = position.BlackKing;
+        WhiteKingBucket = position.WhiteKingBucket;
+        BlackKingBucket = position.BlackKingBucket;
 
         // We also save a copy of _isIncrementalEval, so that current move doesn't affect 'sibling' moves exploration
         IsIncrementalEval = position._isIncrementalEval;

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -794,7 +794,7 @@ public class Position : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void UnmakeMove(Move move, GameState gameState)
+    public void UnmakeMove(Move move, in GameState gameState)
     {
         var oppositeSide = (int)_side;
         var side = Utils.OppositeSide(oppositeSide);

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1299,9 +1299,10 @@ public class Position : IDisposable
         evaluationContext.AttacksBySide[(int)Side.White] = evaluationContext.Attacks[(int)Piece.P] = whitePawnAttacks;
         evaluationContext.AttacksBySide[(int)Side.Black] = evaluationContext.Attacks[(int)Piece.p] = blackPawnAttacks;
 
+        var whiteKing = WhiteKing;
+        var blackKing = BlackKing;
         var whiteBucket = WhiteKingBucket;
         var blackBucket = BlackKingBucket;
-
 
         if (_isIncrementalEval)
         {
@@ -1324,7 +1325,7 @@ public class Position : IDisposable
                 // White pawns
 
                 // King pawn shield bonus
-                pawnScore += KingPawnShield(WhiteKing, whitePawns);
+                pawnScore += KingPawnShield(whiteKing, whitePawns);
 
                 // Pieces protected by pawns bonus
                 pawnScore += PieceProtectedByPawnBonus[(int)Piece.P] * (whitePawnAttacks & whitePawns).CountBits();
@@ -1335,13 +1336,13 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    pawnScore += PawnAdditionalEvaluation(ref evaluationContext, WhiteKingBucket, BlackKingBucket, pieceSquareIndex, (int)Piece.P, WhiteKing, BlackKing);
+                    pawnScore += PawnAdditionalEvaluation(ref evaluationContext, whiteBucket, blackBucket, pieceSquareIndex, (int)Piece.P, whiteKing, blackKing);
                 }
 
                 // Black pawns
 
                 // King pawn shield bonus
-                pawnScore -= KingPawnShield(BlackKing, blackPawns);
+                pawnScore -= KingPawnShield(blackKing, blackPawns);
 
                 // Pieces protected by pawns bonus
                 pawnScore -= PieceProtectedByPawnBonus[(int)Piece.P] * (blackPawnAttacks & blackPawns).CountBits();
@@ -1352,7 +1353,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, BlackKingBucket, WhiteKingBucket, pieceSquareIndex, (int)Piece.p, BlackKing, WhiteKing);
+                    pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, blackBucket, whiteBucket, pieceSquareIndex, (int)Piece.p, blackKing, whiteKing);
                 }
 
                 // Pawn islands
@@ -1374,7 +1375,7 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    packedScore += AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, WhiteKingBucket, BlackKingBucket, pieceIndex, (int)Side.White, blackPawnAttacks, BlackKing);
+                    packedScore += AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, whiteBucket, blackBucket, pieceIndex, (int)Side.White, blackPawnAttacks, blackKing);
                 }
             }
 
@@ -1391,7 +1392,7 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, BlackKingBucket, WhiteKingBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, WhiteKing);
+                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, blackBucket, whiteBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, whiteKing);
                 }
             }
         }
@@ -1417,7 +1418,7 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, (int)Piece.P, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore += AdditionalPieceEvaluation(...);
                 }
@@ -1431,7 +1432,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore -= AdditionalPieceEvaluation(...);
                 }
@@ -1444,7 +1445,7 @@ public class Position : IDisposable
                 // White pawns
 
                 // King pawn shield bonus
-                pawnScore += KingPawnShield(WhiteKing, whitePawns);
+                pawnScore += KingPawnShield(whiteKing, whitePawns);
 
                 // Pieces protected by pawns bonus
                 pawnScore += PieceProtectedByPawnBonus[(int)Piece.P] * (whitePawnAttacks & whitePawns).CountBits();
@@ -1455,15 +1456,15 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, (int)Piece.P, pieceSquareIndex);
 
-                    pawnScore += PawnAdditionalEvaluation(ref evaluationContext, WhiteKingBucket, BlackKingBucket, pieceSquareIndex, (int)Piece.P, WhiteKing, BlackKing);
+                    pawnScore += PawnAdditionalEvaluation(ref evaluationContext, whiteBucket, blackBucket, pieceSquareIndex, (int)Piece.P, whiteKing, blackKing);
                 }
 
                 // Black pawns
 
                 // King pawn shield bonus
-                pawnScore -= KingPawnShield(BlackKing, blackPawns);
+                pawnScore -= KingPawnShield(blackKing, blackPawns);
 
                 // Pieces protected by pawns bonus
                 pawnScore -= PieceProtectedByPawnBonus[(int)Piece.P] * (blackPawnAttacks & blackPawns).CountBits();
@@ -1474,9 +1475,9 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
-                    pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, BlackKingBucket, WhiteKingBucket, pieceSquareIndex, (int)Piece.p, BlackKing, WhiteKing);
+                    pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, blackBucket, whiteBucket, pieceSquareIndex, (int)Piece.p, blackKing, whiteKing);
                 }
 
                 // Pawn islands
@@ -1498,11 +1499,11 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
-                    packedScore += AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, WhiteKingBucket, BlackKingBucket, pieceIndex, (int)Side.White, blackPawnAttacks, BlackKing);
+                    packedScore += AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, whiteBucket, blackBucket, pieceIndex, (int)Side.White, blackPawnAttacks, blackKing);
                 }
             }
 
@@ -1519,11 +1520,11 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
-                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, BlackKingBucket, WhiteKingBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, WhiteKing);
+                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, blackBucket, WhiteKingBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, WhiteKing);
                 }
             }
 
@@ -1534,18 +1535,18 @@ public class Position : IDisposable
 
         // Kings - they can't be incremental due to the king buckets
         packedScore +=
-            PSQT(whiteBucket, blackBucket, (int)Piece.K, WhiteKing)
-            + PSQT(blackBucket, whiteBucket, (int)Piece.k, BlackKing);
+            PSQT(whiteBucket, BlackKingBucket, (int)Piece.K, WhiteKing)
+            + PSQT(BlackKingBucket, whiteBucket, (int)Piece.k, blackKing);
 
         packedScore +=
             KingAdditionalEvaluation(WhiteKing, WhiteKingBucket, (int)Side.White, blackPawnAttacks)
-            - KingAdditionalEvaluation(BlackKing, BlackKingBucket, (int)Side.Black, whitePawnAttacks);
+            - KingAdditionalEvaluation(blackKing, blackBucket, (int)Side.Black, whitePawnAttacks);
 
         var whiteKingAttacks = Attacks.KingAttacks[WhiteKing];
         evaluationContext.Attacks[(int)Piece.K] |= whiteKingAttacks;
         evaluationContext.AttacksBySide[(int)Side.White] |= whiteKingAttacks;
 
-        var blackKingAttacks = Attacks.KingAttacks[BlackKing];
+        var blackKingAttacks = Attacks.KingAttacks[blackKing];
         evaluationContext.Attacks[(int)Piece.k] |= blackKingAttacks;
         evaluationContext.AttacksBySide[(int)Side.Black] |= blackKingAttacks;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1418,7 +1418,7 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore += AdditionalPieceEvaluation(...);
                 }
@@ -1432,7 +1432,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
                     // No incremental eval - included in pawn table | packedScore -= AdditionalPieceEvaluation(...);
                 }
@@ -1456,7 +1456,7 @@ public class Position : IDisposable
                 {
                     whitePawnsCopy = whitePawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, (int)Piece.P, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, (int)Piece.P, pieceSquareIndex);
 
                     pawnScore += PawnAdditionalEvaluation(ref evaluationContext, whiteBucket, blackBucket, pieceSquareIndex, (int)Piece.P, whiteKing, blackKing);
                 }
@@ -1475,7 +1475,7 @@ public class Position : IDisposable
                 {
                     blackPawnsCopy = blackPawnsCopy.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, (int)Piece.p, pieceSquareIndex);
 
                     pawnScore -= PawnAdditionalEvaluation(ref evaluationContext, blackBucket, whiteBucket, pieceSquareIndex, (int)Piece.p, blackKing, whiteKing);
                 }
@@ -1499,7 +1499,7 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(whiteBucket, BlackKingBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(whiteBucket, blackBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
@@ -1520,11 +1520,11 @@ public class Position : IDisposable
                 {
                     bitboard = bitboard.WithoutLS1B(out var pieceSquareIndex);
 
-                    _incrementalEvalAccumulator += PSQT(BlackKingBucket, whiteBucket, pieceIndex, pieceSquareIndex);
+                    _incrementalEvalAccumulator += PSQT(blackBucket, whiteBucket, pieceIndex, pieceSquareIndex);
 
                     _incrementalPhaseAccumulator += GamePhaseByPiece[pieceIndex];
 
-                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, blackBucket, WhiteKingBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, WhiteKing);
+                    packedScore -= AdditionalPieceEvaluation(ref evaluationContext, pieceSquareIndex, blackBucket, whiteBucket, pieceIndex, (int)Side.Black, whitePawnAttacks, whiteKing);
                 }
             }
 
@@ -1535,14 +1535,14 @@ public class Position : IDisposable
 
         // Kings - they can't be incremental due to the king buckets
         packedScore +=
-            PSQT(whiteBucket, BlackKingBucket, (int)Piece.K, WhiteKing)
-            + PSQT(BlackKingBucket, whiteBucket, (int)Piece.k, blackKing);
+            PSQT(whiteBucket, blackBucket, (int)Piece.K, whiteKing)
+            + PSQT(blackBucket, whiteBucket, (int)Piece.k, blackKing);
 
         packedScore +=
-            KingAdditionalEvaluation(WhiteKing, WhiteKingBucket, (int)Side.White, blackPawnAttacks)
+            KingAdditionalEvaluation(whiteKing, whiteBucket, (int)Side.White, blackPawnAttacks)
             - KingAdditionalEvaluation(blackKing, blackBucket, (int)Side.Black, whitePawnAttacks);
 
-        var whiteKingAttacks = Attacks.KingAttacks[WhiteKing];
+        var whiteKingAttacks = Attacks.KingAttacks[whiteKing];
         evaluationContext.Attacks[(int)Piece.K] |= whiteKingAttacks;
         evaluationContext.AttacksBySide[(int)Side.White] |= whiteKingAttacks;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -471,7 +471,6 @@ public class Position : IDisposable
 
                 _kingPawnUniqueIdentifier ^= fullPieceMovementHash;
 
-
                 BlackKing = _pieceBitBoards[(int)Piece.k].GetLS1BIndex();
                 BlackKingBucket = PSQTBucketLayout[BlackKing ^ 56];
             }
@@ -663,6 +662,11 @@ public class Position : IDisposable
                             _board[kingTargetSquare] = newPiece;
                             var hashToApply = ZobristTable.PieceHash(kingTargetSquare, newPiece);
 
+                            WhiteKing = _pieceBitBoards[(int)Piece.K].GetLS1BIndex();
+                            BlackKing = _pieceBitBoards[(int)Piece.k].GetLS1BIndex();
+                            WhiteKingBucket = PSQTBucketLayout[WhiteKing];
+                            BlackKingBucket = PSQTBucketLayout[BlackKing ^ 56];
+
                             var hashFix = hashToRevert ^ hashToApply;
 
                             _uniqueIdentifier ^= hashFix;
@@ -718,6 +722,11 @@ public class Position : IDisposable
                             _occupancyBitBoards[oldSide].SetBit(kingTargetSquare);
                             _board[kingTargetSquare] = newPiece;
                             var hashToApply = ZobristTable.PieceHash(kingTargetSquare, newPiece);
+
+                            WhiteKing = _pieceBitBoards[(int)Piece.K].GetLS1BIndex();
+                            BlackKing = _pieceBitBoards[(int)Piece.k].GetLS1BIndex();
+                            WhiteKingBucket = PSQTBucketLayout[WhiteKing];
+                            BlackKingBucket = PSQTBucketLayout[BlackKing ^ 56];
 
                             var hashFix = hashToRevert ^ hashToApply;
 

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -702,7 +702,7 @@ public static class MoveGenerator
         var gameState = position.MakeMove(move);
 
         bool result = position.WasProduceByAValidMove();
-        position.UnmakeMove(move, gameState);
+        position.UnmakeMove(move, in gameState);
 
         return result;
     }

--- a/src/Lynx/Perft.cs
+++ b/src/Lynx/Perft.cs
@@ -52,7 +52,7 @@ public static class Perft
                 {
                     nodes = PerftRecursiveImpl(position, depth - 1, nodes);
                 }
-                position.UnmakeMove(move, state);
+                position.UnmakeMove(move, in state);
             }
 
             return nodes;
@@ -84,7 +84,7 @@ public static class Perft
                     write($"{move.UCIString()}\t\t{nodes - accumulatedNodes}");
                 }
 
-                position.UnmakeMove(move, state);
+                position.UnmakeMove(move, in state);
             }
 
             write(string.Empty);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -439,7 +439,7 @@ public sealed partial class Engine
         {
             var gameState = Game.CurrentPosition.MakeMove(move);
             bool isPositionValid = Game.CurrentPosition.WasProduceByAValidMove();
-            Game.CurrentPosition.UnmakeMove(move, gameState);
+            Game.CurrentPosition.UnmakeMove(move, in gameState);
 
             if (isPositionValid)
             {
@@ -609,7 +609,7 @@ public sealed partial class Engine
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -433,7 +433,7 @@ public sealed partial class Engine
 
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -452,7 +452,7 @@ public sealed partial class Engine
                 && ttEntry.NodeType != NodeType.Alpha
                 && ply < 3 * depth)     // Preventing search explosions
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
 
                 var verificationDepth = (depth - 1) / 2;    // TODO tune?
                 var singularBeta = ttEntry.Score - (depth * Configuration.EngineSettings.SE_DepthMultiplier);
@@ -513,7 +513,7 @@ public sealed partial class Engine
             {
                 Game.HalfMovesWithoutCaptureOrPawnMove = oldHalfMovesWithoutCaptureOrPawnMove;
                 Game.RemoveFromPositionHashHistory();
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
             }
 
             int score = 0;
@@ -931,7 +931,7 @@ public sealed partial class Engine
             var gameState = position.MakeMove(move);
             if (!position.WasProduceByAValidMove())
             {
-                position.UnmakeMove(move, gameState);
+                position.UnmakeMove(move, in gameState);
                 continue;
             }
 
@@ -947,7 +947,7 @@ public sealed partial class Engine
 #pragma warning disable S2234 // Arguments should be passed in the same order as the method parameters
             int score = -QuiescenceSearch(ply + 1, -beta, -alpha, pvNode, cancellationToken);
 #pragma warning restore S2234 // Arguments should be passed in the same order as the method parameters
-            position.UnmakeMove(move, gameState);
+            position.UnmakeMove(move, in gameState);
 
             PrintMove(position, ply, move, score, isQuiescence: true);
 

--- a/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
+++ b/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
@@ -42,7 +42,7 @@ public class SingleLegalMoveTest : BaseTest
                 singleMove = move;
             }
 
-            pos.UnmakeMove(move, state);
+            pos.UnmakeMove(move, in state);
         }
 
         Assert.LessOrEqual(depth, Configuration.EngineSettings.MaxDepth);

--- a/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
+++ b/tests/Lynx.Test/Model/MoveToEPDStringTest.cs
@@ -106,7 +106,7 @@ public class MoveToEPDStringTest
             {
                 var gameState = position.MakeMove(m);
                 var isLegal = position.WasProduceByAValidMove();
-                position.UnmakeMove(m, gameState);
+                position.UnmakeMove(m, in gameState);
 
                 return isLegal;
             })


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/2152 but using `in GameState`, as recommended due to size 80

```
Test  | perf/cache-king-square-bucket-ingamestate
Elo   | -2.02 +- 4.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 9310: +2458 -2512 =4340
Penta | [148, 1102, 2215, 1036, 154]
https://openbench.lynx-chess.com/test/2287/
```