### PR TITLE
🔍 Correction history - Increase ply - 1 and - 2 weights to 150

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -477,13 +477,13 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation1 { get; set; } = 100;
+    public int CorrHistoryWeight_Continuation1 { get; set; } = 150;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation2 { get; set; } = 100;
+    public int CorrHistoryWeight_Continuation2 { get; set; } = 150;
 
     /// <summary>
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>


### PR DESCRIPTION
```
Test  | search/contcorrhist-tweak-1
Elo   | -3.83 +- 3.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 11348: +2800 -2925 =5623
Penta | [171, 1376, 2658, 1345, 124]
https://openbench.lynx-chess.com/test/2745/
```