### PR TITLE
🔍 Material correction history: weight 100 -> 75

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -471,7 +471,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Material { get; set; } = 100;
+    public int CorrHistoryWeight_Material { get; set; } = 75;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;


### PR DESCRIPTION
```
Test  | search/material-corrhist-weight-75
Elo   | 0.31 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 95184: +23609 -23523 =48052
Penta | [1157, 11401, 22297, 11673, 1064]
https://openbench.lynx-chess.com/test/2709/
```