### PR TITLE
🔍 Continuation correction history II - previous move hash

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -477,7 +477,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation { get; set; } = 100;
+    public int CorrHistoryWeight_Continuation { get; set; } = 50;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -477,7 +477,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation { get; set; } = 50;
+    public int CorrHistoryWeight_Continuation { get; set; } = 100;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -473,6 +473,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Material { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Continuation { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -643,6 +643,9 @@ public static class Constants
     public const int MaterialCorrHistoryHashSize = 2_048;
     public const int MaterialCorrHistoryHashMask = MaterialCorrHistoryHashSize - 1;
 
+    public const int ContinuationCorrHistoryHashSize = 16_384;
+    public const int ContinuationCorrHistoryHashMask = ContinuationCorrHistoryHashSize - 1;
+
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -88,6 +88,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_minorCorrHistory);
         Array.Clear(_majorCorrHistory);
         Array.Clear(_materialCorrHistory);
+        Array.Clear(_continuationCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -265,6 +265,17 @@ public sealed class Game : IDisposable
     public static bool Is50MovesRepetition(int halfMovesWithoutCaptureOrPawnMove) => halfMovesWithoutCaptureOrPawnMove >= 100;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong PreviousMoveHash(int nMovesAgo)
+    {
+        if (_positionHashHistoryPointer >= nMovesAgo)
+        {
+            return _positionHashHistory[_positionHashHistoryPointer - nMovesAgo];
+        }
+
+        return 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public GameState MakeMove(Move moveToPlay)
     {
         var gameState = CurrentPosition.MakeMove(moveToPlay);

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -204,7 +204,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth)
+    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth, int ply)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -277,6 +277,27 @@ public sealed partial class Engine
         ref var materialCorrHistEntry = ref _materialCorrHistory[materialCorrHistIndex];
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
+        // Continuation correction history
+        if (ply >= 2)
+        {
+            var ply1Move = Game.ReadMoveFromStack(ply - 1);
+            var ply2Move = Game.ReadMoveFromStack(ply - 2);
+
+            const int pieceOffset = 64 * 12 * 64;
+            const int targetSquareOffset = 12 * 64;
+            const int previousMovePieceOffset = 64;
+
+            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
+                + (ply1Move.TargetSquare() * targetSquareOffset)
+                + (ply2Move.Piece() * previousMovePieceOffset)
+                + ply2Move.TargetSquare();
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            ref var continuationCorrHist = ref _continuationCorrHistory[materialCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+        }
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short UpdateCorrectionHistory(short previousCorrectedScore, int scaledBonus, int weight)
@@ -297,7 +318,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CorrectStaticEvaluation(Position position, int staticEvaluation)
+    private int CorrectStaticEvaluation(Position position, int staticEvaluation, int ply)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -359,13 +380,36 @@ public sealed partial class Engine
 
         var materialCorrHist = _materialCorrHistory[materialCorrHistIndex];
 
+        // Continuation correction history
+        int continuationCorrHist = 0;
+        if (ply >= 2)
+        {
+            var ply1Move = Game.ReadMoveFromStack(ply - 1);
+            var ply2Move = Game.ReadMoveFromStack(ply - 2);
+
+
+            const int pieceOffset = 64 * 12 * 64;
+            const int targetSquareOffset = 12 * 64;
+            const int previousMovePieceOffset = 64;
+
+            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
+                + (ply1Move.TargetSquare() * targetSquareOffset)
+                + (ply2Move.Piece() * previousMovePieceOffset)
+                + ply2Move.TargetSquare();
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
+        }
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
             + (nonPawnNoSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnNoSTM)
             + (minorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Minor)
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
-            + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material);
+            + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
+            + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -204,7 +204,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth, int ply)
+    private void UpdateCorrectionHistory(Game game, Position position, int evaluationDelta, int depth, int ply)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -278,23 +278,15 @@ public sealed partial class Engine
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
         // Continuation correction history
-        if (ply >= 2)
+        var previousMoveHash = Game.PreviousMoveHash(1);
+        if (previousMoveHash != 0)
         {
-            var ply1Move = Game.ReadMoveFromStack(ply - 1);
-            var ply2Move = Game.ReadMoveFromStack(ply - 2);
-
-            const int pieceOffset = 64 * 12 * 64;
-            const int targetSquareOffset = 12 * 64;
-            const int previousMovePieceOffset = 64;
-
-            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
-                + (ply1Move.TargetSquare() * targetSquareOffset)
-                + (ply2Move.Piece() * previousMovePieceOffset)
-                + ply2Move.TargetSquare();
+            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
 
             Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 
-            ref var continuationCorrHist = ref _continuationCorrHistory[materialCorrHistIndex];
+            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
             continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
         }
 
@@ -380,22 +372,13 @@ public sealed partial class Engine
 
         var materialCorrHist = _materialCorrHistory[materialCorrHistIndex];
 
-        // Continuation correction history
+        // Continuation correction history - Motor author original idea
         int continuationCorrHist = 0;
-        if (ply >= 2)
+        var previousMoveHash = Game.PreviousMoveHash(1);
+        if (previousMoveHash != 0)
         {
-            var ply1Move = Game.ReadMoveFromStack(ply - 1);
-            var ply2Move = Game.ReadMoveFromStack(ply - 2);
-
-
-            const int pieceOffset = 64 * 12 * 64;
-            const int targetSquareOffset = 12 * 64;
-            const int previousMovePieceOffset = 64;
-
-            var continuationCorrHistIndex = (ply1Move.Piece() * pieceOffset)
-                + (ply1Move.TargetSquare() * targetSquareOffset)
-                + (ply2Move.Piece() * previousMovePieceOffset)
-                + ply2Move.TargetSquare();
+            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
 
             Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -82,10 +82,9 @@ public sealed partial class Engine
     private readonly short[] _materialCorrHistory = GC.AllocateArray<short>(Constants.MaterialCorrHistoryHashSize * 2, pinned: true);
 
     /// <summary>
-    /// 12 x 64 x 12 x 64
-    /// previous piece x previous target square x previous previous piece x previous previous target square
+    /// <see cref="Constants.ContinuationCorrHistoryHashSize"/>
     /// </summary>
-    private readonly short[] _continuationCorrHistory = GC.AllocateArray<short>(12 * 64 * 12 * 64, pinned: true);
+    private readonly short[] _continuationCorrHistory = GC.AllocateArray<short>(Constants.ContinuationCorrHistoryHashSize, pinned: true);
 
     /// <summary>
     /// 12 x 64

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -82,6 +82,12 @@ public sealed partial class Engine
     private readonly short[] _materialCorrHistory = GC.AllocateArray<short>(Constants.MaterialCorrHistoryHashSize * 2, pinned: true);
 
     /// <summary>
+    /// 12 x 64 x 12 x 64
+    /// previous piece x previous target square x previous previous piece x previous previous target square
+    /// </summary>
+    private readonly short[] _continuationCorrHistory = GC.AllocateArray<short>(12 * 64 * 12 * 64, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,7 @@ public sealed partial class Engine
                 Debug.Assert(ttEntry.Score != EvaluationConstants.NoScore || ttEntry.NodeType == NodeType.Unknown);
 
                 rawStaticEval = ttEntry.StaticEval;
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
                 phase = position.Phase();
                 position.CalculateThreats(ref evaluationContext);
             }
@@ -185,7 +185,7 @@ public sealed partial class Engine
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
                 _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
             }
 
             stack.StaticEval = staticEval;
@@ -307,7 +307,7 @@ public sealed partial class Engine
         else
         {
             (rawStaticEval, _) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
-            staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+            staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
 
             if (!ttHit)
             {
@@ -777,7 +777,7 @@ public sealed partial class Engine
                 || (nodeType == NodeType.Beta && bestScore <= staticEval)
                 || (nodeType == NodeType.Alpha && bestScore >= staticEval)))
             {
-                UpdateCorrectionHistory(position, bestScore - staticEval, depth);
+                UpdateCorrectionHistory(position, bestScore - staticEval, depth, ply);
             }
 
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
@@ -853,7 +853,7 @@ public sealed partial class Engine
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 
-        var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+        var staticEval = CorrectStaticEvaluation(position, rawStaticEval, ply);
 
         ref var stack = ref Game.Stack(ply);
         stack.StaticEval = staticEval;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -777,7 +777,7 @@ public sealed partial class Engine
                 || (nodeType == NodeType.Beta && bestScore <= staticEval)
                 || (nodeType == NodeType.Alpha && bestScore >= staticEval)))
             {
-                UpdateCorrectionHistory(position, bestScore - staticEval, depth, ply);
+                UpdateCorrectionHistory(Game, position, bestScore - staticEval, depth, ply);
             }
 
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);


### PR DESCRIPTION
```
Test  | search/contcorrhist-alt
Elo   | -1.18 +- 2.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 25858: +6471 -6559 =12828
Penta | [319, 3203, 5942, 3177, 288]
https://openbench.lynx-chess.com/test/2726/
```

```
Test  | search/contcorrhist-alt
Elo   | -3.27 +- 3.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 11792: +2660 -2771 =6361
Penta | [50, 1473, 2964, 1356, 53]
https://openbench.lynx-chess.com/test/2727/
```

Weight 150
```
Test  | search/contcorrhist-alt-150
Elo   | -0.95 +- 2.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 28908: +7176 -7255 =14477
Penta | [301, 3607, 6736, 3490, 320]
https://openbench.lynx-chess.com/test/2728/
```

Weight 50
```
Test  | search/contcorrhist-alt-50
Elo   | -0.70 +- 6.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.27 (-2.25, 2.89) [0.00, 3.00]
Games | 3998: +959 -967 =2072
Penta | [40, 486, 958, 472, 43]
https://openbench.lynx-chess.com/test/2729/
```