### PR TITLE
🔍 IIR min depth 5 -> 6

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -338,7 +338,7 @@ public sealed class EngineSettings
     public int Razoring_NotDepth1Bonus { get; set; } = 205;
 
     [SPSA<int>(enabled: false)]
-    public int IIR_MinDepth { get; set; } = 5;
+    public int IIR_MinDepth { get; set; } = 6;
 
     [SPSA<int>(enabled: false)]
     public int LMP_BaseMovesToTry { get; set; } = 1;


### PR DESCRIPTION
```
Test  | search/iir-mindepth-6-2
Elo   | 0.08 +- 2.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 5.00]
Games | 23048: +5607 -5602 =11839
Penta | [225, 2795, 5508, 2742, 254]
https://openbench.lynx-chess.com/test/2143/
```