### PR TITLE
⚖ Halve eval when there's only 1 pawn left

### DIFF
--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -467,6 +467,11 @@ public partial class Position
             }
             else
             {
+                if (totalPawnsCount == 1)
+                {
+                    eval >>= 1; // /2
+                }
+
                 var winningSideOffset = Utils.PieceOffset(eval >= 0);
 
                 if (gamePhase == 1)


### PR DESCRIPTION
```
Test  | eval/1pawn-halfeval
Elo   | -1.44 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 22146: +5885 -5977 =10284
Penta | [278, 2342, 5923, 2254, 276]
https://openbench.lynx-chess.com/test/2417/
```