### PR TITLE
🔍 Don't do `deeper` on `cutnode`

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -655,7 +655,8 @@ public sealed partial class Engine
                         // It should produce more cutoffs and therefore be faster.
                         // https://web.archive.org/web/20071030220825/http://www.brucemo.com/compchess/programming/pvs.htm
 
-                        var deeper = score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
+                        var deeper = !cutnode
+                            && score > bestScore + Configuration.EngineSettings.LMR_DeeperBase + (Configuration.EngineSettings.LMR_DeeperDepthMultiplier * depth);
                         var shallower = score < bestScore + depth;
 
                         if (deeper && !shallower && newDepth < Configuration.EngineSettings.MaxDepth)


### PR DESCRIPTION
```
Test  | search/deeper-no-cutnode
Elo   | -2.46 +- 3.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 15798: +3956 -4068 =7774
Penta | [199, 1924, 3739, 1864, 173]
https://openbench.lynx-chess.com/test/2751/
```