### PR TITLE
🔍 Material correction history: `kpHash ^ majorHash ^ minorHash`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -467,6 +467,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Major { get; set; } = 179;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Material { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -640,6 +640,9 @@ public static class Constants
     public const int MajorCorrHistoryHashSize = 16_384;
     public const int MajorCorrHistoryHashMask = MajorCorrHistoryHashSize - 1;
 
+    public const int MaterialCorrHistoryHashSize = 2_048;
+    public const int MaterialCorrHistoryHashMask = MaterialCorrHistoryHashSize - 1;
+
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -87,6 +87,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_nonPawnCorrHistory);
         Array.Clear(_minorCorrHistory);
         Array.Clear(_majorCorrHistory);
+        Array.Clear(_materialCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1097,6 +1097,30 @@ public partial class Position : IDisposable
 
     #endregion
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong MaterialHash()
+    {
+        ulong hash = 0;
+
+        var pieces = _pieceBitboards;
+
+#pragma warning disable CS0675 // Bitwise-or operator used on a sign-extended operand - CountBits always returns a positive value
+        hash |= (ulong)pieces[(int)Piece.P].CountBits();
+        hash |= (ulong)pieces[(int)Piece.N].CountBits() << 6;
+        hash |= (ulong)pieces[(int)Piece.B].CountBits() << 12;
+        hash |= (ulong)pieces[(int)Piece.R].CountBits() << 18;
+        hash |= (ulong)pieces[(int)Piece.Q].CountBits() << 24;
+
+        hash |= (ulong)pieces[(int)Piece.p].CountBits() << 30;
+        hash |= (ulong)pieces[(int)Piece.n].CountBits() << 36;
+        hash |= (ulong)pieces[(int)Piece.b].CountBits() << 42;
+        hash |= (ulong)pieces[(int)Piece.r].CountBits() << 48;
+        hash |= (ulong)pieces[(int)Piece.q].CountBits() << 54;
+#pragma warning restore CS0675 // Bitwise-or operator used on a sign-extended operand
+
+        return Utils.Murmur3(hash);
+    }
+
     public int CountPieces() => _pieceBitboards.Sum(b => b.CountBits());
 
     public string FEN(int halfMovesWithoutCaptureOrPawnMove = 0, int fullMoveClock = 1)

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -61,6 +61,7 @@ public partial class Position : IDisposable
     public ulong[] NonPawnHash => _nonPawnHash;
     public ulong MinorHash => _minorHash;
     public ulong MajorHash => _majorHash;
+    public ulong MaterialHash => _kingPawnUniqueIdentifier ^ _majorHash ^ _minorHash;
 
     public Bitboard[] PieceBitboards => _pieceBitboards;
     public Bitboard[] OccupancyBitboards => _occupancyBitboards;
@@ -1096,30 +1097,6 @@ public partial class Position : IDisposable
     }
 
     #endregion
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public ulong MaterialHash()
-    {
-        ulong hash = 0;
-
-        var pieces = _pieceBitboards;
-
-#pragma warning disable CS0675 // Bitwise-or operator used on a sign-extended operand - CountBits always returns a positive value
-        hash |= (ulong)pieces[(int)Piece.P].CountBits();
-        hash |= (ulong)pieces[(int)Piece.N].CountBits() << 6;
-        hash |= (ulong)pieces[(int)Piece.B].CountBits() << 12;
-        hash |= (ulong)pieces[(int)Piece.R].CountBits() << 18;
-        hash |= (ulong)pieces[(int)Piece.Q].CountBits() << 24;
-
-        hash |= (ulong)pieces[(int)Piece.p].CountBits() << 30;
-        hash |= (ulong)pieces[(int)Piece.n].CountBits() << 36;
-        hash |= (ulong)pieces[(int)Piece.b].CountBits() << 42;
-        hash |= (ulong)pieces[(int)Piece.r].CountBits() << 48;
-        hash |= (ulong)pieces[(int)Piece.q].CountBits() << 54;
-#pragma warning restore CS0675 // Bitwise-or operator used on a sign-extended operand
-
-        return Utils.Murmur3(hash);
-    }
 
     public int CountPieces() => _pieceBitboards.Sum(b => b.CountBits());
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -269,7 +269,7 @@ public sealed partial class Engine
         majorCorrHistEntry = UpdateCorrectionHistory(majorCorrHistEntry, scaledBonus, weight);
 
         // Material correction history
-        var materialHash = position.MaterialHash();
+        var materialHash = position.MaterialHash;
         var materialIndex = materialHash & Constants.MaterialCorrHistoryHashMask;
         var materialCorrHistIndex = (2 * materialIndex) + side;
         Debug.Assert(materialCorrHistIndex < (ulong)_materialCorrHistory.Length);
@@ -352,7 +352,7 @@ public sealed partial class Engine
         var majorCorrHist = _majorCorrHistory[majorCorrHistIndex];
 
         // Material correction history
-        var materialHash = position.MaterialHash();
+        var materialHash = position.MaterialHash;
         var materialIndex = materialHash & Constants.MaterialCorrHistoryHashMask;
         var materialCorrHistIndex = (2 * materialIndex) + side;
         Debug.Assert(materialCorrHistIndex < (ulong)_materialCorrHistory.Length);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -268,6 +268,15 @@ public sealed partial class Engine
         ref var majorCorrHistEntry = ref _majorCorrHistory[majorCorrHistIndex];
         majorCorrHistEntry = UpdateCorrectionHistory(majorCorrHistEntry, scaledBonus, weight);
 
+        // Material correction history
+        var materialHash = position.MaterialHash();
+        var materialIndex = materialHash & Constants.MaterialCorrHistoryHashMask;
+        var materialCorrHistIndex = (2 * materialIndex) + side;
+        Debug.Assert(materialCorrHistIndex < (ulong)_materialCorrHistory.Length);
+
+        ref var materialCorrHistEntry = ref _materialCorrHistory[materialCorrHistIndex];
+        materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short UpdateCorrectionHistory(short previousCorrectedScore, int scaledBonus, int weight)
@@ -342,12 +351,21 @@ public sealed partial class Engine
 
         var majorCorrHist = _majorCorrHistory[majorCorrHistIndex];
 
+        // Material correction history
+        var materialHash = position.MaterialHash();
+        var materialIndex = materialHash & Constants.MaterialCorrHistoryHashMask;
+        var materialCorrHistIndex = (2 * materialIndex) + side;
+        Debug.Assert(materialCorrHistIndex < (ulong)_materialCorrHistory.Length);
+
+        var materialCorrHist = _materialCorrHistory[materialCorrHistIndex];
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
             + (nonPawnNoSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnNoSTM)
             + (minorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Minor)
-            + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major);
+            + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
+            + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material);
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -77,7 +77,7 @@ public sealed partial class Engine
 
     /// <summary>
     /// <see cref="Constants.MaterialCorrHistoryHashSize"/> x 2
-    /// Major hash x side to move
+    /// Material hash x side to move
     /// </summary>
     private readonly short[] _materialCorrHistory = GC.AllocateArray<short>(Constants.MaterialCorrHistoryHashSize * 2, pinned: true);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -76,6 +76,12 @@ public sealed partial class Engine
     private readonly short[] _majorCorrHistory = GC.AllocateArray<short>(Constants.MajorCorrHistoryHashSize * 2, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.MaterialCorrHistoryHashSize"/> x 2
+    /// Major hash x side to move
+    /// </summary>
+    private readonly short[] _materialCorrHistory = GC.AllocateArray<short>(Constants.MaterialCorrHistoryHashSize * 2, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Utils.cs
+++ b/src/Lynx/Utils.cs
@@ -256,6 +256,18 @@ public static class Utils
         return ((1 << piece) & MajorPieceMask) != 0;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ulong Murmur3(ulong n)
+    {
+        n ^= n >> 33;
+        n *= 0xff51afd7ed558ccdUL;
+        n ^= n >> 33;
+        n *= 0xc4ceb9fe1a85ec53UL;
+        n ^= n >> 33;
+
+        return n;
+    }
+
     /// <summary>
     /// Recommended in https://learn.microsoft.com/en-us/dotnet/api/system.boolean.tostring
     /// </summary>


### PR DESCRIPTION
```
Test  | search/material-corrhist-zobrist-hash-from-existing
Elo   | -6.61 +- 4.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 7048: +1708 -1842 =3498
Penta | [96, 890, 1664, 800, 74]
https://openbench.lynx-chess.com/test/2708/
```