### PR TITLE
🧬🐛 `genfens`: fix score guards

### DIFF
--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -638,7 +638,7 @@ public sealed class Searcher : IDisposable
             engine.AdjustPosition($"position fen {startposFEN}");
             var searchResult = engine.Search(in searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
 
-            if (searchResult is null || searchResult.Score > maxAllowedEval)
+            if (searchResult is null || Math.Abs(searchResult.Score) > maxAllowedEval)
             {
                 continue;
             }

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -635,7 +635,7 @@ public sealed class Searcher : IDisposable
         {
             var startposFEN = GenerateDatagenStartpos();
 
-            AdjustPosition($"position fen {startposFEN}");
+            engine.AdjustPosition($"position fen {startposFEN}");
             var searchResult = engine.Search(in searchConstraints, isPondering: false, _absoluteSearchCancellationTokenSource.Token, CancellationToken.None);
 
             if (searchResult is null || searchResult.Score > maxAllowedEval)


### PR DESCRIPTION
🤦🏼
- Set the startpos of the _right_ engine
- Fix score guard to avoid high, negative scores