### PR TITLE
🐛 Account for potential OOM exceptions in MultiArray TT allocation

### DIFF
--- a/src/Lynx/Model/MultiArrayTranspositionTable.cs
+++ b/src/Lynx/Model/MultiArrayTranspositionTable.cs
@@ -53,13 +53,50 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
         _tt = GC.AllocateArray<TranspositionTableElement[]>(_ttArrayCount, pinned: true);
         for (int i = 0; i < (int)fullArrayCount; ++i)
         {
-            _tt[i] = GC.AllocateArray<TranspositionTableElement>(Constants.MaxTTArrayLength, pinned: true);
+            try
+            {
+                _tt[i] = GC.AllocateArray<TranspositionTableElement>(Constants.MaxTTArrayLength, pinned: true);
+            }
+            catch (OutOfMemoryException e)
+            {
+                _logger.Warn("Out of memory exception when allocating TT array {ArrayIndex} of size {ArraySize} ({ArraySizeMB} MB)", i + 1, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024);
+
+                itemsLeft = 0;
+
+                if (i > 0)
+                {
+                    _ttArrayCount = i;
+                    fullArrayCount = (ulong)i;
+                    _tt[i] = [];
+                    _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB)", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024);
+                }
+                else
+                {
+                    throw;
+                }
+
+                // Otherwise UpdateHash 
+
+                break;
+            }
         }
 
         if (itemsLeft != 0)
         {
             _logger.Info("1 array of size {ArraySize} ({ArraySizeMB} MB)", itemsLeft, itemsLeft * TranspositionTableElement.Size / 1024 / 1024);
-            _tt[_ttArrayCount - 1] = GC.AllocateArray<TranspositionTableElement>((int)itemsLeft, pinned: true);
+
+            try
+            {
+                _tt[_ttArrayCount - 1] = GC.AllocateArray<TranspositionTableElement>((int)itemsLeft, pinned: true);
+            }
+            catch (OutOfMemoryException e)
+            {
+                _logger.Warn("Out of memory exception when allocating remaining items TT array of size {ArraySize} ({ArraySizeMB} MB)", itemsLeft, itemsLeft * TranspositionTableElement.Size / 1024 / 1024);
+
+                _tt[_ttArrayCount - 1] = [];
+                --_ttArrayCount;
+                _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB)", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024);
+            }
         }
 
         _logger.Info("Multi-Array TT allocation time:\t{0} ms", sw.ElapsedMilliseconds);

--- a/src/Lynx/Model/MultiArrayTranspositionTable.cs
+++ b/src/Lynx/Model/MultiArrayTranspositionTable.cs
@@ -24,6 +24,7 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
         _logger.Info("Allocating Multi-Array TT");
         var sw = Stopwatch.StartNew();
 
+        var oldSizeMBs = SizeMBs;
         SizeMBs = Configuration.EngineSettings.TranspositionTableSize;
 
         Length = CalculateLength(SizeMBs);
@@ -68,14 +69,14 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
                     _ttArrayCount = i;
                     fullArrayCount = (ulong)i;
                     _tt[i] = [];
-                    _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB)", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024);
+                    SizeMBs = (int)(fullArrayCount * (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024ul / 1024ul);
+                    _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB each) - {TotalSizeMB} MB total", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024, SizeMBs);
                 }
                 else
                 {
-                    throw;
+                    SizeMBs = oldSizeMBs;
+                    throw;  // This will cause Searcher.UpdateHash to fail, keeping the old TT
                 }
-
-                // Otherwise UpdateHash 
 
                 break;
             }
@@ -95,7 +96,8 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
 
                 _tt[_ttArrayCount - 1] = [];
                 --_ttArrayCount;
-                _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB)", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024);
+                SizeMBs = (int)(fullArrayCount * (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024ul / 1024ul);
+                _logger.Warn(e, "Using only {ArrayCount} array(s) of size {ArraySize} ({ArraySizeMB} MB each) - {TotalSizeMB} MB total", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024, SizeMBs);
             }
         }
 


### PR DESCRIPTION
The current workaround for the max array size is to allocate.. an array of arrays.
This caused OOM exceptions in TCEC FRD 5 (but weirdly not in Swiss 9) (see [“Out Of Memory” Does Not Refer to Physical Memory](https://learn.microsoft.com/en-us/archive/blogs/ericlippert/out-of-memory-does-not-refer-to-physical-memory).
Local reproduction focused on the .NET 9 -> .NET 10 migration that happened between the versions in [tcec-swiss-9](https://github.com/lynx-chess/Lynx/tree/tcec-swiss-9) and [tcec-frd-5](https://github.com/lynx-chess/Lynx/tree/tcec-frd-5) has been inconsistent for now.

This PR intends to mitigate the issue by catching that specific exception and settling for whatever amount of arrays part of our array-of-arrays TT were successfully allocated. This will avoid playing TCEC events with the default TT size (32MB) if this issue shows up again.