### PR TITLE
🔍 Continuation history 4 ply II 

### DIFF
--- a/src/Lynx/EvaluationConstants.cs
+++ b/src/Lynx/EvaluationConstants.cs
@@ -216,7 +216,7 @@ public static class EvaluationConstants
 
     #endregion
 
-    public const int ContinuationHistoryPlyCount = 2;
+    public const int ContinuationHistoryPlyCount = 4;
 }
 
 #pragma warning restore IDE1006 // Naming Styles

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -139,12 +139,19 @@ public sealed partial class Engine
         var ply2Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply2Move);
         Debug.Assert(ply2Index < _continuationHistory.Length);
 
-        // Continuation history, ply - 4
-        var ply4Move = Game.ReadMoveFromStack(ply - 4);
-        var ply4Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply4Move);
-        Debug.Assert(ply4Index < _continuationHistory.Length);
+        var contHist = _continuationHistory[ply1Index] + _continuationHistory[ply2Index];
 
-        return _continuationHistory[ply1Index] + _continuationHistory[ply2Index] + _continuationHistory[ply4Index];
+        if (ply >= 4)
+        {
+            // Continuation history, ply - 4
+            var ply4Move = Game.ReadMoveFromStack(ply - 4);
+            var ply4Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply4Move);
+            Debug.Assert(ply4Index < _continuationHistory.Length);
+
+            contHist += _continuationHistory[ply4Index];
+        }
+
+        return contHist;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -139,7 +139,12 @@ public sealed partial class Engine
         var ply2Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply2Move);
         Debug.Assert(ply2Index < _continuationHistory.Length);
 
-        return _continuationHistory[ply1Index] + _continuationHistory[ply2Index];
+        // Continuation history, ply - 4
+        var ply4Move = Game.ReadMoveFromStack(ply - 4);
+        var ply4Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply4Move);
+        Debug.Assert(ply4Index < _continuationHistory.Length);
+
+        return _continuationHistory[ply1Index] + _continuationHistory[ply2Index] + _continuationHistory[ply4Index];
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -181,6 +186,17 @@ public sealed partial class Engine
 
                 ref var contHist2 = ref _continuationHistory[ply2Index];
                 contHist2 = (short)ScoreHistoryMove(contHist2, rawHistoryBonus);
+
+                if (ply >= 4)
+                {
+                    // Follow-up history (continuation history, ply - 4)
+                    var ply4Move = Game.ReadMoveFromStack(ply - 4);
+                    var ply4Index = commonIndex + ContinuationHistoryPreviousMoveIndex(ply4Move);
+                    Debug.Assert(ply4Index < _continuationHistory.Length);
+
+                    ref var contHist4 = ref _continuationHistory[ply4Index];
+                    contHist4 = (short)ScoreHistoryMove(contHist4, rawHistoryBonus);
+                }
             }
         }
     }


### PR DESCRIPTION
Previous attempt:
https://github.com/lynx-chess/Lynx/pull/2471

```
Test  | search/conthist-4
Elo   | -5.32 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.81 (-2.25, 2.89) [0.00, 3.00]
Games | 6856: +1684 -1789 =3383
Penta | [89, 869, 1604, 790, 76]
https://openbench.lynx-chess.com/test/2736/
```