### PR TITLE
🔍 Material correction history: weight 100 -> 125

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -471,7 +471,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Material { get; set; } = 100;
+    public int CorrHistoryWeight_Material { get; set; } = 125;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;


### PR DESCRIPTION
```
Test  | search/material-corrhist-weight-125
Elo   | 0.15 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | 74464: +18588 -18555 =37321
Penta | [838, 9129, 17302, 9088, 875]
https://openbench.lynx-chess.com/test/2710/
```