### PR TITLE
🐛 Don't use depth and seldepth 0 on single-move searches

### DIFF
--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -524,12 +524,12 @@ public sealed partial class Engine
 #if MULTITHREAD_DEBUG
                 _id,
 #endif
-                firstLegalMove, score, 0, [firstLegalMove])
+                firstLegalMove, score, 1, [firstLegalMove])
             {
-                DepthReached = 0,
-                Nodes = 0,
-                Time = 0,
-                NodesPerSecond = 0,
+                DepthReached = 1,
+                Nodes = 1,
+                Time = 1,
+                NodesPerSecond = 1,
             };
 
             return true;

--- a/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
+++ b/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
@@ -62,8 +62,8 @@ public class SingleLegalMoveTest : BaseTest
             Assert.AreEqual(-EvaluationConstants.SingleMoveScore, result.Score);
         }
 
-        Assert.AreEqual(0, result.Depth);
-        Assert.AreEqual(0, result.DepthReached);
-        Assert.AreEqual(0, result.NodesPerSecond);
+        Assert.AreEqual(1, result.Depth);
+        Assert.AreEqual(1, result.DepthReached);
+        Assert.AreEqual(1, result.NodesPerSecond);
     }
 }


### PR DESCRIPTION
This breaks OB pgn generation (cutechess/fastchess), with _unknown_ evals showing up
example:
```
[Event "?"]
[Site "?"]
[Date "2026.06.09"]
[Round "1"]
[White "lynx-base"]
[Black "lynx-dev"]
[Result "1-0"]
[FEN "rn2k2r/pp2bppp/4pn2/2pq3b/3P4/N1P2N1P/PP2BPP1/R1BQK2R w KQkq - 0 1"]
[TimeControl "14.49+0.14"]
[ScaleFactor "1.8113112739549364"]

Nb5 {+0.89 14/28 443 292583} Qc6 {-0.56 15/32 409 290188} Bf4 {+0.64 14/30 308 143073} O-O {-0.60 17/29 480 342065} Nc7 {+0.54 16/32 398 281479} Nd5 {-0.63 19/34 1046 653454} Nxd5 {+0.57 16/29 367 201059} exd5 {-0.68 21/34 1512 989898} O-O {+0.76 20/32 1894 1241322} Nd7 {-0.78 17/32 323 240298} dxc5 {+0.45 17/33 694 456563} Nxc5 {-0.78 18/32 569 394539} Re1 {+0.73 17/28 537 400506} Bf6 {-0.49 17/26 509 350570} Be5 {+0.97 18/27 512 314893} Bd8 {-0.70 16/29 387 221244} Bd4 {+1.05 21/31 1542 1067750} Ne6 {-0.73 18/32 560 396110} Be3 {+1.24 18/30 368 255992} Qd6 {-0.97 18/33 738 398513} Nd4 {+1.00 18/30 396 260066} Bxe2 {-0.89 21/36 1297 864867} Qxe2 {+1.39 16/27 274 169179} Bc7 {-0.89 17/30 225 126896} g3 {+1.41 16/33 298 179665} Nxd4 {-0.75 17/31 268 178594} Bxd4 {+1.55 17/35 289 216146} Qd7 {-0.86 18/33 371 214494} Qh5 {+1.14 18/39 1225 713945} f5 {-0.73 16/29 404 257735} Rad1 {+1.31 18/39 1195 796853} f4 {-0.56 17/34 684 459717} Bc5 {+1.25 14/43 232 154699} Rf7 {-0.57 17/33 307 176596} g4 {+1.33 18/33 536 330357} d4 {-1.16 18/35 709 428690} Bxd4 {+1.83 18/34 785 464429} Rd8 {-1.45 19/43 987 635592} Re4 {+1.60 18/33 405 272744} Re8 {-1.37 19/34 371 263469} Rde1 {+2.37 18/33 288 204473} Rxe4 {-2.05 16/32 219 139759} Rxe4 {+2.39 16/38 233 143435} Qc6 {-1.76 16/33 237 152078} f3 {+2.03 17/36 323 222864} Bb6 {-1.70 15/38 210 141538} Qe5 {+1.57 19/37 1149 833641} Bxd4+ {-1.43 15/37 322 186702} Qxd4 {+1.86 14/40 176 74898} a6 {-1.35 15/35 248 167908} Kg2 {+1.65 16/37 444 287470} Rd7 {-1.42 15/39 200 124921} Qf2 {+1.63 16/42 391 267065} g5 {-1.32 17/40 401 298814} h4 {+1.84 15/37 267 185567} h6 {-1.87 16/36 656 399975} Qe2 {+1.84 14/36 189 123322} Kf7 {-1.73 16/46 562 398636} Re5 {+1.75 12/42 211 119733} gxh4 {-1.68 14/41 194 120502} Rf5+ {+2.05 15/47 396 305154} Kg8 {-1.95 14/46 266 212862} Qe8+ {+1.90 16/42 323 257445} Kh7 {-1.88 14/47 270 199304} Rf7+ {+1.92 15/44 174 124800} Rxf7 {-1.94 12/49 152 106763} Qxf7+ {+2.02 16/47 189 132321} Kh8 {unknown}
```