### PR TITLE
⚡  Convert `GameState` in a class and reuse it using `ObjectPool`

### DIFF
--- a/src/Lynx/Model/GameState.cs
+++ b/src/Lynx/Model/GameState.cs
@@ -1,32 +1,24 @@
-﻿namespace Lynx.Model;
+﻿using Microsoft.Extensions.ObjectPool;
+
+namespace Lynx.Model;
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
 
-public readonly struct GameState
+public sealed class GameState
 {
-    public readonly ulong ZobristKey;
+    public ulong ZobristKey;
+    public ulong KingPawnKey;
+    public ulong NonPawnWhiteKey;
+    public ulong NonPawnBlackKey;
+    public ulong MinorKey;
+    public ulong MajorKey;
+    public int IncrementalEvalAccumulator;
+    public int IncrementalPhaseAccumulator;
+    public BoardSquare EnPassant;
+    public byte Castle;
+    public bool IsIncrementalEval;
 
-    public readonly ulong KingPawnKey;
-
-    public readonly ulong NonPawnWhiteKey;
-
-    public readonly ulong NonPawnBlackKey;
-
-    public readonly ulong MinorKey;
-
-    public readonly ulong MajorKey;
-
-    public readonly int IncrementalEvalAccumulator;
-
-    public readonly int IncrementalPhaseAccumulator;
-
-    public readonly BoardSquare EnPassant;
-
-    public readonly byte Castle;
-
-    public readonly bool IsIncrementalEval;
-
-    public GameState(Position position)
+    public void Populate(Position position)
     {
         ZobristKey = position.UniqueIdentifier;
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -375,7 +375,8 @@ public partial class Position : IDisposable
         Debug.Assert(ZobristTable.MinorHash(this) == _minorHash);
         Debug.Assert(ZobristTable.MajorHash(this) == _majorHash);
 
-        var gameState = new GameState(this);
+        var gameState = ObjectPools.GameStatePool.Get();
+        gameState.Populate(this);
 
         var oldSide = (int)_side;
         var offset = Utils.PieceOffset(oldSide);
@@ -936,6 +937,8 @@ public partial class Position : IDisposable
         IncrementalEvalAccumulator = gameState.IncrementalEvalAccumulator;
         IncrementalPhaseAccumulator = gameState.IncrementalPhaseAccumulator;
         IsIncrementalEval = gameState.IsIncrementalEval;
+
+        ObjectPools.GameStatePool.Return(gameState);
 
         Validate();
     }

--- a/src/Lynx/ObjectPools.cs
+++ b/src/Lynx/ObjectPools.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.ObjectPool;
+﻿using Lynx.Model;
+using Microsoft.Extensions.ObjectPool;
 using System.Text;
 
 namespace Lynx;
@@ -8,4 +9,14 @@ public static class ObjectPools
         new DefaultObjectPoolProvider().CreateStringBuilderPool(
             initialCapacity: 256,
             maximumRetainedCapacity: 4 * 1024); //Default value in StringBuilderPooledObjectPolicy.MaximumRetainedCapacity)
+
+    public static readonly ObjectPool<GameState> GameStatePool =
+        new DefaultObjectPoolProvider().Create(new GameStatePooledObjectPolicy());
+}
+
+public class GameStatePooledObjectPolicy : PooledObjectPolicy<GameState>
+{
+    public override GameState Create() => new();
+
+    public override bool Return(GameState _) => true;
 }


### PR DESCRIPTION
```
Test  | perf/gamestate-class-objectpool
Elo   | -8.26 +- 5.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 5720: +1449 -1585 =2686
Penta | [86, 684, 1436, 588, 66]
https://openbench.lynx-chess.com/test/2405/
```