### PR TITLE
⚖ Halve eval when there are no pawns left

### DIFF
--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -404,11 +404,11 @@ public partial class Position
         // Few pieces endgames
         if (gamePhase <= 5)
         {
-            eval >>= 1; // /2
-
             // Pawnless endgames
             if (totalPawnsCount == 0)
             {
+                eval >>= 1; // /2
+
                 switch (gamePhase)
                 {
                     case 5:
@@ -473,6 +473,7 @@ public partial class Position
 
                 if (gamePhase == 1)
                 {
+                    // Bishop vs pawn
                     if (_pieceBitBoards[(int)Piece.B + winningSideOffset] != 0
                         && (_pieceBitBoards[(int)Piece.P + winningSideOffset] & Constants.NotAorH) == 0)
                     {


### PR DESCRIPTION
```
Test  | eval/0pawn-halfeval
Elo   | -4.33 +- 3.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 9796: +2492 -2614 =4690
Penta | [129, 1026, 2674, 976, 93]
https://openbench.lynx-chess.com/test/2418/
```