### PR TITLE
🔍 IIR after fail high pruning

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -120,17 +120,6 @@ public sealed partial class Engine
             ttWasPv = false;
         }
 
-        // Internal iterative reduction (IIR)
-        // If this position isn't found in TT, it has never been searched before,
-        // so the search will be potentially expensive.
-        // Therefore, we search with reduced depth for now, expecting to record a TT move
-        // which we'll be able to use later for the full depth search
-        if (depth >= Configuration.EngineSettings.IIR_MinDepth
-            && (!ttEntryHasBestMove))
-        {
-            --depthExtension;
-        }
-
         var ttPv = pvNode || ttWasPv;
 
         // 🔍 Improving heuristic: the current position has a better static evaluation than


### PR DESCRIPTION
```
Test  | search/iir-after-pruning
Elo   | -0.21 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.32 (-2.25, 2.89) [0.00, 5.00]
Games | 19456: +5159 -5171 =9126
Penta | [240, 2067, 5136, 2035, 250]
https://openbench.lynx-chess.com/test/2358/
```