### PR TITLE
🔍 LMP: increase margin with quiet history

### DIFF
--- a/src/Lynx/Configuration.cs
+++ b/src/Lynx/Configuration.cs
@@ -358,6 +358,9 @@ public sealed class EngineSettings
     [SPSA<int>(enabled: false)]
     public int LMP_MovesDepthMultiplier { get; set; } = 3;
 
+    [SPSA<int>(1, 8192, 410)]
+    public int LMP_QuietHistoryDivisor { get; set; } = 6144;
+
     [SPSA<int>(enabled: false)]
     public int History_MaxMoveValue { get; set; } = 8_192;
 

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -392,7 +392,13 @@ public sealed partial class Engine
             {
                 // 🔍 Late Move Pruning (LMP) - all quiet moves can be pruned
                 // after searching the first few given by the move ordering algorithm
-                if (visitedMovesCounter >= Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1))) // Based on formula suggested by Antares
+                var lmpMargin = Configuration.EngineSettings.LMP_BaseMovesToTry + (Configuration.EngineSettings.LMP_MovesDepthMultiplier * depth * (improving ? 2 : 1));
+                if (!isCapture)
+                {
+                    lmpMargin += quietHistory / Configuration.EngineSettings.LMP_QuietHistoryDivisor;
+                }
+
+                if (visitedMovesCounter >= lmpMargin)
                 {
                     break;
                 }


### PR DESCRIPTION
```
Test  | search/lmp-quiethistory
Elo   | 0.46 +- 1.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.77 (-2.25, 2.89) [0.00, 3.00]
Games | 44032: +11018 -10960 =22054
Penta | [496, 5344, 10257, 5444, 475]
https://openbench.lynx-chess.com/test/2927/
```

```
Test  | search/lmp-quiethistory
Elo   | 0.69 +- 1.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.46 (-2.25, 2.89) [0.00, 3.00]
Games | 91762: +21448 -21267 =49047
Penta | [393, 11024, 22953, 11031, 480]
https://openbench.lynx-chess.com/test/3035/
```