### PR TITLE
🔍 History depth: not increae when in check

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -731,15 +731,18 @@ public sealed partial class Engine
 
                     var historyDepth = depth;
 
-                    if (staticEval <= alpha)
+                    if (!isInCheck)
                     {
-                        ++historyDepth;
-                    }
+                        if (staticEval <= alpha)
+                        {
+                            ++historyDepth;
+                        }
 
-                    // Suggestion by Sirius author
-                    if (bestScore >= beta + Configuration.EngineSettings.History_BestScoreBetaMargin)
-                    {
-                        ++historyDepth;
+                        // Suggestion by Sirius author
+                        if (bestScore >= beta + Configuration.EngineSettings.History_BestScoreBetaMargin)
+                        {
+                            ++historyDepth;
+                        }
                     }
 
                     if (isCapture)


### PR DESCRIPTION
```
Test  | search/historydepth-notincheck
Elo   | -0.77 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.25 (-2.25, 2.89) [0.00, 3.00]
Games | 31940: +7953 -8024 =15963
Penta | [355, 3942, 7442, 3881, 350]
https://openbench.lynx-chess.com/test/3057/
```