### PR TITLE
🔍 SE - prevent singular beta from reporting false mate scores

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -231,7 +231,10 @@ public sealed partial class Engine
                     if (ttCorrectedStaticEval - rfpThreshold >= beta)
                     {
 #pragma warning disable S3949 // Calculations should not overflow - value is being set at the beginning of the else if (!pvNode)
-                        return (ttCorrectedStaticEval + beta) / 2;
+                        return (Math.Abs(ttCorrectedStaticEval) < EvaluationConstants.PositiveCheckmateDetectionLimit
+                            && Math.Abs(beta) < EvaluationConstants.PositiveCheckmateDetectionLimit)
+                            ? (ttCorrectedStaticEval + beta) / 2
+                            : ttCorrectedStaticEval;
 #pragma warning restore S3949 // Calculations should not overflow
                     }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -476,6 +476,11 @@ public sealed partial class Engine
 
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
 
+                if(singularBeta >= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                {
+                    singularBeta = EvaluationConstants.MinEval;
+                }
+
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
 
                 // Singular extension

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -476,7 +476,7 @@ public sealed partial class Engine
 
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
 
-                if(singularBeta >= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                if(singularBeta <= EvaluationConstants.NegativeCheckmateDetectionLimit)
                 {
                     singularBeta = EvaluationConstants.MinEval;
                 }


### PR DESCRIPTION
```
Test  | search/singularbeta
Elo   | -1.43 +- 1.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [-3.00, 1.00]
Games | 41372: +10311 -10481 =20580
Penta | [373, 4634, 10834, 4480, 365]
https://openbench.lynx-chess.com/test/2753/
```