### PR TITLE
⚖️ Reduce 2 knights vs pawn eval

### DIFF
--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -445,6 +445,15 @@ public partial class Position
                     {
                         eval >>= 1; // /2
                     }
+
+                    var whiteKnights = _pieceBitboards[(int)Piece.N];
+                    var blackKnights = _pieceBitboards[(int)Piece.n];
+
+                    // 2 Knights vs Pawn
+                    if ((whiteKnights.CountBits() == 2 && whitePawns == 0) || (blackKnights.CountBits() == 2 && blackPawns == 0))
+                    {
+                        eval >>= 2; // /4
+                    }
                 }
             }
         }


### PR DESCRIPTION
```
Test  | eval/knight-vs-knight-halve-2
Elo   | -2.11 +- 3.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.22 (-2.25, 2.89) [0.00, 3.00]
Games | 7908: +1987 -2035 =3886
Penta | [4, 797, 2398, 753, 2]
https://openbench.lynx-chess.com/test/2900/
```