### PR TITLE
🔍 Quiet move ordering improving bonus

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -209,6 +209,29 @@ public sealed partial class Engine
                 ttCorrectedStaticEval = ttScore;
             }
 
+            // Quiet move ordering bonus
+            var previousMoveStack = Game.Stack(ply - 1);
+            var previousMove = previousMoveStack.Move;
+            if (!parentWasNullMove && previousMove.CapturedPiece() == (int)Piece.None)
+            {
+                var bonus = Math.Clamp((-10 * previousMoveStack.StaticEval) + staticEval, -100, 200);
+
+                Debug.Assert(evaluationContext.AttacksBySide[(int)position.Side] != 0);
+                var sameSideAttacks = evaluationContext.AttacksBySide[(int)position.Side];
+
+                var piece = previousMove.Piece();
+                var sourceSquare = previousMove.SourceSquare();
+                var targetSquare = previousMove.TargetSquare();
+                var isStartSquareAttacked = sameSideAttacks.GetBit(sourceSquare) ? 1 : 0;
+                var isTargetSquareAttacked = sameSideAttacks.GetBit(targetSquare) ? 1 : 0;
+
+                ref var pieceToQuietHistoryEntry = ref PieceToQuietHistoryEntry(piece, targetSquare, isStartSquareAttacked, isTargetSquareAttacked);
+                pieceToQuietHistoryEntry = (short)ScoreHistoryMove(pieceToQuietHistoryEntry, bonus);
+
+                //ref var butterflyQuietHistoryEntry = ref ButterflyQuietHistoryEntry(sourceSquare, targetSquare, isStartSquareAttacked, isTargetSquareAttacked);
+                //butterflyQuietHistoryEntry = (short)ScoreHistoryMove(butterflyQuietHistoryEntry, bonus);
+            }
+
             // Fail-high pruning (moves with high scores) - prune more when improving
             if (!pvNode)
             {


### PR DESCRIPTION
```
Test  | search/quiet-move-ordering-bonus-1
Elo   | -13.31 +- 6.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 3682: +861 -1002 =1819
Penta | [52, 494, 868, 397, 30]
https://openbench.lynx-chess.com/test/2815/
```