### PR TITLE
🔍 QSearch: save static eval only on stand pat beta cutoff

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -859,15 +859,16 @@ public sealed partial class Engine
 
         if (!isInCheck)
         {
-            if (!ttHit)
-            {
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
-            }
-
             // Standing pat beta-cutoff (updating alpha after this check)
             if (standPat >= beta)
             {
                 PrintMessage(ply - 1, "Pruning before starting quiescence search");
+
+                if (!ttHit)
+                {
+                    _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                }
+
                 return standPat;
             }
         }


### PR DESCRIPTION
```
Test  | search/qsearch-savestaticeval-tweak-1
Elo   | -1.62 +- 2.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 22134: +5794 -5897 =10443
Penta | [396, 2676, 4990, 2645, 360]
https://openbench.lynx-chess.com/test/2426/
```