### PR TITLE
🔍LMR min depth 3 -> 2

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -182,7 +182,7 @@ public sealed class EngineSettings
     #region Search
 
     [SPSA<int>(enabled: false)]
-    public int LMR_MinDepth { get; set; } = 3;
+    public int LMR_MinDepth { get; set; } = 2;
 
     [SPSA<int>(enabled: false)]
     public int LMR_MinFullDepthSearchedMoves_PV { get; set; } = 5;


### PR DESCRIPTION
```
Test  | search/lmr-depth-2
Elo   | 0.56 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 152528: +40710 -40464 =71354
Penta | [2621, 18502, 33855, 18582, 2704]
https://openbench.lynx-chess.com/test/2361/
```