### PR TITLE
🐛 Fix potential bug in 50 moves repetition

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -240,15 +240,14 @@ public sealed class Game : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition(ref EvaluationContext evaluationContext)
+    public bool Is50MovesRepetition()
     {
         if (HalfMovesWithoutCaptureOrPawnMove < 100)
         {
             return false;
         }
 
-        var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)CurrentPosition.Side)];
-        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, oppositeSideAttacks);
+        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition);
     }
 
     /// <summary>

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -155,8 +155,7 @@ public sealed partial class Engine
 
         if (depth + depthExtension <= 0)
         {
-            var localOppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)];
-            if (MoveGenerator.CanGenerateAtLeastAValidMove(position, localOppositeSideAttacks))
+            if (MoveGenerator.CanGenerateAtLeastAValidMove(position))
             {
                 return QuiescenceSearch(ply, alpha, beta, pvNode, cancellationToken);
             }
@@ -543,7 +542,7 @@ public sealed partial class Engine
 
             int score = 0;
 
-            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition(ref evaluationContext)))
+            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition()))
             {
                 score = 0;
 
@@ -1006,7 +1005,7 @@ public sealed partial class Engine
         }
 
         if (!isAnyCaptureValid
-            && !MoveGenerator.CanGenerateAtLeastAValidMove(position, evaluationContext.AttacksBySide[Utils.OppositeSide((int)position.Side)])) // Bad captures can be pruned, so all moves need to be generated for now
+            && !MoveGenerator.CanGenerateAtLeastAValidMove(position)) // Bad captures can be pruned, so all moves need to be generated for now
         {
             Debug.Assert(bestMove is null);
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -227,11 +227,11 @@ public class RegressionTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(engine.Game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(engine.Game.Is50MovesRepetition());
         var bestMove = engine.BestMove(new GoCommand("go depth 1"));
 
         engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.UCIString());
-        Assert.IsFalse(engine.Game.Is50MovesRepetition(ref evaluationContext));
+        Assert.IsFalse(engine.Game.Is50MovesRepetition());
     }
 
     // 8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1 - || PV Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6, with b1=Q as the first invalid move there

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -243,7 +243,7 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition());
     }
 
     [Test]
@@ -274,7 +274,7 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.True(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.True(game.Is50MovesRepetition());
     }
 
     [Test]
@@ -309,6 +309,6 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition());
     }
 }


### PR DESCRIPTION
Due to pre-move threats being used

```
Test  | bugfix/50-moves-repetition
Elo   | -2.39 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [-3.00, 1.00]
Games | 19462: +4843 -4977 =9642
Penta | [165, 2170, 5164, 2098, 134]
https://openbench.lynx-chess.com/test/3019/
```