### PR TITLE
🔍  Use the sum of continuation histories in update fomula

### DIFF
--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -1,4 +1,4 @@
-using Lynx.Model;
+﻿using Lynx.Model;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -119,23 +119,64 @@ public sealed partial class Engine
     /// [12][64][12][64]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref short ContinuationHistoryEntry(int piece, int targetSquare, int ply)
+    private int ContinuationHistoryEntry(int piece, int targetSquare, int ply)
     {
         const int pieceOffset = 64 * 12 * 64;
         const int targetSquareOffset = 12 * 64;
-        const int previousMovePieceOffset = 64;
+        //const int previousMovePieceOffset = 64; // Used in ContinuationHistoryCommonIndex
+
+        var commonIndex = (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset);
 
         // Since ContinuationHistoryPlyCount is used for stack indexing, there's never an overflow here
-        var previousMove = Game.ReadMoveFromStack(ply);
+        // Counter move history (continuation history, ply - 1)
+        var ply1Move = Game.ReadMoveFromStack(ply - 1);
+        var ply1Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply1Move);
+        Debug.Assert(ply1Index < _continuationHistory.Length);
 
-        var index = (piece * pieceOffset)
-            + (targetSquare * targetSquareOffset)
-            + (previousMove.Piece() * previousMovePieceOffset)
+        // Follow-up history (continuation history, ply - 2)
+        var ply2Move = Game.ReadMoveFromStack(ply - 2);
+        var ply2Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply2Move);
+        Debug.Assert(ply2Index < _continuationHistory.Length);
+
+        return _continuationHistory[ply1Index] + _continuationHistory[ply2Index];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ContinuationHistoryPreviousMoveIndex(Move previousMove)
+    {
+        const int previousMovePieceOffset = 64;
+
+        return (previousMove.Piece() * previousMovePieceOffset)
             + previousMove.TargetSquare();
+    }
 
-        Debug.Assert(index < _continuationHistory.Length);
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void UpdateContinuationHistory(int piece, int targetSquare, int ply, int rawHistoryBonus)
+    {
+        const int pieceOffset = 64 * 12 * 64;
+        const int targetSquareOffset = 12 * 64;
+        //const int previousMovePieceOffset = 64; // Used in ContinuationHistoryCommonIndex
 
-        return ref _continuationHistory[index];
+        var commonIndex = (piece * pieceOffset)
+            + (targetSquare * targetSquareOffset);
+
+        // Since ContinuationHistoryPlyCount is used for stack indexing, there's never an overflow here
+        // Counter move history (continuation history, ply - 1)
+        var ply1Move = Game.ReadMoveFromStack(ply - 1);
+        var ply1Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply1Move);
+        Debug.Assert(ply1Index < _continuationHistory.Length);
+
+        // Follow-up history (continuation history, ply - 2)
+        var ply2Move = Game.ReadMoveFromStack(ply - 2);
+        var ply2Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply2Move);
+        Debug.Assert(ply2Index < _continuationHistory.Length);
+
+        ref var contHist1 = ref _continuationHistory[ply1Index];
+        contHist1 = (short)ScoreHistoryMove(contHist1, rawHistoryBonus);
+
+        ref var constHist2 = ref _continuationHistory[ply2Index];
+        constHist2 = (short)ScoreHistoryMove(constHist2, rawHistoryBonus);
     }
 
     /// <summary>

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -173,10 +173,12 @@ public sealed partial class Engine
         Debug.Assert(ply2Index < _continuationHistory.Length);
 
         ref var contHist1 = ref _continuationHistory[ply1Index];
-        contHist1 = (short)ScoreHistoryMove(contHist1, rawHistoryBonus);
-
         ref var constHist2 = ref _continuationHistory[ply2Index];
-        constHist2 = (short)ScoreHistoryMove(constHist2, rawHistoryBonus);
+
+        int totalContHist = contHist1 + constHist2;
+
+        contHist1 = ScoreContinuationHistoryMove(rawHistoryBonus, contHist1, totalContHist);
+        constHist2 = ScoreContinuationHistoryMove(rawHistoryBonus, constHist2, totalContHist);
     }
 
     /// <summary>

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -281,8 +281,18 @@ public sealed partial class Engine
     /// Formula taken from EP discord, https://discord.com/channels/1132289356011405342/1132289356447625298/1141102105847922839
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int ScoreHistoryMove(int score, int rawHistoryBonus)
+    private static int ScoreHistoryMove(int previousHistory, int rawHistoryBonus)
     {
-        return score + rawHistoryBonus - (score * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
+        return previousHistory + rawHistoryBonus - (previousHistory * Math.Abs(rawHistoryBonus) / Configuration.EngineSettings.History_MaxMoveValue);
+    }
+
+    /// <summary>
+    /// Soft caps history score
+    /// Idea of using the total continuation history from Plentychess
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static short ScoreContinuationHistoryMove(int rawBonus, short previousContinuationHistoryEntry, int totalContinuationHistory)
+    {
+        return (short)(previousContinuationHistoryEntry + rawBonus - (totalContinuationHistory * Math.Abs(rawBonus) / Configuration.EngineSettings.History_MaxMoveValue));
     }
 }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -51,13 +51,12 @@ public sealed partial class Engine
                 }
 
                 var piece = move.Piece();
-                var targeSquare = move.TargetSquare();
+                var targetSquare = move.TargetSquare();
 
                 // Counter move history
                 return BaseMoveScore
                     + QuietHistoryEntry(position, move, ref evaluationContext)
-                    + ContinuationHistoryEntry(piece, targeSquare, ply - 1)
-                    + ContinuationHistoryEntry(piece, targeSquare, ply - 2);
+                    + ContinuationHistoryEntry(piece, targetSquare, ply);
             }
 
             // History move or 0 if not found
@@ -191,13 +190,7 @@ public sealed partial class Engine
             if (!isRoot)
             {
                 // 🔍 Continuation history
-                // - Counter move history (continuation history, ply - 1)
-                ref var contHist1 = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
-                contHist1 = (short)ScoreHistoryMove(contHist1, rawHistoryBonus);
-
-                // - Follow-up history (continuation history, ply - 2)
-                ref var constHist2 = ref ContinuationHistoryEntry(piece, targetSquare, ply - 2);
-                constHist2 = (short)ScoreHistoryMove(constHist2, rawHistoryBonus);
+                UpdateContinuationHistory(piece, targetSquare, ply, rawHistoryBonus);
             }
 
             ref int visitedMovesBase = ref MemoryMarshal.GetReference(visitedMoves);
@@ -226,11 +219,7 @@ public sealed partial class Engine
                     if (!isRoot)
                     {
                         // 🔍 Continuation history penalty / malus
-                        ref var contHist1 = ref ContinuationHistoryEntry(visitedMovePiece, visitedMoveTargetSquare, ply - 1);
-                        contHist1 = (short)ScoreHistoryMove(contHist1, -rawHistoryMalus);
-
-                        ref var constHist2 = ref ContinuationHistoryEntry(visitedMovePiece, visitedMoveTargetSquare, ply - 2);
-                        constHist2 = (short)ScoreHistoryMove(constHist2, -rawHistoryMalus);
+                        UpdateContinuationHistory(visitedMovePiece, visitedMoveTargetSquare, ply, -rawHistoryMalus);
                     }
                 }
             }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -373,8 +373,7 @@ public sealed partial class Engine
             var targetSquare = move.TargetSquare();
 
             int quietHistory = QuietHistoryEntry(position, move, ref evaluationContext)
-                + ContinuationHistoryEntry(piece, targetSquare, ply - 1)
-                + ContinuationHistoryEntry(piece, targetSquare, ply - 2);
+                + ContinuationHistoryEntry(piece, targetSquare, ply);
 
             // If we prune while getting checkmated, we risk not finding any move and having an empty PV
             bool isNotGettingCheckmated = bestScore > EvaluationConstants.NegativeCheckmateDetectionLimit;
@@ -679,11 +678,7 @@ public sealed partial class Engine
                             ? EvaluationConstants.HistoryBonus[depth]
                             : -EvaluationConstants.HistoryMalus[depth];
 
-                        ref var contHist1 = ref ContinuationHistoryEntry(piece, targetSquare, ply - 1);
-                        contHist1 = (short)ScoreHistoryMove(contHist1, historyBonus);
-
-                        ref var contHist2 = ref ContinuationHistoryEntry(piece, targetSquare, ply - 2);
-                        contHist2 = (short)ScoreHistoryMove(contHist2, historyBonus);
+                        UpdateContinuationHistory(piece, targetSquare, ply, historyBonus);
                     }
                 }
 


### PR DESCRIPTION
```
Test  | search/conthist-update-sum
Elo   | -2.49 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 15790: +3889 -4002 =7899
Penta | [215, 1947, 3651, 1900, 182]
https://openbench.lynx-chess.com/test/2674/
```

```
Test  | search/conthist-update-sum
Elo   | -0.56 +- 1.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.09 (-2.25, 2.89) [0.00, 3.00]
Games | 32728: +7555 -7608 =17565
Penta | [147, 3970, 8190, 3903, 154]
https://openbench.lynx-chess.com/test/2723/
```