### PR TITLE
🐛 Clear `Game` stack when setting position

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -97,6 +97,7 @@ public sealed class Game : IDisposable
     private void Populate(ReadOnlySpan<char> fen, ReadOnlySpan<char> rawMoves)
     {
         _positionHashHistoryPointer = 0;
+        Array.Clear(_stack);
 
 #if DEBUG
         MoveHistory.Clear();


### PR DESCRIPTION
```
Test  | bugfix/clear-stack
Elo   | 2.41 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | 16840: +4554 -4437 =7849
Penta | [214, 1853, 4200, 1908, 245]
https://openbench.lynx-chess.com/test/2449/
```