### PR TITLE
🐛 Calculate missing threats in QSearch

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -851,9 +851,17 @@ public sealed partial class Engine
         ShortMove ttBestMove = ttProbeResult.BestMove;
         _maxDepthReached[ply] = ply;
 
-        var rawStaticEval = ttHit
-            ? ttProbeResult.StaticEval
-            : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
+        int rawStaticEval;
+
+        if (ttHit)
+        {
+            rawStaticEval = ttProbeResult.StaticEval;
+            position.CalculateThreats(ref evaluationContext);
+        }
+        else
+        {
+            rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
+        }
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 


### PR DESCRIPTION
```
Test  | bugfix/missing-threats-calculation
Elo   | -1.80 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.26 (-2.25, 2.89) [-3.00, 1.00]
Games | 29654: +7384 -7538 =14732
Penta | [264, 3444, 7568, 3284, 267]
https://openbench.lynx-chess.com/test/2929/
```