### PR TITLE
🐛 Fix `OutOfMemoryException` + `IndexOutOfRangeException`

### DIFF
--- a/src/Lynx/Model/ITranspositionTable.cs
+++ b/src/Lynx/Model/ITranspositionTable.cs
@@ -10,6 +10,11 @@ public interface ITranspositionTable
 //public readonly struct ITranspositionTable
 {
     /// <summary>
+    /// Request size of the transposition table in MB
+    /// </summary>
+    int RequestedSizeMBs { get; }
+
+    /// <summary>
     /// Size of the transposition table in MB
     /// </summary>
     int SizeMBs { get; }

--- a/src/Lynx/Model/MultiArrayTranspositionTable.cs
+++ b/src/Lynx/Model/MultiArrayTranspositionTable.cs
@@ -72,6 +72,7 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
                     fullArrayCount = (ulong)i;
                     _tt[i] = [];
                     SizeMBs = (int)(fullArrayCount * (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024ul / 1024ul);
+                    Length = CalculateLength(SizeMBs);
                     _logger.Warn("Using only {ArrayCount} TT array(s) of size {ArraySize} ({ArraySizeMB} MB each) - {TotalSizeMB} MB total", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024, SizeMBs);
                 }
                 else
@@ -99,6 +100,7 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
                 _tt[_ttArrayCount - 1] = [];
                 --_ttArrayCount;
                 SizeMBs = (int)(fullArrayCount * (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024ul / 1024ul);
+                Length = CalculateLength(SizeMBs);
                 _logger.Warn(e, "Using only {ArrayCount} TT array(s) of size {ArraySize} ({ArraySizeMB} MB each) - {TotalSizeMB} MB total", fullArrayCount, Constants.MaxTTArrayLength, (ulong)Constants.MaxTTArrayLength * TranspositionTableElement.Size / 1024 / 1024, SizeMBs);
             }
         }

--- a/src/Lynx/Model/MultiArrayTranspositionTable.cs
+++ b/src/Lynx/Model/MultiArrayTranspositionTable.cs
@@ -16,6 +16,7 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
 
     private readonly int _ttArrayCount;
     private readonly TranspositionTableElement[][] _tt = [];
+    public int RequestedSizeMBs { get; }
     public int SizeMBs { get; }
     public ulong Length { get; }
 
@@ -25,7 +26,8 @@ public readonly struct MultiArrayTranspositionTable : ITranspositionTable
         var sw = Stopwatch.StartNew();
 
         var oldSizeMBs = SizeMBs;
-        SizeMBs = Configuration.EngineSettings.TranspositionTableSize;
+        RequestedSizeMBs = Configuration.EngineSettings.TranspositionTableSize;
+        SizeMBs = RequestedSizeMBs;
 
         Length = CalculateLength(SizeMBs);
 

--- a/src/Lynx/Model/SingleArrayTranspositionTable.cs
+++ b/src/Lynx/Model/SingleArrayTranspositionTable.cs
@@ -15,6 +15,7 @@ public readonly struct SingleArrayTranspositionTable : ITranspositionTable
     private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
     private readonly TranspositionTableElement[] _tt = [];
+    public int RequestedSizeMBs { get; }
     public int SizeMBs { get; }
 
     public ulong Length => (ulong)_tt.Length;
@@ -24,7 +25,8 @@ public readonly struct SingleArrayTranspositionTable : ITranspositionTable
         _logger.Debug("Allocating Single Array TT");
         var sw = Stopwatch.StartNew();
 
-        SizeMBs = Configuration.EngineSettings.TranspositionTableSize;
+        RequestedSizeMBs = Configuration.EngineSettings.TranspositionTableSize;
+        SizeMBs = RequestedSizeMBs;
         var ttLength = CalculateLength(SizeMBs);
 
         bool exceptionThrown = false;

--- a/src/Lynx/Searcher.cs
+++ b/src/Lynx/Searcher.cs
@@ -557,7 +557,8 @@ public sealed class Searcher : IDisposable
 
     public bool UpdateHash()
     {
-        if (_ttWrapper.SizeMBs != Configuration.EngineSettings.TranspositionTableSize)
+        if (_ttWrapper.SizeMBs != Configuration.EngineSettings.TranspositionTableSize
+            && _ttWrapper.RequestedSizeMBs != Configuration.EngineSettings.TranspositionTableSize)
         {
             _logger.Info("Resizing TT ({CurrentSize} MB -> {NewSize} MB)", _ttWrapper.SizeMBs, Configuration.EngineSettings.TranspositionTableSize);
             _engineWriter.TryWrite($"info string Resizing TT ({_ttWrapper.SizeMBs} MB -> {Configuration.EngineSettings.TranspositionTableSize} MB)");


### PR DESCRIPTION
- Recalculate `Length` in `MultiArrayTranspositionTable` after `OutOfMemoryException` exception, preventing `IndexOutOfRangeException` due to index calculations using the old `Length`
- Avoid TT re-allocation on `ucinewgame` after `OutOfMemoryException` if the requested TT hash doesn't change, avoiding further `OutOfMemoryException` 

This a fix for the patch [🐛 Account for potential OOM exceptions in MultiArray TT allocation](https://github.com/lynx-chess/Lynx/pull/2520).

The root cause (not being able to use `Hash 262144`, the full 256GB available for TT in TCEC) remains unsolved


<details>

<Summary> TCEC UCI logs </Summary>

```
850 >Lynx 1.11.0-dev-11b72336(0): setoption name Hash value 262144
850 >Lynx 1.11.0-dev-11b72336(0): isready
852 <Lynx 1.11.0-dev-11b72336(0): info string Updating search thread count (1 thread(s) -> 500 thread(s))
1064 <Lynx 1.11.0-dev-11b72336(0): info string Resizing TT (32 MB -> 262144 MB)
1106 <Lynx 1.11.0-dev-11b72336(0): info string Using only 245759 MB for TT (instead of 262144 MB) due to an issue during allocation
************************ Expected failure ************************
1113 <Lynx 1.11.0-dev-11b72336(0): 08:19:55 | [WARN] |Out of memory exception when allocating remaining items TT array of size 1717987602 (16384 MB)
1166 <Lynx 1.11.0-dev-11b72336(0): 08:19:55 | [WARN] |Using only 12 TT array(s) of size 2147483591 (20479 MB each) - 245759 MB total
1166 <Lynx 1.11.0-dev-11b72336(0): System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
1166 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
1166 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
1166 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateArray[T](Int32 length, Boolean pinned)
1166 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Model.MultiArrayTranspositionTable..ctor()
3279 <Lynx 1.11.0-dev-11b72336(0): readyok
Started game 3 of 5400 (Lynx 1.11.0-dev-11b72336 vs Stockfish_15_3M)

59678 >Lynx 1.11.0-dev-11b72336(0): ucinewgame
59678 >Lynx 1.11.0-dev-11b72336(0): setoption name Ponder value false
59678 >Lynx 1.11.0-dev-11b72336(0): setoption name UCI_Opponent value none 3349 computer Stockfish_15_3M
59678 >Lynx 1.11.0-dev-11b72336(0): position startpos
59678 >Lynx 1.11.0-dev-11b72336(0): isready
************************ Attempt to resize to the originally requested Hash, after if failed above ************************
59682 <Lynx 1.11.0-dev-11b72336(0): info string Resizing TT (245759 MB -> 262144 MB)
59688 <Lynx 1.11.0-dev-11b72336(0): 08:20:53 | [WARN] |Out of memory exception when allocating TT array 1 of size 2147483591 (20479 MB)
59688 <Lynx 1.11.0-dev-11b72336(0): System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateArray[T](Int32 length, Boolean pinned)
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Model.MultiArrayTranspositionTable..ctor()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Model.TranspositionTableFactory.Create()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Searcher.UpdateHash()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Searcher.NewGame()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.UCIHandler.HandleNewGame()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.UCIHandler.Handle(String rawCommand, CancellationToken cancellationToken)
59688 <Lynx 1.11.0-dev-11b72336(0): 08:20:53 | [ERROR] |Error trying to read/parse UCI command
59688 <Lynx 1.11.0-dev-11b72336(0): System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateNewArray(IntPtr typeHandlePtr, Int32 length, GC_ALLOC_FLAGS flags, ObjectHandleOnStack ret)
59688 <Lynx 1.11.0-dev-11b72336(0):    at System.GC.AllocateArray[T](Int32 length, Boolean pinned)
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Model.MultiArrayTranspositionTable..ctor()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Model.TranspositionTableFactory.Create()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Searcher.UpdateHash()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Searcher.NewGame()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.UCIHandler.HandleNewGame()
59688 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.UCIHandler.Handle(String rawCommand, CancellationToken cancellationToken)
59698 <Lynx 1.11.0-dev-11b72336(0): readyok
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4 g7g6
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4 g7g6 g1f3
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4 g7g6 g1f3 f8g7
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4 g7g6 g1f3 f8g7 f1e2
59698 >Lynx 1.11.0-dev-11b72336(0): position startpos moves e2e4 d7d5 e4d5 d8d5 b1c3 d5d8 d2d4 g7g6 g1f3 f8g7 f1e2 g8h6
59698 >Lynx 1.11.0-dev-11b72336(0): go wtime 1800000 btime 1800000 winc 3000 binc 18000
************************ Exception due to outdated length ************************
59881 <Lynx 1.11.0-dev-11b72336(0): 08:20:53 | [ERROR] |[#32] Depth 1: unexpected error occurred during the search of position rnbqk2r/ppp1ppbp/6pn/8/3P4/2N2N2/PPP1BPPP/R1BQK2R w KQkq - 0 1, best move will be returned
59882 <Lynx 1.11.0-dev-11b72336(0): System.IndexOutOfRangeException: Index was outside the bounds of the array.
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.QuiescenceSearch(Int32 ply, Int32 alpha, Int32 beta, Boolean pvNode, CancellationToken cancellationToken)
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.QuiescenceSearch(Int32 ply, Int32 alpha, Int32 beta, Boolean pvNode, CancellationToken cancellationToken)
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.QuiescenceSearch(Int32 ply, Int32 alpha, Int32 beta, Boolean pvNode, CancellationToken cancellationToken)
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove, Boolean isVerifyingSE)
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.NegaMax(Int32 depth, Int32 ply, Int32 alpha, Int32 beta, Boolean cutnode, CancellationToken cancellationToken, Boolean parentWasNullMove, Boolean isVerifyingSE)
59882 <Lynx 1.11.0-dev-11b72336(0):    at Lynx.Engine.IDDFS(Boolean isPondering, CancellationToken cancellationToken)
```

</details>

Test where an OOM is explicitly thrown for the last array of the MultiArray TT, which produces the following error but keeps playing:
```
2026-07-08 15:20:16.3663|0|1240|WARN|Lynx.Model.MultiArrayTranspositionTable|Out of memory exception when allocating remaining items TT array of size 1572864 (15 MB) 
2026-07-08 15:20:16.3737|0|1240|WARN|Lynx.Model.MultiArrayTranspositionTable|Multi-Array TT used, but single TT array expected for TT Hash size of 0.01 GB and 1572864 values. Max values are 0.02 GB, 1677721 items 
2026-07-08 15:20:16.3737|0|1240|WARN|Lynx.Model.MultiArrayTranspositionTable|Using only 1 TT array(s) of size 1677721 (15 MB each) - 15 MB total System.OutOfMemoryException: Test exception
   at Lynx.Model.MultiArrayTranspositionTable..ctor()

```

```
Test  | test/oom-bugfix
Elo   | 0.12 +- 7.03 (95%)
Conf  | 4.0+0.04s Threads=1 Hash=31MB
Games | 3010: +773 -772 =1465
Penta | [33, 348, 743, 347, 34]
https://openbench.lynx-chess.com/test/2870/
```