### PR TITLE
🔍 Capture History: add threats II - future threats

### DIFF
--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -962,6 +962,29 @@ public partial class Position
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Bitboard CalculateThreats(int side)
+    {
+        var occupancy = _occupancyBitboards[(int)Side.Both];
+
+        var pieceOffset = Utils.PieceOffset(side);
+        Bitboard threats = 0;
+
+        for (int pieceIndex = (int)Piece.P + pieceOffset; pieceIndex <= (int)Piece.K + pieceOffset; ++pieceIndex)
+        {
+            var board = _pieceBitboards[pieceIndex];
+            var attacks = MoveGenerator._pieceAttacks[pieceIndex];
+
+            while (board != 0)
+            {
+                board = board.WithoutLS1B(out var square);
+                threats |= attacks(square, occupancy);
+            }
+        }
+
+        return threats;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private int Threats(EvaluationContext evaluationContext, Side side, int oppositeSide)
     {
         var occupancy = OccupancyBitboards[(int)Side.Both];

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -102,7 +102,7 @@ public sealed partial class Engine
     /// [12][64][12][2][2]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref short CaptureHistoryEntry(Position position, Move move, ref EvaluationContext evaluationContext)
+    private ref short CaptureHistoryEntry(int moveOppositeSide, Move move, ref EvaluationContext evaluationContext)
     {
         const int pieceOffset = 64 * 12 * 2 * 2;
         const int targetSquareOffset = 12 * 2 * 2;
@@ -114,7 +114,7 @@ public sealed partial class Engine
         var capturedPiece = move.CapturedPiece();
         var piece = move.Piece();
 
-        var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)];
+        var oppositeSideAttacks = evaluationContext.AttacksBySide[moveOppositeSide];
         Debug.Assert(oppositeSideAttacks != 0);
 
         var isStartSquareAttacked = oppositeSideAttacks.GetBit(sourceSquare) ? 1 : 0;

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -99,17 +99,32 @@ public sealed partial class Engine
     }
 
     /// <summary>
-    /// [12][64][12]
+    /// [12][64][12][2][2]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref short CaptureHistoryEntry(int piece, int targetSquare, int capturedPiece)
+    private ref short CaptureHistoryEntry(Position position, Move move, ref EvaluationContext evaluationContext)
     {
-        const int pieceOffset = 64 * 12;
-        const int targetSquareOffset = 12;
+        const int pieceOffset = 64 * 12 * 2 * 2;
+        const int targetSquareOffset = 12 * 2 * 2;
+        const int capturedPieceOffset = 2 * 2;
+        const int startSquareAttackedOffset = 2;
+
+        var sourceSquare = move.SourceSquare();
+        var targetSquare = move.TargetSquare();
+        var capturedPiece = move.CapturedPiece();
+        var piece = move.Piece();
+
+        var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)];
+        Debug.Assert(oppositeSideAttacks != 0);
+
+        var isStartSquareAttacked = oppositeSideAttacks.GetBit(sourceSquare) ? 1 : 0;
+        var isTargetSquareAttacked = oppositeSideAttacks.GetBit(targetSquare) ? 1 : 0;
 
         var index = (piece * pieceOffset)
             + (targetSquare * targetSquareOffset)
-            + capturedPiece;
+            + (capturedPiece * capturedPieceOffset)
+            + (isStartSquareAttacked * startSquareAttackedOffset)
+            + isTargetSquareAttacked;
 
         Debug.Assert(index < _captureHistory.Length);
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -102,20 +102,19 @@ public sealed partial class Engine
     /// [12][64][12][2][2]
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref short CaptureHistoryEntry(int moveOppositeSide, Move move, ref EvaluationContext evaluationContext)
+    private ref short CaptureHistoryEntry(Move move, Bitboard oppositeSideAttacks)
     {
         const int pieceOffset = 64 * 12 * 2 * 2;
         const int targetSquareOffset = 12 * 2 * 2;
         const int capturedPieceOffset = 2 * 2;
         const int startSquareAttackedOffset = 2;
 
+        Debug.Assert(oppositeSideAttacks != 0);
+
         var sourceSquare = move.SourceSquare();
         var targetSquare = move.TargetSquare();
         var capturedPiece = move.CapturedPiece();
         var piece = move.Piece();
-
-        var oppositeSideAttacks = evaluationContext.AttacksBySide[moveOppositeSide];
-        Debug.Assert(oppositeSideAttacks != 0);
 
         var isStartSquareAttacked = oppositeSideAttacks.GetBit(sourceSquare) ? 1 : 0;
         var isTargetSquareAttacked = oppositeSideAttacks.GetBit(targetSquare) ? 1 : 0;

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -38,10 +38,10 @@ public sealed partial class Engine
     private readonly short[] _butterflyQuietHistory = GC.AllocateArray<short>(ButterflyHistoryLength, pinned: true);
 
     /// <summary>
-    /// 12 x 64 x 12,
-    /// piece x target square x captured piece
+    /// 12 x 64 x 12 x 2 x 2
+    /// piece x target square x captured piece  x source is attacked x target is attacked
     /// </summary>
-    private readonly short[] _captureHistory = GC.AllocateArray<short>(12 * 64 * 12, pinned: true);
+    private readonly short[] _captureHistory = GC.AllocateArray<short>(12 * 64 * 12 * 2 * 2, pinned: true);
 
     /// <summary>
     /// 12 x 64 x 12 x 64

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -91,7 +91,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(piece, move.TargetSquare(), capturedPiece);
+                + CaptureHistoryEntry(position, move, ref evaluationContext);
         }
 
         if (isPromotion)
@@ -108,7 +108,7 @@ public sealed partial class Engine
     /// Returns the score evaluation of a move
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal int ScoreMoveQSearch(Position position, Move move, ShortMove bestMoveTTCandidate = default)
+    internal int ScoreMoveQSearch(Position position, Move move, ref EvaluationContext evaluationContext, ShortMove bestMoveTTCandidate = default)
     {
         if ((ShortMove)move == bestMoveTTCandidate)
         {
@@ -147,7 +147,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(piece, move.TargetSquare(), capturedPiece);
+                + CaptureHistoryEntry(position, move, ref evaluationContext);
         }
 
         if (isPromotion)
@@ -253,12 +253,12 @@ public sealed partial class Engine
     /// Capture history
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move)
+    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Position position, int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, ref EvaluationContext evaluationContext)
     {
         var rawHistoryBonus = HistoryBonus[depth];
         var rawHistoryMalus = HistoryMalus[depth];
 
-        ref var captureHistoryEntry = ref CaptureHistoryEntry(move.Piece(), move.TargetSquare(), move.CapturedPiece());
+        ref var captureHistoryEntry = ref CaptureHistoryEntry(position, move, ref evaluationContext);
         captureHistoryEntry = (short)ScoreHistoryMove(captureHistoryEntry, rawHistoryBonus);
 
         // 🔍 Capture history penalty/malus
@@ -271,7 +271,7 @@ public sealed partial class Engine
 
             if (capturedPiece != (int)Piece.None)
             {
-                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(visitedMove.Piece(), visitedMove.TargetSquare(), capturedPiece);
+                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(position, visitedMove, ref evaluationContext);
                 captureHistoryVisitedMove = (short)ScoreHistoryMove(captureHistoryVisitedMove, -rawHistoryMalus);
             }
         }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -91,7 +91,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(position, move, ref evaluationContext);
+                + CaptureHistoryEntry(Utils.OppositeSide((int)position.Side), move, ref evaluationContext);
         }
 
         if (isPromotion)
@@ -147,7 +147,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(position, move, ref evaluationContext);
+                + CaptureHistoryEntry(Utils.OppositeSide((int)position.Side), move, ref evaluationContext);
         }
 
         if (isPromotion)
@@ -253,12 +253,12 @@ public sealed partial class Engine
     /// Capture history
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Position position, int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, ref EvaluationContext evaluationContext)
+    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(int side, int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, ref EvaluationContext evaluationContext)
     {
         var rawHistoryBonus = HistoryBonus[depth];
         var rawHistoryMalus = HistoryMalus[depth];
 
-        ref var captureHistoryEntry = ref CaptureHistoryEntry(position, move, ref evaluationContext);
+        ref var captureHistoryEntry = ref CaptureHistoryEntry(side, move, ref evaluationContext);
         captureHistoryEntry = (short)ScoreHistoryMove(captureHistoryEntry, rawHistoryBonus);
 
         // 🔍 Capture history penalty/malus
@@ -271,7 +271,7 @@ public sealed partial class Engine
 
             if (capturedPiece != (int)Piece.None)
             {
-                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(position, visitedMove, ref evaluationContext);
+                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(side, visitedMove, ref evaluationContext);
                 captureHistoryVisitedMove = (short)ScoreHistoryMove(captureHistoryVisitedMove, -rawHistoryMalus);
             }
         }

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -91,7 +91,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(Utils.OppositeSide((int)position.Side), move, ref evaluationContext);
+                + CaptureHistoryEntry(move, evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)]);
         }
 
         if (isPromotion)
@@ -147,7 +147,7 @@ public sealed partial class Engine
             return baseCaptureScore
                 + MostValuableVictimLeastValuableAttacker[piece][capturedPiece]
                 //+ EvaluationConstants.MVV_PieceValues[capturedPiece]
-                + CaptureHistoryEntry(Utils.OppositeSide((int)position.Side), move, ref evaluationContext);
+                + CaptureHistoryEntry(move, evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)]);
         }
 
         if (isPromotion)
@@ -253,12 +253,12 @@ public sealed partial class Engine
     /// Capture history
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(int side, int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, ref EvaluationContext evaluationContext)
+    private void UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(int depth, ReadOnlySpan<int> visitedMoves, int visitedMovesCounter, int move, Bitboard oppositeSideAttacks)
     {
         var rawHistoryBonus = HistoryBonus[depth];
         var rawHistoryMalus = HistoryMalus[depth];
 
-        ref var captureHistoryEntry = ref CaptureHistoryEntry(side, move, ref evaluationContext);
+        ref var captureHistoryEntry = ref CaptureHistoryEntry(move, oppositeSideAttacks);
         captureHistoryEntry = (short)ScoreHistoryMove(captureHistoryEntry, rawHistoryBonus);
 
         // 🔍 Capture history penalty/malus
@@ -271,7 +271,7 @@ public sealed partial class Engine
 
             if (capturedPiece != (int)Piece.None)
             {
-                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(side, visitedMove, ref evaluationContext);
+                ref var captureHistoryVisitedMove = ref CaptureHistoryEntry(visitedMove, oppositeSideAttacks);
                 captureHistoryVisitedMove = (short)ScoreHistoryMove(captureHistoryVisitedMove, -rawHistoryMalus);
             }
         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -580,7 +580,7 @@ public sealed partial class Engine
                             if (isCapture)
                             {
                                 reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter]
-                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry((int)position.Side, move, ref evaluationContext) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
+                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry(move, position.CalculateThreats((int)position.Side)) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
                             }
                             else
                             {
@@ -741,7 +741,7 @@ public sealed partial class Engine
 
                     if (isCapture)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Utils.OppositeSide((int)position.Side), historyDepth, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(historyDepth, visitedMoves, visitedMovesCounter, move, evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)]);
                     }
                     else
                     {
@@ -983,7 +983,7 @@ public sealed partial class Engine
 
                     if (move.CapturedPiece() != (int)Piece.None)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Utils.OppositeSide((int)position.Side), 3, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(3, visitedMoves, visitedMovesCounter, move, evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)]);
                     }
 
                     nodeType = NodeType.Beta;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -580,7 +580,7 @@ public sealed partial class Engine
                             if (isCapture)
                             {
                                 reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter]
-                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry(piece, move.TargetSquare(), capturedPiece) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
+                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry(position, move, ref evaluationContext) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
                             }
                             else
                             {
@@ -741,7 +741,7 @@ public sealed partial class Engine
 
                     if (isCapture)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(historyDepth, visitedMoves, visitedMovesCounter, move);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(position, historyDepth, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
                     }
                     else
                     {
@@ -896,6 +896,12 @@ public sealed partial class Engine
             return staticEval;
         }
 
+        if (ttHit)
+        {
+            // Populating threats for capture history, used for scoring moves
+            position.CalculateThreats(ref evaluationContext);
+        }
+
         var nodeType = NodeType.Alpha;
         Move? bestMove = null;
         int bestScore = standPat;
@@ -908,7 +914,7 @@ public sealed partial class Engine
         ref var movesRef = ref MemoryMarshal.GetReference(pseudoLegalMoves);
         for (int i = 0; i < pseudoLegalMoves.Length; ++i)
         {
-            Unsafe.Add(ref moveScoresRef, i) = ScoreMoveQSearch(position, Unsafe.Add(ref movesRef, i), ttBestMove);
+            Unsafe.Add(ref moveScoresRef, i) = ScoreMoveQSearch(position, Unsafe.Add(ref movesRef, i), ref evaluationContext, ttBestMove);
         }
 
         Span<Move> visitedMoves = stackalloc Move[pseudoLegalMoves.Length];
@@ -977,7 +983,7 @@ public sealed partial class Engine
 
                     if (move.CapturedPiece() != (int)Piece.None)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(3, visitedMoves, visitedMovesCounter, move);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(position, 3, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
                     }
 
                     nodeType = NodeType.Beta;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -580,7 +580,7 @@ public sealed partial class Engine
                             if (isCapture)
                             {
                                 reduction = EvaluationConstants.LMRReductions[1][depth][visitedMovesCounter]
-                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry(position, move, ref evaluationContext) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
+                                    - (EvaluationConstants.LMRScaleFactor * CaptureHistoryEntry((int)position.Side, move, ref evaluationContext) / Configuration.EngineSettings.LMR_History_Divisor_Noisy);
                             }
                             else
                             {
@@ -741,7 +741,7 @@ public sealed partial class Engine
 
                     if (isCapture)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(position, historyDepth, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Utils.OppositeSide((int)position.Side), historyDepth, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
                     }
                     else
                     {
@@ -983,7 +983,7 @@ public sealed partial class Engine
 
                     if (move.CapturedPiece() != (int)Piece.None)
                     {
-                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(position, 3, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
+                        UpdateMoveOrderingHeuristicsOnCaptureBetaCutoff(Utils.OppositeSide((int)position.Side), 3, visitedMoves, visitedMovesCounter, move, ref evaluationContext);
                     }
 
                     nodeType = NodeType.Beta;


### PR DESCRIPTION
Similar to https://github.com/lynx-chess/Lynx/pull/2552

```
Test  | search/capthist-threats-3
Elo   | -1.02 +- 2.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 27964: +7008 -7090 =13866
Penta | [331, 3444, 6530, 3330, 347]
https://openbench.lynx-chess.com/test/2749/
```