### PR TITLE
🔍 QSearch: save static eval only on stand pat beta cutoff - as lowerbound

### DIFF
--- a/src/Lynx/Model/ITranspositionTable.cs
+++ b/src/Lynx/Model/ITranspositionTable.cs
@@ -101,12 +101,12 @@ public interface ITranspositionTable
     /// <param name="staticEval">Static evaluation of the position</param>
     /// <param name="wasPv">Whether this position was part of the principal variation</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv)
+    void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv, NodeType nodeType = NodeType.Unknown)
     {
         ref var entry = ref GetTTEntry(position, halfMovesWithoutCaptureOrPawnMove);
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(GenerateTTKey(position.UniqueIdentifier), EvaluationConstants.NoScore, staticEval, depth: 0, NodeType.Unknown, wasPv ? 1 : 0, null);
+        entry.Update(GenerateTTKey(position.UniqueIdentifier), EvaluationConstants.NoScore, staticEval, depth: 0, nodeType, wasPv ? 1 : 0, null);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -866,7 +866,7 @@ public sealed partial class Engine
 
                 if (!ttHit)
                 {
-                    _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                    _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv, NodeType.Beta);
                 }
 
                 return standPat;


### PR DESCRIPTION
https://github.com/lynx-chess/Lynx/pull/2257 but lowerbound

```
Test  | search/qsearch-savestaticeval-tweak-2
Elo   | -3.08 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 13968: +3656 -3780 =6532
Penta | [245, 1729, 3123, 1679, 208]
https://openbench.lynx-chess.com/test/2427/
```