### PR TITLE
🔍 Razoring simplification: no need to run QSearch when tt corrected eval - depth > 1

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -258,7 +258,11 @@ public sealed partial class Engine
 
                             if (score < beta)               // Static evaluation indicates fail-low node
                             {
-                                var qSearchScore = QuiescenceSearch(ply, alpha, beta, pvNode, cancellationToken);
+                                // Pawnocchio idea: no need to run QSearch when the eval is already corrected by the TT score,
+                                // that corrected eval is at least as good as QSearch result would be
+                                var qSearchScore = ttCorrectedStaticEval != staticEval
+                                    ? ttCorrectedStaticEval
+                                    : QuiescenceSearch(ply, alpha, beta, pvNode, cancellationToken);
                                 if (qSearchScore < beta)    // Quiescence score also indicates fail-low node
                                 {
                                     return qSearchScore > score


### PR DESCRIPTION
#2039 followup

```
Test  | search/pawny-simplification-II
Elo   | -0.44 +- 2.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.94 (-2.25, 2.89) [0.00, 3.00]
Games | 16680: +4039 -4060 =8581
Penta | [150, 2040, 3983, 2015, 152]
https://openbench.lynx-chess.com/test/2325/
```