### PR TITLE
🔍 TT: Make `SaveStaticEval` method invoke `RecordHash`

### DIFF
--- a/src/Lynx/Model/ITranspositionTable.cs
+++ b/src/Lynx/Model/ITranspositionTable.cs
@@ -101,12 +101,14 @@ public interface ITranspositionTable
     /// <param name="staticEval">Static evaluation of the position</param>
     /// <param name="wasPv">Whether this position was part of the principal variation</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv)
+    void SaveStaticEval(Position position, int halfMovesWithoutCaptureOrPawnMove, int staticEval, bool wasPv, int ply)
     {
+        const int StaticEvalEntryDepth = 0;
+
         ref var entry = ref GetTTEntry(position, halfMovesWithoutCaptureOrPawnMove);
 
         // Extra key checks here (right before saving) failed for MT in https://github.com/lynx-chess/Lynx/pull/1566
-        entry.Update(GenerateTTKey(position.UniqueIdentifier), EvaluationConstants.NoScore, staticEval, depth: 0, NodeType.Unknown, wasPv ? 1 : 0, move: null);
+        RecordHash(position, halfMovesWithoutCaptureOrPawnMove, staticEval, StaticEvalEntryDepth, ply, EvaluationConstants.NoScore, NodeType.Unknown, wasPv);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -184,7 +184,7 @@ public sealed partial class Engine
             else
             {
                 (rawStaticEval, phase) = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext);
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv, ply);
                 staticEval = CorrectStaticEvaluation(position, rawStaticEval);
             }
 
@@ -314,7 +314,7 @@ public sealed partial class Engine
 
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv, ply);
             }
         }
 
@@ -880,7 +880,7 @@ public sealed partial class Engine
         {
             if (!ttHit)
             {
-                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv);
+                _tt.SaveStaticEval(position, Game.HalfMovesWithoutCaptureOrPawnMove, rawStaticEval, ttPv, ply);
             }
 
             // Standing pat beta-cutoff (updating alpha after this check)


### PR DESCRIPTION
Not super critical, relevant for bucket attempts

```
Test  | tt/RecordHash-method-for-savestaticeval
Elo   | -0.47 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [0.00, 3.00]
Games | 38626: +9615 -9667 =19344
Penta | [352, 4444, 9793, 4352, 372]
https://openbench.lynx-chess.com/test/2861/
```