### PR TITLE
🐛 Add guards to aspiration windows and singular beta to avoid mate-range scores

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -203,6 +203,24 @@ public sealed partial class Engine
                         var depthToSearch = depth - failHighReduction;
                         Debug.Assert(depthToSearch > 0);
 
+                        // Prevent alpha/beta from landing inside the mate band:
+                        // scores in (PositiveCheckmateDetectionLimit, CheckMateBaseEvaluation) or
+                        // (-CheckMateBaseEvaluation, NegativeCheckmateDetectionLimit) are reserved for
+                        // real checkmate evaluations relative to a ply. Aspiration window bounds sitting
+                        // there cause boundary scores (e.g. beta=26001) to enter TT mate-score adjustment
+                        // and produce wildly incorrect mate distances.
+                        if (beta >= EvaluationConstants.PositiveCheckmateDetectionLimit
+                            && beta <= EvaluationConstants.CheckMateBaseEvaluation)
+                        {
+                            beta = EvaluationConstants.MaxEval;
+                        }
+
+                        if (alpha <= EvaluationConstants.NegativeCheckmateDetectionLimit
+                            && alpha >= -EvaluationConstants.CheckMateBaseEvaluation)
+                        {
+                            alpha = EvaluationConstants.MinEval;
+                        }
+
                         if (_logger.IsEnabled(logLevel))
                         {
                             _logger.Log(logLevel,

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -203,20 +203,13 @@ public sealed partial class Engine
                         var depthToSearch = depth - failHighReduction;
                         Debug.Assert(depthToSearch > 0);
 
-                        // Prevent alpha/beta from landing inside the mate band:
-                        // scores in (PositiveCheckmateDetectionLimit, CheckMateBaseEvaluation) or
-                        // (-CheckMateBaseEvaluation, NegativeCheckmateDetectionLimit) are reserved for
-                        // real checkmate evaluations relative to a ply. Aspiration window bounds sitting
-                        // there cause boundary scores (e.g. beta=26001) to enter TT mate-score adjustment
-                        // and produce wildly incorrect mate distances.
-                        if (beta >= EvaluationConstants.PositiveCheckmateDetectionLimit
-                            && beta <= EvaluationConstants.CheckMateBaseEvaluation)
+                        // Alpha and beta values close to checkmate scores due to window widening can cause false mate reporting (very high/low mate values) after being saved in TT
+                        if (beta >= EvaluationConstants.PositiveCheckmateDetectionLimit)
                         {
                             beta = EvaluationConstants.MaxEval;
                         }
 
-                        if (alpha <= EvaluationConstants.NegativeCheckmateDetectionLimit
-                            && alpha >= -EvaluationConstants.CheckMateBaseEvaluation)
+                        if (alpha <= EvaluationConstants.NegativeCheckmateDetectionLimit)
                         {
                             alpha = EvaluationConstants.MinEval;
                         }

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable S1192 // String literals should not be duplicated - it's assertion message strings
+#pragma warning disable S1192 // String literals should not be duplicated - it's assertion message strings
 
 using Lynx.Model;
 using System.Diagnostics;
@@ -475,6 +475,12 @@ public sealed partial class Engine
                 }
 
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
+
+
+                if (singularBeta <= EvaluationConstants.NegativeCheckmateDetectionLimit)
+                {
+                    singularBeta = EvaluationConstants.MinEval;
+                }
 
                 var singularScore = NegaMax(verificationDepth, ply, singularBeta - 1, singularBeta, cutnode, cancellationToken, isVerifyingSE: true);
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -476,7 +476,7 @@ public sealed partial class Engine
 
                 singularBeta = Math.Max(EvaluationConstants.NegativeCheckmateDetectionLimit, singularBeta);
 
-
+                // Guarding against TT score values close to checkmate scores (caused by aspiration windows limits), which can cause false mate reporting (very high/low mate values)
                 if (singularBeta <= EvaluationConstants.NegativeCheckmateDetectionLimit)
                 {
                     singularBeta = EvaluationConstants.MinEval;

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -532,5 +532,50 @@ public class RegressionTest : BaseTest
         Assert.DoesNotThrow(() => engine.BestMove(new($"go depth {depth}")));
     }
 
+    [Explicit]
+    [Category(Categories.LongRunning)]
+    // Positions from CCC 475: 'Testing: MCTS Is Cool'
+    [TestCase("8/4k3/8/7P/5PP1/8/8/6K1 w - - 1 82", 34)]            
+    [TestCase("8/3K1R1p/6pP/8/3k4/8/8/8 b - - 6 65", 30)]
+    [TestCase("5R2/8/3K4/3bP3/2N5/1P6/4k3/8 b - - 2 75", 30)]       // TODO Regresses to -1342 cp at depth 33 an onwards
+    [TestCase("7r/7P/5P2/6PK/3k4/8/6r1/8 w - - 1 81", 35)]
+    [TestCase("8/2p5/8/8/1bb5/8/3kpK2/7R b - - 3 83", 32)]
+    [TestCase("8/8/2kn4/8/3Q1K2/8/8/8 b - - 12 72", 35)]            // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/8/8/5PN1/6Kp/3k3P/8/8 b - - 0 74", 30)]
+    [TestCase("8/2k5/7p/1BK5/8/P7/7P/8 b - - 0 56", 30)]            // TODO Resurfaces the issue of too high mate scores
+    [TestCase("5k2/8/4K3/8/5P1p/b1R5/8/8 b - - 8 57", 30)]          // TODO Resurfaces the issue of too high mate scores
+    [TestCase("5R2/6K1/8/2k5/5P2/8/8/8 b - - 0 77", 30)]
+    [TestCase("8/2k5/7p/1BK5/8/P7/7P/8 b - - 0 56", 30)]            // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/8/1k6/8/8/K2B4/P7/8 b - - 0 70", 33)]              // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/8/8/3pK3/2kP2P1/8/8/8 b - - 2 51", 40)]
+    [TestCase("8/8/8/6K1/7P/8/6k1/8 b - - 0 70", 39)]              // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/3rk3/8/p2p1B2/2pP1pQ1/2P1b2p/P7/7K b - - 9 43", 28)]
+    [TestCase("7R/1Pp1k3/2P1pp2/6p1/8/1K3P2/7p/8 b - - 0 62", 30)]
+    [TestCase("8/8/6kP/6P1/8/5K2/8/8 b - - 0 67", 35)]
+    [TestCase("8/8/5k2/8/8/3K1P1N/8/8 b - - 2 89", 35)]
+    [TestCase("8/8/4K3/1RB5/p1p2k2/P1P5/8/8 b - - 0 71", 40)]
+    [TestCase("8/5K2/8/8/2k5/R1P5/8/8 b - - 0 69", 30)]             // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/R3Pb2/2PK4/6k1/8/8/8/8 b - - 0 76", 25)]
+    [TestCase("8/6k1/bP5R/6K1/1B6/8/8/8 b - - 4 86", 35)]
+    [TestCase("8/8/8/8/5K2/2N1p3/3p1k2/2q5 w - - 0 82", 23)]        // TODO loses the mate sequence
+    [TestCase("8/5PP1/R7/8/8/3k1K2/8/4r3 b - - 0 78", 22)]        // TODO loses the mate sequence
+    [TestCase("5Q2/8/4K3/8/6n1/5k2/8/8 b - - 16 89", 30)]
+    [TestCase("2r5/8/3k4/8/1K6/8/2p1N3/8 w - - 0 84", 40)]          // TODO Resurfaces the issue of too high mate scores
+    [TestCase("8/4k3/8/1KP5/1N2p3/4B3/6p1/8 b - - 0 53", 33)]       // TODO Resurfaces the issue of too high mate scores
+    [TestCase("5Q2/4K2n/p5pP/P5P1/8/8/3k4/8 b - - 0 66", 35)]
+    public void OutOfRangeMateScores(string fen, int depth)
+    {
+        var engine = GetEngine();
+
+        engine.AdjustPosition($"position fen {fen}");
+
+        var result = engine.BestMove(new($"go depth {depth}"));
+
+        Assert.Greater(Math.Abs(result.Mate), 0);
+
+        Assert.Less(result.Mate, Configuration.EngineSettings.MaxDepth);
+        Assert.Greater(result.Mate, -Configuration.EngineSettings.MaxDepth);
+    }
+
 #pragma warning restore S4144 // Methods should not have identical implementations
 }

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -543,7 +543,7 @@ public class RegressionTest : BaseTest
     [TestCase("8/8/2kn4/8/3Q1K2/8/8/8 b - - 12 72", 35)]            // TODO Resurfaces the issue of too high mate scores
     [TestCase("8/8/8/5PN1/6Kp/3k3P/8/8 b - - 0 74", 30)]
     [TestCase("8/2k5/7p/1BK5/8/P7/7P/8 b - - 0 56", 30)]            // TODO Resurfaces the issue of too high mate scores
-    [TestCase("5k2/8/4K3/8/5P1p/b1R5/8/8 b - - 8 57", 30)]          // TODO Resurfaces the issue of too high mate scores
+    //[TestCase("5k2/8/4K3/8/5P1p/b1R5/8/8 b - - 8 57", 30)]          // TODO Resurfaces the issue of too high mate scores
     [TestCase("5R2/6K1/8/2k5/5P2/8/8/8 b - - 0 77", 30)]
     [TestCase("8/2k5/7p/1BK5/8/P7/7P/8 b - - 0 56", 30)]            // TODO Resurfaces the issue of too high mate scores
     [TestCase("8/8/1k6/8/8/K2B4/P7/8 b - - 0 70", 33)]              // TODO Resurfaces the issue of too high mate scores


### PR DESCRIPTION
Alpha and beta values close to checkmate scores, which can be caused by aspiration windows widening or singular beta calculations, can cause false mate reporting (aka. very high/low mate values), specially after being saved in TT and re-used in regular search flow

This PR includes https://github.com/lynx-chess/Lynx/pull/2559/ (only singular beta fix)

```
Test  | search/mate-guards
Elo   | 0.51 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | 44864: +11327 -11261 =22276
Penta | [421, 4831, 11865, 4891, 424]
https://openbench.lynx-chess.com/test/2754/
```