### PR TITLE
Refactor threat calculation

### DIFF
--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Diagnostics;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -66,17 +67,16 @@ public partial class Position
         //    return result;
         //}
 
+        CalculateThreats(ref evaluationContext);
+
         int packedScore = 0;
         int gamePhase = 0;
 
         var whitePawns = _pieceBitboards[(int)Piece.P];
         var blackPawns = _pieceBitboards[(int)Piece.p];
 
-        Bitboard whitePawnAttacks = whitePawns.ShiftUpRightAndLeft();
-        Bitboard blackPawnAttacks = blackPawns.ShiftDownRightAndLeft();
-
-        evaluationContext.AttacksBySide[(int)Side.White] = evaluationContext.Attacks[(int)Piece.P] = whitePawnAttacks;
-        evaluationContext.AttacksBySide[(int)Side.Black] = evaluationContext.Attacks[(int)Piece.p] = blackPawnAttacks;
+        Bitboard whitePawnAttacks = evaluationContext.Attacks[(int)Piece.P];
+        Bitboard blackPawnAttacks = evaluationContext.Attacks[(int)Piece.p];
 
         var whiteKing = _pieceBitboards[(int)Piece.K].GetLS1BIndex();
         var blackKing = _pieceBitboards[(int)Piece.k].GetLS1BIndex();
@@ -277,13 +277,8 @@ public partial class Position
             KingAdditionalEvaluation(whiteKing, whiteBucket, (int)Side.White, blackPawnAttacks)
             - KingAdditionalEvaluation(blackKing, blackBucket, (int)Side.Black, whitePawnAttacks);
 
-        var whiteKingAttacks = Attacks.KingAttacks[whiteKing];
-        evaluationContext.Attacks[(int)Piece.K] |= whiteKingAttacks;
-        evaluationContext.AttacksBySide[(int)Side.White] |= whiteKingAttacks;
-
-        var blackKingAttacks = Attacks.KingAttacks[blackKing];
-        evaluationContext.Attacks[(int)Piece.k] |= blackKingAttacks;
-        evaluationContext.AttacksBySide[(int)Side.Black] |= blackKingAttacks;
+        var whiteKingAttacks = evaluationContext.Attacks[(int)Piece.K];
+        var blackKingAttacks = evaluationContext.Attacks[(int)Piece.k];
 
         // King mobility
         var whiteKingAttacksCount =
@@ -633,8 +628,6 @@ public partial class Position
         var sameSidePawns = _pieceBitboards[pieceIndex - pawnToKnightOffset];
 
         var attacks = Attacks.KnightAttacks[squareIndex];
-        evaluationContext.Attacks[(int)Piece.N + Utils.PieceOffset(pieceSide)] |= attacks;
-        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -661,8 +654,6 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.BishopAttacks(squareIndex, occupancy);
-        evaluationContext.Attacks[(int)Piece.B + offset] |= attacks;
-        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -773,8 +764,6 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.RookAttacks(squareIndex, occupancy);
-        evaluationContext.Attacks[(int)Piece.R + Utils.PieceOffset(pieceSide)] |= attacks;
-        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -829,8 +818,6 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.QueenAttacks(squareIndex, occupancy);
-        evaluationContext.Attacks[(int)Piece.Q + Utils.PieceOffset(pieceSide)] |= attacks;
-        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -1051,6 +1038,8 @@ public partial class Position
 
         var oppositeSideKingSquare = _pieceBitboards[(int)Piece.k - offset].GetLS1BIndex();
         var oppositeSideAttacks = evaluationContext.AttacksBySide[oppositeSide];
+
+        Debug.Assert(oppositeSideAttacks != 0, "Missing threat calculations");
 
         Span<Bitboard> checkThreats = stackalloc Bitboard[5];
 

--- a/src/Lynx/Evaluation.cs
+++ b/src/Lynx/Evaluation.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Numerics;
+﻿using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -67,16 +66,17 @@ public partial class Position
         //    return result;
         //}
 
-        CalculateThreats(ref evaluationContext);
-
         int packedScore = 0;
         int gamePhase = 0;
 
         var whitePawns = _pieceBitboards[(int)Piece.P];
         var blackPawns = _pieceBitboards[(int)Piece.p];
 
-        Bitboard whitePawnAttacks = evaluationContext.Attacks[(int)Piece.P];
-        Bitboard blackPawnAttacks = evaluationContext.Attacks[(int)Piece.p];
+        Bitboard whitePawnAttacks = whitePawns.ShiftUpRightAndLeft();
+        Bitboard blackPawnAttacks = blackPawns.ShiftDownRightAndLeft();
+
+        evaluationContext.AttacksBySide[(int)Side.White] = evaluationContext.Attacks[(int)Piece.P] = whitePawnAttacks;
+        evaluationContext.AttacksBySide[(int)Side.Black] = evaluationContext.Attacks[(int)Piece.p] = blackPawnAttacks;
 
         var whiteKing = _pieceBitboards[(int)Piece.K].GetLS1BIndex();
         var blackKing = _pieceBitboards[(int)Piece.k].GetLS1BIndex();
@@ -277,8 +277,13 @@ public partial class Position
             KingAdditionalEvaluation(whiteKing, whiteBucket, (int)Side.White, blackPawnAttacks)
             - KingAdditionalEvaluation(blackKing, blackBucket, (int)Side.Black, whitePawnAttacks);
 
-        var whiteKingAttacks = evaluationContext.Attacks[(int)Piece.K];
-        var blackKingAttacks = evaluationContext.Attacks[(int)Piece.k];
+        var whiteKingAttacks = Attacks.KingAttacks[whiteKing];
+        evaluationContext.Attacks[(int)Piece.K] |= whiteKingAttacks;
+        evaluationContext.AttacksBySide[(int)Side.White] |= whiteKingAttacks;
+
+        var blackKingAttacks = Attacks.KingAttacks[blackKing];
+        evaluationContext.Attacks[(int)Piece.k] |= blackKingAttacks;
+        evaluationContext.AttacksBySide[(int)Side.Black] |= blackKingAttacks;
 
         // King mobility
         var whiteKingAttacksCount =
@@ -628,6 +633,8 @@ public partial class Position
         var sameSidePawns = _pieceBitboards[pieceIndex - pawnToKnightOffset];
 
         var attacks = Attacks.KnightAttacks[squareIndex];
+        evaluationContext.Attacks[(int)Piece.N + Utils.PieceOffset(pieceSide)] |= attacks;
+        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -654,6 +661,8 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.BishopAttacks(squareIndex, occupancy);
+        evaluationContext.Attacks[(int)Piece.B + offset] |= attacks;
+        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -764,6 +773,8 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.RookAttacks(squareIndex, occupancy);
+        evaluationContext.Attacks[(int)Piece.R + Utils.PieceOffset(pieceSide)] |= attacks;
+        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -818,6 +829,8 @@ public partial class Position
 
         var occupancy = _occupancyBitboards[(int)Side.Both];
         var attacks = Attacks.QueenAttacks(squareIndex, occupancy);
+        evaluationContext.Attacks[(int)Piece.Q + Utils.PieceOffset(pieceSide)] |= attacks;
+        evaluationContext.AttacksBySide[pieceSide] |= attacks;
 
         // Mobility
         var squaresToExcludeFromMobility = ~(sameSidePawns | enemyPawnAttacks);
@@ -1038,8 +1051,6 @@ public partial class Position
 
         var oppositeSideKingSquare = _pieceBitboards[(int)Piece.k - offset].GetLS1BIndex();
         var oppositeSideAttacks = evaluationContext.AttacksBySide[oppositeSide];
-
-        Debug.Assert(oppositeSideAttacks != 0, "Missing threat calculations");
 
         Span<Bitboard> checkThreats = stackalloc Bitboard[5];
 

--- a/src/Lynx/Model/Position.cs
+++ b/src/Lynx/Model/Position.cs
@@ -1016,6 +1016,8 @@ public partial class Position : IDisposable
     {
         var attacks = evaluationContext.AttacksBySide[(int)attackingSide];
 
+        Debug.Assert(attacks != 0, "Missing threat calculation");
+
         if (attacks != 0)
         {
             return (attacks & squaresBitboard) != 0;

--- a/src/Lynx/MoveGenerator.cs
+++ b/src/Lynx/MoveGenerator.cs
@@ -375,6 +375,8 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateKingMoves(ref int localIndex, Span<Move> movePool, int piece, Position position, ref EvaluationContext evaluationContext)
     {
+        Debug.Assert(evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)] != 0, "Missing threat calculations");
+
         var sourceSquare = position.PieceBitboards[piece].GetLS1BIndex();
         var occupancy = position.OccupancyBitboards[(int)Side.Both];
 
@@ -435,6 +437,8 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void GenerateKingCaptures(ref int localIndex, Span<Move> movePool, int piece, Position position, ref EvaluationContext evaluationContext)
     {
+        Debug.Assert(evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)] != 0, "Missing threat calculations");
+
         var sourceSquare = position.PieceBitboards[piece].GetLS1BIndex();
         var oppositeSide = Utils.OppositeSide((int)position.Side);
 
@@ -466,13 +470,13 @@ public static class MoveGenerator
         try
         {
 #endif
-        return IsAnyPawnMoveValid(position, offset)
-            || IsAnyKingMoveValid((int)Piece.K + offset, position, ref evaluationContext)    // in?
-            || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.B + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.N + offset, position)
-            || IsAnyPieceMoveValid((int)Piece.R + offset, position)
-            || IsAnyCastlingMoveValid(position, ref evaluationContext);
+            return IsAnyPawnMoveValid(position, offset)
+                || IsAnyKingMoveValid((int)Piece.K + offset, position, ref evaluationContext)    // in?
+                || IsAnyPieceMoveValid((int)Piece.Q + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.B + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.N + offset, position)
+                || IsAnyPieceMoveValid((int)Piece.R + offset, position)
+                || IsAnyCastlingMoveValid(position, ref evaluationContext);
 #if DEBUG
         }
         catch (Exception e)
@@ -673,6 +677,8 @@ public static class MoveGenerator
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsAnyKingMoveValid(int piece, Position position, ref EvaluationContext evaluationContext)
     {
+        Debug.Assert(evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)] != 0, "Missing threat calculations");
+
         var sourceSquare = position.PieceBitboards[piece].GetLS1BIndex();
         var occupancy = position.OccupancyBitboards[(int)Side.Both];
 

--- a/src/Lynx/Search/Helpers.cs
+++ b/src/Lynx/Search/Helpers.cs
@@ -87,7 +87,7 @@ public sealed partial class Engine
         var sourceSquare = move.SourceSquare();
         var targetSquare = move.TargetSquare();
         var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)];
-        Debug.Assert(oppositeSideAttacks != 0);
+        Debug.Assert(oppositeSideAttacks != 0, "Missing threat calculations");
 
         var isStartSquareAttacked = oppositeSideAttacks.GetBit(sourceSquare) ? 1 : 0;
         var isTargetSquareAttacked = oppositeSideAttacks.GetBit(targetSquare) ? 1 : 0;
@@ -520,8 +520,16 @@ public sealed partial class Engine
     private void ValidatePVTable()
     {
         var position = Game.CurrentPosition;
+
+        Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
+        Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
+
+        var evaluationContext = new EvaluationContext(buffer);
+
         for (int i = 0; i < PVTable.Indexes[1]; ++i)
         {
+            position.CalculateThreats(ref evaluationContext);
+
             if (_pVTable[i] == default)
             {
                 for (int j = i + 1; j < PVTable.Indexes[1]; ++j)
@@ -550,9 +558,11 @@ public sealed partial class Engine
         static void TryParseMove(Position position, int i, int move)
         {
             Span<Move> movePool = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];
-
             Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
+
             var evaluationContext = new EvaluationContext(buffer);
+
+            position.CalculateThreats(ref evaluationContext);
 
             if (!MoveExtensions.TryParseFromUCIString(
                move.UCIString(),

--- a/src/Lynx/Search/MoveOrdering.cs
+++ b/src/Lynx/Search/MoveOrdering.cs
@@ -176,7 +176,7 @@ public sealed partial class Engine
             int rawHistoryMalus = HistoryMalus[depth];
 
             var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)];
-            Debug.Assert(oppositeSideAttacks != 0);
+            Debug.Assert(oppositeSideAttacks != 0, "Missing threat calculations");
 
             var sourceSquare = move.SourceSquare();
             var isStartSquareAttacked = oppositeSideAttacks.GetBit(sourceSquare) ? 1 : 0;

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -853,17 +853,9 @@ public sealed partial class Engine
         ShortMove ttBestMove = ttProbeResult.BestMove;
         _maxDepthReached[ply] = ply;
 
-        int rawStaticEval;
-
-        if (ttHit)
-        {
-            rawStaticEval = ttProbeResult.StaticEval;
-            position.CalculateThreats(ref evaluationContext);
-        }
-        else
-        {
-            rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
-        }
+        var rawStaticEval = ttHit
+            ? ttProbeResult.StaticEval
+            : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 
@@ -900,6 +892,11 @@ public sealed partial class Engine
         if (standPat > alpha)
         {
             alpha = standPat;
+        }
+
+        if (ttHit)
+        {
+            position.CalculateThreats(ref evaluationContext);
         }
 
         Span<Move> moves = stackalloc Move[Constants.MaxNumberOfPseudolegalMovesInAPosition];

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,6 +155,8 @@ public sealed partial class Engine
 
         if (depth + depthExtension <= 0)
         {
+            position.CalculateThreats(ref evaluationContext);
+
             if (MoveGenerator.CanGenerateAtLeastAValidMove(position, ref evaluationContext))
             {
                 return QuiescenceSearch(ply, alpha, beta, pvNode, cancellationToken);
@@ -851,9 +853,17 @@ public sealed partial class Engine
         ShortMove ttBestMove = ttProbeResult.BestMove;
         _maxDepthReached[ply] = ply;
 
-        var rawStaticEval = ttHit
-            ? ttProbeResult.StaticEval
-            : position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
+        int rawStaticEval;
+
+        if (ttHit)
+        {
+            rawStaticEval = ttProbeResult.StaticEval;
+            position.CalculateThreats(ref evaluationContext);
+        }
+        else
+        {
+            rawStaticEval = position.StaticEvaluation(Game.HalfMovesWithoutCaptureOrPawnMove, _pawnEvalTable, ref evaluationContext).Score;
+        }
 
         Debug.Assert(rawStaticEval != EvaluationConstants.NoScore, "Assertion failed", "All TT entries should have a static eval");
 


### PR DESCRIPTION
Calculate threats at the beginning of static eval and add ensure threats are always available in all paths that need them
This includes https://github.com/lynx-chess/Lynx/pull/2624

Slowdown
<img width="726" height="164" alt="imagen" src="https://github.com/user-attachments/assets/086a42a7-5cfb-47ec-b6b9-14634fff528c" />
```
Test  | refactor/simplify-threat-calculation
Elo   | -16.44 +- 7.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.28 (-2.25, 2.89) [-3.00, 1.00]
Games | 2496: +569 -687 =1240
Penta | [29, 353, 600, 239, 27]
https://openbench.lynx-chess.com/test/2977/
```

Even after last commit, slowdown
<img width="736" height="165" alt="imagen" src="https://github.com/user-attachments/assets/fc0e5fe1-fab1-491c-a098-79ab482d325b" />

```
Test  | refactor/simplify-threat-calculation
Elo   | -5.19 +- 4.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [-3.00, 1.00]
Games | 8096: +1979 -2100 =4017
Penta | [91, 946, 2081, 853, 77]
https://openbench.lynx-chess.com/test/2979/
```