### PR TITLE
🔍 Threats correction history

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -485,6 +485,12 @@ public sealed class EngineSettings
     [SPSA<int>(50, 250, 15)]
     public int CorrHistoryWeight_Continuation2 { get; set; } = 100;
 
+    /// <summary>
+    /// Needs to be re-scaled dividing by <see cref="EvaluationConstants.CorrHistScaleFactor"/>
+    /// </summary>
+    [SPSA<int>(50, 250, 15)]
+    public int CorrHistoryWeight_Threats { get; set; } = 100;
+
     [SPSA<int>(enabled: false)]
     public int TT_50MR_Start { get; set; } = 20;
 

--- a/src/Lynx/Constants.cs
+++ b/src/Lynx/Constants.cs
@@ -646,6 +646,9 @@ public static class Constants
     public const int ContinuationCorrHistoryHashSize = 16_384;
     public const int ContinuationCorrHistoryHashMask = ContinuationCorrHistoryHashSize - 1;
 
+    public const int ThreatsCorrHistoryHashSize = 16_384;
+    public const int ThreatsCorrHistoryHashMask = ThreatsCorrHistoryHashSize - 1;
+
     public const string NumberWithSignFormat = "+#;-#;0";
 }
 

--- a/src/Lynx/Engine.cs
+++ b/src/Lynx/Engine.cs
@@ -89,6 +89,7 @@ public sealed partial class Engine : IDisposable
         Array.Clear(_majorCorrHistory);
         Array.Clear(_materialCorrHistory);
         Array.Clear(_continuationCorrHistory);
+        Array.Clear(_threatsCorrHistory);
 
         // No need to clear killer move or pv table because they're cleared on every search (IDDFS)
     }

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -204,7 +204,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth)
+    private void UpdateCorrectionHistory(Position position, int evaluationDelta, int depth, ref EvaluationContext evaluationContext)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -302,6 +302,23 @@ public sealed partial class Engine
             continuationCorrHist = UpdateCorrectionHistory(continuationCorrHist, scaledBonus, weight);
         }
 
+        // Threats correction history
+        var oppositeSideThreats = evaluationContext.AttacksBySide[oppositeSide];
+        if (oppositeSideThreats == 0)
+        {
+            position.CalculateThreats(ref evaluationContext);
+            oppositeSideThreats = evaluationContext.AttacksBySide[oppositeSide];
+        }
+
+        var threatenedPieces = oppositeSideThreats & position.OccupancyBitboards[side];
+        var threatsHash = Utils.Murmur3(threatenedPieces);
+        var threatsCorrHistIndex = (int)(threatsHash & Constants.ThreatsCorrHistoryHashMask);
+
+        Debug.Assert(threatsCorrHistIndex < _threatsCorrHistory.Length);
+
+        ref var threatsCorrHist = ref _threatsCorrHistory[threatsCorrHistIndex];
+        threatsCorrHist = UpdateCorrectionHistory(threatsCorrHist, scaledBonus, weight);
+
         // Common update logic
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static short UpdateCorrectionHistory(short previousCorrectedScore, int scaledBonus, int weight)
@@ -322,7 +339,7 @@ public sealed partial class Engine
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private int CorrectStaticEvaluation(Position position, int staticEvaluation)
+    private int CorrectStaticEvaluation(Position position, int staticEvaluation, ref EvaluationContext evaluationContext)
     {
         var side = (ulong)position.Side;
         var oppositeSide = Utils.OppositeSide((int)side);
@@ -409,6 +426,21 @@ public sealed partial class Engine
             continuationCorrHist2 = _continuationCorrHistory[continuationCorrHistIndex];
         }
 
+        // Threats correction history - Motor author original idea
+        var oppositeSideThreats = evaluationContext.AttacksBySide[oppositeSide];
+        if (oppositeSideThreats == 0)
+        {
+            position.CalculateThreats(ref evaluationContext);
+            oppositeSideThreats = evaluationContext.AttacksBySide[oppositeSide];
+        }
+
+        var threatenedPieces = oppositeSideThreats & position.OccupancyBitboards[side];
+        var threatsHash = Utils.Murmur3(threatenedPieces);
+        var threatsCorrHistIndex = (int)(threatsHash & Constants.ThreatsCorrHistoryHashMask);
+        Debug.Assert(threatsCorrHistIndex < _threatsCorrHistory.Length);
+
+        var threatsCorrHist = _threatsCorrHistory[threatsCorrHistIndex];
+
         // Correction aggregation
         var correction = (pawnCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Pawn)
             + (nonPawnSTMCorrHist * Configuration.EngineSettings.CorrHistoryWeight_NonPawnSTM)
@@ -417,7 +449,8 @@ public sealed partial class Engine
             + (majorCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Major)
             + (materialCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Material)
             + (continuationCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Continuation1)
-            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2);
+            + (continuationCorrHist2 * Configuration.EngineSettings.CorrHistoryWeight_Continuation2)
+            + (threatsCorrHist * Configuration.EngineSettings.CorrHistoryWeight_Threats);
 
         var correctStaticEval = staticEvaluation + (correction / (EvaluationConstants.CorrectionHistoryScale * EvaluationConstants.CorrHistScaleFactor));
 

--- a/src/Lynx/Search/IDDFS.cs
+++ b/src/Lynx/Search/IDDFS.cs
@@ -87,6 +87,11 @@ public sealed partial class Engine
     private readonly short[] _continuationCorrHistory = GC.AllocateArray<short>(Constants.ContinuationCorrHistoryHashSize, pinned: true);
 
     /// <summary>
+    /// <see cref="Constants.ThreatsCorrHistoryHashSize"/>
+    /// </summary>
+    private readonly short[] _threatsCorrHistory = GC.AllocateArray<short>(Constants.ThreatsCorrHistoryHashSize, pinned: true);
+
+    /// <summary>
     /// 12 x 64
     /// piece x target square
     /// </summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -177,7 +177,7 @@ public sealed partial class Engine
                 Debug.Assert(ttEntry.Score != EvaluationConstants.NoScore || ttEntry.NodeType == NodeType.Unknown);
 
                 rawStaticEval = ttEntry.StaticEval;
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ref evaluationContext);
                 phase = position.Phase();
                 position.CalculateThreats(ref evaluationContext);
             }
@@ -185,7 +185,7 @@ public sealed partial class Engine
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
                 _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
-                staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+                staticEval = CorrectStaticEvaluation(position, rawStaticEval, ref evaluationContext);
             }
 
             stack.StaticEval = staticEval;
@@ -307,7 +307,7 @@ public sealed partial class Engine
         else
         {
             (rawStaticEval, _) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
-            staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+            staticEval = CorrectStaticEvaluation(position, rawStaticEval, ref evaluationContext);
 
             if (!ttHit)
             {
@@ -777,7 +777,7 @@ public sealed partial class Engine
                 || (nodeType == NodeType.Beta && bestScore <= staticEval)
                 || (nodeType == NodeType.Alpha && bestScore >= staticEval)))
             {
-                UpdateCorrectionHistory(position, bestScore - staticEval, depth);
+                UpdateCorrectionHistory(position, bestScore - staticEval, depth, ref evaluationContext);
             }
 
             _tt.RecordHash(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, depth, ply, bestScore, nodeType, ttPv, bestMove);
@@ -853,7 +853,7 @@ public sealed partial class Engine
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 
-        var staticEval = CorrectStaticEvaluation(position, rawStaticEval);
+        var staticEval = CorrectStaticEvaluation(position, rawStaticEval, ref evaluationContext);
 
         ref var stack = ref Game.Stack(ply);
         stack.StaticEval = staticEval;


### PR DESCRIPTION
```
Test  | search/threatscorrhist-1
Elo   | -3.40 +- 3.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.30 (-2.25, 2.89) [0.00, 3.00]
Games | 12584: +3078 -3201 =6305
Penta | [154, 1569, 2962, 1460, 147]
https://openbench.lynx-chess.com/test/2740/
```