### PR TITLE
🔍 Only keep TT move when keys match - use 0

### DIFF
--- a/src/Lynx/Model/TranspositionTableElement.cs
+++ b/src/Lynx/Model/TranspositionTableElement.cs
@@ -123,11 +123,13 @@ public struct TranspositionTableElement
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void Update(ushort key, int score, int staticEval, int depth, NodeType nodeType, int wasPv, Move? move)
     {
-        _key = key;
         _score = (short)score;
         _staticEval = (short)staticEval;
         _depth = MemoryMarshal.AsBytes(MemoryMarshal.CreateSpan(ref depth, 1))[0];
         _type_WasPv = (byte)(wasPv | ((int)nodeType << NodeTypeOffset));
-        _move = move != null ? (ShortMove)move : Move;    // Suggested by cj5716 instead of 0. https://github.com/lynx-chess/Lynx/pull/462
+        _move = move is null && _key == key
+            ? Move
+            : ((ShortMove?)move ?? 0);
+        _key = key;
     }
 }


### PR DESCRIPTION
```
Test  | tt/keepmove-only-matchingkeys
Elo   | -7.61 +- 4.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 6258: +1496 -1633 =3129
Penta | [72, 838, 1438, 717, 64]
https://openbench.lynx-chess.com/test/2864/
```