### PR TITLE
🔍 SE: low depth extensions alt impl I - replacing existing impl

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -484,7 +484,10 @@ public sealed class EngineSettings
     public int SE_DoubleExtensions_Max { get; set; } = 6;
 
     [SPSA<int>(enabled: false)]
-    public int SE_LowDepthExtension { get; set; } = 9;
+    public int SE_LowDepthExtension_Depth { get; set; } = 9;
+
+    [SPSA<int>(10, 50, 4)]
+    public int SE_LowDepthExtension_Margin { get; set; } = 25;
 
     #endregion
 }


### PR DESCRIPTION
```
Test  | search/se-lowdepth-alt-1
Elo   | -2.03 +- 4.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.95 (-2.25, 2.89) [0.00, 5.00]
Games | 7528: +1768 -1812 =3948
Penta | [49, 931, 1851, 881, 52]
https://openbench.lynx-chess.com/test/2359/
```