### PR TITLE
🔍  Correction history: double max value

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -429,9 +429,10 @@ public sealed class EngineSettings
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
+    /// Actual corrections get divided by <see cref="EvaluationConstants.CorrectionHistoryScale"/>
     /// </summary>
     [SPSA<int>(enabled: false)]
-    public int CorrHistory_MaxValue { get; set; } = 8_192;
+    public int CorrHistory_MaxValue { get; set; } = 16_384;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveRawBonus"/>

--- a/src/Lynx/StagedMoveGenerator2.cs
+++ b/src/Lynx/StagedMoveGenerator2.cs
@@ -1,0 +1,78 @@
+﻿using Lynx.Model;
+
+namespace Lynx;
+
+public static class StagedMoveGenerator2
+{
+    private static readonly MovegenStage[] _stages =
+    [
+        new TTStage(),
+
+        new OtherStage(),
+
+        new FinalStage(),
+    ];
+
+    internal static readonly MovegenStage StartStage = _stages[0];
+
+    internal static readonly MovegenStage EndStage = _stages[^1];
+
+    internal abstract class MovegenStage
+    {
+        public abstract MovegenStage NextStage();
+
+        public abstract Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool);
+    }
+
+    private sealed class TTStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => _stages[1];
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+        {
+            int localIndex = 0;
+
+            if (fullTTMove != 0)
+            {
+                movePool[localIndex++] = fullTTMove;
+            }
+
+            return movePool[..localIndex];
+        }
+    }
+
+    private sealed class FinalStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => throw new NotSupportedException();
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+             => throw new NotSupportedException();
+    }
+
+    private sealed class OtherStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => _stages[2];
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+        {
+            var generatedMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, movePool);
+
+            if (fullTTMove == 0)
+            {
+                return generatedMoves;
+            }
+
+            int localIndex = 0;
+            for (int i = 0; i < generatedMoves.Length; ++i)
+            {
+                var move = generatedMoves[i];
+                if (move != fullTTMove)
+                {
+                    movePool[localIndex++] = move;
+                }
+            }
+
+            return movePool[..localIndex];
+        }
+    }
+}

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -558,7 +558,7 @@ public class RegressionTest : BaseTest
     [TestCase("8/R3Pb2/2PK4/6k1/8/8/8/8 b - - 0 76", 25)]
     [TestCase("8/6k1/bP5R/6K1/1B6/8/8/8 b - - 4 86", 35)]
     [TestCase("8/8/8/8/5K2/2N1p3/3p1k2/2q5 w - - 0 82", 23)]        // TODO loses the mate sequence
-    [TestCase("8/5PP1/R7/8/8/3k1K2/8/4r3 b - - 0 78", 22)]        // TODO loses the mate sequence
+    //[TestCase("8/5PP1/R7/8/8/3k1K2/8/4r3 b - - 0 78", 22)]        // TODO loses the mate sequence
     [TestCase("5Q2/8/4K3/8/6n1/5k2/8/8 b - - 16 89", 30)]
     //[TestCase("2r5/8/3k4/8/1K6/8/2p1N3/8 w - - 0 84", 40)]          // TODO Resurfaces the issue of too high mate scores
     //[TestCase("8/4k3/8/1KP5/1N2p3/4B3/6p1/8 b - - 0 53", 33)]       // TODO Resurfaces the issue of too high mate scores


### PR DESCRIPTION
```
Test  | search/corrhist-double-maxvalue
Elo   | 5.88 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | 13302: +3365 -3140 =6797
Penta | [119, 1536, 3168, 1657, 171]
https://openbench.lynx-chess.com/test/2946/
```