### PR TITLE
🔍 Continuation correction history - ply - 3

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -485,6 +485,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Continuation2 { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Continuation3 { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -278,28 +278,19 @@ public sealed partial class Engine
         materialCorrHistEntry = UpdateCorrectionHistory(materialCorrHistEntry, scaledBonus, weight);
 
         // Continuation correction history
-        var previousMoveHash = Game.PreviousMoveHash(1);
-        if (previousMoveHash != 0)
+        for (int i = 1; i <= 3; ++i)
         {
-            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+            var previousMoveHash = Game.PreviousMoveHash(i);
+            if (previousMoveHash != 0)
+            {
+                var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+                var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
 
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+                Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
 
-            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
-            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
-        }
-
-        var previousPreviousMoveHash = Game.PreviousMoveHash(2);
-        if (previousPreviousMoveHash != 0)
-        {
-            var continuationIndex = position.UniqueIdentifier ^ previousPreviousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
-
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
-
-            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
-            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+                ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+                continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+            }
         }
 
         // Common update logic
@@ -386,6 +377,9 @@ public sealed partial class Engine
 
         // Continuation correction history - Motor author original idea
         int continuationCorrHist = 0;
+        int continuationCorrHist2 = 0;
+        int continuationCorrHist3 = 0;
+
         var previousMoveHash = Game.PreviousMoveHash(1);
         if (previousMoveHash != 0)
         {
@@ -397,7 +391,6 @@ public sealed partial class Engine
             continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
-        int continuationCorrHist2 = 0;
         var previousPreviousMoveHash = Game.PreviousMoveHash(2);
         if (previousPreviousMoveHash != 0)
         {
@@ -409,6 +402,17 @@ public sealed partial class Engine
             continuationCorrHist2 = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
+        var previousPreviousPreviousMoveHash = Game.PreviousMoveHash(3);
+        if (previousPreviousPreviousMoveHash != 0)
+        {
+            var continuationIndex = position.UniqueIdentifier ^ previousPreviousPreviousMoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            continuationCorrHist3 = _continuationCorrHistory[continuationCorrHistIndex];
+        }
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
@@ -417,7 +421,8 @@ public sealed partial class Engine
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
             + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
             + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
-            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2);
+            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2)
+            + (continuationCorrHist3 * Configuration.EngineSettings.CorrHistoryWeight_Continuation3);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 


### PR DESCRIPTION
Weight 75
```
Test  | search/contcorrhist-3
Elo   | -1.37 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 23646: +5848 -5941 =11857
Penta | [294, 2913, 5485, 2854, 277]
https://openbench.lynx-chess.com/test/2743/
```

Before ply - 4, weight 100
```
Test  | search/contcorrhist-3
Elo   | 0.12 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.31 (-2.25, 2.89) [0.00, 3.00]
Games | 71470: +17900 -17876 =35694
Penta | [850, 8690, 16631, 8714, 850]
https://openbench.lynx-chess.com/test/2741/
```
