### PR TITLE
🔍 SE: Split margins in capture and not

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -478,7 +478,10 @@ public sealed class EngineSettings
     public int SE_DepthMultiplier { get; set; } = 1;
 
     [SPSA<int>(0, 50, 5)]
-    public int SE_DoubleExtensions_Margin { get; set; } = 1;
+    public int SE_DoubleExtensions_Margin_Capture { get; set; } = 1;
+
+    [SPSA<int>(0, 100, 10)]
+    public int SE_DoubleExtensions_Margin_Quiet { get; set; } = 40;
 
     [SPSA<int>(enabled: false)]
     public int SE_DoubleExtensions_Max { get; set; } = 6;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -470,9 +470,13 @@ public sealed partial class Engine
                 {
                     ++singularDepthExtensions;
 
+                    var doubleExtensionMargin = isCapture
+                        ? Configuration.EngineSettings.SE_DoubleExtensions_Margin_Capture
+                        : Configuration.EngineSettings.SE_DoubleExtensions_Margin_Quiet;
+
                     // Double extension
                     if (!pvNode
-                        && singularScore + Configuration.EngineSettings.SE_DoubleExtensions_Margin < singularBeta
+                        && singularScore + doubleExtensionMargin < singularBeta
                         && stack.DoubleExtensions <= Configuration.EngineSettings.SE_DoubleExtensions_Max)
                     {
                         ++singularDepthExtensions;


### PR DESCRIPTION
```
Test  | search/se-quiet-margin
Elo   | -0.54 +- 3.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.98 (-2.25, 2.89) [0.00, 3.00]
Games | 16768: +4459 -4485 =7824
Penta | [313, 2097, 3622, 2007, 345]
https://openbench.lynx-chess.com/test/2335/
```

```
Test  | search/se-quiet-margin
Elo   | -7.94 +- 6.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.03 (-2.25, 2.89) [0.00, 5.00]
Games | 2890: +652 -718 =1520
Penta | [20, 390, 689, 328, 18]
https://openbench.lynx-chess.com/test/2336/
```