### PR TITLE
🐛 Fix makefile for latest .NET versions when passing an $EXE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 EXE=
 
 RUNTIME=
-OUTPUT_DIR=artifacts/Lynx/
+PUBLISH_DIR=artifacts/Lynx/
+OUTPUT_DIR=
 
 ifeq ($(OS),Windows_NT)
 	ifeq ($(PROCESSOR_ARCHITEW6432),AMD64)
@@ -41,7 +42,7 @@ ifndef RUNTIME
 endif
 
 ifdef EXE
-	OUTPUT_DIR=./
+	OUTPUT_DIR=../../
 endif
 
 build:
@@ -51,7 +52,7 @@ test:
 	dotnet test -c Release  & dotnet test -c Release --filter "TestCategory=Configuration" & dotnet test -c Release --filter "TestCategory=LongRunning" & dotnet test -c Release --filter "TestCategory=Perft"
 
 publish:
-	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:ExecutableName=$(EXE) -o ${OUTPUT_DIR}
+	dotnet publish src/Lynx.Cli/Lynx.Cli.csproj --runtime ${RUNTIME} --self-contained /p:Optimized=true /p:ExecutableName=$(EXE) -o ${PUBLISH_DIR} /p:FinalDestination=${OUTPUT_DIR} --tl:off
 
 run:
 	dotnet run --project src/Lynx.Cli/Lynx.Cli.csproj -c Release --runtime ${RUNTIME}

--- a/src/Lynx.Cli/Lynx.Cli.csproj
+++ b/src/Lynx.Cli/Lynx.Cli.csproj
@@ -48,11 +48,22 @@
     </None>
   </ItemGroup>
 
-  <Target Name="Rename" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and '$(ExecutableName)'!='$(AssemblyName)'">
+  <Target Name="RenameExe" AfterTargets="Publish" Condition="'$(ExecutableName)'!='' and '$(ExecutableName)'!='$(AssemblyName)'">
     <Message Text="Attempting to rename executable file from $(PublishDir)/$(AssemblyName) to $(PublishDir)/$(ExecutableName)" Importance="high" />
     <Move SourceFiles="$(PublishDir)/$(AssemblyName)" DestinationFiles="$(PublishDir)/$(ExecutableName)" ContinueOnError="true" />
     <Message Text="Attempting to rename executable file from $(PublishDir)\$(AssemblyName).exe to $(PublishDir)/$(ExecutableName).exe" Importance="high" />
     <Move SourceFiles="$(PublishDir)/$(AssemblyName).exe" DestinationFiles="$(PublishDir)/$(ExecutableName).exe" ContinueOnError="true" />
+  </Target>
+
+  <Target Name="MovePublishOutput" AfterTargets="RenameExe" Condition="'$(FinalDestination)' != ''">
+    <!-- Inside the target so that it's evaluated right before Copy,
+      enumerating the files generated during the build -->
+    <ItemGroup>
+      <FilesToMove Include="$(PublishDir)/**/*.*" />
+    </ItemGroup>
+    
+    <Message Text="Moving the content of $(PublishDir) to $(FinalDestination)" Importance="high" />
+    <Copy SourceFiles="@(FilesToMove)" DestinationFolder="$(FinalDestination)" ContinueOnError="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Prevent OB from running `dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -o .`, since that's apparently no longer acceptable in latest .NET 10 versions.
Add instead a `FinalDestination` parameter with the expected final location of the publish files, in order to be able to manually move them

Context:

```bash
make 'EXE=lynx-9DB032C3'
```

invokes:
```bash
dotnet publish src/Lynx.Cli/Lynx.Cli.csproj --runtime win-x64 --self-contained /p:Optimized=true /p:ExecutableName=lynx-9DB032C3 -o ./
```

`dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -o .` doesn't work for .NET SDK 10.0.201 or 10.0.301, while it did for .NET 10.0.101 and 10.0.109 🙄.

```BASH
$ dotnet publish src/Lynx.Cli/Lynx.Cli.csproj -o .
CSC : error CS5001: Program does not contain a static 'Main' method suitable for an entry point
```

After this change, the following command is usedm no longer problematic:
```bash
dotnet publish src/Lynx.Cli/Lynx.Cli.csproj --runtime win-x64 --self-contained /p:Optimized=true /p:ExecutableName=lynx-9DB032C3 -o artifacts/Lynx/ /p:FinalDestination=../../ --tl:off
```
