### PR TITLE
🔍 Continuation correction history - ply - 4

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -489,7 +489,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation3 { get; set; } = 100;
+    public int CorrHistoryWeight_Continuation4 { get; set; } = 100;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -485,6 +485,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Continuation2 { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Continuation3 { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -278,19 +278,40 @@ public sealed partial class Engine
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
         // Continuation correction history
-        for (int i = 1; i <= 3; ++i)
+        var previousMoveHash = Game.PreviousMoveHash(1);
+        if (previousMoveHash != 0)
         {
-            var previousMoveHash = Game.PreviousMoveHash(i);
-            if (previousMoveHash != 0)
-            {
-                var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
-                var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
 
-                Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 
-                ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
-                continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
-            }
+            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+        }
+
+        var previousPreviousMoveHash = Game.PreviousMoveHash(2);
+        if (previousPreviousMoveHash != 0)
+        {
+            var continuationIndex = position.UniqueIdentifier ^ previousPreviousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+        }
+
+        var previous4MoveHash = Game.PreviousMoveHash(4);
+        if (previous4MoveHash != 0)
+        {
+            var continuationIndex = position.UniqueIdentifier ^ previous4MoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
         }
 
         // Common update logic
@@ -378,7 +399,7 @@ public sealed partial class Engine
         // Continuation correction history - Motor author original idea
         int continuationCorrHist = 0;
         int continuationCorrHist2 = 0;
-        int continuationCorrHist3 = 0;
+        int continuationCorrHist4 = 0;
 
         var previousMoveHash = Game.PreviousMoveHash(1);
         if (previousMoveHash != 0)
@@ -402,7 +423,7 @@ public sealed partial class Engine
             continuationCorrHist2 = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
-        var previousPreviousPreviousMoveHash = Game.PreviousMoveHash(3);
+        var previousPreviousPreviousMoveHash = Game.PreviousMoveHash(4);
         if (previousPreviousPreviousMoveHash != 0)
         {
             var continuationIndex = position.UniqueIdentifier ^ previousPreviousPreviousMoveHash;
@@ -410,7 +431,7 @@ public sealed partial class Engine
 
             Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 
-            continuationCorrHist3 = _continuationCorrHistory[continuationCorrHistIndex];
+            continuationCorrHist4 = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
         // Correction aggregation
@@ -422,7 +443,7 @@ public sealed partial class Engine
             + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
             + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
             + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2)
-            + (continuationCorrHist3 * Configuration.EngineSettings.CorrHistoryWeight_Continuation3);
+            + (continuationCorrHist4 * Configuration.EngineSettings.CorrHistoryWeight_Continuation4);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -278,28 +278,19 @@ public sealed partial class Engine
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
         // Continuation correction history
-        var previousMoveHash = Game.PreviousMoveHash(1);
-        if (previousMoveHash != 0)
+        for (int i = 1; i <= 3; ++i)
         {
-            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+            var previousMoveHash = Game.PreviousMoveHash(i);
+            if (previousMoveHash != 0)
+            {
+                var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+                var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
 
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+                Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 
-            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
-            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
-        }
-
-        var previousPreviousMoveHash = Game.PreviousMoveHash(2);
-        if (previousPreviousMoveHash != 0)
-        {
-            var continuationIndex = position.UniqueIdentifier ^ previousPreviousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
-
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
-
-            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
-            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+                ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+                continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+            }
         }
 
         // Common update logic
@@ -386,6 +377,9 @@ public sealed partial class Engine
 
         // Continuation correction history - Motor author original idea
         int continuationCorrHist = 0;
+        int continuationCorrHist2 = 0;
+        int continuationCorrHist3 = 0;
+
         var previousMoveHash = Game.PreviousMoveHash(1);
         if (previousMoveHash != 0)
         {
@@ -397,7 +391,6 @@ public sealed partial class Engine
             continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
-        int continuationCorrHist2 = 0;
         var previousPreviousMoveHash = Game.PreviousMoveHash(2);
         if (previousPreviousMoveHash != 0)
         {
@@ -409,6 +402,17 @@ public sealed partial class Engine
             continuationCorrHist2 = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
+        var previousPreviousPreviousMoveHash = Game.PreviousMoveHash(3);
+        if (previousPreviousPreviousMoveHash != 0)
+        {
+            var continuationIndex = position.UniqueIdentifier ^ previousPreviousPreviousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            continuationCorrHist3 = _continuationCorrHistory[continuationCorrHistIndex];
+        }
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
@@ -417,7 +421,8 @@ public sealed partial class Engine
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
             + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
             + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
-            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2);
+            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2)
+            + (continuationCorrHist3 * Configuration.EngineSettings.CorrHistoryWeight_Continuation3);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 


### PR DESCRIPTION
```
Test  | search/contcorrhist-4
Elo   | 3.40 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | 26538: +6800 -6540 =13198
Penta | [280, 3156, 6169, 3352, 312]
https://openbench.lynx-chess.com/test/2742/
```