### PR TITLE
🔍 Do threefold repetition check (instead of 'twofold') on root searches

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -209,9 +209,11 @@ public sealed class Game : IDisposable
     /// Basic algorithm described in https://web.archive.org/web/20201107002606/https://marcelk.net/2013-04-06/paper/upcoming-rep-v2.pdf
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool IsThreefoldRepetition()
+    public bool IsThreefoldRepetition(int ply)
     {
         var currentHash = CurrentPosition.UniqueIdentifier;
+
+        var twofoldRepetitionDetected = false;
 
         // [_positionHashHistoryPointer - 1] would be the last one, we want to start searching 2 earlier and finish HalfMovesWithoutCaptureOrPawnMove earlier
         var limit = Math.Max(0, _positionHashHistoryPointer - 1 - HalfMovesWithoutCaptureOrPawnMove);
@@ -219,7 +221,12 @@ public sealed class Game : IDisposable
         {
             if (currentHash == _positionHashHistory[i])
             {
-                return true;
+                if (ply > 0 || twofoldRepetitionDetected)
+                {
+                    return true;
+                }
+
+                twofoldRepetitionDetected = true;
             }
         }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -540,7 +540,7 @@ public sealed partial class Engine
 
             int score = 0;
 
-            if (canBeRepetition && (Game.IsThreefoldRepetition() || Game.Is50MovesRepetition(ref evaluationContext)))
+            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition(ref evaluationContext)))
             {
                 score = 0;
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -248,9 +248,7 @@ public class RegressionTest : BaseTest
         var engine = GetEngine();
         engine.AdjustPosition(positionCommand);
 
-        var bestMove = engine.BestMove(new GoCommand($"go depth {5}"));
-        Assert.Zero(bestMove.Score);
-        Assert.AreEqual(1, bestMove.Moves.Length);
+        var bestMove = engine.BestMove(new GoCommand($"go depth 20"));
         Assert.AreEqual("b8c7", bestMove.BestMove.UCIString());
     }
 

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -1,7 +1,9 @@
 ﻿using Lynx.Model;
+using Lynx.UCI.Commands.GUI;
 using NUnit.Framework;
 
 namespace Lynx.Test;
+
 public class GameTest : BaseTest
 {
     [Test]
@@ -27,19 +29,24 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
     }
 
     [Test]
@@ -66,19 +73,24 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[4]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[6]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
     }
 
     [Test]
@@ -107,16 +119,19 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[2]));
 
         game.MakeMove(repeatedMoves[3]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[5]));
 
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[6]));
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         game.MakeMove(repeatedMoves[7]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         // Position with castling rights, lost in move Ke1d1
         winningPosition = new Position("1n2k2r/8/8/8/8/8/4PPPP/1N2K2R w Kk - 0 1");
@@ -141,7 +156,8 @@ public class GameTest : BaseTest
         }
 
         game.MakeMove(repeatedMoves[^1]);
-        Assert.False(game.IsThreefoldRepetition());                      // Same position, but white not can't castle
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.False(game.IsThreefoldRepetition(1));
 
 #if DEBUG
         Assert.AreEqual(repeatedMoves.Count, game.MoveHistory.Count);
@@ -154,7 +170,44 @@ public class GameTest : BaseTest
         Assert.DoesNotThrow(() => game.MakeMove(repeatedMoves[4]));
 
         game.MakeMove(repeatedMoves[5]);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.False(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
+    }
+
+    [Test]
+    public void IsThreefoldRepetition_NoTwoFoldAtRoot()
+    {
+        var game = new Game(Constants.InitialPositionFEN);
+        game.ParsePositionCommand("position fen r7/PK6/8/5k2/R7/8/8/8 b - - 6 101 moves a8g8 a4a5 f5e4 a5a4");
+
+        Assert.False(game.IsThreefoldRepetition(0));
+
+        var engine = GetEngine();
+        engine.SetGame(game);
+
+        var result = engine.BestMove(new("go depth 20"));
+
+        Assert.Less(result.Score, 0);
+    }
+
+    [TestCase("position startpos moves d2d4 g8f6 c2c4 e7e6 g1f3 d7d5 b1c3 f8e7 c1f4 e8g8" +
+        " e2e3 c7c5 d4c5 e7c5 a2a3 a7a6 d1d2 d5c4 f1c4 b7b5 c4d3 c8b7 b2b4 b7f3 b4c5 f3g2" +
+        " h1g1 g2f3 g1g3 f3c6 f4h6 g7g6 h6f8 d8f8 a3a4 b5b4 c3a2 b4b3 a2c1 f8c5 c1b3 c5d5" +
+        " b3a5 d5h1 d3f1 c6d5 d2c3 b8d7 c3c7 h1e4 f1c4 e4c2 a1a2 c2c1 e1e2 d7e5 c7e5 d5c4" +
+        " a5c4 c1c4 e2f3 c4a2 e5f6 a2a4 f3g2 a8c8 g3f3 a4d7 f6e5 d7b5 e5d6 a6a5 d6e7 c8f8" +
+        " e7d6 a5a4 e3e4 b5c4 f3e3 f8c8 h2h3 c4b5 e3f3 b5g5 f3g3 g5a5 g3d3 a5g5 d3g3 g5b5" +
+        " g3f3 b5a5 f3d3 a5a8 d6b4 c8b8 b4c4 a4a3 d3d2 b8b2 d2b2 a3b2 c4b4 a8a2 b4b8 g8g7" +
+        " b8e5 g7g8 e5b8 g8g7 b8e5 f7f6 e5c7 g7g8 c7b8 g8f7 b8c7 f7g8 c7b8 g8g7")]
+    public void NoThreefoldRepetition(string positionCommand)
+    {
+        for (int depth = 1; depth < 5; ++depth)
+        {
+            var engine = GetEngine();
+            engine.AdjustPosition(positionCommand);
+
+            var bestMove = engine.BestMove(new GoCommand($"go depth {depth}"));
+            Assert.NotZero(bestMove.Score);
+        }
     }
 
     [Test]

--- a/tests/Lynx.Test/OnlineTablebaseProberTest.cs
+++ b/tests/Lynx.Test/OnlineTablebaseProberTest.cs
@@ -369,7 +369,8 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         // Using local method due to async Span limitation
         static Game ParseGame()
@@ -395,7 +396,8 @@ public class OnlineTablebaseProberTest
         Assert.AreEqual("h8g7", result.BestMove.UCIString());
 
         game.MakeMove(result.BestMove);
-        Assert.True(game.IsThreefoldRepetition());
+        Assert.True(game.IsThreefoldRepetition(0));
+        Assert.True(game.IsThreefoldRepetition(1));
 
         // Using local method due to async Span limitation
         static Game ParseGame()


### PR DESCRIPTION
Previously explored in #819 

```
Test  | search/threefold-root
Elo   | -0.13 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | 115322: +28950 -28992 =57380
Penta | [1041, 12692, 30236, 12652, 1040]
https://openbench.lynx-chess.com/test/2737/
```