### PR TITLE
🔍 QSearch LMR - >=2moves && capturehistory <= 2000

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -350,9 +350,12 @@ public sealed class EngineSettings
 
     [SPSA<int>(enabled: false)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
-    
+
     [SPSA<int>(enabled: false)]
-    public int LMP_MaxMovesToTry { get; set; } = 2;
+    public int LMP_QSearch_MaxMovesToTry { get; set; } = 2;
+
+    [SPSA<int>(enabled: false)]
+    public int LMP_QSearch_MaxCaptureHistory { get; set; } = -2048;
 
     [SPSA<int>(enabled: false)]
     public int History_MaxMoveValue { get; set; } = 8_192;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -907,13 +907,6 @@ public sealed partial class Engine
 
         for (int moveIndex = 0; moveIndex < pseudoLegalMoves.Length; ++moveIndex)
         {
-            // QS LMP
-            if (!isInCheck
-                && visitedMovesCounter >= Configuration.EngineSettings.LMP_MaxMovesToTry)
-            {
-                break;
-            }
-
             // Incremental move sorting, inspired by https://github.com/jw1912/Chess-Challenge and suggested by toanth
             // There's no need to sort all the moves since most of them don't get checked anyway
             // So just find the first unsearched one with the best score and try it
@@ -933,6 +926,14 @@ public sealed partial class Engine
             // Value copies
             var move = Unsafe.Add(ref movesRef, moveIndex);
             var moveScore = Unsafe.Add(ref moveScoresRef, moveIndex);
+
+            // QS LMP
+            if (!isInCheck
+                && visitedMovesCounter >= Configuration.EngineSettings.LMP_QSearch_MaxMovesToTry
+                && CaptureHistoryEntry(move) <= Configuration.EngineSettings.LMP_QSearch_MaxCaptureHistory)
+            {
+                break;
+            }
 
             // 🔍 QSearch SEE pruning: pruning bad captures
             if (moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue)


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/2177 with capture history
See also #2198

```
Test  | search/qs-lmp-2moves-capturehistory--2000
Elo   | -0.65 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 35850: +9691 -9758 =16401
Penta | [654, 4388, 7931, 4275, 677]
https://openbench.lynx-chess.com/test/2348/
```