### PR TITLE
Add node fudging option for datagen

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -119,7 +119,7 @@ public sealed class EngineSettings
     /// <summary>
     /// Torch concept: doing fudging soft-nodes during datagen
     /// </summary>
-    public int SoftNodeFudging { get; set; } = 2_000;
+    public int SoftNodeFudging { get; set; }
 
     /// <summary>
     /// Real NPS aren't calculated until the last search command.

--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -117,6 +117,11 @@ public sealed class EngineSettings
     public bool SoftNodes { get; set; }
 
     /// <summary>
+    /// Torch concept: doing fudging soft-nodes during datagen
+    /// </summary>
+    public int SoftNodeFudging { get; set; } = 2_000;
+
+    /// <summary>
     /// Real NPS aren't calculated until the last search command.
     /// This option enables the report of an NPS estimation by the main thread
     /// </summary>

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -76,7 +76,7 @@ public static class TimeManager
             }
 
             var fudgingAmount = Configuration.EngineSettings.SoftNodeFudging;
-            var extraNodes = Random.Shared.Next(-fudgingAmount, +fudgingAmount);
+            var extraNodes = fudgingAmount <= 0 ? 0 : Random.Shared.Next(-fudgingAmount, +fudgingAmount);
 
             maxNodes = goCommand.Nodes + (ulong)extraNodes;
 

--- a/src/Lynx/TimeManager.cs
+++ b/src/Lynx/TimeManager.cs
@@ -75,12 +75,15 @@ public static class TimeManager
                 _logger.Warn("Nodes will be treated as soft nodes, since hard nodes aren't supported. Please enable SoftNodes via UCI (or configuration) before sending 'go nodes' commands to avoid this warning");
             }
 
-            maxNodes = goCommand.Nodes;
+            var fudgingAmount = Configuration.EngineSettings.SoftNodeFudging;
+            var extraNodes = Random.Shared.Next(-fudgingAmount, +fudgingAmount);
+
+            maxNodes = goCommand.Nodes + (ulong)extraNodes;
 
             // This limit makes up for the lack of hard nodes, to avoid 'hangs' in search explosions
             hardLimitTimeBound = (int)Math.Max(
                 (ulong)Configuration.EngineSettings.Datagen_GenFens_MinHardTimeBound,
-                3 * goCommand.Nodes * 1000 / Configuration.EngineSettings.Estimated_NPS);
+                3 * maxNodes * 1000 / Configuration.EngineSettings.Estimated_NPS);
 
             _logger.Info("Soft nodes search (nodes {0}, hard time bound {1}ms)", maxNodes, hardLimitTimeBound);
         }

--- a/tests/Lynx.Test/TimeManagerTest.cs
+++ b/tests/Lynx.Test/TimeManagerTest.cs
@@ -12,6 +12,7 @@ public class TimeManagerTest
     public void CalculateTimeManagementTest_GoNodes_SoftNodesDisabled()
     {
         Configuration.EngineSettings.SoftNodes = false;
+        Configuration.EngineSettings.SoftNodeFudging = 0;
 
         var game = new Game(Constants.InitialPositionFEN);
         const int nodes = 666;


### PR DESCRIPTION
Not really proven to be useful, but..
```
Test  | selfgen/58-nodefudging-5k
Elo   | -9.72 +- 7.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.23 (-2.25, 2.89) [0.00, 3.00]
Games | 2896: +743 -824 =1329
Penta | [65, 372, 630, 341, 40]
https://openbench.lynx-chess.com/test/2974/
```