### PR TITLE
🟰 Reduce multithreading logging

### DIFF
--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -52,7 +52,7 @@ public sealed partial class Engine : IDisposable
             _moveNodeCount[i] = new ulong[64];
         }
 
-        _logger.Info("Engine {0} initialized", _id);
+        _logger.Debug("Engine {0} initialized", _id);
     }
 
     public void Warmup()

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -529,7 +529,7 @@ public sealed partial class Engine
             //  search in helper engines sometimes get cancelled before any meaningful result is found, so we don't want a warning either
             if (isPondering || !IsMainEngine)
             {
-                _logger.Info(noDepth1Message);
+                _logger.Debug(noDepth1Message);
             }
             else
             {


### PR DESCRIPTION
Don't spam engine initializations and no-depth-1 non-main-engine messages (happens on checkmate occasions).

This sounds great to have when testing 8 cores, becomes less fun with 500