### PR TITLE
🐛 Fix potential bug in 50 moves repetition II

### DIFF
--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -240,7 +240,7 @@ public sealed class Game : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool Is50MovesRepetition(ref EvaluationContext evaluationContext)
+    public bool Is50MovesRepetition()
     {
         if (HalfMovesWithoutCaptureOrPawnMove < 100)
         {

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -247,8 +247,7 @@ public sealed class Game : IDisposable
             return false;
         }
 
-        var oppositeSideAttacks = CurrentPosition.OppositeSideAttacks();
-        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, oppositeSideAttacks);
+        return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition);
     }
 
     /// <summary>

--- a/src/Lynx/Model/Game.cs
+++ b/src/Lynx/Model/Game.cs
@@ -247,7 +247,7 @@ public sealed class Game : IDisposable
             return false;
         }
 
-        var oppositeSideAttacks = evaluationContext.AttacksBySide[Utils.OppositeSide((int)CurrentPosition.Side)];
+        var oppositeSideAttacks = CurrentPosition.OppositeSideAttacks();
         return !CurrentPosition.IsInCheck() || MoveGenerator.CanGenerateAtLeastAValidMove(CurrentPosition, oppositeSideAttacks);
     }
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -543,7 +543,7 @@ public sealed partial class Engine
 
             int score = 0;
 
-            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition(ref evaluationContext)))
+            if (canBeRepetition && (Game.IsThreefoldRepetition(ply) || Game.Is50MovesRepetition()))
             {
                 score = 0;
 

--- a/tests/Lynx.Test/BestMove/RegressionTest.cs
+++ b/tests/Lynx.Test/BestMove/RegressionTest.cs
@@ -227,11 +227,11 @@ public class RegressionTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(engine.Game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(engine.Game.Is50MovesRepetition());
         var bestMove = engine.BestMove(new GoCommand("go depth 1"));
 
         engine.AdjustPosition(positionCommand + " " + bestMove.BestMove.UCIString());
-        Assert.IsFalse(engine.Game.Is50MovesRepetition(ref evaluationContext));
+        Assert.IsFalse(engine.Game.Is50MovesRepetition());
     }
 
     // 8/2Q4p/4pppk/4P3/8/7P/q4PK1/1q6 w - - 0 1 - || PV Qc7 Kh6 e5 b1=Q Qxb1 Qxb1 exf6, with b1=Q as the first invalid move there

--- a/tests/Lynx.Test/GameTest.cs
+++ b/tests/Lynx.Test/GameTest.cs
@@ -243,7 +243,7 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition());
     }
 
     [Test]
@@ -274,7 +274,7 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.True(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.True(game.Is50MovesRepetition());
     }
 
     [Test]
@@ -309,6 +309,6 @@ public class GameTest : BaseTest
         Span<Bitboard> buffer = stackalloc Bitboard[EvaluationContext.RequiredBufferSize];
         var evaluationContext = new EvaluationContext(buffer);
 
-        Assert.False(game.Is50MovesRepetition(ref evaluationContext));
+        Assert.False(game.Is50MovesRepetition());
     }
 }


### PR DESCRIPTION
#2654 but KISS

```
Test  | bugfix/50-moves-repetition-2
Elo   | 1.56 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | 22322: +5643 -5543 =11136
Penta | [183, 2384, 5930, 2478, 186]
https://openbench.lynx-chess.com/test/3024/
```