### PR TITLE
🔍  Correction history: halve max value

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -429,9 +429,10 @@ public sealed class EngineSettings
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveValue"/>
+    /// Actual corrections get divided by <see cref="EvaluationConstants.CorrectionHistoryScale"/>
     /// </summary>
     [SPSA<int>(enabled: false)]
-    public int CorrHistory_MaxValue { get; set; } = 8_192;
+    public int CorrHistory_MaxValue { get; set; } = 4_096;
 
     /// <summary>
     /// Initial value same as <see cref="History_MaxMoveRawBonus"/>

--- a/src/Lynx/StagedMoveGenerator2.cs
+++ b/src/Lynx/StagedMoveGenerator2.cs
@@ -1,0 +1,78 @@
+﻿using Lynx.Model;
+
+namespace Lynx;
+
+public static class StagedMoveGenerator2
+{
+    private static readonly MovegenStage[] _stages =
+    [
+        new TTStage(),
+
+        new OtherStage(),
+
+        new FinalStage(),
+    ];
+
+    internal static readonly MovegenStage StartStage = _stages[0];
+
+    internal static readonly MovegenStage EndStage = _stages[^1];
+
+    internal abstract class MovegenStage
+    {
+        public abstract MovegenStage NextStage();
+
+        public abstract Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool);
+    }
+
+    private sealed class TTStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => _stages[1];
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+        {
+            int localIndex = 0;
+
+            if (fullTTMove != 0)
+            {
+                movePool[localIndex++] = fullTTMove;
+            }
+
+            return movePool[..localIndex];
+        }
+    }
+
+    private sealed class FinalStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => throw new NotSupportedException();
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+             => throw new NotSupportedException();
+    }
+
+    private sealed class OtherStage : MovegenStage
+    {
+        public override MovegenStage NextStage() => _stages[2];
+
+        public override Span<Move> GenerateMoves(short ttMove, Move fullTTMove, Position position, ref EvaluationContext evaluationContext, Span<Move> movePool)
+        {
+            var generatedMoves = MoveGenerator.GenerateAllMoves(position, ref evaluationContext, movePool);
+
+            if (fullTTMove == 0)
+            {
+                return generatedMoves;
+            }
+
+            int localIndex = 0;
+            for (int i = 0; i < generatedMoves.Length; ++i)
+            {
+                var move = generatedMoves[i];
+                if (move != fullTTMove)
+                {
+                    movePool[localIndex++] = move;
+                }
+            }
+
+            return movePool[..localIndex];
+        }
+    }
+}


### PR DESCRIPTION
```
Test  | search/corrhist-halve-maxvalue
Elo   | -7.86 +- 7.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.93 (-2.25, 2.89) [0.00, 3.00]
Games | 2520: +602 -659 =1259
Penta | [44, 312, 582, 301, 21]
https://openbench.lynx-chess.com/test/2945/
```

Superseded by #2634 