### PR TITLE
🔍 IIR: pvNode or cutnode

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -126,6 +126,7 @@ public sealed partial class Engine
         // Therefore, we search with reduced depth for now, expecting to record a TT move
         // which we'll be able to use later for the full depth search
         if (depth >= Configuration.EngineSettings.IIR_MinDepth
+            && (pvNode || cutnode)
             && (!ttEntryHasBestMove))
         {
             --depthExtension;


### PR DESCRIPTION
#2027 again

```
Test  | search/iir-pvnode-cutnode
Elo   | -21.08 +- 8.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 2574: +636 -792 =1146
Penta | [61, 364, 562, 270, 30]
https://openbench.lynx-chess.com/test/2372/
```