### PR TITLE
⭐ Add support for UCI `go nodes` as soft nodes

### DIFF
--- a/src/Lynx.Cli/appsettings.json
+++ b/src/Lynx.Cli/appsettings.json
@@ -16,7 +16,8 @@
     "UseOnlineTablebaseInRootPositions": false, // Experimental, requires network connection
     "ShowWDL": false,
     "IsPonder": false,
-    "EstimateMultithreadedSearchNPS": false
+    "EstimateMultithreadedSearchNPS": false,
+    "SoftNodes": false
   },
 
   // Logging settings

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -114,6 +114,8 @@ public sealed class EngineSettings
 
     public bool UCI_Minimal { get; set; }
 
+    public bool SoftNodes { get; set; }
+
     /// <summary>
     /// Real NPS aren't calculated until the last search command.
     /// This option enables the report of an NPS estimation by the main thread

--- a/src/Lynx/Model/SearchConstraints.cs
+++ b/src/Lynx/Model/SearchConstraints.cs
@@ -17,19 +17,26 @@ public readonly struct SearchConstraints
 
     public const int DefaultSoftLimitTimeBound  = DefaultTimeBound;
 
+    public const ulong DefaultMaxNodes = 10_000_000_000_000_000_000;
+
+    public const int DefaultMaxDepth = -1;
+
     public readonly int HardLimitTimeBound;
 
     public readonly int SoftLimitTimeBound;
 
     public readonly int MaxDepth;
 
-    public static readonly SearchConstraints InfiniteSearchConstraint = new(DefaultHardLimitTimeBound, DefaultSoftLimitTimeBound, -1);
+    public readonly ulong MaxNodes;
 
-    public SearchConstraints(int hardLimitTimeBound, int softLimitTimeBound, int maxDepth)
+    public static readonly SearchConstraints InfiniteSearchConstraint = new(DefaultHardLimitTimeBound, DefaultSoftLimitTimeBound, DefaultMaxDepth, DefaultMaxNodes);
+
+    public SearchConstraints(int hardLimitTimeBound, int softLimitTimeBound, int maxDepth, ulong maxNodes)
     {
         HardLimitTimeBound = hardLimitTimeBound;
         SoftLimitTimeBound = softLimitTimeBound;
         MaxDepth = maxDepth;
+        MaxNodes = maxNodes;
     }
 }
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -149,7 +149,8 @@ public sealed partial class Engine
 
         try
         {
-            if (!isPondering && OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
+            if (!isPondering && _searchConstraints.MaxDepth == SearchConstraints.DefaultMaxDepth && _searchConstraints.MaxNodes == SearchConstraints.DefaultMaxNodes
+                && OnlyOneLegalMove(ref firstLegalMove, out var onlyOneLegalMoveSearchResult))
             {
                 if (!Configuration.EngineSettings.UCI_Minimal)
                 {
@@ -434,15 +435,30 @@ public sealed partial class Engine
         }
 
         var maxDepth = _searchConstraints.MaxDepth;
-        if (maxDepth > 0)
+        if (maxDepth != SearchConstraints.DefaultMaxDepth)
         {
             var shouldContinue = depth + 1 <= maxDepth;
 
             if (!shouldContinue)
             {
                 _logger.Log(logLevel,
-                    "[#{EngineId}] Depth {Depth}: stopping, max. depth reached",
+                    "[#{EngineId}] Depth {Depth}: stopping, max. go command depth reached",
                     _id, depth);
+            }
+
+            return shouldContinue;
+        }
+
+        var maxNodes = _searchConstraints.MaxNodes;
+        if (maxNodes != SearchConstraints.DefaultMaxNodes)
+        {
+            var shouldContinue = _nodes <= maxNodes;
+
+            if (!shouldContinue)
+            {
+                _logger.Log(logLevel,
+                    "[#{EngineId}] Nodes {Nodes}: stopping, go command nodes reached",
+                    _id, _nodes);
             }
 
             return shouldContinue;

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -17,7 +17,8 @@ public static class TimeManager
 
     public static SearchConstraints CalculateTimeManagement(Game game, GoCommand goCommand)
     {
-        int maxDepth = -1;
+        int maxDepth = SearchConstraints.DefaultMaxDepth;
+        ulong maxNodes = SearchConstraints.DefaultMaxNodes;
         int hardLimitTimeBound = SearchConstraints.DefaultHardLimitTimeBound;
         int softLimitTimeBound = SearchConstraints.DefaultSoftLimitTimeBound;
 
@@ -67,13 +68,18 @@ public static class TimeManager
             maxDepth = Configuration.EngineSettings.MaxDepth;
             _logger.Info("Infinite search (depth {0})", maxDepth);
         }
+        else if (goCommand.Nodes > 0)
+        {
+            maxNodes = goCommand.Nodes;
+            _logger.Info("Soft nodes search (nodes {0})", maxNodes);
+        }
         else
         {
             maxDepth = Engine.DefaultMaxDepth;
             _logger.Warn("Unexpected or unsupported go command");
         }
 
-        return new(hardLimitTimeBound, softLimitTimeBound, maxDepth);
+        return new(hardLimitTimeBound, softLimitTimeBound, maxDepth, maxNodes);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -70,8 +70,15 @@ public static class TimeManager
         }
         else if (goCommand.Nodes > 0)
         {
-            maxNodes = goCommand.Nodes;
-            _logger.Info("Soft nodes search (nodes {0})", maxNodes);
+            if (Configuration.EngineSettings.SoftNodes)
+            {
+                maxNodes = goCommand.Nodes;
+                _logger.Info("Soft nodes search (nodes {0})", maxNodes);
+            }
+            else
+            {
+                _logger.Warn("Only soft nodes are supported, please enable SoftNodes via UCI or configuration before sending 'go nodes' commands");
+            }
         }
         else
         {

--- a/src/Lynx/UCI/Commands/GUI/GoCommand.cs
+++ b/src/Lynx/UCI/Commands/GUI/GoCommand.cs
@@ -72,8 +72,8 @@ public sealed class GoCommand
     public int MoveTime { get; }
     public bool Infinite { get; }
     public bool Ponder { get; }
+    public ulong Nodes { get; }
 
-    public static int Nodes => throw new NotSupportedException();
     public static int Mate => throw new NotSupportedException();
 
 #pragma warning disable CA1002, MA0016 // Do not expose generic lists
@@ -213,13 +213,15 @@ public sealed class GoCommand
             }
             else if (key.Equals(NodesSpan, StringComparison.OrdinalIgnoreCase))
             {
-                _logger.Warn("nodes not supported in go command, it will be safely ignored");
-                ++i;
+                if (ulong.TryParse(commandAsSpan[ranges[++i]], out var value))
+                {
+                    Nodes = value;
+                }
             }
             else if (key.Equals(MateSpan, StringComparison.OrdinalIgnoreCase))
             {
                 _logger.Warn("mate not supported in go command, it will be safely ignored");
-                ++i;
+                i++;
             }
             else if (key.Equals(SearchmovesSpan, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/Lynx/UCIHandler.cs
+++ b/src/Lynx/UCIHandler.cs
@@ -296,6 +296,14 @@ public sealed class UCIHandler
                     }
                     break;
                 }
+            case "softnodes":
+                {
+                    if (length > 4 && bool.TryParse(command[commandItems[4]], out var value))
+                    {
+                        Configuration.EngineSettings.SoftNodes = value;
+                    }
+                    break;
+                }
 
             default:
                 if (!SPSAAttributeHelpers.ParseUCIOption(command, commandItems, lowerCaseFirstWord, length))

--- a/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
+++ b/tests/Lynx.Test/BestMove/SingleLegalMoveTest.cs
@@ -30,7 +30,6 @@ public class SingleLegalMoveTest : BaseTest
     public void SingleMove(string fen)
     {
         // Arrange
-        const int depth = 61;
         Move? singleMove = null;
         var pos = new Position(fen);
         foreach (var move in MoveGenerator.GenerateAllMoves(pos))
@@ -45,10 +44,9 @@ public class SingleLegalMoveTest : BaseTest
             pos.UnmakeMove(move, state);
         }
 
-        Assert.LessOrEqual(depth, Configuration.EngineSettings.MaxDepth);
-
         // Act
-        var result = SearchBestMove(fen, depth);
+        var engine = GetEngine(fen);
+        var result = engine.BestMove(new("go wtime 1000000 btime 1000000"));
 
         Assert.AreEqual(singleMove, result.BestMove);
         Assert.AreEqual(singleMove, result.Moves.Single());

--- a/tests/Lynx.Test/Commands/GoCommandTest.cs
+++ b/tests/Lynx.Test/Commands/GoCommandTest.cs
@@ -19,9 +19,9 @@ public class GoCommandTest
         Assert.AreEqual(50, goCommand.MovesToGo);
         Assert.AreEqual(60, goCommand.Depth);
         Assert.AreEqual(70, goCommand.MoveTime);
+        Assert.AreEqual(90, goCommand.Nodes);
         Assert.True(goCommand.Ponder);
         _ = Assert.Throws<NotSupportedException>(() => _ = GoCommand.Mate);
-        _ = Assert.Throws<NotSupportedException>(() => _ = GoCommand.Nodes);
         _ = Assert.Throws<NotSupportedException>(() => _ = GoCommand.SearchMoves);
     }
 

--- a/tests/Lynx.Test/TimeManagerTest.cs
+++ b/tests/Lynx.Test/TimeManagerTest.cs
@@ -1,0 +1,33 @@
+﻿using Lynx.Model;
+using NUnit.Framework;
+
+namespace Lynx.Test;
+
+[Explicit]
+[Category(Categories.Configuration)]
+[NonParallelizable]
+public class TimeManagerTest
+{
+    [Test]
+    public void CalculateTimeManagementTest_GoNodes_SoftNodesDisabled()
+    {
+        Configuration.EngineSettings.SoftNodes = false;
+
+        var game = new Game(Constants.InitialPositionFEN);
+
+        var restrictions = TimeManager.CalculateTimeManagement(game, new UCI.Commands.GUI.GoCommand("go nodes 1000"));
+        Assert.AreEqual(SearchConstraints.DefaultMaxNodes, restrictions.MaxNodes);
+    }
+
+    [Test]
+    public void CalculateTimeManagementTest_GoNodes_SoftNodesEnabled()
+    {
+        Configuration.EngineSettings.SoftNodes = true;
+
+        var game = new Game(Constants.InitialPositionFEN);
+        const int nodes = 666;
+
+        var restrictions = TimeManager.CalculateTimeManagement(game, new UCI.Commands.GUI.GoCommand($"go nodes {nodes}"));
+        Assert.AreEqual(nodes, restrictions.MaxNodes);
+    }
+}


### PR DESCRIPTION
`go nodes` works now as 'soft nodes' search if `SoftNodes` is enabled via UCI or config.
Additionally, `go depth` behavior is fixed on single-legal move situations: requested depth is honored now.
Same applies to `go nodes`.