### PR TITLE
🔍 Set `improving` to false if we were in check 2 plies ago

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -262,6 +262,12 @@ public sealed class Game : IDisposable
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ulong[] CopyPositionHashHistory() => _positionHashHistory[.._positionHashHistoryPointer];
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void UpdateInCheckinStack(int n, bool inCheck) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].InCheck = inCheck;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool ReadInCheckFromStack(int n) => _stack[n + EvaluationConstants.ContinuationHistoryPlyCount].InCheck;
+
     internal void ClearPositionHashHistory() => _positionHashHistoryPointer = 0;
 
     private void Dispose(bool disposing)

--- a/src/Lynx/Model/PlyStackEntry.cs
+++ b/src/Lynx/Model/PlyStackEntry.cs
@@ -8,6 +8,8 @@ public struct PlyStackEntry
 
     public Move Move { get; set; }
 
+    public bool InCheck { get; set; }
+
     public PlyStackEntry()
     {
         StaticEval = int.MaxValue;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable S1192 // String literals should not be duplicated - it's assertion message strings
 
 using Lynx.Model;
+using NLog.LayoutRenderers;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -147,6 +148,7 @@ public sealed partial class Engine
         int phase = int.MaxValue;
 
         ref var stack = ref Game.Stack(ply);
+        stack.InCheck = isInCheck;
         stack.DoubleExtensions = Game.ReadDoubleExtensionsFromStack(ply - 1);
 
         if (isInCheck && !isVerifyingSE)
@@ -194,7 +196,7 @@ public sealed partial class Engine
             if (ply >= 2)
             {
                 var evalDiff = staticEval - Game.ReadStaticEvalFromStack(ply - 2);
-                improving = evalDiff >= 0;
+                improving = evalDiff >= 0 && !Game.ReadInCheckFromStack(ply - 2);
                 improvingRate = evalDiff / (double)Configuration.EngineSettings.ImprovingRate;
             }
 


### PR DESCRIPTION
```
Test  | search/improving-noincheck-2plyago
Elo   | -7.67 +- 6.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.61 (-2.25, 2.89) [0.00, 3.00]
Games | 4756: +1240 -1345 =2171
Penta | [94, 638, 1008, 555, 83]
https://openbench.lynx-chess.com/test/2425/
```