### PR TITLE
🔍 Correction history - ply - 6

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -491,6 +491,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Continuation4 { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Continuation6 { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -314,6 +314,18 @@ public sealed partial class Engine
             continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
         }
 
+        var previous6MoveHash = Game.PreviousMoveHash(6);
+        if (previous6MoveHash != 0)
+        {
+            var continuationIndex = position.UniqueIdentifier ^ previous6MoveHash;
+            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+            ref var continuationCorrHist = ref _continuationCorrHistory[continuationCorrHistIndex];
+            continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
+        }
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short UpdateCorrectionHistory(short previousCorrectedScore, int scaledBonus, int weight)
@@ -397,42 +409,10 @@ public sealed partial class Engine
         var materialCorrHist = _materialCorrHistory[materialCorrHistIndex];
 
         // Continuation correction history - Motor author original idea
-        int continuationCorrHist = 0;
-        int continuationCorrHist2 = 0;
-        int continuationCorrHist4 = 0;
-
-        var previousMoveHash = Game.PreviousMoveHash(1);
-        if (previousMoveHash != 0)
-        {
-            var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
-
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
-
-            continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
-        }
-
-        var previousPreviousMoveHash = Game.PreviousMoveHash(2);
-        if (previousPreviousMoveHash != 0)
-        {
-            var continuationIndex = position.UniqueIdentifier ^ previousPreviousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
-
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
-
-            continuationCorrHist2 = _continuationCorrHistory[continuationCorrHistIndex];
-        }
-
-        var previousPreviousPreviousMoveHash = Game.PreviousMoveHash(4);
-        if (previousPreviousPreviousMoveHash != 0)
-        {
-            var continuationIndex = position.UniqueIdentifier ^ previousPreviousPreviousMoveHash;
-            var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
-
-            Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
-
-            continuationCorrHist4 = _continuationCorrHistory[continuationCorrHistIndex];
-        }
+        int continuationCorrHist1 = ContinuationCorrHistory(1);
+        int continuationCorrHist2 = ContinuationCorrHistory(2);
+        int continuationCorrHist4 = ContinuationCorrHistory(4);
+        int continuationCorrHist6 = ContinuationCorrHistory(6);
 
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
@@ -441,13 +421,33 @@ public sealed partial class Engine
             + (minorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Minor)
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
             + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
-            + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
+            + (continuationCorrHist1 * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
             + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2)
-            + (continuationCorrHist4 * Configuration.EngineSettings.CorrHistoryWeight_Continuation4);
+            + (continuationCorrHist4 * Configuration.EngineSettings.CorrHistoryWeight_Continuation4)
+            + (continuationCorrHist6 * Configuration.EngineSettings.CorrHistoryWeight_Continuation6);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 
         return Math.Clamp(correctStaticEval, EvaluationConstants.MinStaticEval, EvaluationConstants.MaxStaticEval);
+
+
+        int ContinuationCorrHistory(int ply)
+        {
+            var continuationCorrHist = 0;
+
+            var previousMoveHash = Game.PreviousMoveHash(ply);
+            if (previousMoveHash != 0)
+            {
+                var continuationIndex = position.UniqueIdentifier ^ previousMoveHash;
+                var continuationCorrHistIndex = (int)(continuationIndex & Constants.ContinuationCorrHistoryHashMask);
+
+                Debug.Assert(continuationCorrHistIndex < _continuationCorrHistory.Length);
+
+                continuationCorrHist = _continuationCorrHistory[continuationCorrHistIndex];
+            }
+
+            return continuationCorrHist;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
```
Test  | search/contcorrhist-6
Elo   | -5.15 +- 4.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.10 (-2.25, 2.89) [0.00, 3.00]
Games | 8166: +2006 -2127 =4033
Penta | [101, 1042, 1907, 943, 90]
https://openbench.lynx-chess.com/test/2744/
```