### PR TITLE
🔍 Correction history - Reduce ply - 4 weight to 150

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -489,7 +489,7 @@ public sealed class EngineSettings
     /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
     /// </summary>
     [SPSA<int>(50, 250, 15)]
-    public int CorrHistoryWeight_Continuation4 { get; set; } = 100;
+    public int CorrHistoryWeight_Continuation4 { get; set; } = 75;
 
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;


### PR DESCRIPTION
Aligned with https://github.com/lynx-chess/Lynx/pull/2545
```
Test  | search/contcorrhist-tweak-2
Elo   | -0.12 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 53418: +13505 -13523 =26390
Penta | [630, 6492, 12486, 6468, 633]
https://openbench.lynx-chess.com/test/2746/
```