### PR TITLE
🔍 Continuation correction history I - indexing by `[lastMove][previousToLastMove]`

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -473,6 +473,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Material { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Continuation { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -643,6 +643,9 @@ public static class Constants
     public const int MaterialCorrHistoryHashSize = 2_048;
     public const int MaterialCorrHistoryHashMask = MaterialCorrHistoryHashSize - 1;
 
+    public const int ContinuationCorrHistoryHashSize = 16_384;
+    public const int ContinuationCorrHistoryHashMask = ContinuationCorrHistoryHashSize - 1;
+
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -88,6 +88,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_minorCorrHistory);
         Array.Clear(_majorCorrHistory);
         Array.Clear(_materialCorrHistory);
+        Array.Clear(_continuationCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -204,7 +204,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth)
+    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth, int ply)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -277,6 +277,27 @@ public sealed partial class Engine
         ref var materialCorrHistEntry = ref _materialCorrHistory[materialCorrHistIndex];
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
+        // Continuation correction history
+        if (ply >= 2)
+        {
+            var ply1Move = Game.ReadMoveFromStack(ply - 1);
+            var ply2Move = Game.ReadMoveFromStack(ply - 2);
+
+            const int pieceOffset = 64 * 12 * 64;
+            const int targetSquareOffset = 12 * 64;
+            const int previousMovePieceOffset = 64;
+
+            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
+                + (ply1Move.TargetSquare() * targetSquareOffset)
+                + (ply2Move.Piece() * previousMovePieceOffset)
+                + ply2Move.TargetSquare();
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            ref var continuationCorrHist = ref _continuationCorrHistory[materialCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+        }
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short UpdateCorrectionHistory(short previousCorrectedScore, int scaledBonus, int weight)
@@ -297,7 +318,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CorrectStaticEvaluation(Position position, int staticEvaluation)
+    private int CorrectStaticEvaluation(Position position, int staticEvaluation, int ply)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -359,13 +380,36 @@ public sealed partial class Engine
 
         var materialCorrHist = _materialCorrHistory[materialCorrHistIndex];
 
+        // Continuation correction history
+        int continuationCorrHist = 0;
+        if (ply >= 2)
+        {
+            var ply1Move = Game.ReadMoveFromStack(ply - 1);
+            var ply2Move = Game.ReadMoveFromStack(ply - 2);
+
+
+            const int pieceOffset = 64 * 12 * 64;
+            const int targetSquareOffset = 12 * 64;
+            const int previousMovePieceOffset = 64;
+
+            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
+                + (ply1Move.TargetSquare() * targetSquareOffset)
+                + (ply2Move.Piece() * previousMovePieceOffset)
+                + ply2Move.TargetSquare();
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
+        }
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
             + (nonPawnNoSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnNoSTM)
             + (minorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Minor)
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
-            + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material);
+            + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
+            + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -82,6 +82,12 @@ public sealed partial class Engine
     private readonly short[] _materialCorrHistory = GC.AllocateArray<short>(Constants.MaterialCorrHistoryHashSize * 2, pinned: true);
 
     /// <summary>
+    /// 12 x 64 x 12 x 64
+    /// previous piece x previous target square x previous previous piece x previous previous target square
+    /// </summary>
+    private readonly short[] _continuationCorrHistory = GC.AllocateArray<short>(12 * 64 * 12 * 64, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,7 @@ public sealed partial class Engine
                 Debug.Assert(ttEntry.Score != EvaluationConstants.NoScore || ttEntry.NodeType == NodeType.Unknown);
 
                 rawStaticEval = ttEntry.StaticEval;
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
                 phase = position.Phase();
                 position.CalculateThreats(ref evaluationContext);
             }
@@ -185,7 +185,7 @@ public sealed partial class Engine
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
                 _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
             }
 
             stack.StaticEval = staticEval;
@@ -307,7 +307,7 @@ public sealed partial class Engine
         else
         {
             (rawStaticEval, _) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
-            staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+            staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
 
             if (!ttHit)
             {
@@ -777,7 +777,7 @@ public sealed partial class Engine
                 || (nodeType == NodeType.Beta && bestScore <= staticEval)
                 || (nodeType == NodeType.Alpha && bestScore >= staticEval)))
             {
-                UpdateCorrectionHistory(position, bestScore - staticEval, depth);
+                UpdateCorrectionHistory(position, bestScore - staticEval, depth, ply);
             }
 
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
@@ -853,7 +853,7 @@ public sealed partial class Engine
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 
-        var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+        var staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
 
         ref var stack = ref Game.Stack(ply);
         stack.StaticEval = staticEval;


### PR DESCRIPTION
Indexing by [lastMove][previousToLastMove]

```
Test  | search/contcorrhist-1
Elo   | -1.99 +- 3.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -1.31 (-2.25, 2.89) [0.00, 3.00]
Games | 9782: +2209 -2265 =5308
Penta | [30, 1169, 2557, 1097, 38]
https://openbench.lynx-chess.com/test/2722/
```

Weight 50

```
Test  | search/contcorrhist-2
Elo   | -3.49 +- 3.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 11536: +2823 -2939 =5774
Penta | [96, 1394, 2904, 1278, 96]
https://openbench.lynx-chess.com/test/2724/
```