### PR TITLE
🔍 History depth: not increae when in check II

### DIFF
--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -731,15 +731,18 @@ public sealed partial class Engine
 
                     var historyDepth = depth;
 
-                    if (staticEval <= alpha)
+                    if (!isInCheck)
                     {
-                        ++historyDepth;
-                    }
+                        if (staticEval <= alpha)
+                        {
+                            ++historyDepth;
+                        }
 
-                    // Suggestion by Sirius author
-                    if (bestScore >= beta + Configuration.EngineSettings.History_BestScoreBetaMargin)
-                    {
-                        ++historyDepth;
+                        // Suggestion by Sirius author
+                        if (bestScore >= beta + Configuration.EngineSettings.History_BestScoreBetaMargin)
+                        {
+                            ++historyDepth;
+                        }
                     }
 
                     if (isCapture)

--- a/src/Lynx/Search/NegaMax.cs
+++ b/src/Lynx/Search/NegaMax.cs
@@ -731,13 +731,13 @@ public sealed partial class Engine
 
                     var historyDepth = depth;
 
+                    if (staticEval <= alpha)
+                    {
+                        ++historyDepth;
+                    }
+
                     if (!isInCheck)
                     {
-                        if (staticEval <= alpha)
-                        {
-                            ++historyDepth;
-                        }
-
                         // Suggestion by Sirius author
                         if (bestScore >= beta + Configuration.EngineSettings.History_BestScoreBetaMargin)
                         {


### PR DESCRIPTION
See also https://github.com/lynx-chess/Lynx/pull/2674
```
Test  | search/historydepth-notincheck-2
Elo   | -0.00 +- 1.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.27 (-2.25, 2.89) [0.00, 3.00]
Games | 60892: +15277 -15277 =30338
Penta | [708, 7296, 14442, 7288, 712]
https://openbench.lynx-chess.com/test/3059/
```