### PR TITLE
🔍 Bad noisy FP

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -414,6 +414,22 @@ public sealed partial class Engine
                     break;
                 }
 
+                // 🔍 Bad Noisy Futility Pruning (FP)
+                var badNoisyFPValue = staticEval + (120 * depth) + (375 * visitedMovesCounter / 128);
+
+                if(!isInCheck
+                    && depth < 6
+                    && moveScore < EvaluationConstants.PromotionMoveScoreValue && moveScore >= EvaluationConstants.BadCaptureMoveBaseScoreValue // Bad noisy
+                    && badNoisyFPValue <= alpha)
+                {
+                    if(isNotGettingCheckmated && bestScore < badNoisyFPValue)
+                    {
+                        bestScore = badNoisyFPValue;
+                    }
+
+                    break;
+                }
+
                 // 🔍 PVS SEE pruning
                 if (isCapture)
                 {


### PR DESCRIPTION
```
Test  | search/badnoisyfp-1
Elo   | -3.32 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 13082: +3457 -3582 =6043
Penta | [244, 1583, 2965, 1552, 197]
https://openbench.lynx-chess.com/test/2367/
```